### PR TITLE
fix(server): allow access-key authenticated remote callers to browse directories via /api/fs/list

### DIFF
--- a/internal/server/fs_handlers.go
+++ b/internal/server/fs_handlers.go
@@ -28,20 +28,12 @@ type fsEntry struct {
 // folder picker. Selecting a directory sets the session working dir through the
 // existing PATCH /api/sessions/{id}/working_dir; this endpoint only browses.
 //
-// Localhost-only, gated per request: listing discloses the server's filesystem
-// layout, which is harmless on a loopback-bound single-user serve (the agent
-// can already reach any path through terminal) but must not leak to a peer that
-// reached the server off-box. The check is on the peer being loopback, not on
-// the process bind address, so the same server can offer the picker to a local
-// browser while denying it to a tunnelled/remote peer, which then falls back to
-// typed paths or upload. This layers on top of requireAuth — a valid access key
-// is still required — as an additional gate specific to this endpoint.
+// Access-key authenticated callers (including remote peers) may browse any
+// reachable directory. Unauthenticated callers are still restricted to loopback
+// by requireAuth, like every other /api/* route. Unlike the native folder dialog
+// (which literally opens a desktop window and stays loopback-only), there is
+// no per-endpoint remote check here — the access key is the sole gate.
 func (s *Server) handleFsList(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
-		writeError(w, http.StatusForbidden, "directory browsing is available only from the local machine")
-		return
-	}
-
 	// Empty path starts at the user's home directory (a native open-dialog
 	// default). expandDir would resolve "" to the launch dir, which is less
 	// useful as a starting point.

--- a/internal/server/fs_handlers_test.go
+++ b/internal/server/fs_handlers_test.go
@@ -18,24 +18,16 @@ type fsListResponse struct {
 	Truncated bool      `json:"truncated"`
 }
 
-func doFsList(t *testing.T, remoteAddr, path string) *httptest.ResponseRecorder {
+func doFsList(t *testing.T, path string) *httptest.ResponseRecorder {
 	t.Helper()
 	url := "/api/fs/list"
 	if path != "" {
 		url += "?path=" + path
 	}
 	req := httptest.NewRequest(http.MethodGet, url, nil)
-	req.RemoteAddr = remoteAddr
 	rec := httptest.NewRecorder()
 	(&Server{}).handleFsList(rec, req)
 	return rec
-}
-
-func TestFsListRejectsNonLoopback(t *testing.T) {
-	rec := doFsList(t, "203.0.113.7:54321", "")
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("non-loopback peer: got %d, want 403", rec.Code)
-	}
 }
 
 func TestFsListHappyPath(t *testing.T) {
@@ -51,7 +43,7 @@ func TestFsListHappyPath(t *testing.T) {
 		linkOK = false // some CI filesystems disallow symlinks; skip that assertion
 	}
 
-	rec := doFsList(t, "127.0.0.1:12345", root)
+	rec := doFsList(t, root)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got %d, want 200 (%s)", rec.Code, rec.Body.String())
 	}
@@ -109,10 +101,10 @@ func TestFsListErrors(t *testing.T) {
 	file := filepath.Join(root, "a-file")
 	mustWrite(t, file)
 
-	if rec := doFsList(t, "127.0.0.1:1", filepath.Join(root, "nope")); rec.Code != http.StatusBadRequest {
+	if rec := doFsList(t, filepath.Join(root, "nope")); rec.Code != http.StatusBadRequest {
 		t.Errorf("missing path: got %d, want 400", rec.Code)
 	}
-	if rec := doFsList(t, "127.0.0.1:1", file); rec.Code != http.StatusBadRequest {
+	if rec := doFsList(t, file); rec.Code != http.StatusBadRequest {
 		t.Errorf("file path: got %d, want 400", rec.Code)
 	}
 }
@@ -126,7 +118,7 @@ func TestFsListTruncates(t *testing.T) {
 	for i := 0; i < fsListCap+50; i++ {
 		mustWrite(t, filepath.Join(root, "f"+strconv.Itoa(i)))
 	}
-	rec := doFsList(t, "127.0.0.1:1", root)
+	rec := doFsList(t, root)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got %d, want 200", rec.Code)
 	}
@@ -151,7 +143,7 @@ func TestFsListDefaultsToHome(t *testing.T) {
 	if err != nil {
 		t.Skip("no home dir")
 	}
-	rec := doFsList(t, "127.0.0.1:1", "")
+	rec := doFsList(t, "")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got %d, want 200 (%s)", rec.Code, rec.Body.String())
 	}


### PR DESCRIPTION
Closes #1615

## 改动

移除 handleFsList 里的 isLoopbackRemote 检查，让持有 access key 的远程用户也能通过 Web UI 浏览目录并切换工作目录。

### 背景

issue #1615 反馈：公网访问 octo 时，点击目录切换按钮提示 "directory browsing is available only from the local machine"。

根因是 /api/fs/list 在 requireAuth 之上额外叠加了 isLoopbackRemote 硬检查——即使持有有效 access key 的远程用户也被拒绝。而真正执行切换的 PATCH /api/sessions/{id}/working_dir 并无此限制，只需要 access key。

### 改动点

- fs_handlers.go：移除 loopback 检查，认证交给上层 requireAuth
- fs_handlers_test.go：删除 TestFsListRejectsNonLoopback，doFsList 去掉不再使用的 remoteAddr 参数

### 不受影响

- POST /api/native/pick-folder 保持 loopback 限制——它打开原生桌面对话框，仅在桌面端注册
- 无 key 的未认证用户仍被 requireAuth 拦截