### PR TITLE
feat: raise default max-tokens from 16384 to 32768

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -178,8 +178,8 @@ func resolveMaxTurns(flagVal int, seeded, interactive bool) int {
 // model whose ceiling is below the target backs off at the API (see the agent
 // loop's isMaxTokensTooLargeErr). See dev-docs/truncation-recovery.md.
 const (
-	escalateMaxTokensOpenAI    = 32768
-	escalateMaxTokensAnthropic = 32768
+	escalateMaxTokensOpenAI    = 65536
+	escalateMaxTokensAnthropic = 65536
 )
 
 // resolveMaxTokensEscalate picks the escalated cap: an explicit flag (>= 0)

--- a/dev-docs/truncation-recovery.md
+++ b/dev-docs/truncation-recovery.md
@@ -59,8 +59,8 @@ conservative default per protocol, overridable by flag/env:
 
 | Provider | first attempt | escalation target |
 |---|---|---|
-| OpenAI protocol | provider default (4096) | 16384 |
-| Anthropic protocol | provider default (4096) | 32768 |
+| OpenAI protocol | provider default (32768) | 65536 |
+| Anthropic protocol | provider default (32768) | 65536 |
 
 - `--max-tokens-escalate N` / `OCTO_MAX_TOKENS_ESCALATE=N` overrides it;
   `0` disables escalation entirely.

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -34,10 +34,10 @@ const MessagesPath = "/v1/messages"
 const DefaultAPIVersion = "2023-06-01"
 
 // DefaultMaxTokens caps response length when a caller doesn't specify one.
-// 16384 leaves room for the large code edits agent turns routinely emit while
-// staying well below the model ceilings; truncation escalation (32768) sits on
+// 32768 leaves room for the large code edits agent turns routinely emit while
+// staying well below the model ceilings; truncation escalation (65536) sits on
 // top. See cmd/octo escalateMaxTokensAnthropic and dev-docs/truncation-recovery.md.
-const DefaultMaxTokens = 16384
+const DefaultMaxTokens = 32768
 
 // DefaultStreamIdleTimeout bounds how long a streaming response may go silent
 // (no bytes received) before SendStream aborts it as a stall. The Messages API

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -28,10 +28,10 @@ const DefaultBaseURL = "https://api.openai.com"
 const ChatCompletionsPath = "/v1/chat/completions"
 
 // DefaultMaxTokens caps response length when a caller doesn't specify one.
-// 16384 mirrors the Anthropic provider's default so behaviour stays consistent
+// 32768 mirrors the Anthropic provider's default so behaviour stays consistent
 // across backends. OpenAI itself treats max_tokens as optional (model
-// maximum if omitted); we send 16384 anyway for predictability.
-const DefaultMaxTokens = 16384
+// maximum if omitted); we send 32768 anyway for predictability.
+const DefaultMaxTokens = 32768
 
 // DialectDeepSeek selects DeepSeek's reasoning quirks (the thinking on/off
 // toggle) on a Client. Assign it to Client.Dialect for the "deepseek" vendor;

--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -391,13 +391,18 @@ func TestEventSinkDoneCarriesStopReason(t *testing.T) {
 	var events []SubAgentEvent
 	m.SetOnEvent(func(ev SubAgentEvent) { mu.Lock(); events = append(events, ev); mu.Unlock() })
 
+	// SetOnExit must be registered before Start(): the fixedSpawner returns
+	// immediately, so the async goroutine can complete and fire the exit hook
+	// before Start() returns — registering after Start() races that fire and
+	// loses the notification on a fast runner.
+	exited := make(chan struct{})
+	m.SetOnExit(func(SubAgentNotification) { close(exited) })
+
 	id, err := m.Start(SpawnRequest{Description: "d", Prompt: "p"})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	_ = id
-	exited := make(chan struct{})
-	m.SetOnExit(func(SubAgentNotification) { close(exited) })
 	select {
 	case <-exited:
 	case <-time.After(5 * time.Second):


### PR DESCRIPTION
Modern models commonly ship with 1M+ context windows, yet octo's per-response output cap defaulted to 16384 — frequently truncating large file writes and long-form answers, forcing users to hit the two-layer recovery path (escalate + resume) on routine turns.

Bump the provider DefaultMaxTokens (OpenAI + Anthropic) to 32768, and the truncation-escalation target from 32768 to 65536, so a single attempt clears most real-world payloads. The escalation mechanism stays intact for anything larger.

<!-- Write this PR description in English. -->

## What

<!-- One or two sentences: what does this PR change? -->

## Why

<!-- The need this addresses, and who benefits. -->

## User-visible impact

<!-- Default behavior changes? New config? Breaking changes? "None" is a valid answer. -->

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [ ] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [ ] No new dependencies (or justified below)
- [ ] Fits the existing design / naming / layering

### 2. Need

- [ ] Common need that benefits most users, **or** scope and side effects are explained below
- [ ] No unintended impact on other users' workflows or defaults

### 3. Code

- [ ] All tests pass
- [ ] Coverage does not drop; new code has new tests
- [ ] Commit messages and this PR are written in English
- [ ] This branch was created from the latest `main` and is currently up to date with it

### Bonus

- [ ] This PR was authored using Octo itself

---

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs you considered, or follow-ups planned. -->
