### PR TITLE
fix(desktop): add /usr/libexec to systemDirs so login-shell PATH sync works on Apple Silicon

### DIFF
--- a/internal/shellpath/sync.go
+++ b/internal/shellpath/sync.go
@@ -86,6 +86,13 @@ func looksLikeFullPath(current string) bool {
 		"/bin":             {},
 		"/usr/games":       {},
 		"/usr/local/games": {},
+		// /usr/libexec ships on Apple Silicon's default GUI PATH (path_helper
+		// injects it via /etc/paths.d). It is a system directory, not a
+		// user/package-manager one, so it must not count as "full" — otherwise
+		// a GUI-launched PATH of /bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec
+		// would skip the login-shell sync and Homebrew on /opt/homebrew/bin
+		// would never be added.
+		"/usr/libexec": {},
 	}
 	for _, p := range strings.Split(current, string(os.PathListSeparator)) {
 		p = strings.TrimSpace(p)

--- a/internal/shellpath/sync_test.go
+++ b/internal/shellpath/sync_test.go
@@ -88,11 +88,12 @@ func TestLooksLikeFullPath(t *testing.T) {
 			want: true,
 		},
 		{
-			// path_helper can inject /usr/local/bin into an otherwise-minimal GUI
-			// PATH; that alone is not evidence the login shell ran, so it must NOT
-			// count as full (this is the false positive the tightening fixes).
-			name: "system dirs plus path_helper /usr/local/bin is not full",
-			path: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+			// path_helper can inject /usr/local/bin and Apple Silicon's GUI
+			// default adds /usr/libexec; neither alone is evidence the login
+			// shell ran, so neither counts as full (a GUI-launched PATH may be
+			// /bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec — the bug this fixes).
+			name: "system dirs plus /usr/local/bin and /usr/libexec is not full",
+			path: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/libexec",
 			want: false,
 		},
 		{


### PR DESCRIPTION
## Problem

On Apple Silicon macOS, a GUI-launched process inherits a default PATH
that includes `/usr/libexec` (injected by `path_helper` via
`/etc/paths.d`):

```
/bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec
```

`looksLikeFullPath` in `internal/shellpath/sync.go` classifies the PATH
as "already full" because `/usr/libexec` is not in its `systemDirs`
allowlist. That makes `SyncToLoginShell` skip the login-shell PATH sync,
so `/opt/homebrew/bin` (Homebrew) is never added — and every tool the
agent later tries to spawn (git, node, docker, etc.) fails with
"command not installed".

## Fix

Add `/usr/libexec` to the `systemDirs` allowlist in `looksLikeFullPath`.
Extend one existing test case to cover the Apple Silicon GUI default
PATH precisely (`/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/libexec`
→ not full).

## Verification

- `go test ./internal/shellpath/` passes, including the new case.
- Reproducing the bug on a real GUI-launched `octo-desktop` (PID
  88455, v1.12.23) confirmed the process PATH was exactly
  `/bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec` with Homebrew missing.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
