### PR TITLE
supervisor: cache os.Executable() at startup to survive upgrade swap (fix #1614)

### DIFF
--- a/cmd/octo/serve_supervisor.go
+++ b/cmd/octo/serve_supervisor.go
@@ -18,6 +18,11 @@ import (
 // exit code server.ExitRestart.
 const serveWorkerEnv = "OCTO_SERVE_WORKER"
 
+// osExecutable is a stub hook for tests; production code calls os.Executable.
+// spawnServeWorker caches its result at construction time (see its doc), and
+// this variable is the seam that lets tests verify that caching.
+var osExecutable = os.Executable
+
 // superviseLoop drives the supervisor: spawn a worker, wait, and dispatch on
 // its exit code — server.ExitRestart respawns (picking up a replaced binary),
 // anything else propagates. A signal received while a worker runs is
@@ -71,17 +76,31 @@ func superviseLoop(spawn func() (func() int, func(os.Signal), error), sigCh <-ch
 
 // spawnServeWorker returns the production spawn function for superviseLoop:
 // re-exec the current binary with `serve <args>` and the worker marker env.
-// The binary path is re-resolved on every spawn so transient failures are not
-// cached forever and, on platforms where os.Executable() resolves by path
-// (not by inode), a binary replaced on disk takes effect on the next restart
-// without the supervisor itself changing.
+//
+// The binary path is resolved ONCE, at supervisor startup, and cached for the
+// lifetime of the supervisor. This is load-bearing for the upgrade swap flow:
+// swap() renames the running binary aside (octo → octo.old.<ts>.<pid>) and
+// renames the new binary into place (.octo.new.<pid> → octo). On Linux,
+// os.Executable() reads /proc/self/exe, which reflects the running inode's
+// *current* name — so after the rename it returns the now-deleted aside name,
+// and the next worker spawn fails with ENOENT. Caching the path at startup
+// sidesteps this: the cached string still says "octo", and after the rename
+// that path points at the new binary. (On macOS the same code path happens to
+// work because KERN_PROC_PATHNAME is a static snapshot — but the cache makes
+// the correctness explicit and platform-independent.)
 func spawnServeWorker(args []string, stdout, stderr io.Writer) func() (func() int, func(os.Signal), error) {
-	return spawnServeWorkerWithResolver(args, stdout, stderr, os.Executable)
+	exe, resolveErr := osExecutable()
+	return spawnServeWorkerWithResolver(args, stdout, stderr, func() (string, error) {
+		return exe, resolveErr
+	})
 }
 
 // spawnServeWorkerWithResolver is the testable core of spawnServeWorker.
-// resolver is called on every worker spawn so tests can fake a changing binary
-// path without touching the real executable.
+// resolver is called on every worker spawn so tests can fake a binary path
+// that changes between spawns without touching the real executable. The
+// production resolver (a closure over a cached os.Executable() result)
+// ignores this and always returns the same path, which is what makes the
+// upgrade swap flow safe — see spawnServeWorker's doc comment.
 func spawnServeWorkerWithResolver(args []string, stdout, stderr io.Writer, resolver func() (string, error)) func() (func() int, func(os.Signal), error) {
 	return func() (func() int, func(os.Signal), error) {
 		exe, err := resolver()

--- a/cmd/octo/serve_supervisor_test.go
+++ b/cmd/octo/serve_supervisor_test.go
@@ -179,6 +179,42 @@ func TestSpawnServeWorker_ReResolvesExecutablePath(t *testing.T) {
 	}
 }
 
+// TestSpawnServeWorker_CachesExecutablePath is the regression guard for the
+// upgrade-swap bug (issue #1614 follow-up): spawnServeWorker must resolve
+// os.Executable() ONCE at construction time and reuse that path for every
+// subsequent worker spawn. If it re-resolved on every spawn, the rename in
+// swap() (octo → octo.old.<ts>.<pid>) would make /proc/self/exe on Linux
+// return the now-deleted aside name, and the next worker spawn would fail with
+// ENOENT. Caching makes the path string stable across the rename.
+func TestSpawnServeWorker_CachesExecutablePath(t *testing.T) {
+	// Swap in a counting fake resolver, restore the real one on cleanup.
+	orig := osExecutable
+	calls := 0
+	osExecutable = func() (string, error) {
+		calls++
+		return orig()
+	}
+	defer func() { osExecutable = orig }()
+
+	var stdout, stderr bytes.Buffer
+	spawn := spawnServeWorker(nil, &stdout, &stderr)
+
+	// Construction should have resolved exactly once.
+	if calls != 1 {
+		t.Fatalf("osExecutable calls after construction = %d, want 1", calls)
+	}
+
+	// Three more spawns. The production resolver is a closure over the cached
+	// value, so osExecutable must NOT be called again.
+	for i := 0; i < 3; i++ {
+		_, _, _ = spawn()
+	}
+
+	if calls != 1 {
+		t.Errorf("osExecutable calls after 3 spawns = %d, want 1 (path must be cached)", calls)
+	}
+}
+
 func TestShouldSupervise(t *testing.T) {
 	cases := []struct {
 		noSupervisor bool

--- a/cmd/octo/serve_supervisor_test.go
+++ b/cmd/octo/serve_supervisor_test.go
@@ -187,12 +187,14 @@ func TestSpawnServeWorker_ReResolvesExecutablePath(t *testing.T) {
 // return the now-deleted aside name, and the next worker spawn would fail with
 // ENOENT. Caching makes the path string stable across the rename.
 func TestSpawnServeWorker_CachesExecutablePath(t *testing.T) {
-	// Swap in a counting fake resolver, restore the real one on cleanup.
+	// Swap in a counting fake resolver that returns a non-existent path, so
+	// cmd.Start() fails immediately without spawning a real process. Restore
+	// the real resolver on cleanup.
 	orig := osExecutable
 	calls := 0
 	osExecutable = func() (string, error) {
 		calls++
-		return orig()
+		return "/fake/octo/does/not/exist", nil
 	}
 	defer func() { osExecutable = orig }()
 
@@ -205,9 +207,13 @@ func TestSpawnServeWorker_CachesExecutablePath(t *testing.T) {
 	}
 
 	// Three more spawns. The production resolver is a closure over the cached
-	// value, so osExecutable must NOT be called again.
+	// value, so osExecutable must NOT be called again. Each spawn fails because
+	// the path does not exist — that's expected and harmless.
 	for i := 0; i < 3; i++ {
-		_, _, _ = spawn()
+		_, _, err := spawn()
+		if err == nil {
+			t.Fatalf("spawn %d: expected error from fake path, got nil", i)
+		}
 	}
 
 	if calls != 1 {


### PR DESCRIPTION
## Summary
- Fixes the real root cause behind issue #1614 (the upgrade-swap failure that PR #1616's positional-arg guard did not touch).
- `swap()` renames the running binary aside (`octo` → `octo.old.<ts>.<pid>`) and renames the new binary into place. On Linux, `os.Executable()` reads `/proc/self/exe`, which reflects the running inode's *current* name — so after the rename it returns the now-deleted aside name, and the next worker spawn fails with `fork/exec octo.old.xxx: no such file or directory`. That error is the supervisor log line the reporter pasted.
- Resolve the path ONCE at supervisor startup and cache it. The cached string still says `octo`, and after the rename that path points at the new binary. macOS happened to work because `KERN_PROC_PATHNAME` is a static snapshot, but the cache makes correctness explicit and platform-independent.
- Adds `TestSpawnServeWorker_CachesExecutablePath` as a regression guard: it stubs `osExecutable` and asserts the resolver is called exactly once at construction, never again across spawns.

## Verification
- `go test ./cmd/octo/` — all pass, including the new caching test and the existing `TestSpawnServeWorker_ReResolvesExecutablePath`.
- `go test ./internal/upgrade/` — all pass.
- `go build ./cmd/octo/` — clean.

## Test plan
- [x] New test pins the "resolve once, cache forever" contract.
- [x] Existing `TestSpawnServeWorker_ReResolvesExecutablePath` still passes (the `spawnServeWorkerWithResolver` helper still calls resolver per-spawn; only the production closure caches).
- [x] All other supervisor/serve tests still pass.

🤖 Generated with [Claude Code](https://claude.ai/code)
