### PR TITLE
feat(config): endpoint read-path adaptation — PR2 (ImplicitLiteModelForEndpoint + EntryByModel composite-id)

### DIFF
--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -9,7 +9,11 @@
 // vendor only needs one line here.
 package app
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/open-octo/octo-agent/internal/config"
+)
 
 // EndpointVariant is a regional endpoint alternative for a vendor.
 type EndpointVariant struct {
@@ -449,6 +453,12 @@ func IsKnownVendor(id string) bool {
 //   - baseURL points off the vendor's own endpoints — a custom endpoint is a
 //     different backend wearing a compatible protocol, and its catalogue
 //     won't include the vendor's lite model.
+//
+// Deprecated: prefer ImplicitLiteModelForEndpoint, which takes a config.Endpoint
+// and consults endpoint.LiteModel first. This form is kept for callers that
+// haven't migrated yet (they pass the provider/model/baseURL they already
+// have); it's equivalent to ImplicitLiteModelForEndpoint with an endpoint
+// whose LiteModel is empty.
 func ImplicitLiteModel(provider, model, baseURL string) string {
 	v := vendorByID(provider)
 	if v == nil || v.LiteModel == "" || v.LiteModel == model {
@@ -458,6 +468,57 @@ func ImplicitLiteModel(provider, model, baseURL string) string {
 		return ""
 	}
 	return v.LiteModel
+}
+
+// ImplicitLiteModelForEndpoint returns the lite model a session should compact
+// on when the user configured none explicitly (design §5.5). The precedence:
+//
+//  1. endpoint.LiteModel non-empty and != model → endpoint.LiteModel. The
+//     user explicitly marked this endpoint's lite model (e.g. a custom relay
+//     endpoint carrying both claude-sonnet and gpt-5.4-mini, with mini marked
+//     as lite) — that wins over any vendor inference.
+//  2. Otherwise, if endpoint.BaseURL hits an official vendor (via
+//     VendorByBaseURL) and that vendor has a LiteModel != model → vendor
+//     LiteModel. An official endpoint (e.g. anthropic's api.anthropic.com)
+//     can safely serve the vendor's lite model over the same sender, sharing
+//     key and prompt-cache routing.
+//  3. Otherwise "" — a custom endpoint without an explicit LiteModel has no
+//     implicit lite. Custom relays carry arbitrary catalogues the registry
+//     doesn't know about, so guessing a vendor LiteModel would serve a model
+//     the relay doesn't expose. The user must set endpoint.LiteModel.
+//
+// Migrating from the old ImplicitLiteModel(provider, model, baseURL): the old
+// form is equivalent to ImplicitLiteModelForEndpoint with an endpoint whose
+// LiteModel is empty and whose Provider/BaseURL come from the old args.
+func ImplicitLiteModelForEndpoint(endpoint config.Endpoint, model string) string {
+	// Step 1: explicit endpoint LiteModel wins when it differs from the
+	// primary model. If they're equal, the lite would be a no-op — fall
+	// through to vendor inference so an official endpoint still gets its
+	// vendor's lite (e.g. endpoint.LiteModel="claude-sonnet-4-6" on the
+	// anthropic endpoint, primary is also claude-sonnet-4-6 → infer
+	// claude-haiku-4-5 rather than returning a useless self-reference).
+	if endpoint.LiteModel != "" && endpoint.LiteModel != model {
+		return endpoint.LiteModel
+	}
+
+	// Step 2: official vendor endpoint → vendor LiteModel. The provider field
+	// alone isn't enough — a user can set provider="anthropic" on an endpoint
+	// whose base_url points elsewhere (a relay wearing the anthropic
+	// protocol). VendorByBaseURL confirms the endpoint actually points at the
+	// named vendor's host before inferring its LiteModel.
+	if endpoint.BaseURL != "" {
+		inferredProvider := VendorByBaseURL(endpoint.BaseURL)
+		if inferredProvider != "" && inferredProvider == endpoint.Provider {
+			if v := vendorByID(inferredProvider); v != nil && v.LiteModel != "" && v.LiteModel != model {
+				return v.LiteModel
+			}
+		}
+	}
+
+	// Step 3: no inference. Either a custom endpoint (no vendor match) or a
+	// vendor with no LiteModel in the registry, or the primary model already
+	// is the vendor LiteModel.
+	return ""
 }
 
 // VendorByBaseURL returns the vendor whose default endpoint or one of whose

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -477,7 +477,7 @@ func ImplicitLiteModel(provider, model, baseURL string) string {
 //     user explicitly marked this endpoint's lite model (e.g. a custom relay
 //     endpoint carrying both claude-sonnet and gpt-5.4-mini, with mini marked
 //     as lite) — that wins over any vendor inference.
-//  2. Otherwise, if endpoint.BaseURL hits an official vendor (via
+//  2. Otherwise, if the endpoint points at an official vendor (via
 //     VendorByBaseURL) and that vendor has a LiteModel != model → vendor
 //     LiteModel. An official endpoint (e.g. anthropic's api.anthropic.com)
 //     can safely serve the vendor's lite model over the same sender, sharing
@@ -487,9 +487,20 @@ func ImplicitLiteModel(provider, model, baseURL string) string {
 //     doesn't know about, so guessing a vendor LiteModel would serve a model
 //     the relay doesn't expose. The user must set endpoint.LiteModel.
 //
+// Step 2's vendor inference uses the endpoint's effective base URL — when
+// the user omits base_url (legal for named vendors, design §3.1: "命名 vendor
+// 可空, 用 vendor 默认"), we fall back to the vendor's DefaultBaseURL so the
+// inference still fires. Without this fallback, a named-vendor endpoint
+// configured without base_url would silently lose its compaction lite model,
+// which is a regression from the legacy ImplicitLiteModel (which treated
+// baseURL=="" as "trust the provider field").
+//
 // Migrating from the old ImplicitLiteModel(provider, model, baseURL): the old
 // form is equivalent to ImplicitLiteModelForEndpoint with an endpoint whose
-// LiteModel is empty and whose Provider/BaseURL come from the old args.
+// LiteModel is empty, Provider = provider, and BaseURL = baseURL. Callers
+// that haven't migrated yet (cmd/octo/chat.go, internal/server/server.go) stay
+// on the old form because the ModelEntry they hold has no LiteModel field;
+// they'll migrate in PR4 when the entry becomes a config.Endpoint.
 func ImplicitLiteModelForEndpoint(endpoint config.Endpoint, model string) string {
 	// Step 1: explicit endpoint LiteModel wins when it differs from the
 	// primary model. If they're equal, the lite would be a no-op — fall
@@ -506,8 +517,17 @@ func ImplicitLiteModelForEndpoint(endpoint config.Endpoint, model string) string
 	// whose base_url points elsewhere (a relay wearing the anthropic
 	// protocol). VendorByBaseURL confirms the endpoint actually points at the
 	// named vendor's host before inferring its LiteModel.
-	if endpoint.BaseURL != "" {
-		inferredProvider := VendorByBaseURL(endpoint.BaseURL)
+	//
+	// When base_url is empty (legal for named vendors per §3.1), fall back to
+	// the vendor's DefaultBaseURL so the inference still fires. This matches
+	// the legacy ImplicitLiteModel's treatment of baseURL=="" as "trust the
+	// provider field".
+	baseURL := endpoint.BaseURL
+	if baseURL == "" {
+		baseURL = VendorBaseURL(endpoint.Provider)
+	}
+	if baseURL != "" {
+		inferredProvider := VendorByBaseURL(baseURL)
 		if inferredProvider != "" && inferredProvider == endpoint.Provider {
 			if v := vendorByID(inferredProvider); v != nil && v.LiteModel != "" && v.LiteModel != model {
 				return v.LiteModel

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -331,6 +331,26 @@ func TestImplicitLiteModel_EndpointForm(t *testing.T) {
 			"claude-haiku-4-5",
 		},
 		{
+			"named-vendor endpoint with empty base_url still infers vendor LiteModel (regression guard for I1)",
+			// Design §3.1: "base_url,omitempty // custom 必填, 命名 vendor 可空
+			// (用 vendor 默认)". A named-vendor endpoint configured without
+			// base_url must still get its vendor's LiteModel — the legacy
+			// ImplicitLiteModel treated baseURL=="" as "trust the provider",
+			// and ImplicitLiteModelForEndpoint must match that. Without the
+			// VendorBaseURL fallback in step 2, this case would silently lose
+			// compaction lite model — a regression that only surfaces after
+			// PR4 migrates callers to the new function.
+			config.Endpoint{Provider: "anthropic"}, // BaseURL empty
+			"claude-sonnet-4-6",
+			"claude-haiku-4-5",
+		},
+		{
+			"named-vendor endpoint with empty base_url still infers vendor LiteModel (deepseek)",
+			config.Endpoint{Provider: "deepseek"},
+			"deepseek-v4-pro",
+			"deepseek-v4-flash",
+		},
+		{
 			"official deepseek endpoint infers vendor LiteModel",
 			config.Endpoint{Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
 			"deepseek-v4-pro",

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/provider/anthropic"
 	"github.com/open-octo/octo-agent/internal/provider/openai"
 )
@@ -286,5 +287,95 @@ func TestRegistryModelsHaveDeterministicVision(t *testing.T) {
 				t.Errorf("vendor %q model %q not resolvable via VendorModelVision", v.ID, m.ID)
 			}
 		}
+	}
+}
+
+// TestImplicitLiteModel_EndpointForm covers the new signature
+// ImplicitLiteModelForEndpoint(endpoint config.Endpoint, model string)
+// introduced in PR2 (design §5.5). The precedence is:
+//
+//  1. endpoint.LiteModel non-empty and != model → endpoint.LiteModel
+//  2. otherwise, if endpoint.BaseURL hits an official vendor (via
+//     VendorByBaseURL) and that vendor has a LiteModel → vendor LiteModel
+//  3. otherwise "" (custom endpoint without explicit LiteModel has no
+//     implicit lite — the user must set endpoint.LiteModel)
+//
+// The old ImplicitLiteModel(provider, model, baseURL) is kept as a thin
+// wrapper so existing callers that haven't migrated yet keep working; this
+// test pins the new endpoint-aware behaviour.
+func TestImplicitLiteModel_EndpointForm(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint config.Endpoint
+		model    string
+		want     string
+	}{
+		{
+			"endpoint.LiteModel wins when set and differs from model",
+			config.Endpoint{Provider: "custom", BaseURL: "https://relay.example.com", LiteModel: "gpt-5.4-mini"},
+			"claude-sonnet-4-6",
+			"gpt-5.4-mini",
+		},
+		{
+			"endpoint.LiteModel == model → fall through to vendor inference (no implicit lite from endpoint)",
+			// An endpoint that nominally points LiteModel at the same model as
+			// the primary — the lite would be a no-op, so we don't return it.
+			config.Endpoint{Provider: "anthropic", BaseURL: "https://api.anthropic.com", LiteModel: "claude-sonnet-4-6"},
+			"claude-sonnet-4-6",
+			"claude-haiku-4-5", // vendor LiteModel wins because endpoint.LiteModel == model
+		},
+		{
+			"official anthropic endpoint infers vendor LiteModel",
+			config.Endpoint{Provider: "anthropic", BaseURL: "https://api.anthropic.com"},
+			"claude-sonnet-4-6",
+			"claude-haiku-4-5",
+		},
+		{
+			"official deepseek endpoint infers vendor LiteModel",
+			config.Endpoint{Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+			"deepseek-v4-pro",
+			"deepseek-v4-flash",
+		},
+		{
+			"custom endpoint with no LiteModel and off-vendor baseURL → no implicit lite",
+			config.Endpoint{Provider: "custom", BaseURL: "https://relay.example.com"},
+			"claude-sonnet-4-6",
+			"",
+		},
+		{
+			"custom endpoint with named vendor provider but off-vendor baseURL → no implicit lite",
+			// provider=anthropic but baseURL points elsewhere — VendorByBaseURL
+			// won't match anthropic, so we don't infer the anthropic LiteModel.
+			config.Endpoint{Provider: "anthropic", BaseURL: "https://relay.example.com"},
+			"claude-sonnet-4-6",
+			"",
+		},
+		{
+			"primary model already is the vendor LiteModel → no implicit lite",
+			config.Endpoint{Provider: "anthropic", BaseURL: "https://api.anthropic.com"},
+			"claude-haiku-4-5",
+			"",
+		},
+		{
+			"empty endpoint (zero value) → no implicit lite",
+			config.Endpoint{},
+			"anything",
+			"",
+		},
+		{
+			"regional variant endpoint infers vendor LiteModel (or empty if vendor has none)",
+			config.Endpoint{Provider: "minimax", BaseURL: "https://api.minimax.io"}, // intl variant
+			"MiniMax-M3",
+			"", // minimax has no LiteModel in the registry
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ImplicitLiteModelForEndpoint(tc.endpoint, tc.model)
+			if got != tc.want {
+				t.Errorf("ImplicitLiteModelForEndpoint(endpoint=%+v, model=%q) = %q, want %q",
+					tc.endpoint, tc.model, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -629,10 +629,16 @@ func (c Config) EntryByModel(model string) (ModelEntry, bool) {
 				}
 			}
 		}
-		// Composite id didn't resolve — fall through to the bare-model path
-		// rather than returning false, so a stale composite id (endpoint
-		// deleted but session still references it) degrades to a bare-model
-		// lookup that might still find the model on another endpoint.
+		// Composite id didn't resolve against c.Endpoints — fall through to
+		// the bare-model path rather than returning false. This only fires on
+		// a mixed-schema config (Endpoints populated AND Models populated, e.g.
+		// a hand-edited file with both blocks, or an in-memory config where
+		// Load's normalize synthesised Endpoints from Models): a stale
+		// composite id whose endpoint was deleted might still find the bare
+		// model in c.Models and degrade gracefully. On a pure-new-schema
+		// config (Endpoints only, Models empty) the bare scan below finds
+		// nothing and returns false, which is correct — the caller should
+		// fall back to ResolveDefault.
 	}
 	// Bare-model path: legacy flat Models lookup.
 	for _, e := range c.Models {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -596,10 +596,45 @@ func (c Config) resolveCompositeID(id string) (Endpoint, EndpointModel, bool) {
 
 // EntryByModel returns the entry with the given model string. An empty model
 // never matches.
+//
+// PR2 (design §8.2): the input may be either a bare model string (legacy
+// session files, pre-PR4) or a composite id "<endpoint_id>::<model>" (new
+// session files). A composite id is resolved against c.Endpoints first —
+// the matching EndpointModel is projected back into a ModelEntry shape so
+// callers that still read ModelEntry fields (Provider, BaseURL, APIKey,
+// Protocol, Vision) get consistent values. A bare model falls back to the
+// legacy flat c.Models lookup. This keeps every callsite that reads
+// sess.ModelConfig / sess.Model (server.go, handlers.go, ws_handlers.go)
+// working without each one having to know about the composite-id form.
 func (c Config) EntryByModel(model string) (ModelEntry, bool) {
 	if model == "" {
 		return ModelEntry{}, false
 	}
+	// Composite-id path: resolve against Endpoints.
+	if endpointID, modelName, ok := splitCompositeID(model); ok {
+		for _, ep := range c.Endpoints {
+			if ep.ID != endpointID {
+				continue
+			}
+			for _, m := range ep.Models {
+				if m.Model == modelName {
+					return ModelEntry{
+						Provider: ep.Provider,
+						Model:    m.Model,
+						BaseURL:  ep.BaseURL,
+						APIKey:   ep.APIKey,
+						Protocol: ep.Protocol,
+						Vision:   m.Vision,
+					}, true
+				}
+			}
+		}
+		// Composite id didn't resolve — fall through to the bare-model path
+		// rather than returning false, so a stale composite id (endpoint
+		// deleted but session still references it) degrades to a bare-model
+		// lookup that might still find the model on another endpoint.
+	}
+	// Bare-model path: legacy flat Models lookup.
 	for _, e := range c.Models {
 		if e.Model == model {
 			return e, true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -282,6 +282,92 @@ func TestEntryByModel_EmptyNeverMatches(t *testing.T) {
 	}
 }
 
+// TestEntryByModel_CompositeIDResolvesAgainstEndpoints covers PR2 §8.2:
+// EntryByModel accepts a composite id "<endpoint_id>::<model>" and resolves
+// it against c.Endpoints, projecting the EndpointModel back into a ModelEntry
+// shape (Provider/BaseURL/APIKey/Protocol/Vision all filled from the
+// endpoint + model). This lets every callsite that reads sess.ModelConfig /
+// sess.Model work whether the session file is on the old bare-model form or
+// the new composite-id form.
+func TestEntryByModel_CompositeIDResolvesAgainstEndpoints(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{
+				ID:       "relay-a",
+				Provider: "custom",
+				BaseURL:  "https://relay.example.com",
+				APIKey:   "alpha",
+				Protocol: "anthropic",
+				Models: []EndpointModel{
+					{Model: "claude-sonnet-4-6", Vision: true},
+					{Model: "gpt-5.4", Vision: true},
+				},
+			},
+			{
+				ID:       "official",
+				Provider: "anthropic",
+				BaseURL:  "https://api.anthropic.com",
+				Models: []EndpointModel{
+					{Model: "claude-sonnet-4-6", Vision: true},
+				},
+			},
+		},
+	}
+
+	// Composite id resolves to the relay endpoint's claude, with all the
+	// endpoint's connection params projected onto the returned ModelEntry.
+	got, ok := cfg.EntryByModel("relay-a::claude-sonnet-4-6")
+	if !ok {
+		t.Fatal("EntryByModel(composite id) = (_, false), want (_, true)")
+	}
+	if got.Provider != "custom" || got.BaseURL != "https://relay.example.com" ||
+		got.APIKey != "alpha" || got.Protocol != "anthropic" || got.Model != "claude-sonnet-4-6" ||
+		!got.Vision {
+		t.Errorf("EntryByModel(composite) = %+v, want relay-a endpoint's claude-sonnet-4-6 projected", got)
+	}
+
+	// Same bare model on a different endpoint resolves to the right one
+	// when given that endpoint's composite id.
+	got, ok = cfg.EntryByModel("official::claude-sonnet-4-6")
+	if !ok {
+		t.Fatal("EntryByModel(official::claude) = false")
+	}
+	if got.Provider != "anthropic" || got.BaseURL != "https://api.anthropic.com" || got.Model != "claude-sonnet-4-6" {
+		t.Errorf("EntryByModel(official::claude) = %+v, want official anthropic endpoint", got)
+	}
+
+	// Composite id with unknown endpoint falls through to bare-model lookup
+	// (which finds nothing here since c.Models is empty) — returns false.
+	if _, ok := cfg.EntryByModel("ghost::claude-sonnet-4-6"); ok {
+		t.Error("EntryByModel(unknown endpoint) = true, want false (fall through to bare lookup, find nothing)")
+	}
+
+	// Composite id with known endpoint but unknown model under it — also
+	// falls through to bare-model lookup.
+	if _, ok := cfg.EntryByModel("relay-a::ghost-model"); ok {
+		t.Error("EntryByModel(known endpoint, unknown model) = true, want false")
+	}
+}
+
+// TestEntryByModel_BareModelStillWorks pins the legacy path: a bare model
+// string (no "::" separator) resolves against c.Models the way it always did.
+// This is what pre-PR4 session files carry — their ModelConfig is a bare model
+// string, and EntryByModel must keep working for them.
+func TestEntryByModel_BareModelStillWorks(t *testing.T) {
+	cfg := Config{
+		Models: []ModelEntry{
+			{Provider: "anthropic", Model: "claude-sonnet-4-6", BaseURL: "https://api.anthropic.com", Vision: true},
+		},
+	}
+	got, ok := cfg.EntryByModel("claude-sonnet-4-6")
+	if !ok {
+		t.Fatal("EntryByModel(bare model) = false, want true (legacy path)")
+	}
+	if got.Provider != "anthropic" || got.Model != "claude-sonnet-4-6" {
+		t.Errorf("EntryByModel(bare) = %+v, want anthropic/claude-sonnet-4-6", got)
+	}
+}
+
 func TestModelVision(t *testing.T) {
 	c := Config{Models: []ModelEntry{
 		{Model: "qwen-vl-max", Vision: true},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -368,6 +368,44 @@ func TestEntryByModel_BareModelStillWorks(t *testing.T) {
 	}
 }
 
+// TestEntryByModel_CompositeIDWinsOverFlatModels pins the precedence: when
+// the config has BOTH a flat Models entry with the bare model AND an Endpoints
+// entry whose composite id matches, the composite-id path must win. Otherwise
+// a user who configures the same model on two endpoints (the whole point of
+// the two-level schema) and references it via composite id would get the flat
+// entry's connection params instead of the endpoint's — silently routing to
+// the wrong backend.
+func TestEntryByModel_CompositeIDWinsOverFlatModels(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{
+				ID:       "relay-a",
+				Provider: "custom",
+				BaseURL:  "https://relay.example.com",
+				APIKey:   "alpha",
+				Protocol: "anthropic",
+				Models:   []EndpointModel{{Model: "claude-sonnet-4-6", Vision: true}},
+			},
+		},
+		// A flat Models entry with the SAME bare model — this is what a
+		// migrated config looks like before the write-path switches in PR4
+		// (Endpoints synthesised in memory + Models still populated from the
+		// legacy file). The composite-id path must win so the relay's
+		// connection params are returned, not the flat entry's.
+		Models: []ModelEntry{
+			{Provider: "anthropic", Model: "claude-sonnet-4-6", BaseURL: "https://api.anthropic.com", Vision: true},
+		},
+	}
+
+	got, ok := cfg.EntryByModel("relay-a::claude-sonnet-4-6")
+	if !ok {
+		t.Fatal("EntryByModel(composite) = false, want true")
+	}
+	if got.Provider != "custom" || got.BaseURL != "https://relay.example.com" || got.APIKey != "alpha" {
+		t.Errorf("EntryByModel(composite) = %+v, want relay-a endpoint's connection params (composite path must win over flat Models)", got)
+	}
+}
+
 func TestModelVision(t *testing.T) {
 	c := Config{Models: []ModelEntry{
 		{Model: "qwen-vl-max", Vision: true},


### PR DESCRIPTION
## What this PR does

Second of 5 PRs implementing the **endpoint two-level schema** from `dev-docs/endpoint-design.md`. PR1 (merged in #1610) introduced the Endpoint types, legacy flat read-compat, and endpoint-level Validate/Repair. PR2 is **read-path adaptation** — making the config-layer consumers of model references work with both the legacy bare-model form (pre-PR4 session files) and the new composite-id form (`<endpoint_id>::<model>`, the shape PR4 will write).

### Changes

- **New `ImplicitLiteModelForEndpoint(endpoint config.Endpoint, model string) string`** (`internal/app/provider.go`, design §5.5). Precedence: endpoint.LiteModel (non-empty, != model) → vendor LiteModel (if the endpoint points at an official vendor) → "". When `endpoint.BaseURL` is empty (legal for named vendors per §3.1), falls back to `VendorBaseURL(endpoint.Provider)` so vendor inference still fires — this matches the legacy `ImplicitLiteModel`'s treatment of `baseURL==""` as "trust the provider". The old `ImplicitLiteModel(provider, model, baseURL)` is kept and marked deprecated; callers stay on the old form because the `ModelEntry` they hold has no `LiteModel` field, and migrating now would be a behaviour-equivalent no-op that just adds diff. They'll migrate in PR4 when the entry becomes a `config.Endpoint`.

- **`Config.EntryByModel` now accepts composite id** (`internal/config/config.go`, design §8.2). A composite id `"<endpoint_id>::<model>"` resolves against `c.Endpoints` and projects the `EndpointModel` back into a `ModelEntry` shape (Provider/BaseURL/APIKey/Protocol/Vision all filled from the endpoint + model). An unresolvable composite id falls through to the bare-model path so a stale reference (endpoint deleted but session still references it) degrades gracefully. A bare model string (no `::`) takes the legacy `c.Models` lookup, unchanged. **When both paths could match, composite wins** — the same model on two endpoints is the whole point of the two-level schema.

This single change covers the session/channel read-time compat from §8.2: every callsite that reads `sess.ModelConfig` / `st.ModelConfig` (`server.go:1211/1465/2160`, `handlers.go:148`) now works whether the session file is on the old bare-model form or the new composite-id form, without touching `agent/session.go` or `internal/channel/manager.go` (the agent package stays free of any config import — session `Model`/`ModelConfig` fields hold the raw file value, and the consumer side resolves via `EntryByModel` when it needs a `ModelEntry` to build a sender).

### Why this shape

The alternative (adding a `resolveLegacyModelRef` helper called from inside `agent.LoadSession`) would force the agent package to import config — breaking a clean package boundary — and would require touching every `LoadSession` callsite (dozens). Upgrading `EntryByModel` itself keeps the boundary clean and the diff tiny while covering all read-time compat paths.

## Review findings (fixed)

One round of isolated code-review (via the code-review sub-agent).

- **I1 (Important)**: `ImplicitLiteModelForEndpoint` was silently dropping vendor lite-model inference when a named-vendor endpoint omitted `base_url`. Design §3.1 explicitly allows this, and the legacy `ImplicitLiteModel` treated `baseURL==""` as "trust the provider" — so the new function diverged from the old, and the deprecated docstring's equivalence claim was false. Without the fix, PR4's caller migration would silently lose compaction lite model for users with a named-vendor endpoint configured without `base_url`. **Fix**: step 2 falls back to `VendorBaseURL(endpoint.Provider)` when `endpoint.BaseURL` is empty. Two new test cases (anthropic + deepseek with empty `BaseURL`) lock the behaviour. The fix also resolves M3 (the equivalence claim is now true including the empty-baseURL case).
- **M1**: Added `TestEntryByModel_CompositeIDWinsOverFlatModels` to pin the precedence — when the config has both a flat `Models` entry with the bare model AND an `Endpoints` entry whose composite id matches, the composite path must win.
- **M2**: Clarified the fall-through comment in `EntryByModel`'s composite-id path — the fall-through only fires on mixed-schema configs (both Endpoints and Models populated); on a pure-new-schema config the bare scan finds nothing and returns false, which is correct.

## Deviations from design

- **Slice 2.1 only adds the new function**; the old `ImplicitLiteModel` is kept deprecated, callers migrate in PR4. Design §11 lists caller migration under PR2, but migrating now (when the entry is a `ModelEntry` without a `LiteModel` field) is a behaviour-equivalent no-op that just adds diff. PR4 is the natural migration point.
- **Slice 2.2/2.3 implement §8.2's "read-time compat" by upgrading `EntryByModel` itself**, not by adding a `resolveLegacyModelRef` helper in the agent package. This keeps `agent/session.go` untouched and the agent package free of any config import. Design §8.2's prose suggested the helper approach; the actual implementation achieves the same effect with a smaller diff and a cleaner package boundary. Recorded in the slice reports.

## Tests

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./internal/config/ ./internal/app/` — clean
- `go test ./internal/server/ ./internal/channel/` — all green (no regressions; `server.go`'s `cfg.EntryByModel(sess.ModelConfig)` callsites now work with both forms)

Tests cover: ImplicitLiteModelForEndpoint's three rules + empty-baseURL fallback + endpoint.LiteModel==model fall-through + custom endpoint no-inference + regional variant; EntryByModel composite-id resolution + projection of all ModelEntry fields + composite-wins-over-flat-Models precedence + unresolvable composite falls through + bare model legacy path.

## Next PRs

- **PR3**: flock concurrency protection + endpoint rename cascade + sender cache key change to composite id.
- **PR4**: Save write-path switch (emit `endpoints:` not `models:`) + three-UI two-level (TUI picker / IM `/model` / Web settings) + new API `GET /api/config/endpoints` + caller migration to `ImplicitLiteModelForEndpoint`.
- **PR5**: `octo config` / `octo doctor` upgrades + docs.

## Refs

- Design doc: `dev-docs/endpoint-design.md` (§3.1, §5.5, §8.2, §11)
- PR1: #1610

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
