### PR TITLE
feat(config): endpoint concurrency + rename cascade + sender cache — PR3

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -695,6 +695,96 @@ func (c *Config) SetEntry(e ModelEntry) bool {
 	return false
 }
 
+// RenameEndpoint renames an endpoint id across the config: it updates the
+// endpoint's ID field AND rewrites any Default/Lite composite-id prefixes
+// that point at the old id. The rename runs under the config flock so a
+// concurrent Save can't interleave and drop the reference update (design §6).
+//
+// Session files (which carry their own model_config composite-id references
+// in ~/.octo/sessions/*.jsonl) are NOT scanned or updated — that's
+// intentionally deferred. A stale composite id whose endpoint was renamed
+// falls through EntryByModel's bare-model path (Slice 2.2), which finds the
+// model in c.Models (still populated during PR1-3) and degrades gracefully.
+// Scanning every session file on every rename is a heavy operation for a
+// rare event, and the fall-through makes the staleness tolerable. PR4 may
+// revisit this if the fall-through proves insufficient.
+//
+// The caller must validate newID before calling (RenameEndpoint does not
+// re-validate; it's a mechanical rename). Returns ErrEndpointNotFound if
+// oldID doesn't match any endpoint.
+func (c *Config) RenameEndpoint(oldID, newID string) error {
+	// Find the endpoint and bail if it doesn't exist — renaming a
+	// non-existent endpoint is a caller bug.
+	idx := -1
+	for i := range c.Endpoints {
+		if c.Endpoints[i].ID == oldID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("endpoint %q not found", oldID)
+	}
+
+	// Update the endpoint's own ID.
+	c.Endpoints[idx].ID = newID
+
+	// Rewrite Default/Lite composite-id prefixes. A composite id is
+	// "<endpoint_id>::<model>" — we only swap the prefix, the model stays.
+	c.Default = renameCompositePrefix(c.Default, oldID, newID)
+	c.Lite = renameCompositePrefix(c.Lite, oldID, newID)
+	return nil
+}
+
+// renameCompositePrefix rewrites a composite id's endpoint prefix from oldID
+// to newID. If id doesn't match the "<oldID>::..." shape, it's returned
+// unchanged (it might point at a different endpoint, or be empty).
+func renameCompositePrefix(id, oldID, newID string) string {
+	if id == "" {
+		return ""
+	}
+	prefix := oldID + "::"
+	if !strings.HasPrefix(id, prefix) {
+		return id // points at a different endpoint, leave it
+	}
+	return newID + "::" + strings.TrimPrefix(id, prefix)
+}
+
+// ErrEndpointNotFound is returned by RenameEndpoint (and future endpoint
+// mutations) when the named endpoint doesn't exist in c.Endpoints.
+var ErrEndpointNotFound = errors.New("endpoint not found")
+
+// Mutate performs an atomic read-modify-write on config.yml under the flock:
+// it acquires the exclusive lock, Loads the latest config, applies fn (which
+// may modify the Config in place), and Saves the result. Use this for any
+// mutation that depends on the current state of the file (renaming an
+// endpoint, updating Default/Lite references, etc.) — without it, two
+// concurrent goroutines can both Load the pre-mutation state and the later
+// Save silently drops the earlier mutation.
+//
+// fn must not call Save itself (Mutate does that via saveLocked, which skips
+// re-locking) and must not take long (it holds the lock). If fn returns an
+// error, Mutate aborts without saving and returns the error.
+func Mutate(fn func(*Config) error) error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return withConfigLock(path, func() error {
+		cfg, err := Load()
+		if err != nil {
+			return fmt.Errorf("config.Mutate: load: %w", err)
+		}
+		if err := fn(&cfg); err != nil {
+			return err
+		}
+		return cfg.saveLocked(path)
+	})
+}
+
 // Path returns the absolute path to the config file (~/.octo/config.yml).
 func Path() (string, error) {
 	home, err := os.UserHomeDir()
@@ -1289,6 +1379,10 @@ func resetLastGoodForTest() {
 // changes. The lock is advisory (flock / LockFileEx) — co-operating
 // processes honour it. NFS home directories are a known weak spot; documented
 // in dev-docs/endpoint-design.md §7.3.
+//
+// Callers that need read-modify-write atomicity (e.g. renaming an endpoint
+// and updating Default/Lite references) should use Mutate, which holds the
+// lock across Load+modify+Save — calling Save directly in that pattern races.
 func (c Config) Save() error {
 	path, err := Path()
 	if err != nil {
@@ -1298,32 +1392,40 @@ func (c Config) Save() error {
 		return err
 	}
 	return withConfigLock(path, func() error {
-		// Shallow copy with the new-schema fields cleared so yaml.Marshal emits
-		// only the legacy flat form. The Models slice is shared by reference,
-		// which is fine — we don't mutate it.
-		saved := c
-		saved.Endpoints = nil
-		saved.Default = ""
-		saved.Lite = ""
-		data, err := yaml.Marshal(saved)
-		if err != nil {
-			return err
-		}
-		if err := os.WriteFile(path, data, 0o600); err != nil {
-			return err
-		}
-		// Rolling backup of the last config we wrote (always valid, since it's a
-		// marshaled Config): `octo config --fix` restores from it when a later hand
-		// edit leaves config.yml unparseable. Best-effort — a backup failure must
-		// never fail the save itself.
-		_ = os.WriteFile(path+".bak", data, 0o600)
-		if legacy, lerr := legacyPath(); lerr == nil {
-			if _, statErr := os.Stat(legacy); statErr == nil {
-				_ = os.Rename(legacy, legacy+".bak")
-			}
-		}
-		return nil
+		return c.saveLocked(path)
 	})
+}
+
+// saveLocked writes the config without acquiring the flock. Used by Save
+// (which wraps it in withConfigLock) and by Mutate (which already holds the
+// lock and needs to save without re-locking — re-locking would deadlock since
+// flock on a fresh fd blocks on the same inode).
+func (c Config) saveLocked(path string) error {
+	// Shallow copy with the new-schema fields cleared so yaml.Marshal emits
+	// only the legacy flat form. The Models slice is shared by reference,
+	// which is fine — we don't mutate it.
+	saved := c
+	saved.Endpoints = nil
+	saved.Default = ""
+	saved.Lite = ""
+	data, err := yaml.Marshal(saved)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	// Rolling backup of the last config we wrote (always valid, since it's a
+	// marshaled Config): `octo config --fix` restores from it when a later hand
+	// edit leaves config.yml unparseable. Best-effort — a backup failure must
+	// never fail the save itself.
+	_ = os.WriteFile(path+".bak", data, 0o600)
+	if legacy, lerr := legacyPath(); lerr == nil {
+		if _, statErr := os.Stat(legacy); statErr == nil {
+			_ = os.Rename(legacy, legacy+".bak")
+		}
+	}
+	return nil
 }
 
 // BackupPath returns the rolling-backup path (config.yml.bak) that Save writes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -709,9 +709,14 @@ func (c *Config) SetEntry(e ModelEntry) bool {
 // rare event, and the fall-through makes the staleness tolerable. PR4 may
 // revisit this if the fall-through proves insufficient.
 //
-// The caller must validate newID before calling (RenameEndpoint does not
-// re-validate; it's a mechanical rename). Returns ErrEndpointNotFound if
-// oldID doesn't match any endpoint.
+// newID must not collide with another endpoint's ID — RenameEndpoint checks
+// and returns ErrEndpointIDInUse if it would. The caller is still expected
+// to have validated newID against the id regex (^[a-zA-Z0-9_-]+$) first;
+// RenameEndpoint does the collision check defensively but not the format
+// check.
+//
+// Returns ErrEndpointNotFound (wrap-target for errors.Is) if oldID doesn't
+// match any endpoint.
 func (c *Config) RenameEndpoint(oldID, newID string) error {
 	// Find the endpoint and bail if it doesn't exist — renaming a
 	// non-existent endpoint is a caller bug.
@@ -723,7 +728,17 @@ func (c *Config) RenameEndpoint(oldID, newID string) error {
 		}
 	}
 	if idx < 0 {
-		return fmt.Errorf("endpoint %q not found", oldID)
+		return fmt.Errorf("%w: %s", ErrEndpointNotFound, oldID)
+	}
+
+	// Defensive collision check — renaming onto an existing id would produce
+	// a duplicate, which Validate classifies as unfixable (§14.3). The doc
+	// says the caller must validate, but a one-line check here prevents a
+	// caller bug from silently corrupting the config.
+	for i, ep := range c.Endpoints {
+		if i != idx && ep.ID == newID {
+			return fmt.Errorf("%w: %s", ErrEndpointIDInUse, newID)
+		}
 	}
 
 	// Update the endpoint's own ID.
@@ -751,8 +766,14 @@ func renameCompositePrefix(id, oldID, newID string) string {
 }
 
 // ErrEndpointNotFound is returned by RenameEndpoint (and future endpoint
-// mutations) when the named endpoint doesn't exist in c.Endpoints.
+// mutations) when the named endpoint doesn't exist in c.Endpoints. Wrap-target
+// for errors.Is — callers can distinguish "not found" from other errors.
 var ErrEndpointNotFound = errors.New("endpoint not found")
+
+// ErrEndpointIDInUse is returned by RenameEndpoint when newID already matches
+// another endpoint's ID — renaming onto it would produce a duplicate, which
+// Validate classifies as unfixable (§14.3). Wrap-target for errors.Is.
+var ErrEndpointIDInUse = errors.New("endpoint id already in use")
 
 // Mutate performs an atomic read-modify-write on config.yml under the flock:
 // it acquires the exclusive lock, Loads the latest config, applies fn (which

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1271,10 +1271,6 @@ func resetLastGoodForTest() {
 // API keys), creating ~/.octo if needed. A legacy config.yaml present at that
 // moment is renamed to config.yaml.bak — best effort, because config.yml wins
 // the read order regardless.
-// Save writes the config to ~/.octo/config.yml with mode 0600 (it may hold
-// API keys), creating ~/.octo if needed. A legacy config.yaml present at that
-// moment is renamed to config.yaml.bak — best effort, because config.yml wins
-// the read order regardless.
 //
 // PR1 invariant (design §4.3): Save must write the legacy flat form
 // (models: + default_model: + lite_model:), NOT the new endpoints: form.
@@ -1284,6 +1280,15 @@ func resetLastGoodForTest() {
 // tags (Load still needs to honour an explicit endpoints: block the user
 // hand-writes, per §4.1 step 1), Save marshals a shallow copy with the new
 // fields cleared.
+//
+// PR3 (design §7.1): Save holds an exclusive flock on the lockfile for the
+// duration of the write, serialising concurrent Save calls across processes.
+// octo-agent has multiple entry points (TUI process + octo serve + octo
+// config command) that can all write config.yml simultaneously; without
+// the lock, a later writer would silently overwrite an earlier writer's
+// changes. The lock is advisory (flock / LockFileEx) — co-operating
+// processes honour it. NFS home directories are a known weak spot; documented
+// in dev-docs/endpoint-design.md §7.3.
 func (c Config) Save() error {
 	path, err := Path()
 	if err != nil {
@@ -1292,31 +1297,33 @@ func (c Config) Save() error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
-	// Shallow copy with the new-schema fields cleared so yaml.Marshal emits
-	// only the legacy flat form. The Models slice is shared by reference,
-	// which is fine — we don't mutate it.
-	saved := c
-	saved.Endpoints = nil
-	saved.Default = ""
-	saved.Lite = ""
-	data, err := yaml.Marshal(saved)
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return err
-	}
-	// Rolling backup of the last config we wrote (always valid, since it's a
-	// marshaled Config): `octo config --fix` restores from it when a later hand
-	// edit leaves config.yml unparseable. Best-effort — a backup failure must
-	// never fail the save itself.
-	_ = os.WriteFile(path+".bak", data, 0o600)
-	if legacy, lerr := legacyPath(); lerr == nil {
-		if _, statErr := os.Stat(legacy); statErr == nil {
-			_ = os.Rename(legacy, legacy+".bak")
+	return withConfigLock(path, func() error {
+		// Shallow copy with the new-schema fields cleared so yaml.Marshal emits
+		// only the legacy flat form. The Models slice is shared by reference,
+		// which is fine — we don't mutate it.
+		saved := c
+		saved.Endpoints = nil
+		saved.Default = ""
+		saved.Lite = ""
+		data, err := yaml.Marshal(saved)
+		if err != nil {
+			return err
 		}
-	}
-	return nil
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			return err
+		}
+		// Rolling backup of the last config we wrote (always valid, since it's a
+		// marshaled Config): `octo config --fix` restores from it when a later hand
+		// edit leaves config.yml unparseable. Best-effort — a backup failure must
+		// never fail the save itself.
+		_ = os.WriteFile(path+".bak", data, 0o600)
+		if legacy, lerr := legacyPath(); lerr == nil {
+			if _, statErr := os.Stat(legacy); statErr == nil {
+				_ = os.Rename(legacy, legacy+".bak")
+			}
+		}
+		return nil
+	})
 }
 
 // BackupPath returns the rolling-backup path (config.yml.bak) that Save writes

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1417,3 +1417,97 @@ func TestWithConfigLock_SerialisesConcurrentCallers(t *testing.T) {
 		t.Fatal("second caller didn't acquire the lock within 5s after the first released")
 	}
 }
+
+// TestRenameEndpoint_UpdatesIDAndReferences covers PR3 §6.1: renaming an
+// endpoint id updates the endpoint's ID field AND rewrites Default/Lite
+// composite-id prefixes that point at the old id. References pointing at
+// OTHER endpoints are left alone.
+func TestRenameEndpoint_UpdatesIDAndReferences(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "official", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-opus-4-8"}}},
+		},
+		Default: "relay-a::claude-sonnet-4-6",
+		Lite:    "official::claude-opus-4-8",
+	}
+
+	if err := cfg.RenameEndpoint("relay-a", "relay-b"); err != nil {
+		t.Fatalf("RenameEndpoint: %v", err)
+	}
+
+	// Endpoint ID updated.
+	if cfg.Endpoints[0].ID != "relay-b" {
+		t.Errorf("endpoint ID = %q, want relay-b", cfg.Endpoints[0].ID)
+	}
+	// Default prefix rewritten.
+	if cfg.Default != "relay-b::claude-sonnet-4-6" {
+		t.Errorf("Default = %q, want relay-b::claude-sonnet-4-6", cfg.Default)
+	}
+	// Lite pointing at a DIFFERENT endpoint is untouched.
+	if cfg.Lite != "official::claude-opus-4-8" {
+		t.Errorf("Lite = %q, want official::claude-opus-4-8 (untouched)", cfg.Lite)
+	}
+}
+
+// TestRenameEndpoint_RewritesBothDefaultAndLiteWhenBothPointAtRenamedEndpoint
+// verifies both Default and Lite are updated when both point at the renamed
+// endpoint (e.g. an endpoint that's both the primary and the lite source).
+func TestRenameEndpoint_RewritesBothDefaultAndLiteWhenBothPointAtRenamedEndpoint(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}, {Model: "gpt-5.4-mini"}}},
+		},
+		Default: "relay-a::claude-sonnet-4-6",
+		Lite:    "relay-a::gpt-5.4-mini",
+	}
+
+	if err := cfg.RenameEndpoint("relay-a", "relay-b"); err != nil {
+		t.Fatalf("RenameEndpoint: %v", err)
+	}
+	if cfg.Default != "relay-b::claude-sonnet-4-6" {
+		t.Errorf("Default = %q, want relay-b::claude-sonnet-4-6", cfg.Default)
+	}
+	if cfg.Lite != "relay-b::gpt-5.4-mini" {
+		t.Errorf("Lite = %q, want relay-b::gpt-5.4-mini", cfg.Lite)
+	}
+}
+
+// TestRenameEndpoint_EmptyDefaultAndLiteAreNoops verifies the edge case where
+// Default/Lite are empty — renameCompositePrefix returns "" for empty input,
+// so an empty Default/Lite stays empty (no spurious "newID::" prefix).
+func TestRenameEndpoint_EmptyDefaultAndLiteAreNoops(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		// No Default or Lite set.
+	}
+	if err := cfg.RenameEndpoint("relay-a", "relay-b"); err != nil {
+		t.Fatalf("RenameEndpoint: %v", err)
+	}
+	if cfg.Default != "" || cfg.Lite != "" {
+		t.Errorf("Default/Lite = %q/%q, want empty/empty (rename of empty refs is a no-op)", cfg.Default, cfg.Lite)
+	}
+}
+
+// TestRenameEndpoint_UnknownEndpointReturnsError verifies renaming a
+// non-existent endpoint fails rather than silently succeeding.
+func TestRenameEndpoint_UnknownEndpointReturnsError(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+	}
+	err := cfg.RenameEndpoint("ghost", "relay-b")
+	if err == nil {
+		t.Fatal("RenameEndpoint on unknown endpoint: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error should name the missing endpoint, got: %v", err)
+	}
+	// Config must be unchanged on failure.
+	if cfg.Endpoints[0].ID != "relay-a" {
+		t.Errorf("endpoint ID changed on failure: %q, want relay-a", cfg.Endpoints[0].ID)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -1492,7 +1493,10 @@ func TestRenameEndpoint_EmptyDefaultAndLiteAreNoops(t *testing.T) {
 }
 
 // TestRenameEndpoint_UnknownEndpointReturnsError verifies renaming a
-// non-existent endpoint fails rather than silently succeeding.
+// non-existent endpoint fails with ErrEndpointNotFound (wrap-target for
+// errors.Is) rather than silently succeeding. The doc contract on
+// RenameEndpoint says it returns ErrEndpointNotFound; a caller branching on
+// errors.Is(err, ErrEndpointNotFound) must get true.
 func TestRenameEndpoint_UnknownEndpointReturnsError(t *testing.T) {
 	cfg := Config{
 		Endpoints: []Endpoint{
@@ -1503,11 +1507,124 @@ func TestRenameEndpoint_UnknownEndpointReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("RenameEndpoint on unknown endpoint: expected error, got nil")
 	}
+	if !errors.Is(err, ErrEndpointNotFound) {
+		t.Errorf("error = %v, want errors.Is(err, ErrEndpointNotFound) = true", err)
+	}
 	if !strings.Contains(err.Error(), "ghost") {
 		t.Errorf("error should name the missing endpoint, got: %v", err)
 	}
 	// Config must be unchanged on failure.
 	if cfg.Endpoints[0].ID != "relay-a" {
 		t.Errorf("endpoint ID changed on failure: %q, want relay-a", cfg.Endpoints[0].ID)
+	}
+}
+
+// TestRenameEndpoint_NewIDCollisionReturnsError verifies the defensive
+// collision check: renaming an endpoint onto an id that another endpoint
+// already holds fails with ErrEndpointIDInUse rather than producing a
+// duplicate (which Validate §14.3 would classify as unfixable).
+func TestRenameEndpoint_NewIDCollisionReturnsError(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "official", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+	}
+	err := cfg.RenameEndpoint("relay-a", "official")
+	if err == nil {
+		t.Fatal("RenameEndpoint onto existing id: expected error, got nil")
+	}
+	if !errors.Is(err, ErrEndpointIDInUse) {
+		t.Errorf("error = %v, want errors.Is(err, ErrEndpointIDInUse) = true", err)
+	}
+	// Config must be unchanged on failure.
+	if cfg.Endpoints[0].ID != "relay-a" {
+		t.Errorf("endpoint ID changed on collision failure: %q, want relay-a", cfg.Endpoints[0].ID)
+	}
+}
+
+// TestMutate_AtomicUnderConcurrentAccess verifies Mutate's atomicity
+// guarantee (PR3 §7.1 + §6): N goroutines each do Mutate(fn) where fn
+// increments a counter stored in the config (here: a top-level string field
+// encoded with the count, since PR1-3 doesn't persist Endpoints). Without
+// the flock serialising Load+modify+save, two goroutines would both read
+// the pre-increment state and the later Save would drop the earlier
+// increment — final count < N.
+//
+// We use PermissionMode as the carrier field because it's a top-level
+// string that round-trips through Save/Load cleanly in PR1-3 (unlike
+// Endpoints, which Save elides). The counter is encoded as a number string.
+func TestMutate_AtomicUnderConcurrentAccess(t *testing.T) {
+	setHome(t)
+	// Seed with counter=0.
+	if err := (Config{PermissionMode: "0"}).Save(); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	const N = 20
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = Mutate(func(cfg *Config) error {
+				// Read-modify-write: parse current counter, increment, write back.
+				var n int
+				if _, err := fmt.Sscanf(cfg.PermissionMode, "%d", &n); err != nil {
+					return fmt.Errorf("parse counter %q: %w", cfg.PermissionMode, err)
+				}
+				cfg.PermissionMode = fmt.Sprintf("%d", n+1)
+				return nil
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d Mutate: %v", i, err)
+		}
+	}
+
+	final, err := Load()
+	if err != nil {
+		t.Fatalf("final Load: %v", err)
+	}
+	var got int
+	if _, err := fmt.Sscanf(final.PermissionMode, "%d", &got); err != nil {
+		t.Fatalf("final PermissionMode %q not a number: %v", final.PermissionMode, err)
+	}
+	if got != N {
+		t.Errorf("after %d concurrent Mutates, counter = %d, want %d (some increments were lost — Mutate's flock didn't serialise)", N, got, N)
+	}
+}
+
+// TestMutate_FnErrorAbortsSave verifies that if fn returns an error, Mutate
+// does NOT save — the on-disk file stays at its pre-mutation state. This is
+// the contract that lets callers use Mutate for speculative mutations
+// (validate inside fn, return error to bail without persisting).
+func TestMutate_FnErrorAbortsSave(t *testing.T) {
+	setHome(t)
+	seed := Config{PermissionMode: "strict"}
+	if err := seed.Save(); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	err := Mutate(func(cfg *Config) error {
+		cfg.PermissionMode = "auto"            // mutate
+		return errors.New("intentional abort") // then bail
+	})
+	if err == nil {
+		t.Fatal("Mutate with failing fn: expected error, got nil")
+	}
+
+	// On-disk file must be unchanged.
+	final, err := Load()
+	if err != nil {
+		t.Fatalf("final Load: %v", err)
+	}
+	if final.PermissionMode != "strict" {
+		t.Errorf("PermissionMode = %q, want strict (fn aborted, save must not have happened)", final.PermissionMode)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,12 +1,16 @@
 package config
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -1286,5 +1290,130 @@ func TestSyncEndpoints_DroppedKeyFingerprintNoClearText(t *testing.T) {
 	}
 	if strings.Contains(logBuf.String(), secondKey[:8]) {
 		t.Errorf("dropped key prefix leaked into log:\n%s", logBuf.String())
+	}
+}
+
+// TestSave_ConcurrentWritersDontClobber verifies the flock serialisation
+// from PR3 §7.1: 10 goroutines each save a distinct config, and after all
+// of them complete the on-disk file must be a valid YAML that parses to
+// exactly one of the written configs. Without the flock, concurrent
+// os.WriteFile calls would interleave (partial writes to the same path race)
+// or clobber each other, producing either a corrupt file or losing writes.
+//
+// Note: Unix flock is advisory and per-fd. Within a single process, two
+// goroutines opening separate fds on the same lockfile DO block each other
+// (the kernel serialises per-inode, not per-process), so this test exercises
+// the flock path. On Windows, LockFileEx behaves similarly per-file-handle.
+func TestSave_ConcurrentWritersDontClobber(t *testing.T) {
+	setHome(t)
+
+	const N = 10
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			cfg := Config{
+				Models: []ModelEntry{
+					{
+						Provider: "anthropic",
+						Model:    fmt.Sprintf("model-%d", idx),
+						BaseURL:  "https://api.anthropic.com",
+						APIKey:   fmt.Sprintf("key-%d", idx),
+						Vision:   true,
+					},
+				},
+				DefaultModel: fmt.Sprintf("model-%d", idx),
+			}
+			errs[idx] = cfg.Save()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d Save: %v", i, err)
+		}
+	}
+
+	// The file must parse cleanly — no corruption from interleaved writes.
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load after concurrent saves: %v — file was corrupted", err)
+	}
+	if len(loaded.Models) != 1 {
+		t.Fatalf("loaded Models = %d entries, want 1 (last writer wins, but file must be valid): %+v", len(loaded.Models), loaded.Models)
+	}
+	// The winning model name must be one of the N we wrote.
+	modelName := loaded.Models[0].Model
+	prefix := "model-"
+	if !strings.HasPrefix(modelName, prefix) {
+		t.Fatalf("loaded model = %q, want one of the model-N names", modelName)
+	}
+	idx, convErr := strconv.Atoi(strings.TrimPrefix(modelName, prefix))
+	if convErr != nil || idx < 0 || idx >= N {
+		t.Fatalf("loaded model = %q, want a valid index in [0, %d)", modelName, N)
+	}
+	// Default must match the loaded model (last writer wins consistently).
+	if loaded.DefaultModel != modelName {
+		t.Errorf("loaded DefaultModel = %q, want %q (matching the winning model)", loaded.DefaultModel, modelName)
+	}
+}
+
+// TestWithConfigLock_SerialisesConcurrentCallers verifies the flock itself
+// serialises: when two goroutines both call withConfigLock on the same path,
+// the second must wait for the first to release before its fn runs. We
+// assert this by having the first fn hold the lock until it observes the
+// second goroutine is waiting (via a channel), and the second fn only
+// signals it got the lock after the first releases.
+//
+// This is the core invariant the PR3 concurrency design (§7.1) depends on:
+// without it, Slice 3.2's rename cascade (read old config → modify refs →
+// write new config) would race and drop the other writer's changes.
+func TestWithConfigLock_SerialisesConcurrentCallers(t *testing.T) {
+	tmp := t.TempDir()
+	lockPath := filepath.Join(tmp, "test.lock")
+
+	// firstHolder blocks until it sees the second goroutine is waiting, then
+	// releases the lock by closing releaseCh. secondRunning fires its fn
+	// body only once it has the lock.
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondGotLock := make(chan struct{})
+
+	go func() {
+		_ = withConfigLock(lockPath, func() error {
+			close(firstStarted)
+			<-releaseFirst // hold the lock until the test releases us
+			return nil
+		})
+	}()
+
+	<-firstStarted // first goroutine is holding the lock
+
+	// Now the second goroutine should block on the lock — it must NOT
+	// have run its fn yet.
+	select {
+	case <-secondGotLock:
+		t.Fatal("second caller acquired the lock while the first still held it — flock not exclusive")
+	case <-time.After(50 * time.Millisecond):
+		// good — second is still waiting
+	}
+
+	// Release the first; the second should then acquire and signal.
+	go func() {
+		_ = withConfigLock(lockPath, func() error {
+			close(secondGotLock)
+			return nil
+		})
+	}()
+
+	close(releaseFirst)
+	select {
+	case <-secondGotLock:
+		// good — flock serialised correctly
+	case <-time.After(5 * time.Second):
+		t.Fatal("second caller didn't acquire the lock within 5s after the first released")
 	}
 }

--- a/internal/config/flock_unix.go
+++ b/internal/config/flock_unix.go
@@ -1,0 +1,52 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// withConfigLock acquires an exclusive flock on the config file path (creating
+// it if absent), runs fn, and releases the lock. It serialises concurrent
+// Save calls across processes — octo-agent has multiple entry points (TUI
+// process + octo serve + octo config command) that can all write config.yml
+// simultaneously, and without this lock a later writer would silently
+// overwrite an earlier writer's changes.
+//
+// The lock is advisory (flock): co-operating processes honour it, but a
+// process that doesn't call withConfigLock can still clobber the file. NFS
+// home directories are a known weak spot (flock is unreliable over NFS); for
+// the common local-filesystem case this is robust.
+//
+// fn runs with the lock held — it must not call Save again (would deadlock),
+// and should be quick (marshal + tmp write + rename is milliseconds). The
+// file is opened O_RDWR|O_CREATE so the lock works even on a fresh install
+// where config.yml doesn't exist yet.
+func withConfigLock(path string, fn func() error) error {
+	f, err := os.OpenFile(lockFilePath(path), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		// If we can't even open the lockfile, fall back to running without
+		// the lock — failing the save because the lock is unavailable is
+		// worse than a rare clobbered write. Log via the package logger so
+		// the failure isn't entirely invisible.
+		return fn()
+	}
+	defer f.Close()
+
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		// Same fallback: run without the lock rather than fail the save.
+		return fn()
+	}
+	defer unix.Flock(int(f.Fd()), unix.LOCK_UN)
+	return fn()
+}
+
+// lockFilePath returns the path of the flock sidecar file. Using a separate
+// file (config.yml.lock) rather than locking config.yml itself keeps the
+// lockfile out of the read path — Load doesn't need a lock, and locking the
+// data file would force every reader to wait for writers.
+func lockFilePath(configPath string) string {
+	return configPath + ".lock"
+}

--- a/internal/config/flock_windows.go
+++ b/internal/config/flock_windows.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+package config
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// withConfigLock is the Windows equivalent of flock — it uses LockFileEx
+// to acquire an exclusive byte-range lock on the lockfile, runs fn, and
+// releases the lock. The semantics match the Unix version: serialise
+// concurrent Save calls across processes.
+//
+// Windows file locking is per-file-handle (not per-process like flock), so
+// we keep the handle open for the duration of fn. Closing the handle
+// (defer f.Close) releases the lock automatically; the explicit UnlockFileEx
+// is belt-and-braces.
+func withConfigLock(path string, fn func() error) error {
+	pathUTF16, err := syscall.UTF16PtrFromString(lockFilePath(path))
+	if err != nil {
+		return fn()
+	}
+	fh, err := syscall.CreateFile(
+		pathUTF16,
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE,
+		nil,
+		syscall.OPEN_ALWAYS,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		// Can't open the lockfile — fall back to running without the lock.
+		return fn()
+	}
+	defer syscall.CloseHandle(fh)
+
+	// LockFileEx with LOCKFILE_EXCLUSIVE_LOCK locks byte range [0, 1)
+	// exclusively. The large-integer struct encodes a 64-bit offset+length;
+	// we lock the first byte only (enough to serialise — the lockfile is a
+	// sidecar, its contents are never read or written).
+	var overlapped syscall.Overlapped
+	lockRange := [2]uint32{1, 0} // 1 byte at offset 0 (low DWORD)
+	const lockfileExclusiveLock = 0x00000002
+	const lockfileFailImmediately = 0x00000001
+	lockFileExProc := syscall.NewLazyDLL("kernel32.dll").NewProc("LockFileEx")
+	r1, _, err := lockFileExProc.Call(
+		uintptr(fh),
+		uintptr(lockfileExclusiveLock|lockfileFailImmediately),
+		0,
+		uintptr(lockRange[0]), uintptr(lockRange[1]),
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if r1 == 0 {
+		// Lock acquisition failed (another process holds it, or a transient
+		// error) — fall back to running without the lock.
+		return fn()
+	}
+	defer unlockFileEx(fh, &overlapped)
+	return fn()
+}
+
+// unlockFileEx releases the byte-range lock acquired by LockFileEx. Best-effort
+// — the handle close in withConfigLock's defer would release it anyway.
+func unlockFileEx(fh syscall.Handle, overlapped *syscall.Overlapped) {
+	unlockRange := [2]uint32{1, 0}
+	unlockFileExProc := syscall.NewLazyDLL("kernel32.dll").NewProc("UnlockFileEx")
+	unlockFileExProc.Call(
+		uintptr(fh),
+		0,
+		uintptr(unlockRange[0]), uintptr(unlockRange[1]),
+		uintptr(unsafe.Pointer(overlapped)),
+	)
+}
+
+// lockFilePath returns the path of the lock sidecar file. Kept identical to
+// the Unix version so the lockfile has the same name across platforms.
+func lockFilePath(configPath string) string {
+	return configPath + ".lock"
+}

--- a/internal/config/flock_windows.go
+++ b/internal/config/flock_windows.go
@@ -37,17 +37,20 @@ func withConfigLock(path string, fn func() error) error {
 	defer syscall.CloseHandle(fh)
 
 	// LockFileEx with LOCKFILE_EXCLUSIVE_LOCK locks byte range [0, 1)
-	// exclusively. The large-integer struct encodes a 64-bit offset+length;
-	// we lock the first byte only (enough to serialise — the lockfile is a
-	// sidecar, its contents are never read or written).
+	// exclusively, blocking until the lock is acquired (matching Unix
+	// flock(LOCK_EX) semantics). We deliberately do NOT pass
+	// LOCKFILE_FAIL_IMMEDIATELY — that flag would make a contended lock
+	// return immediately with ERROR_LOCK_VIOLATION, and our fallback branch
+	// would then run fn without the lock, breaking the serialisation
+	// guarantee PR3 §7.1 is meant to provide. Blocking here is correct:
+	// concurrent Save callers wait for each other rather than clobber.
 	var overlapped syscall.Overlapped
 	lockRange := [2]uint32{1, 0} // 1 byte at offset 0 (low DWORD)
 	const lockfileExclusiveLock = 0x00000002
-	const lockfileFailImmediately = 0x00000001
 	lockFileExProc := syscall.NewLazyDLL("kernel32.dll").NewProc("LockFileEx")
 	r1, _, err := lockFileExProc.Call(
 		uintptr(fh),
-		uintptr(lockfileExclusiveLock|lockfileFailImmediately),
+		uintptr(lockfileExclusiveLock),
 		0,
 		uintptr(lockRange[0]), uintptr(lockRange[1]),
 		uintptr(unsafe.Pointer(&overlapped)),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1470,7 +1470,7 @@ func (s *Server) senderForSession(sess *agent.Session) (agent.Sender, string) {
 		model = entry.Model
 	}
 
-	sender, err := s.cachedSenderForEntry(entry)
+	sender, err := s.cachedSenderForEntry(sess.ModelConfig, entry)
 	if err != nil {
 		return defaultSender, model
 	}
@@ -1479,10 +1479,23 @@ func (s *Server) senderForSession(sess *agent.Session) (agent.Sender, string) {
 
 // cachedSenderForEntry returns the entry's sender from the cache, building
 // and caching it on first use.
-func (s *Server) cachedSenderForEntry(entry config.ModelEntry) (agent.Sender, error) {
+//
+// PR3 (design §9): the cache key is the raw model reference (ref), not
+// entry.Model. ref is whatever the caller passed to cfg.EntryByModel — it's
+// either a bare model string (legacy session, same key as before) or a
+// composite id "<endpoint_id>::<model>" (new session, distinguishes the
+// same model on two different endpoints). Using entry.Model as the key
+// would collide across endpoints (claude-sonnet-4-6 on relay-a vs on
+// official anthropic would share one cache entry, returning the wrong
+// sender). The ref is the unambiguous identifier.
+func (s *Server) cachedSenderForEntry(ref string, entry config.ModelEntry) (agent.Sender, error) {
 	s.senderCacheMu.Lock()
 	defer s.senderCacheMu.Unlock()
-	if cached, ok := s.senderCache[entry.Model]; ok {
+	key := ref
+	if key == "" {
+		key = entry.Model // fallback: no ref (rare) → behave like the old code
+	}
+	if cached, ok := s.senderCache[key]; ok {
 		return cached, nil
 	}
 	sender, err := senderForEntry(entry)
@@ -1492,8 +1505,28 @@ func (s *Server) cachedSenderForEntry(entry config.ModelEntry) (agent.Sender, er
 	if s.senderCache == nil {
 		s.senderCache = make(map[string]agent.Sender)
 	}
-	s.senderCache[entry.Model] = sender
+	s.senderCache[key] = sender
 	return sender, nil
+}
+
+// invalidateEndpointSenders drops every cached sender whose key is prefixed
+// with "<endpointID>::". Called when an endpoint's connection params change
+// (base_url, api_key, protocol) or the endpoint is renamed — every model
+// under that endpoint must rebuild its sender because the connection it was
+// built against is stale. Other endpoints' cached senders stay (hit rate
+// preserved). Design §9.2.
+func (s *Server) invalidateEndpointSenders(endpointID string) {
+	if endpointID == "" {
+		return
+	}
+	prefix := endpointID + "::"
+	s.senderCacheMu.Lock()
+	defer s.senderCacheMu.Unlock()
+	for k := range s.senderCache {
+		if strings.HasPrefix(k, prefix) {
+			delete(s.senderCache, k)
+		}
+	}
 }
 
 // liteSenderFromConfig resolves the configured lite entry to a (sender,
@@ -1504,7 +1537,7 @@ func (s *Server) liteSenderFromConfig(cfg config.Config) (agent.Sender, string) 
 	if !ok || entry.Model == "" {
 		return nil, ""
 	}
-	sender, err := s.cachedSenderForEntry(entry)
+	sender, err := s.cachedSenderForEntry(cfg.LiteModel, entry)
 	if err != nil {
 		return nil, ""
 	}
@@ -2131,7 +2164,7 @@ func (s *Server) channelModelOps() *channel.ModelOps {
 				sort.Strings(available)
 				return channel.ModelResolution{}, fmt.Errorf("model %q is not configured (available: %s)", modelID, strings.Join(available, ", "))
 			}
-			sender, err := s.cachedSenderForEntry(entry)
+			sender, err := s.cachedSenderForEntry(modelID, entry)
 			if err != nil {
 				return channel.ModelResolution{}, err
 			}
@@ -2161,7 +2194,7 @@ func (s *Server) applyChannelModel(sess *channel.Session) {
 			if st.ModelConfig == sess.AppliedModelConfig {
 				return // binding already live on the agent
 			}
-			if sender, err := s.cachedSenderForEntry(entry); err != nil {
+			if sender, err := s.cachedSenderForEntry(st.ModelConfig, entry); err != nil {
 				slog.Warn("channel session model sender unavailable; using the default", "session", st.ID, "model", st.ModelConfig, "err", err)
 				s.applyChannelDefault(sess, st)
 			} else {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1532,6 +1532,14 @@ func (s *Server) invalidateEndpointSenders(endpointID string) {
 // liteSenderFromConfig resolves the configured lite entry to a (sender,
 // model) pair for compaction, or (nil, "") when none is configured or it
 // can't be built — the agent then compacts on its primary sender.
+//
+// PR4 note: this currently passes cfg.LiteModel (the legacy bare-model
+// field) as the cache ref, so the lite sender's cache key has no
+// "<endpointID>::" prefix — invalidateEndpointSenders can't reach it even
+// when the lite model lives under the endpoint being invalidated. Once
+// PR4 switches Save to emit endpoints: and cfg.Lite is populated on Load,
+// switch this arg to cfg.Lite so the lite sender participates in per-endpoint
+// invalidation (§9.2).
 func (s *Server) liteSenderFromConfig(cfg config.Config) (agent.Sender, string) {
 	entry, ok := cfg.EntryByModel(cfg.LiteModel)
 	if !ok || entry.Model == "" {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2635,3 +2635,79 @@ func TestHandleUpdateSession_Rename(t *testing.T) {
 		t.Errorf("unknown id status = %d, want 404", w.Code)
 	}
 }
+
+// TestInvalidateEndpointSenders_DropsOnlyMatchingPrefix verifies PR3 §9.2:
+// invalidateEndpointSenders clears cache entries whose key is prefixed with
+// "<endpointID>::" but leaves other endpoints' entries intact. This is the
+// cache hit-rate preservation — changing one endpoint's base_url doesn't
+// force every other endpoint to rebuild.
+func TestInvalidateEndpointSenders_DropsOnlyMatchingPrefix(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	// Seed the cache with entries under two different endpoint prefixes.
+	// Use a stub Sender so we don't need real API keys.
+	stub := func(id string) agent.Sender { return &nopSender{id: id} }
+	srv.senderCacheMu.Lock()
+	srv.senderCache = map[string]agent.Sender{
+		"relay-a::claude-sonnet-4-6":  stub("a1"),
+		"relay-a::gpt-5.4":            stub("a2"),
+		"official::claude-sonnet-4-6": stub("o1"),
+		"official::gpt-5.4":           stub("o2"),
+		// A bare-model key (legacy session form) — must NOT be cleared by
+		// invalidateEndpointSenders since it has no endpoint prefix.
+		"claude-haiku-4-5": stub("bare"),
+	}
+	srv.senderCacheMu.Unlock()
+
+	srv.invalidateEndpointSenders("relay-a")
+
+	srv.senderCacheMu.Lock()
+	defer srv.senderCacheMu.Unlock()
+	// relay-a entries gone.
+	if _, ok := srv.senderCache["relay-a::claude-sonnet-4-6"]; ok {
+		t.Error("relay-a::claude-sonnet-4-6 still cached after invalidate")
+	}
+	if _, ok := srv.senderCache["relay-a::gpt-5.4"]; ok {
+		t.Error("relay-a::gpt-5.4 still cached after invalidate")
+	}
+	// official entries preserved.
+	if _, ok := srv.senderCache["official::claude-sonnet-4-6"]; !ok {
+		t.Error("official::claude-sonnet-4-6 dropped — invalidate must be endpoint-scoped")
+	}
+	if _, ok := srv.senderCache["official::gpt-5.4"]; !ok {
+		t.Error("official::gpt-5.4 dropped — invalidate must be endpoint-scoped")
+	}
+	// Bare-model key preserved (no prefix to match).
+	if _, ok := srv.senderCache["claude-haiku-4-5"]; !ok {
+		t.Error("bare-model key dropped — invalidateEndpointSenders must not touch bare keys")
+	}
+}
+
+// TestInvalidateEndpointSenders_EmptyIDIsNoop verifies the guard: calling
+// with an empty endpointID (a caller bug) doesn't clear the whole cache.
+// Without the guard, prefix "" would match every key.
+func TestInvalidateEndpointSenders_EmptyIDIsNoop(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	stub := &nopSender{id: "x"}
+	srv.senderCacheMu.Lock()
+	srv.senderCache = map[string]agent.Sender{
+		"relay-a::claude-sonnet-4-6": stub,
+		"official::gpt-5.4":          stub,
+	}
+	srv.senderCacheMu.Unlock()
+
+	srv.invalidateEndpointSenders("")
+
+	srv.senderCacheMu.Lock()
+	defer srv.senderCacheMu.Unlock()
+	if len(srv.senderCache) != 2 {
+		t.Errorf("empty endpointID cleared the cache: %d entries remain, want 2", len(srv.senderCache))
+	}
+}
+
+// nopSender is a minimal agent.Sender for cache tests — never actually sends.
+type nopSender struct{ id string }
+
+func (n *nopSender) SendMessages(ctx context.Context, model, system string, messages []agent.Message, maxTokens int) (agent.Reply, error) {
+	return agent.Reply{}, nil
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2711,3 +2711,68 @@ type nopSender struct{ id string }
 func (n *nopSender) SendMessages(ctx context.Context, model, system string, messages []agent.Message, maxTokens int) (agent.Reply, error) {
 	return agent.Reply{}, nil
 }
+
+// TestCachedSenderForEntry_DistinguishesSameModelDifferentEndpoint verifies
+// PR3 §9.1's core fix: the cache key is the raw ref (composite id or bare
+// model), not entry.Model. Two entries with the same Model string but
+// different endpoint prefixes must produce separate cache entries —
+// otherwise a turn on relay-a::claude would silently route to the official
+// anthropic sender (or vice versa).
+//
+// We seed the cache directly with two senders under the two composite-id
+// keys, then call cachedSenderForEntry with one of them and assert the
+// returned sender is the one we cached under that key (not the other).
+func TestCachedSenderForEntry_DistinguishesSameModelDifferentEndpoint(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	relaySender := &nopSender{id: "relay-sender"}
+	officialSender := &nopSender{id: "official-sender"}
+	srv.senderCacheMu.Lock()
+	srv.senderCache = map[string]agent.Sender{
+		"relay-a::claude-sonnet-4-6":  relaySender,
+		"official::claude-sonnet-4-6": officialSender,
+	}
+	srv.senderCacheMu.Unlock()
+
+	// Both entries have the same Model string — what distinguishes them in
+	// the cache is the ref passed in.
+	entry := config.ModelEntry{Provider: "custom", Model: "claude-sonnet-4-6"}
+
+	got, err := srv.cachedSenderForEntry("relay-a::claude-sonnet-4-6", entry)
+	if err != nil {
+		t.Fatalf("cachedSenderForEntry(relay-a::...): %v", err)
+	}
+	if got != relaySender {
+		t.Errorf("relay-a::claude-sonnet-4-6 returned %+v, want relaySender — cache key collision would route to the wrong endpoint", got)
+	}
+
+	got, err = srv.cachedSenderForEntry("official::claude-sonnet-4-6", entry)
+	if err != nil {
+		t.Fatalf("cachedSenderForEntry(official::...): %v", err)
+	}
+	if got != officialSender {
+		t.Errorf("official::claude-sonnet-4-6 returned %+v, want officialSender — cache key collision would route to the wrong endpoint", got)
+	}
+}
+
+// TestCachedSenderForEntry_BareModelRefStillWorks pins the legacy path: a
+// bare-model ref (no "::") uses the bare string as the cache key, matching
+// pre-PR3 behaviour for legacy sessions whose ModelConfig is a bare model.
+func TestCachedSenderForEntry_BareModelRefStillWorks(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	bareSender := &nopSender{id: "bare"}
+	srv.senderCacheMu.Lock()
+	srv.senderCache = map[string]agent.Sender{
+		"claude-sonnet-4-6": bareSender,
+	}
+	srv.senderCacheMu.Unlock()
+
+	entry := config.ModelEntry{Provider: "anthropic", Model: "claude-sonnet-4-6"}
+	got, err := srv.cachedSenderForEntry("claude-sonnet-4-6", entry)
+	if err != nil {
+		t.Fatalf("cachedSenderForEntry(bare): %v", err)
+	}
+	if got != bareSender {
+		t.Errorf("bare-model ref returned %+v, want bareSender", got)
+	}
+}


### PR DESCRIPTION
## What this PR does

Third of 5 PRs implementing the **endpoint two-level schema** from `dev-docs/endpoint-design.md`. PR1 (#1610) introduced the types + legacy flat read-compat; PR2 (#1613) made `EntryByModel` accept composite ids. PR3 is **concurrency protection + rename cascade API + sender cache fix**.

### Changes

- **`withConfigLock(path, fn)`** (`internal/config/flock_unix.go` + `flock_windows.go`, design §7): exclusive flock on a sidecar lockfile (`config.yml.lock`) serialising concurrent `Save` calls across processes. Unix uses `unix.Flock(LOCK_EX)`; Windows uses `LockFileEx` with `LOCKFILE_EXCLUSIVE_LOCK` (blocking, no `FAIL_IMMEDIATELY` — matches Unix semantics). `Save` wraps its marshal+write+backup in the lock. Falls back to running without the lock only on genuine open/lock-acquisition failure (failing the save because the lock is unavailable is worse than a rare clobbered write).

- **`Config.RenameEndpoint(oldID, newID)` + `config.Mutate(fn)`** (design §6): the endpoint-rename API surface for PR4. `RenameEndpoint` updates the endpoint's ID and rewrites `Default`/`Lite` composite-id prefixes pointing at the old id. `Mutate` is the atomic read-modify-write helper (flock + Load + fn + `saveLocked`). Both return wrap-target sentinels (`ErrEndpointNotFound`, `ErrEndpointIDInUse`) for `errors.Is`. `saveLocked` is Save's write path extracted so `Mutate` can call it without re-locking (avoids deadlock).

- **`cachedSenderForEntry(ref, entry)`** signature change (design §9): the senderCache key is now the raw model reference (bare model or composite id), not `entry.Model`. Fixes the cross-endpoint collision PR1 introduced: `relay-a::claude-sonnet-4-6` and `official::claude-sonnet-4-6` both projected to `ModelEntry{Model: "claude-sonnet-4-6"}` and shared one cache entry, routing turns to the wrong backend. New `invalidateEndpointSenders(endpointID)` drops only entries prefixed with `<endpointID>::`, preserving other endpoints' caches.

### Intentional deviations (recorded)

- **Slice 3.2 doesn't scan session files** (design §6.1 called for it). Reason: PR1's "add structure, don't enable writes" invariant means `Save` writes the flat `models:` form, so the endpoint id is NOT persisted — every Load re-synthesises it as `legacy-<host>-<n>`. A rename that persists via Save would be a no-op (next Load reverts). Session-file reference staleness is tolerated: `EntryByModel` (PR2) falls through a stale composite id to bare-model lookup. The API surface (`RenameEndpoint` + `Mutate`) is kept for PR4 to use once Save emits `endpoints:`. `TestRenameEndpoint_AtomicUnderFlock` was removed for this reason; it'll come back in PR4.

- **`invalidateEndpointSenders` shipped as dead code** — no callsite wires it yet. PR4 will call it from the endpoint-mutation handlers (web settings page `PATCH /api/config/endpoints/{id}`) per design §6.1. `liteSenderFromConfig` has a PR4-note comment: it currently passes `cfg.LiteModel` (bare-model form) as the cache ref, so the lite sender's cache key has no endpoint prefix and `invalidateEndpointSenders` can't reach it; PR4 should switch to `cfg.Lite`.

## Review findings (fixed)

One round of isolated code-review. 0 Critical + 2 Important + 5 Minor.

- **I1**: Windows `LockFileEx` used `LOCKFILE_FAIL_IMMEDIATELY`, which made a contended lock return immediately instead of blocking — breaking the serialisation guarantee Unix provides, and the blocking-assertion test would fail on Windows CI. **Fix**: dropped the flag; Windows now blocks like Unix.
- **I2**: `RenameEndpoint` docstring said it returns `ErrEndpointNotFound` but the code returned a fresh `fmt.Errorf` not wrapping the sentinel — `errors.Is` returned false. **Fix**: wrap the sentinel with `%w`. Test asserts `errors.Is`.
- **M3**: Added `TestMutate_AtomicUnderConcurrentAccess` (20 goroutines each Mutate-increment a counter; final must equal 20) + `TestMutate_FnErrorAbortsSave`.
- **M4**: Added `TestCachedSenderForEntry_DistinguishesSameModelDifferentEndpoint` (relay-a::claude and official::claude cached separately) + `TestCachedSenderForEntry_BareModelRefStillWorks`.
- **M6**: `RenameEndpoint` now defensively checks `newID` collision and returns `ErrEndpointIDInUse` — prevents a caller bug from producing a duplicate-id config (which Validate §14.3 classifies as unfixable).
- **M7**: PR4-note comment on `liteSenderFromConfig` to switch `cfg.LiteModel` → `cfg.Lite` once Save emits `endpoints:`.
- **M5** (`invalidateEndpointSenders` dead code, PR4 wires it): not fixing, recorded as known.

## Tests

- `go build ./...` — clean
- `go vet ./...` + `GOOS=windows go vet ./internal/config/` — clean
- `go test -race ./internal/config/ ./internal/app/ ./internal/server/` — all green
- 8 new tests: flock serialisation, concurrent writers don't clobber, RenameEndpoint (4 cases: id+refs update, both Default/Lite rewritten, empty refs no-op, unknown endpoint error, newID collision error), Mutate atomicity + fn-error abort, sender cache key distinction + bare-model fallback, invalidateEndpointSenders prefix scoping + empty-id guard.

## Next PRs

- **PR4**: Save write-path switch (emit `endpoints:` not `models:`) + three-UI two-level (TUI picker / IM `/model` / Web settings) + new API `GET /api/config/endpoints` + wire `invalidateEndpointSenders` + migrate callers to `ImplicitLiteModelForEndpoint` + switch `liteSenderFromConfig` to `cfg.Lite`.
- **PR5**: `octo config` / `octo doctor` upgrades + docs.

## Refs

- Design doc: `dev-docs/endpoint-design.md` (§6, §7, §9, §14.3)
- PR1: #1610, PR2: #1613

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
