### PR TITLE
serve: reject positional args with a helpful error (fix #1614)

### DIFF
--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -54,7 +54,14 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-
+	// Reject any positional argument: serve takes flags only, and a bare
+	// value like ":19099" silently falls into fs.Args() (defaulting --addr to
+	// 127.0.0.1:8088) — see issue #1614. Point the user at the flag form
+	// explicitly instead of letting the wrong port start quietly.
+	if rest := fs.Args(); len(rest) > 0 {
+		fmt.Fprintf(stderr, "octo serve: unexpected positional argument(s) %q — use flags for every option (e.g. `octo serve -addr %s -d`)\n", rest, rest[0])
+		return 2
+	}
 	if *stop {
 		return stopDaemon(stdout, stderr)
 	}

--- a/cmd/octo/serve_test.go
+++ b/cmd/octo/serve_test.go
@@ -48,3 +48,36 @@ func TestDisplayURLHost(t *testing.T) {
 		t.Errorf("wildcard bind should yield host:8080, got %q", got)
 	}
 }
+
+// TestServeRejectsPositionalArgs pins the #1614 fix: a bare value like
+// ":19099" must not silently fall through to fs.Args() (which would leave
+// --addr at its default 127.0.0.1:8088). runServe should refuse with a
+// helpful error pointing at the flag form.
+func TestServeRejectsPositionalArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runServe([]string{":19099", "-d"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "unexpected positional argument") {
+		t.Errorf("want positional-argument error, got:\n%s", out)
+	}
+	if !strings.Contains(out, "-addr :19099") {
+		t.Errorf("error should suggest the correct flag form, got:\n%s", out)
+	}
+}
+
+// TestServeRejectsPositionalArgsAlone covers the bare case from #1614:
+// a lone ":19099" with no other flag still errors (no daemon/supervisor
+// path to fall through to).
+func TestServeRejectsPositionalArgsAlone(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runServe([]string{":19099"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "unexpected positional argument") {
+		t.Errorf("want positional-argument error, got:\n%s", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Closes #1614 — `octo serve :19099 -d` silently binds `127.0.0.1:8088` because the bare `:19099` falls into `fs.Args()`, which `serve` ignores. The user only notices after an upgrade/restart, when the server appears to "roll back" to 8088.
- The restart path (`cmd/octo/serve_supervisor.go:91`) passes argv verbatim and is not at fault; the real defect is the wrong-port command starting **quietly**.
- After this change, `runServe` exits 2 with a message that shows the correct flag form:

  ```
  octo serve: unexpected positional argument(s) [":19099" "-d"] — use flags for every option (e.g. `octo serve -addr :19099 -d`)
  ```

## Verification
- `go test ./cmd/octo/` — all pass (`TestServeRejectsPositionalArgs`, `TestServeRejectsPositionalArgsAlone`, `TestServeDefaultAddrIsLoopback` still green).
- `go build ./cmd/octo/` — clean.
- Manual: `octo serve :19099 -d` now returns exit 2 with the corrective hint instead of silently binding 8088.

## Test plan
- [x] Unit test covering `:19099 -d` (the issue's exact failing command).
- [x] Unit test covering `:19099` alone.
- [x] Existing `TestServeDefaultAddrIsLoopback` still passes — `-h` still works (flag-only path untouched).

🤖 Generated with [Claude Code](https://claude.ai/code)
