### PR TITLE
feat(config): endpoint UI two-level — PR4b

### DIFF
--- a/cmd/octo/model_picker_test.go
+++ b/cmd/octo/model_picker_test.go
@@ -44,7 +44,9 @@ func pickUpdate(m *tuiModel, msg tea.Msg) *tuiModel {
 }
 
 // TestDispatchModel_NoArgOpensPicker verifies that "/model" without an argument
-// opens the picker overlay (instead of printing a usage error).
+// opens the picker overlay (instead of printing a usage error). PR4b: the
+// picker is two-level — two distinct (provider, base_url) groups become two
+// endpoints, and the cursor starts on the active model's endpoint.
 func TestDispatchModel_NoArgOpensPicker(t *testing.T) {
 	writeModelsConfig(t, config.Config{
 		Models: []config.ModelEntry{
@@ -57,15 +59,21 @@ func TestDispatchModel_NoArgOpensPicker(t *testing.T) {
 	m := newPickerTestModel("gpt-4o")
 	model, _ := m.dispatchModel("")
 
-	if model.(*tuiModel).modelPicker == nil {
+	p := model.(*tuiModel).modelPicker
+	if p == nil {
 		t.Fatal("expected picker to be open after dispatchModel(\"\")")
 	}
-	if len(model.(*tuiModel).modelPicker.items) != 2 {
-		t.Errorf("picker items = %d, want 2", len(model.(*tuiModel).modelPicker.items))
+	if len(p.endpoints) != 2 {
+		t.Fatalf("picker endpoints = %d, want 2 (one per distinct provider): %+v", len(p.endpoints), p.endpoints)
 	}
-	// Cursor should start on the active model (gpt-4o = index 0).
-	if model.(*tuiModel).modelPicker.idx != 0 {
-		t.Errorf("picker cursor = %d, want 0 (active model)", model.(*tuiModel).modelPicker.idx)
+	// Current endpoint should have exactly its models exposed as items.
+	if len(p.items) != len(p.endpoints[p.epIdx].items) {
+		t.Errorf("picker items = %d, want %d (current endpoint's models)", len(p.items), len(p.endpoints[p.epIdx].items))
+	}
+	// Cursor should start on the active model (gpt-4o). Its endpoint is the
+	// openai one; within that endpoint gpt-4o is the only (→ index 0) model.
+	if p.idx != 0 {
+		t.Errorf("picker cursor = %d, want 0 (active model)", p.idx)
 	}
 }
 
@@ -84,18 +92,30 @@ func TestDispatchModel_NoArgCursorOnActive(t *testing.T) {
 	m := newPickerTestModel("claude-sonnet-4-6")
 	m.dispatchModel("")
 
-	if m.modelPicker.idx != 1 {
-		t.Errorf("picker cursor = %d, want 1 (claude-sonnet-4-6)", m.modelPicker.idx)
+	p := m.modelPicker
+	if p == nil {
+		t.Fatal("picker not open")
+	}
+	// The active model claude-sonnet-4-6 is the only model under the anthropic
+	// endpoint, so idx within that endpoint is 0; the endpoint cursor should be
+	// on the anthropic endpoint (index 1, assuming openai→0, anthropic→1,
+	// deepseek→2 ordering).
+	if p.idx != 0 {
+		t.Errorf("picker model cursor = %d, want 0 (claude-sonnet-4-6 is the only model in its endpoint)", p.idx)
+	}
+	if p.endpoints[p.epIdx].items[0].name != "claude-sonnet-4-6" {
+		t.Errorf("active endpoint = %q, want the one holding claude-sonnet-4-6", p.endpoints[p.epIdx].items[0].name)
 	}
 }
 
 // TestDispatchModel_PickerKeyDown verifies DOWN advances the cursor (with
-// wrap) and UP moves it back, while the picker stays open.
+// wrap) and UP moves it back, while the picker stays open. Uses a single
+// endpoint with two models so ↑↓ stays within one endpoint.
 func TestDispatchModel_PickerKeyDown(t *testing.T) {
 	writeModelsConfig(t, config.Config{
 		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
-			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+			{Model: "gpt-4o", Provider: "openai", BaseURL: "https://api.openai.com"},
+			{Model: "gpt-4.1", Provider: "openai", BaseURL: "https://api.openai.com"},
 		},
 		DefaultModel: "gpt-4o",
 	})
@@ -103,6 +123,9 @@ func TestDispatchModel_PickerKeyDown(t *testing.T) {
 	m := newPickerTestModel("gpt-4o")
 	m.dispatchModel("")
 
+	if len(m.modelPicker.endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint (same provider+base_url), got %d", len(m.modelPicker.endpoints))
+	}
 	// Down → index 1
 	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyDown})
 	if m.modelPicker.idx != 1 {
@@ -139,8 +162,10 @@ func TestDispatchModel_PickerKeyEsc(t *testing.T) {
 }
 
 // TestDispatchModel_PickerKeyEnter verifies Enter switches to the highlighted
-// model and clears the picker. Two models share a provider + base URL so
-// ensureSender returns early (no live rebuild needed).
+// (endpoint, model) and clears the picker. The accept path now produces a
+// composite id "<endpoint>::<model>" so the receiver resolves the right
+// endpoint's connection params (PR4b). Two models share a provider + base URL
+// so ensureSender returns early (no live rebuild needed).
 func TestDispatchModel_PickerKeyEnter(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
 	writeModelsConfig(t, config.Config{
@@ -154,24 +179,26 @@ func TestDispatchModel_PickerKeyEnter(t *testing.T) {
 	m := newPickerTestModel("deepseek-v4-flash")
 	m.dispatchModel("")
 
-	// Move to index 1 (deepseek-v4-pro)
+	// Move to index 1 (deepseek-v4-pro) within the single endpoint.
 	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyDown})
-	// Enter accepts
+	// Enter accepts.
 	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.modelPicker != nil {
 		t.Error("picker should be cleared after Enter")
 	}
-	if m.a.Model != "deepseek-v4-pro" {
-		t.Errorf("active model = %q, want deepseek-v4-pro", m.a.Model)
+	// m.a.Model is now the composite id; EntryByModel resolves it back to the
+	// same model id, so we assert the suffix rather than the bare name.
+	if !strings.HasSuffix(m.a.Model, "::deepseek-v4-pro") {
+		t.Errorf("active model = %q, want suffix ::deepseek-v4-pro", m.a.Model)
 	}
 }
 
-// TestModelPickerView_Renders verifies the overlay lists all models with
-// provider/endpoint info.
+// TestModelPickerView_Renders verifies the overlay shows the focused endpoint's
+// models (collapsed for others — ←→ switches focus to reveal theirs).
 func TestModelPickerView_Renders(t *testing.T) {
 	writeModelsConfig(t, config.Config{
 		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
+			{Model: "gpt-4o", Provider: "openai", BaseURL: "https://api.openai.com"},
 			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
 		},
 		DefaultModel: "gpt-4o",
@@ -180,18 +207,89 @@ func TestModelPickerView_Renders(t *testing.T) {
 	m := newPickerTestModel("gpt-4o")
 	m.dispatchModel("")
 
+	// Initial focus is on the openai endpoint (where gpt-4o lives).
 	out := m.modelPickerView()
 	if !strings.Contains(out, "gpt-4o") {
-		t.Errorf("picker view missing gpt-4o:\n%s", out)
+		t.Errorf("picker view missing focused model gpt-4o:\n%s", out)
 	}
-	if !strings.Contains(out, "deepseek-v4-flash") {
-		t.Errorf("picker view missing deepseek-v4-flash:\n%s", out)
+	if !strings.Contains(out, "https://api.openai.com") {
+		t.Errorf("picker view missing focused endpoint's base URL:\n%s", out)
 	}
 	if !strings.Contains(out, "https://api.deepseek.com") {
-		t.Errorf("picker view missing base URL:\n%s", out)
+		t.Errorf("picker view missing other endpoint's header:\n%s", out)
 	}
 	if !strings.Contains(out, "Switch model") {
 		t.Errorf("picker view missing prompt:\n%s", out)
+	}
+	if !strings.Contains(out, "←/→ endpoint") {
+		t.Errorf("picker view missing ←→ hint:\n%s", out)
+	}
+
+	// ←→ moves focus to the deepseek endpoint; its models now appear.
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyRight})
+	out = m.modelPickerView()
+	if !strings.Contains(out, "deepseek-v4-flash") {
+		t.Errorf("picker view missing deepseek-v4-flash after →:\n%s", out)
+	}
+}
+
+// TestModelPicker_TwoLevelEndpointSwitch exercises the PR4b ←→ keys: with two
+// endpoints, ←/→ cycle the endpoint cursor and reset the model cursor to 0,
+// and Enter on the second endpoint's model dispatches a composite id that
+// resolves to that endpoint's connection params.
+func TestModelPicker_TwoLevelEndpointSwitch(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+	t.Setenv("OPENAI_API_KEY", "test-openai-key")
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai", BaseURL: "https://api.openai.com", APIKey: "sk-openai"},
+			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com", APIKey: "sk-deepseek"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.dispatchModel("")
+
+	if len(m.modelPicker.endpoints) != 2 {
+		t.Fatalf("endpoints = %d, want 2: %+v", len(m.modelPicker.endpoints), m.modelPicker.endpoints)
+	}
+	// Start: focused on the openai endpoint (where gpt-4o lives), model idx 0.
+	if m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name != "gpt-4o" {
+		t.Errorf("initial endpoint = %q, want the one with gpt-4o", m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name)
+	}
+
+	// → moves to the deepseek endpoint and resets model idx to 0.
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyRight})
+	if m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name != "deepseek-v4-flash" {
+		t.Errorf("after →: endpoint = %q, want deepseek endpoint",
+			m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name)
+	}
+	if m.modelPicker.idx != 0 {
+		t.Errorf("after →: model idx = %d, want 0 (reset on endpoint switch)", m.modelPicker.idx)
+	}
+
+	// → again wraps back to the openai endpoint.
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyRight})
+	if m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name != "gpt-4o" {
+		t.Errorf("after →→ (wrap): endpoint = %q, want gpt-4o endpoint",
+			m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name)
+	}
+
+	// ← wraps to the deepseek endpoint (the last one).
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyLeft})
+	if m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name != "deepseek-v4-flash" {
+		t.Errorf("after ← (wrap): endpoint = %q, want deepseek endpoint",
+			m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name)
+	}
+
+	// Enter on deepseek-v4-flash dispatches the composite id.
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.modelPicker != nil {
+		t.Fatal("picker should be cleared after Enter")
+	}
+	if m.a.Model != "legacy-api-deepseek-com-0::deepseek-v4-flash" {
+		t.Errorf("active model = %q, want legacy-api-deepseek-com-0::deepseek-v4-flash", m.a.Model)
 	}
 }
 

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -617,16 +617,16 @@ type tuiModel struct {
 // exercised by TestModelPicker_TwoLevelEndpointSwitch.
 type modelPicker struct {
 	endpoints []pickerEndpoint
-	epIdx     int // highlighted endpoint
+	epIdx     int         // highlighted endpoint
 	items     []complItem // alias for endpoints[epIdx].items; kept for tests + view
 	idx       int         // highlighted model within the current endpoint
 }
 
 // pickerEndpoint is one channel in the two-level model picker.
 type pickerEndpoint struct {
-	id      string        // endpoint ID; used to build the composite id on accept
-	display string        // one-line header shown above the endpoint's models (name · provider · base_url)
-	items   []complItem   // models under this endpoint (name = model id, desc = extra hint)
+	id      string      // endpoint ID; used to build the composite id on accept
+	display string      // one-line header shown above the endpoint's models (name · provider · base_url)
+	items   []complItem // models under this endpoint (name = model id, desc = extra hint)
 }
 
 // subAgentUI is the live panel state for one running sub-agent.

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -600,9 +600,33 @@ type tuiModel struct {
 }
 
 // modelPicker is the state of the arrow-key model-switch overlay.
+//
+// PR4b (design §12.1): the picker is two-level. endpoints holds one entry per
+// configured channel (provider + base_url group), each carrying its own items
+// (the models under that endpoint). epIdx selects the current endpoint; idx
+// selects the model within endpoints[epIdx].items. ←/→ cycle endpoints, ↑/↓
+// cycle models within the current endpoint, Enter dispatches the composite id
+// "<endpoint_id>::<model>", Esc dismisses.
+//
+// items/idx at the top level are kept for backward compatibility with the
+// single-level tests in model_picker_test.go that drive the picker via
+// dispatchModel("") and expect a flat list — those tests still seed flat
+// models: configs that normalise to one endpoint per (provider, base_url)
+// group, so the two-level shape reduces to "one endpoint, its models" and
+// the existing ↑↓/Enter/Esc assertions still hold. The new ←→ behaviour is
+// exercised by TestModelPicker_TwoLevelEndpointSwitch.
 type modelPicker struct {
-	items []complItem // one per configured model (name = model id, desc = provider + base URL)
-	idx   int         // highlighted row
+	endpoints []pickerEndpoint
+	epIdx     int // highlighted endpoint
+	items     []complItem // alias for endpoints[epIdx].items; kept for tests + view
+	idx       int         // highlighted model within the current endpoint
+}
+
+// pickerEndpoint is one channel in the two-level model picker.
+type pickerEndpoint struct {
+	id      string        // endpoint ID; used to build the composite id on accept
+	display string        // one-line header shown above the endpoint's models (name · provider · base_url)
+	items   []complItem   // models under this endpoint (name = model id, desc = extra hint)
 }
 
 // subAgentUI is the live panel state for one running sub-agent.

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -79,10 +79,24 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.modelPicker != nil {
 		switch msg.Type {
 		case tea.KeyDown:
-			m.modelPicker.idx = (m.modelPicker.idx + 1) % len(m.modelPicker.items)
+			items := m.modelPicker.endpoints[m.modelPicker.epIdx].items
+			m.modelPicker.idx = (m.modelPicker.idx + 1) % len(items)
+			m.modelPicker.items = items
 			return m, nil
 		case tea.KeyUp:
-			m.modelPicker.idx = (m.modelPicker.idx - 1 + len(m.modelPicker.items)) % len(m.modelPicker.items)
+			items := m.modelPicker.endpoints[m.modelPicker.epIdx].items
+			m.modelPicker.idx = (m.modelPicker.idx - 1 + len(items)) % len(items)
+			m.modelPicker.items = items
+			return m, nil
+		case tea.KeyLeft:
+			m.modelPicker.epIdx = (m.modelPicker.epIdx - 1 + len(m.modelPicker.endpoints)) % len(m.modelPicker.endpoints)
+			m.modelPicker.idx = 0
+			m.modelPicker.items = m.modelPicker.endpoints[m.modelPicker.epIdx].items
+			return m, nil
+		case tea.KeyRight:
+			m.modelPicker.epIdx = (m.modelPicker.epIdx + 1) % len(m.modelPicker.endpoints)
+			m.modelPicker.idx = 0
+			m.modelPicker.items = m.modelPicker.endpoints[m.modelPicker.epIdx].items
 			return m, nil
 		case tea.KeyEnter:
 			if !msg.Alt {
@@ -999,63 +1013,170 @@ func (m *tuiModel) dispatchTranscript(arg string) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// openModelPicker arms m.modelPicker with the configured models (name +
-// provider + base URL), cursor starting on the active model. The picker renders
-// as an overlay and owns ↑/↓/Enter/Esc until the user picks or cancels. Returns
-// false if no models are configured (rare — there's always at least the default).
+// openModelPicker arms m.modelPicker with the configured models, two-level
+// (endpoint → model). The data comes from cfg.Endpoints — PR1-3's normalize()
+// already projects the legacy flat cfg.Models into this shape, so a one-endpoint
+// flat config and a hand-written endpoints: config both work here. The cursor
+// starts on the active model: m.a.Model may be a bare model (legacy session) or
+// a composite id (post-PR4b session), so we match either form against each
+// endpoint's models. Returns false when no models are configured anywhere.
 func (m *tuiModel) openModelPicker() bool {
 	cfg, err := config.Load()
-	if err != nil || len(cfg.Models) == 0 {
+	if err != nil || len(cfg.Endpoints) == 0 {
 		return false
 	}
-	items := make([]complItem, 0, len(cfg.Models))
-	for _, e := range cfg.Models {
-		desc := e.Provider
-		if e.BaseURL != "" {
-			desc += " · " + e.BaseURL
+
+	endpoints := make([]pickerEndpoint, 0, len(cfg.Endpoints))
+	for _, ep := range cfg.Endpoints {
+		if len(ep.Models) == 0 {
+			continue
 		}
-		items = append(items, complItem{name: e.Model, desc: desc})
+		pe := pickerEndpoint{id: ep.ID}
+		pe.display = ep.ID
+		if ep.Name != "" {
+			pe.display = ep.Name
+		}
+		pe.display += " · " + ep.Provider
+		if ep.BaseURL != "" {
+			pe.display += " · " + ep.BaseURL
+		}
+		pe.items = make([]complItem, 0, len(ep.Models))
+		for _, mdl := range ep.Models {
+			pe.items = append(pe.items, complItem{name: mdl.Model, desc: ep.ID + "::" + mdl.Model})
+		}
+		endpoints = append(endpoints, pe)
 	}
-	idx := 0
-	for i, it := range items {
-		if it.name == m.a.Model {
+	if len(endpoints) == 0 {
+		return false
+	}
+
+	m.modelPicker = &modelPicker{endpoints: endpoints, epIdx: 0, idx: 0}
+	m.modelPicker.items = m.modelPicker.endpoints[0].items
+	// Position cursor on the active model. Two forms of active model:
+	//   - composite id "<endpoint>::<model>" (post-PR4b session, set by a
+	//     prior /model dispatch) — unambiguous, matches exactly one endpoint.
+	//   - bare model "<model>" (legacy session, never ran /model) — may exist
+	//     under multiple endpoints. When it does, prefer the default endpoint
+	//     (cfg.Default's endpoint, resolved via ParseModelFlag's step 2a)
+	//     rather than the first in config order, mirroring ParseModelFlag's
+	//     own "default endpoint first" rule so the picker opens on the same
+	//     endpoint a bare `--model <X>` would have selected.
+	active := m.a.Model
+	if endpointID, _, hasCid := splitCompositeIDForPicker(active); hasCid {
+		for ei, ep := range endpoints {
+			if ep.id != endpointID {
+				continue
+			}
+			for mi, it := range ep.items {
+				if it.name == active[len(endpointID)+2:] {
+					m.modelPicker.epIdx = ei
+					m.modelPicker.idx = mi
+					m.modelPicker.items = endpoints[ei].items
+					return true
+				}
+			}
+		}
+	}
+	// Bare active model: collect all endpoints that carry it, prefer the
+	// default endpoint if any of them is the default, else first match.
+	type hit struct{ ep, mi int }
+	var hits []hit
+	for ei, ep := range endpoints {
+		for mi, it := range ep.items {
+			if it.name == active {
+				hits = append(hits, hit{ei, mi})
+			}
+		}
+	}
+	if len(hits) > 0 {
+		pick := hits[0]
+		if defaultEpID, _, hasDefault := splitCompositeIDForPicker(cfg.Default); hasDefault {
+			for _, h := range hits {
+				if endpoints[h.ep].id == defaultEpID {
+					pick = h
+					break
+				}
+			}
+		}
+		m.modelPicker.epIdx = pick.ep
+		m.modelPicker.idx = pick.mi
+		m.modelPicker.items = endpoints[pick.ep].items
+	}
+	return true
+}
+
+// splitCompositeIDForPicker splits "<endpoint_id>::<model>". Returns
+// hasCid=false when the input doesn't contain "::" (a bare model name).
+// Thin wrapper around config.splitCompositeID's semantics; duplicated here
+// because splitCompositeID is unexported in package config and the picker
+// lives in package main.
+func splitCompositeIDForPicker(id string) (endpointID, model string, hasCid bool) {
+	idx := -1
+	for i := 0; i+1 < len(id); i++ {
+		if id[i] == ':' && id[i+1] == ':' {
 			idx = i
 			break
 		}
 	}
-	m.modelPicker = &modelPicker{items: items, idx: idx}
-	return true
+	if idx < 0 {
+		return "", "", false
+	}
+	return id[:idx], id[idx+2:], true
 }
 
-// acceptModelPicker switches to the highlighted model and clears the picker.
+// acceptModelPicker switches to the highlighted (endpoint, model) and clears
+// the picker. The model is passed to dispatchModel as the composite id
+// "<endpoint_id>::<model>" so the receiver resolves the right endpoint's
+// connection params (PR2's EntryByModel handles the composite id form).
 func (m *tuiModel) acceptModelPicker() (tea.Model, tea.Cmd) {
 	p := m.modelPicker
 	m.modelPicker = nil
-	if p == nil || p.idx < 0 || p.idx >= len(p.items) {
+	if p == nil || p.epIdx < 0 || p.epIdx >= len(p.endpoints) {
 		return m, nil
 	}
-	return m.dispatchModel(p.items[p.idx].name)
+	ep := p.endpoints[p.epIdx]
+	if p.idx < 0 || p.idx >= len(ep.items) {
+		return m, nil
+	}
+	return m.dispatchModel(ep.id + "::" + ep.items[p.idx].name)
 }
 
-// modelPickerView renders the model-switch overlay, reusing the completion menu
-// styles so it reads as the same family of UI.
+// modelPickerView renders the model-switch overlay, two-level: each endpoint
+// is a header line, with its models listed indented below. The current
+// endpoint is highlighted; the cursor (▸) marks the highlighted model within
+// the current endpoint. ←→ switch endpoint, ↑↓ switch model, Enter selects.
 func (m *tuiModel) modelPickerView() string {
 	p := m.modelPicker
-	if p == nil || len(p.items) == 0 {
+	if p == nil || len(p.endpoints) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteString(selectPromptStyle.Render("Switch model:") + "\n")
-	for i, it := range p.items {
-		label := fmt.Sprintf("%-24s", it.name)
-		if i == p.idx {
-			b.WriteString("  " + complSelStyle.Render("▸ "+label) + " " + hintStyle.Render(it.desc))
+	for ei, ep := range p.endpoints {
+		// Endpoint header. Highlight the focused one.
+		if ei == p.epIdx {
+			b.WriteString("  " + complSelStyle.Render("▣ "+ep.display))
 		} else {
-			b.WriteString("  " + complNameStyle.Render(label) + " " + hintStyle.Render(it.desc))
+			b.WriteString("  " + complNameStyle.Render(ep.display))
 		}
 		b.WriteByte('\n')
+		// Only render the focused endpoint's models — collapsing the others
+		// keeps the overlay short (one endpoint's worth of models at a time)
+		// and matches the ←→ mental model: "I'm in this endpoint, ↑↓ moves
+		// within it; ←→ jumps to another endpoint and its models appear."
+		if ei == p.epIdx {
+			for mi, it := range ep.items {
+				label := fmt.Sprintf("%-24s", it.name)
+				if mi == p.idx {
+					b.WriteString("    " + complSelStyle.Render("▸ "+label) + " " + hintStyle.Render(it.desc))
+				} else {
+					b.WriteString("    " + complNameStyle.Render(label) + " " + hintStyle.Render(it.desc))
+				}
+				b.WriteByte('\n')
+			}
+		}
 	}
-	b.WriteString(hintStyle.Render("  ↑/↓ select · Enter switch · Esc dismiss"))
+	b.WriteString(hintStyle.Render("  ←/→ endpoint · ↑/↓ model · Enter switch · Esc dismiss"))
 	b.WriteByte('\n')
 	return b.String()
 }

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -158,10 +158,21 @@ func (s *Session) Interrupt() bool {
 type AgentFactory func() *agent.Agent
 
 // ModelInfo describes one configured model entry for /model listings.
+//
+// PR4b (design §12.2): the listing is two-level — each info carries its
+// EndpointID/EndpointName so the manager can group models under their channel
+// header, and CompositeID ("<endpoint>::<model>") so /model can be told to
+// switch to a specific endpoint's copy of a model that may exist under more
+// than one. Model stays the bare model id (also still accepted by /model for
+// back-compat — Resolve runs it through ParseModelFlag's default-priority
+// path).
 type ModelInfo struct {
-	Model    string // the model id, also the /model argument that selects it
-	Provider string
-	Default  bool // the config-wide default entry
+	EndpointID   string // the channel this model lives under; empty only on a misconfigured ops
+	EndpointName string // display name for the channel header
+	Model        string // the bare model id
+	CompositeID  string // "<endpoint>::<model>" — the precise /model argument
+	Provider     string
+	Default      bool // the config-wide default entry (composite id matches cfg.Default)
 }
 
 // ModelResolution is the server-resolved outcome of a /model switch request:
@@ -385,27 +396,99 @@ func (m *Manager) cmdModel(ev InboundEvent, arg string) string {
 }
 
 // modelListReply renders the no-argument /model listing: the session's
-// current model plus every configured entry, marking current and default.
+// current model plus every configured entry, grouped by endpoint (PR4b design
+// §12.2). Each endpoint is a header line; its models are listed below with
+// their composite id (the precise /model argument). The current and default
+// models are marked.
+//
+// Backward compat: when ModelOps returns ModelInfo values with no EndpointID
+// (e.g. a stale or test-injected ops), the listing falls back to the flat
+// one-line-per-model shape so the command still produces something readable
+// rather than crashing on a missing endpoint dimension.
 func (m *Manager) modelListReply(sess *Session) string {
 	infos := m.modelOps.List()
 	if len(infos) == 0 {
 		return "No models configured. Run `octo config` to add one."
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "Current model: %s\nAvailable:", sess.Agent.Model)
-	for _, info := range infos {
-		mark := ""
-		switch {
-		case info.Model == sess.Agent.Model && info.Default:
-			mark = " ← current (default)"
-		case info.Model == sess.Agent.Model:
-			mark = " ← current"
-		case info.Default:
-			mark = " (default)"
-		}
-		fmt.Fprintf(&b, "\n• %s (%s)%s", info.Model, info.Provider, mark)
+	fmt.Fprintf(&b, "Current model: %s\n", sess.Agent.Model)
+
+	// Group by endpoint, preserving the order List returned (which is the
+	// config order — Endpoints[0].Models[0], Endpoints[0].Models[1], …).
+	type group struct {
+		endpointID   string
+		endpointName string
+		models       []ModelInfo
 	}
-	b.WriteString("\nSwitch: /model <name> — or /model default to follow the default model.")
+	var groups []*group
+	groupIdx := map[string]int{}
+	hasEndpoints := false
+	for _, info := range infos {
+		if info.EndpointID == "" {
+			continue // fall back to flat rendering below
+		}
+		hasEndpoints = true
+		if idx, ok := groupIdx[info.EndpointID]; ok {
+			groups[idx].models = append(groups[idx].models, info)
+			continue
+		}
+		groupIdx[info.EndpointID] = len(groups)
+		groups = append(groups, &group{
+			endpointID:   info.EndpointID,
+			endpointName: info.EndpointName,
+			models:       []ModelInfo{info},
+		})
+	}
+
+	if !hasEndpoints {
+		// Flat fallback (legacy/test ops without endpoint info).
+		b.WriteString("Available:")
+		for _, info := range infos {
+			mark := ""
+			switch {
+			case info.Model == sess.Agent.Model && info.Default:
+				mark = " ← current (default)"
+			case info.Model == sess.Agent.Model:
+				mark = " ← current"
+			case info.Default:
+				mark = " (default)"
+			}
+			fmt.Fprintf(&b, "\n• %s (%s)%s", info.Model, info.Provider, mark)
+		}
+		b.WriteString("\nSwitch: /model <name> — or /model default to follow the default model.")
+		return b.String()
+	}
+
+	b.WriteString("Channels:")
+	for _, g := range groups {
+		header := g.endpointID
+		if g.endpointName != "" && g.endpointName != g.endpointID {
+			header = fmt.Sprintf("%s (%s)", g.endpointID, g.endpointName)
+		}
+		fmt.Fprintf(&b, "\n  %s", header)
+		for _, info := range g.models {
+			mark := ""
+			// The "current" mark is keyed off the persisted binding
+			// (sess.AppliedModelConfig, a composite id) rather than
+			// sess.Agent.Model (a bare model id). Keying off the bare model
+			// would mark the same model on every endpoint that carries it
+			// (e.g. claude-sonnet-4-6 under both relay and official). The
+			// composite id is unambiguous — only the endpoint the user
+			// actually switched to gets the mark. An unbound session (never
+			// ran /model) shows no "current" mark, which is correct: the
+			// session is on the server default, not any endpoint's binding.
+			switch {
+			case info.CompositeID == sess.AppliedModelConfig && info.Default:
+				mark = " ← current (default)"
+			case info.CompositeID == sess.AppliedModelConfig:
+				mark = " ← current"
+			case info.Default:
+				mark = " (default)"
+			}
+			fmt.Fprintf(&b, "\n    • %s%s", info.CompositeID, mark)
+		}
+	}
+	b.WriteString("\nSwitch: /model <endpoint>::<model> — or /model default to follow the default model.")
 	return b.String()
 }
 

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -586,6 +586,51 @@ func TestCmdModel_ListMarksCurrent(t *testing.T) {
 	}
 }
 
+// TestCmdModel_ListGroupsByEndpoint covers the PR4b two-level shape (§12.2):
+// when List returns ModelInfo with EndpointID set, the no-argument /model
+// listing groups models under their endpoint header and shows the composite
+// id as the switch argument. The current and default models are still marked.
+func TestCmdModel_ListGroupsByEndpoint(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
+	mgr.SetModelOps(&ModelOps{
+		List: func() []ModelInfo {
+			return []ModelInfo{
+				{EndpointID: "relay-a", EndpointName: "中转站A", Model: "claude-sonnet-4-6", CompositeID: "relay-a::claude-sonnet-4-6", Provider: "custom", Default: true},
+				{EndpointID: "relay-a", EndpointName: "中转站A", Model: "gpt-5.4", CompositeID: "relay-a::gpt-5.4", Provider: "custom"},
+				{EndpointID: "official", EndpointName: "官方", Model: "claude-opus-4-8", CompositeID: "official::claude-opus-4-8", Provider: "anthropic"},
+			}
+		},
+		Resolve: func(modelID string) (ModelResolution, error) {
+			return ModelResolution{}, fmt.Errorf("unused in this test")
+		},
+	})
+	sess := mgr.GetOrCreateSession(ev)
+	// The "current" mark is keyed off the persisted binding (composite id),
+	// not the bare model on the agent — so set AppliedModelConfig.
+	sess.AppliedModelConfig = "relay-a::claude-sonnet-4-6"
+
+	reply := mgr.cmdModel(ev, "")
+	for _, want := range []string{
+		"relay-a (中转站A)",
+		"relay-a::claude-sonnet-4-6",
+		"relay-a::gpt-5.4",
+		"official (官方)",
+		"official::claude-opus-4-8",
+		"current (default)",
+		"<endpoint>::<model>",
+	} {
+		if !strings.Contains(reply, want) {
+			t.Errorf("listing should contain %q, got:\n%s", want, reply)
+		}
+	}
+	// Default badge should NOT appear on gpt-5.4 (only on claude-sonnet-4-6).
+	if strings.Contains(reply, "gpt-5.4 (default)") {
+		t.Errorf("gpt-5.4 must not be marked default:\n%s", reply)
+	}
+}
+
 // TestCmdModel_SwitchPersistsBinding: /model <name> swaps the live agent's
 // sender+model and persists the binding to the session store.
 func TestCmdModel_SwitchPersistsBinding(t *testing.T) {

--- a/internal/server/channel_model_test.go
+++ b/internal/server/channel_model_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -105,11 +106,27 @@ func TestChannelModelOps_Resolve(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve kimi-k2.6: %v", err)
 	}
-	if bound.Model != "kimi-k2.6" || bound.BoundEntry != "kimi-k2.6" {
-		t.Errorf("bound resolution = (%q, %q), want (kimi-k2.6, kimi-k2.6)", bound.Model, bound.BoundEntry)
+	// PR4b: bare model resolves through ParseModelFlag; the bound entry is the
+	// composite id pointing at kimi's endpoint. The exact endpoint id is the
+	// synthesised legacy-<host>-<n> form, so assert by suffix.
+	if bound.Model != "kimi-k2.6" {
+		t.Errorf("bound model = %q, want kimi-k2.6", bound.Model)
+	}
+	if !strings.HasSuffix(bound.BoundEntry, "::kimi-k2.6") {
+		t.Errorf("bound entry = %q, want suffix ::kimi-k2.6 (composite id)", bound.BoundEntry)
 	}
 	if bound.Sender == srv.getSender() {
 		t.Error("configured entry must not ride the default sender")
+	}
+
+	// Composite id path: resolve the same model by its composite id (read
+	// back from the bare-model resolution) — must produce the same binding.
+	bound2, err := ops.Resolve(bound.BoundEntry)
+	if err != nil {
+		t.Fatalf("resolve composite id %q: %v", bound.BoundEntry, err)
+	}
+	if bound2.BoundEntry != bound.BoundEntry {
+		t.Errorf("composite-id resolution = %q, want %q", bound2.BoundEntry, bound.BoundEntry)
 	}
 
 	if _, err := ops.Resolve("nope"); err == nil {
@@ -124,6 +141,12 @@ func TestChannelModelOps_Resolve(t *testing.T) {
 	for _, info := range infos {
 		if info.Model == "claude-sonnet-4-6" && info.Default {
 			sawDefault = true
+		}
+		if info.EndpointID == "" || info.CompositeID == "" {
+			t.Errorf("info missing endpoint grouping: %+v", info)
+		}
+		if info.CompositeID != info.EndpointID+"::"+info.Model {
+			t.Errorf("composite id = %q, want %s::%s", info.CompositeID, info.EndpointID, info.Model)
 		}
 	}
 	if !sawDefault {

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -236,6 +236,77 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ─── GET /api/config/endpoints ───────────────────────────────────────────────
+
+// endpointsResponse is the two-level shape served by GET /api/config/endpoints
+// (design §10.1). PR4b ships only the read path: the frontend renders this as
+// read-only endpoint cards with their model lists; the write path (CRUD on
+// endpoints) lands in PR5 alongside the Save format switch.
+//
+// Security: APIKey is never echoed. HasAPIKey reports presence so the UI can
+// badge "已配置 / 未设置" without exposing the secret.
+type endpointsResponse struct {
+	Endpoints []endpointConfigJSON `json:"endpoints"`
+	Default   string                `json:"default,omitempty"`
+	Lite      string                `json:"lite,omitempty"`
+}
+
+// endpointConfigJSON is one channel in the two-level response.
+//
+// APIKey is deliberately absent from the JSON shape: the read API never echoes
+// the secret. HasAPIKey is the only key-related field the frontend gets, so it
+// can badge "已配置 / 未设置" without learning the key itself (design §10.1,
+// §19.1).
+type endpointConfigJSON struct {
+	ID        string              `json:"id"`
+	Name      string              `json:"name,omitempty"`
+	Provider  string              `json:"provider"`
+	BaseURL   string              `json:"base_url,omitempty"`
+	Protocol  string              `json:"protocol,omitempty"`
+	HasAPIKey bool                `json:"has_api_key"`
+	LiteModel string              `json:"lite_model,omitempty"`
+	Models    []endpointModelJSON `json:"models"`
+}
+
+// endpointModelJSON is one model under an endpoint.
+type endpointModelJSON struct {
+	Model  string `json:"model"`
+	Vision bool   `json:"vision"`
+}
+
+// handleGetEndpoints serves the two-level endpoint view. Data comes straight
+// from config.Load's in-memory Endpoints (syncEndpointsFromModels already
+// projects the legacy flat Models list into this shape, so PR4b works against
+// either schema). Default/Lite are echoed as composite ids verbatim — on a
+// legacy flat config they're synthesised by syncEndpointsFromModels, on a
+// hand-written new-schema config they're whatever the user typed.
+func (s *Server) handleGetEndpoints(w http.ResponseWriter, r *http.Request) {
+	cfg, _ := config.Load()
+
+	out := endpointsResponse{
+		Endpoints: make([]endpointConfigJSON, 0, len(cfg.Endpoints)),
+		Default:   cfg.Default,
+		Lite:      cfg.Lite,
+	}
+	for _, ep := range cfg.Endpoints {
+		em := endpointConfigJSON{
+			ID:        ep.ID,
+			Name:      ep.Name,
+			Provider:  ep.Provider,
+			BaseURL:   ep.BaseURL,
+			Protocol:  ep.Protocol,
+			HasAPIKey: ep.APIKey != "",
+			LiteModel: ep.LiteModel,
+			Models:    make([]endpointModelJSON, 0, len(ep.Models)),
+		}
+		for _, m := range ep.Models {
+			em.Models = append(em.Models, endpointModelJSON{Model: m.Model, Vision: m.Vision})
+		}
+		out.Endpoints = append(out.Endpoints, em)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
 // ─── PUT /api/config/show_reasoning ─────────────────────────────────────────
 
 type putShowReasoningRequest struct {

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -247,8 +247,8 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 // badge "已配置 / 未设置" without exposing the secret.
 type endpointsResponse struct {
 	Endpoints []endpointConfigJSON `json:"endpoints"`
-	Default   string                `json:"default,omitempty"`
-	Lite      string                `json:"lite,omitempty"`
+	Default   string               `json:"default,omitempty"`
+	Lite      string               `json:"lite,omitempty"`
 }
 
 // endpointConfigJSON is one channel in the two-level response.

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -655,6 +656,159 @@ func TestConfigModels_SetLiteToggles(t *testing.T) {
 
 	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/ghost/lite", ""); w.Code != http.StatusNotFound {
 		t.Errorf("set-lite unknown id = %d, want 404", w.Code)
+	}
+}
+
+// getEndpointsResponse calls GET /api/config/endpoints and decodes the body.
+func getEndpointsResponse(t *testing.T, srv *Server) endpointsResponse {
+	t.Helper()
+	w := doJSON(t, srv, http.MethodGet, "/api/config/endpoints", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/config/endpoints = %d: %s", w.Code, w.Body.String())
+	}
+	var resp endpointsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode endpoints response: %v (body: %s)", err, w.Body.String())
+	}
+	return resp
+}
+
+// TestGetEndpoints_ReturnsTwoLevelShape pins the PR4b contract: a legacy flat
+// models: config is served as the two-level { endpoints, default, lite } shape
+// described in design §10.1, with has_api_key reporting key presence (never
+// the key itself) and default/lite expressed as composite ids.
+func TestGetEndpoints_ReturnsTwoLevelShape(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-main-12345678", Vision: true},
+			{Provider: "anthropic", Model: "claude-haiku-4-5", APIKey: "sk-main-12345678"},
+			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", APIKey: "sk-kimi"},
+		},
+		DefaultModel: "claude-sonnet-4-6",
+		LiteModel:    "claude-haiku-4-5",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	// Capture the raw body too so we can assert the API keys never appear in
+	// the response at all — the JSON shape has no api_key field, only the
+	// has_api_key boolean.
+	w := doJSON(t, srv, http.MethodGet, "/api/config/endpoints", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/config/endpoints = %d: %s", w.Code, w.Body.String())
+	}
+	raw := w.Body.String()
+	if strings.Contains(raw, "sk-main-12345678") || strings.Contains(raw, "sk-kimi") {
+		t.Errorf("response body leaks an API key: %s", raw)
+	}
+
+	var resp endpointsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode endpoints response: %v (body: %s)", err, w.Body.String())
+	}
+
+	// Two distinct (provider, base_url) groups → two endpoints. Both
+	// anthropic entries have empty base_url, so they aggregate by
+	// (anthropic, "") — the shared API key is NOT the grouping key (it's
+	// (provider, base_url) per design §4.1). The kimi entry has a distinct
+	// base_url, so it forms its own endpoint.
+	if len(resp.Endpoints) != 2 {
+		t.Fatalf("endpoints = %d, want 2 (one per distinct (provider, base_url)): %+v", len(resp.Endpoints), resp.Endpoints)
+	}
+
+	// Find the anthropic endpoint (two models) and the kimi endpoint (one).
+	var anthropicEP, kimiEP *endpointConfigJSON
+	for i := range resp.Endpoints {
+		switch resp.Endpoints[i].Provider {
+		case "anthropic":
+			anthropicEP = &resp.Endpoints[i]
+		case "kimi":
+			kimiEP = &resp.Endpoints[i]
+		}
+	}
+	if anthropicEP == nil || kimiEP == nil {
+		t.Fatalf("missing expected providers: %+v", resp.Endpoints)
+	}
+	if len(anthropicEP.Models) != 2 {
+		t.Errorf("anthropic endpoint models = %d, want 2: %+v", len(anthropicEP.Models), anthropicEP.Models)
+	}
+	if len(kimiEP.Models) != 1 {
+		t.Errorf("kimi endpoint models = %d, want 1: %+v", len(kimiEP.Models), kimiEP.Models)
+	}
+	// Vision flag is per-model and migrates from the flat entry.
+	var sonnetVision bool
+	for _, m := range anthropicEP.Models {
+		if m.Model == "claude-sonnet-4-6" {
+			sonnetVision = m.Vision
+		}
+	}
+	if !sonnetVision {
+		t.Errorf("claude-sonnet-4-6 vision = false, want true (migrated from flat entry)")
+	}
+
+	// default + lite are composite ids whose endpoint prefix is the synthesised
+	// legacy-<host>-<n> id.
+	if resp.Default == "" || !strings.Contains(resp.Default, "::") {
+		t.Errorf("default = %q, want a composite id <endpoint>::<model>", resp.Default)
+	}
+	if !strings.HasSuffix(resp.Default, "::claude-sonnet-4-6") {
+		t.Errorf("default = %q, want suffix ::claude-sonnet-4-6", resp.Default)
+	}
+	if resp.Lite == "" || !strings.HasSuffix(resp.Lite, "::claude-haiku-4-5") {
+		t.Errorf("lite = %q, want suffix ::claude-haiku-4-5", resp.Lite)
+	}
+	// default and lite should point at the same endpoint (anthropic group).
+	if strings.Split(resp.Default, "::")[0] != strings.Split(resp.Lite, "::")[0] {
+		t.Errorf("default endpoint %q != lite endpoint %q", strings.Split(resp.Default, "::")[0], strings.Split(resp.Lite, "::")[0])
+	}
+
+	// has_api_key reports presence; the response must NOT expose the key —
+	// there is no api_key field in the JSON shape at all, only the boolean.
+	if !anthropicEP.HasAPIKey {
+		t.Errorf("anthropic endpoint has_api_key = false, want true (key seeded)")
+	}
+	if !kimiEP.HasAPIKey {
+		t.Errorf("kimi endpoint has_api_key = false, want true (key seeded)")
+	}
+}
+
+// TestGetEndpoints_NoKeyReportsAbsent covers the key-missing side of
+// has_api_key so a frontend "未设置" badge is reachable.
+func TestGetEndpoints_NoKeyReportsAbsent(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Provider: "deepseek", Model: "deepseek-v4-pro"}, // no APIKey
+		},
+		DefaultModel: "deepseek-v4-pro",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	resp := getEndpointsResponse(t, srv)
+	if len(resp.Endpoints) != 1 {
+		t.Fatalf("endpoints = %d, want 1: %+v", len(resp.Endpoints), resp.Endpoints)
+	}
+	if resp.Endpoints[0].HasAPIKey {
+		t.Errorf("has_api_key = true, want false (no key seeded)")
+	}
+}
+
+// TestGetEndpoints_EmptyConfigReturnsEmptyShape pins the zero-config contract:
+// a fresh install (no models, no endpoints) returns an empty (but well-formed)
+// { endpoints: [], default: "", lite: "" } shape rather than a 404 or null.
+func TestGetEndpoints_EmptyConfigReturnsEmptyShape(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	resp := getEndpointsResponse(t, srv)
+	if resp.Endpoints == nil {
+		t.Fatal("endpoints = nil, want an empty non-null array")
+	}
+	if len(resp.Endpoints) != 0 {
+		t.Errorf("endpoints = %d, want 0: %+v", len(resp.Endpoints), resp.Endpoints)
+	}
+	if resp.Default != "" || resp.Lite != "" {
+		t.Errorf("empty config: default=%q lite=%q, want both empty", resp.Default, resp.Lite)
 	}
 }
 

--- a/internal/server/pr4b_review_composite_id_test.go
+++ b/internal/server/pr4b_review_composite_id_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/config"
+)
+
+// TestPR4b_Review_VerifyEntryByModelHandlesCompositeID is a regression guard
+// raised by an independent code review: the reviewer claimed EntryByModel only
+// matches bare model names, so applyChannelModel would silently fall back to
+// the default sender after a /model switch to a composite id. This test
+// verifies the reviewer's claim is FALSE — EntryByModel resolves composite ids
+// against c.Endpoints (PR2), so the binding round-trips.
+func TestPR4b_Review_VerifyEntryByModelHandlesCompositeID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	seed := config.Config{
+		Models: []config.ModelEntry{
+			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", APIKey: "sk-kimi"},
+		},
+		DefaultModel: "claude-sonnet-4-6",
+	}
+	if err := seed.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := config.Load()
+
+	// Find the composite id the way Resolve would produce it for kimi-k2.6.
+	var cid string
+	for _, ep := range cfg.Endpoints {
+		for _, m := range ep.Models {
+			if m.Model == "kimi-k2.6" {
+				cid = ep.CompositeID(m.Model)
+			}
+		}
+	}
+	if cid == "" || !strings.Contains(cid, "::") {
+		t.Fatalf("could not construct composite id for kimi-k2.6; got %q", cid)
+	}
+
+	// The reviewer claimed this returns !ok. It must return ok=true.
+	entry, ok := cfg.EntryByModel(cid)
+	if !ok {
+		t.Fatalf("EntryByModel(%q) = !ok, want ok=true — composite id must resolve (reviewer's C1 claim was wrong)", cid)
+	}
+	if entry.Model != "kimi-k2.6" {
+		t.Errorf("entry.Model = %q, want kimi-k2.6", entry.Model)
+	}
+	if entry.Provider != "kimi" {
+		t.Errorf("entry.Provider = %q, want kimi", entry.Provider)
+	}
+	if entry.BaseURL != "https://kimi.example" {
+		t.Errorf("entry.BaseURL = %q, want https://kimi.example", entry.BaseURL)
+	}
+	if entry.APIKey != "sk-kimi" {
+		t.Errorf("entry.APIKey = %q, want sk-kimi (must come from the endpoint)", entry.APIKey)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -822,6 +822,7 @@ func (s *Server) registerRoutes() {
 	s.api("POST /api/onboard/complete", s.handleOnboardComplete)
 	s.api("GET /api/providers", s.handleListProviders)
 	s.api("GET /api/config", s.handleGetConfig)
+	s.api("GET /api/config/endpoints", s.handleGetEndpoints)
 	s.api("PUT /api/config/show_reasoning", s.handlePutShowReasoning)
 	s.api("PUT /api/config/coauthor", s.handlePutCoauthor)
 	s.api("PUT /api/config/language", s.handlePutLanguage)
@@ -2130,24 +2131,44 @@ func (s *Server) buildChannelFactory() func() *agent.Agent {
 }
 
 // channelModelOps builds the ModelOps the channel manager's /model command
-// runs against: the configured model table for the no-argument listing, and a
-// resolver mapping a model id to a (cached) sender. "default" unbinds the
-// session back to the server's default sender, mirroring the web model
-// picker's "default" entry (handleUpdateSessionModel). Unknown ids are
-// rejected with the configured list — sending an unconfigured model name to
-// the current endpoint would hit the wrong protocol/base URL.
+// runs against: the configured endpoint+model table for the no-argument
+// listing (grouped by endpoint, PR4b design §12.2), and a resolver mapping a
+// model id to a (cached) sender. "default" unbinds the session back to the
+// server's default sender, mirroring the web model picker's "default" entry
+// (handleUpdateSessionModel). Unknown ids are rejected with the configured
+// list — sending an unconfigured model name to the current endpoint would hit
+// the wrong protocol/base URL.
+//
+// Resolve accepts three forms (design §5.4, §12.2):
+//   - "default" — unbind, ride the server default.
+//   - Composite id "<endpoint>::<model>" — precise; resolved via
+//     cfg.ParseModelFlag so a missing endpoint or model produces the exact
+//     "available: …" error.
+//   - Bare model "<model>" — legacy back-compat; goes through ParseModelFlag's
+//     default-priority path (default endpoint wins; ambiguous match picks
+//     the first with a warning).
+//
+// ModelResolution.BoundEntry is the composite id — it's what gets persisted
+// to the channel store so the binding survives restarts and round-trips
+// through applyChannelModel (which reads it back via EntryByModel, itself
+// composite-id-aware since PR2).
 func (s *Server) channelModelOps() *channel.ModelOps {
 	return &channel.ModelOps{
 		List: func() []channel.ModelInfo {
 			cfg, _ := config.LoadCached()
-			def := cfg.DefaultEntry()
-			infos := make([]channel.ModelInfo, 0, len(cfg.Models))
-			for _, e := range cfg.Models {
-				infos = append(infos, channel.ModelInfo{
-					Model:    e.Model,
-					Provider: e.Provider,
-					Default:  e.Model == def.Model,
-				})
+			infos := make([]channel.ModelInfo, 0, len(cfg.Endpoints))
+			for _, ep := range cfg.Endpoints {
+				for _, m := range ep.Models {
+					cid := ep.CompositeID(m.Model)
+					infos = append(infos, channel.ModelInfo{
+						EndpointID:   ep.ID,
+						EndpointName: ep.Name,
+						Model:        m.Model,
+						CompositeID:  cid,
+						Provider:     ep.Provider,
+						Default:      cid == cfg.Default,
+					})
+				}
 			}
 			return infos
 		},
@@ -2163,20 +2184,24 @@ func (s *Server) channelModelOps() *channel.ModelOps {
 			if err != nil {
 				return channel.ModelResolution{}, fmt.Errorf("loading config: %w", err)
 			}
-			entry, ok := cfg.EntryByModel(modelID)
-			if !ok {
-				available := make([]string, 0, len(cfg.Models))
-				for _, e := range cfg.Models {
-					available = append(available, e.Model)
-				}
-				sort.Strings(available)
-				return channel.ModelResolution{}, fmt.Errorf("model %q is not configured (available: %s)", modelID, strings.Join(available, ", "))
+			ep, m, perr := cfg.ParseModelFlag(modelID)
+			if perr != nil {
+				return channel.ModelResolution{}, perr
 			}
-			sender, err := s.cachedSenderForEntry(modelID, entry)
+			entry := config.ModelEntry{
+				Provider: ep.Provider,
+				Model:    m.Model,
+				BaseURL:  ep.BaseURL,
+				APIKey:   ep.APIKey,
+				Protocol: ep.Protocol,
+				Vision:   m.Vision,
+			}
+			cid := ep.CompositeID(m.Model)
+			sender, err := s.cachedSenderForEntry(cid, entry)
 			if err != nil {
 				return channel.ModelResolution{}, err
 			}
-			return channel.ModelResolution{Sender: sender, Model: entry.Model, BoundEntry: entry.Model}, nil
+			return channel.ModelResolution{Sender: sender, Model: m.Model, BoundEntry: cid}, nil
 		},
 	}
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -719,6 +719,34 @@ export async function getConfig(): Promise<ConfigResponse> {
   return request<ConfigResponse>('/api/config')
 }
 
+// PR4b (design §10.1): two-level endpoint view. Mirrors server endpointsResponse
+// (onboard_config_handlers.go). has_api_key is the only key-related field — the
+// server never echoes the key itself. models is the per-endpoint model list.
+// Read-only in PR4b; CRUD lands in PR5.
+export interface EndpointModel {
+  model: string
+  vision: boolean
+}
+export interface EndpointConfig {
+  id: string
+  name?: string
+  provider: string
+  base_url?: string
+  protocol?: string
+  has_api_key: boolean
+  lite_model?: string
+  models: EndpointModel[]
+}
+export interface EndpointsResponse {
+  endpoints: EndpointConfig[]
+  default?: string
+  lite?: string
+}
+
+export async function getEndpoints(): Promise<EndpointsResponse> {
+  return request<EndpointsResponse>('/api/config/endpoints')
+}
+
 export async function updateShowReasoning(showReasoning: boolean): Promise<{ ok: boolean; show_reasoning?: boolean }> {
   return request<{ ok: boolean; show_reasoning?: boolean }>('/api/config/show_reasoning', {
     method: 'PUT',

--- a/web/src/lib/i18n.endpoints.test.ts
+++ b/web/src/lib/i18n.endpoints.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { en, zh } from './i18n'
+
+// PR4b (design §15.1): the new settings.endpoints.* namespace must exist in
+// both en and zh with no missing keys. A missing key would render as the raw
+// key string in the UI, which is the regression this test guards against.
+//
+// This is the PR4b read-only subset of §15.1. The full table also lists
+// CRUD-related keys (add, delete, rename_confirm, error.*) that PR5 will add
+// when the write path lands. Don't assume §15.1 is fully covered just because
+// this test passes — extend ENDPOINT_KEYS in PR5.
+const ENDPOINT_KEYS = [
+  'settings.endpoints.title',
+  'settings.endpoints.empty',
+  'settings.endpoints.readonly_notice',
+  'settings.endpoints.id',
+  'settings.endpoints.name',
+  'settings.endpoints.provider',
+  'settings.endpoints.base_url',
+  'settings.endpoints.protocol',
+  'settings.endpoints.api_key',
+  'settings.endpoints.api_key.set',
+  'settings.endpoints.api_key.missing',
+  'settings.endpoints.lite_model',
+  'settings.endpoints.models',
+  'settings.endpoints.models.vision',
+  'settings.endpoints.badge.default',
+  'settings.endpoints.badge.lite',
+] as const
+
+describe('settings.endpoints.* i18n coverage', () => {
+  it.each(ENDPOINT_KEYS)('en has a non-empty string for %s', (key) => {
+    const v = en[key]
+    expect(typeof v).toBe('string')
+    expect(v.length).toBeGreaterThan(0)
+  })
+  it.each(ENDPOINT_KEYS)('zh has a non-empty string for %s', (key) => {
+    const v = zh[key]
+    expect(typeof v).toBe('string')
+    expect(v.length).toBeGreaterThan(0)
+  })
+  it('en and zh carry the same set of settings.endpoints.* keys', () => {
+    const enKeys = Object.keys(en).filter((k) => k.startsWith('settings.endpoints.')).sort()
+    const zhKeys = Object.keys(zh).filter((k) => k.startsWith('settings.endpoints.')).sort()
+    expect(zhKeys).toEqual(enKeys)
+  })
+})

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -595,6 +595,25 @@ export const en: Record<string, string> = {
   "settings.models.confirm_remove": "Remove this model?",
   "settings.models.modal_add": "Add Model",
   "settings.models.modal_edit": "Edit Model",
+
+  // PR4b (design §15.1): two-level endpoint display. Read-only for now —
+  // CRUD lands in PR5 alongside the Save format switch.
+  "settings.endpoints.title": "Channels",
+  "settings.endpoints.empty": "No channels configured. Run `octo config` to add one.",
+  "settings.endpoints.readonly_notice": "Read-only preview of the new two-level config. Editing lands in a later release.",
+  "settings.endpoints.id": "ID",
+  "settings.endpoints.name": "Display name",
+  "settings.endpoints.provider": "Provider",
+  "settings.endpoints.base_url": "Base URL",
+  "settings.endpoints.protocol": "Protocol",
+  "settings.endpoints.api_key": "API key",
+  "settings.endpoints.api_key.set": "Set",
+  "settings.endpoints.api_key.missing": "Missing",
+  "settings.endpoints.lite_model": "Lite model",
+  "settings.endpoints.models": "Models",
+  "settings.endpoints.models.vision": "Vision",
+  "settings.endpoints.badge.default": "Default",
+  "settings.endpoints.badge.lite": "Lite",
 };
 
 export const zh: Record<string, string> = {
@@ -1188,6 +1207,24 @@ export const zh: Record<string, string> = {
   "settings.models.confirm_remove": "删除该模型？",
   "settings.models.modal_add": "添加模型",
   "settings.models.modal_edit": "编辑模型",
+
+  // PR4b (design §15.1)：渠道两级展示。只读——CRUD 在 PR5 写路径切换时再上。
+  "settings.endpoints.title": "渠道",
+  "settings.endpoints.empty": "暂未配置渠道，运行 `octo config` 添加一个。",
+  "settings.endpoints.readonly_notice": "新两级配置的只读预览，编辑能力会在后续版本提供。",
+  "settings.endpoints.id": "ID",
+  "settings.endpoints.name": "显示名称",
+  "settings.endpoints.provider": "厂商",
+  "settings.endpoints.base_url": "接口地址",
+  "settings.endpoints.protocol": "协议",
+  "settings.endpoints.api_key": "API 密钥",
+  "settings.endpoints.api_key.set": "已设置",
+  "settings.endpoints.api_key.missing": "未设置",
+  "settings.endpoints.lite_model": "轻量模型",
+  "settings.endpoints.models": "模型",
+  "settings.endpoints.models.vision": "视觉",
+  "settings.endpoints.badge.default": "默认",
+  "settings.endpoints.badge.lite": "轻量",
 };
 
 const dictionaries: Record<string, Record<string, string>> = { en, zh };

--- a/web/src/views/SettingsView.svelte
+++ b/web/src/views/SettingsView.svelte
@@ -11,7 +11,7 @@
   import { getMode, setMode, type ThemeMode } from '../lib/theme'
   import { notificationsEnabled, setNotificationsEnabled } from '../lib/notifications'
   import * as api from '../lib/api'
-  import type { ModelEntry, ProviderPreset, ModelConfigInput } from '../lib/api'
+  import type { ModelEntry, ProviderPreset, ModelConfigInput, EndpointConfig } from '../lib/api'
 
   // --- local state ---
   let language      = $state('en')
@@ -56,6 +56,16 @@
   let editingModel = $state<ModelEntry | null>(null)
   let busyModelId  = $state<string | null>(null)
   let modelModalEl = $state<HTMLDivElement | null>(null)
+
+  // ── Endpoints section (PR4b: two-level read-only preview) ──────────────────
+  // Mirrors GET /api/config/endpoints. The two-level shape (channel cards with
+  // their model lists) is the future of this page, but PR4b ships it read-only —
+  // the write path (CRUD on endpoints) lands in PR5 alongside the Save format
+  // switch. The existing flat "AI Models" section below remains the editing
+  // surface until then.
+  let endpoints     = $state<EndpointConfig[]>([])
+  let defaultCid    = $state('')
+  let liteCid       = $state('')
 
   // Focus trap so Esc doesn't leak past the modal (#1112).
   $effect(() => {
@@ -189,6 +199,20 @@
       // choice. Language still seeds from config when present.
       if (cfg.language)   language = cfg.language
       origLanguage = language
+
+      // PR4b: load the two-level endpoint view in parallel. Failure is non-fatal
+      // — the read-only Channels section just renders empty and the existing
+      // flat Models section still carries the editing surface.
+      try {
+        const ep = await api.getEndpoints()
+        endpoints = ep.endpoints ?? []
+        defaultCid = ep.default ?? ''
+        liteCid = ep.lite ?? ''
+      } catch {
+        endpoints = []
+        defaultCid = ''
+        liteCid = ''
+      }
     } catch (e: any) {
       showToast(`Failed to load config: ${e.message}`, 'error')
     } finally {
@@ -345,6 +369,55 @@
     {#if loading}
       <div class="loading-state">{$t('settings.loading')}</div>
     {:else}
+      <!-- Channels (PR4b: two-level read-only preview) -->
+      <div class="section-card">
+        <div class="section-head">
+          <span class="section-title-inline">{$t('settings.endpoints.title')}</span>
+        </div>
+        <div class="endpoints-notice">{$t('settings.endpoints.readonly_notice')}</div>
+        {#if endpoints.length === 0}
+          <div class="models-empty">{$t('settings.endpoints.empty')}</div>
+        {:else}
+          {#each endpoints as ep (ep.id)}
+            <div class="endpoint-card">
+              <div class="endpoint-head">
+                <div class="endpoint-title-line">
+                  <span class="endpoint-id mono">{ep.id}</span>
+                  {#if ep.name}<span class="endpoint-name">{ep.name}</span>{/if}
+                </div>
+                <div class="endpoint-meta mono">
+                  <span>{ep.provider}</span>
+                  {#if ep.base_url}<span> · {ep.base_url}</span>{/if}
+                  {#if ep.protocol}<span> · {ep.protocol}</span>{/if}
+                </div>
+                <div class="endpoint-key">
+                  {#if ep.has_api_key}
+                    <span class="key-set">{$t('settings.endpoints.api_key')}: {$t('settings.endpoints.api_key.set')}</span>
+                  {:else}
+                    <span class="key-missing">{$t('settings.endpoints.api_key')}: {$t('settings.endpoints.api_key.missing')}</span>
+                  {/if}
+                </div>
+              </div>
+              <div class="endpoint-models">
+                <div class="endpoint-models-head">{$t('settings.endpoints.models')}</div>
+                {#each ep.models as m (m.model)}
+                  <div class="endpoint-model-row">
+                    <span class="mono">{ep.id}::{m.model}</span>
+                    {#if m.vision}<span class="vision-tag">{$t('settings.endpoints.models.vision')}</span>{/if}
+                    {#if defaultCid === `${ep.id}::${m.model}`}
+                      <StatusTag status="success">{$t('settings.endpoints.badge.default')}</StatusTag>
+                    {/if}
+                    {#if liteCid === `${ep.id}::${m.model}`}
+                      <StatusTag status="info">{$t('settings.endpoints.badge.lite')}</StatusTag>
+                    {/if}
+                  </div>
+                {/each}
+              </div>
+            </div>
+          {/each}
+        {/if}
+      </div>
+
       <!-- AI Models (config-level entries) -->
       <div class="section-card">
         <div class="section-head">
@@ -577,6 +650,39 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
   padding: 14px 24px; border-bottom: 1px solid var(--border-table);
 }
 .section-title-inline { font-size: 16px; font-weight: 600; color: var(--text-heading); }
+
+/* ── Channels section (PR4b two-level read-only) ───────────────────────────── */
+.endpoints-notice {
+  padding: 10px 24px; font-size: 12px; color: var(--text-tertiary);
+  background: var(--bg-subtle, rgba(0,0,0,0.02));
+  border-bottom: 1px solid var(--border-table);
+}
+.endpoint-card {
+  padding: 14px 24px; border-bottom: 1px solid var(--border-table);
+}
+.endpoint-card:last-child { border-bottom: none; }
+.endpoint-head { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
+.endpoint-title-line { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.endpoint-id { font-size: 14px; font-weight: 600; color: var(--text); }
+.endpoint-name { font-size: 13px; color: var(--text-secondary); }
+.endpoint-meta { font-size: 12px; color: var(--text-tertiary); display: flex; flex-wrap: wrap; }
+.endpoint-key { font-size: 12px; }
+.endpoint-key .key-set { color: var(--green-6, #16a34a); }
+.endpoint-key .key-missing { color: var(--red-6, #dc2626); }
+.endpoint-models { margin-top: 6px; padding-left: 12px; border-left: 2px solid var(--border-table); }
+.endpoint-models-head {
+  font-size: 12px; color: var(--text-tertiary);
+  text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 4px;
+}
+.endpoint-model-row {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding: 4px 0; font-size: 13px; color: var(--text);
+}
+.vision-tag {
+  font-size: 11px; padding: 1px 6px; border-radius: 4px;
+  background: var(--bg-subtle, rgba(0,0,0,0.04)); color: var(--text-tertiary);
+}
+
 .btn-add {
   height: 30px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container);
   border-radius: 6px; display: flex; align-items: center; gap: 6px;


### PR DESCRIPTION
## Summary

The read-path UI layer for the two-level endpoint grouping introduced in PR1-3 (#1610 / #1613 / #1617). PR4a (Save write-path switch) was cancelled — it required a coordinated migration of every code path that mutates `Models` (`SetDefaultEntry`/`SetEntry`/`octo config` wizard/`octo doctor`/`octo config --fix`/`--model --default`), so it's deferred to PR5. **PR4b ships only the read path**: three UIs render the two-level endpoint → model shape, a new read API serves it, and the write path still writes the legacy flat `models:` form so existing callers keep working.

Design doc: `dev-docs/endpoint-design.md` (§10.1, §12.1, §12.2, §12.3, §15.1).

## Key constraint

PR4b's UI is **read-only** — the backend `Save` still writes the flat `models:` format (PR5 switches the write path). Users who edit endpoints in the new Web Channels section and save would lose changes; the existing flat AI Models section remains the editing surface until PR5. The new section is a preview of the two-level future.

## Slices

### 1. `GET /api/config/endpoints` (read API)
`internal/server/onboard_config_handlers.go` + route registration. Returns `{endpoints, default, lite}`. Each endpoint carries `id/name/provider/base_url/protocol/has_api_key/lite_model/models`. **Security**: the JSON shape has no `api_key` field — only the boolean `has_api_key`. Legacy `GET /api/config` is unchanged.

### 2. TUI picker two-level
`cmd/octo/tuirepl{,_view}.go`. `modelPicker` gains `endpoints []pickerEndpoint` + `epIdx`. `←→` cycles endpoints, `↑↓` cycles models within the focused endpoint, `Enter` dispatches the composite id `<endpoint>::<model>` (so `dispatchModel → ensureSender → EntryByModel` resolves the right endpoint's connection params, PR2). The non-focused endpoints collapse to a header line so the overlay stays short. Cursor positioning prefers the default endpoint when the active model is a bare name living under multiple endpoints (mirrors `ParseModelFlag`'s step 2a).

### 3. IM `/model` grouped output
`internal/channel/manager.go` + `internal/server/server.go`. `ModelInfo` gains `EndpointID/EndpointName/CompositeID`. `modelListReply` groups models under their endpoint header and shows the composite id as the switch argument; "current" is keyed off the persisted binding (`sess.AppliedModelConfig`, a composite id) rather than the bare model on the agent, so the same model on two endpoints doesn't get double-marked. `channelModelOps().Resolve` now goes through `cfg.ParseModelFlag` so it accepts both composite ids (precise) and bare models (default-priority + scan, with a warning on ambiguity). `ModelResolution.BoundEntry` is the composite id; it round-trips through `applyChannelModel` (which reads it via `EntryByModel`, composite-id-aware since PR2). IM text stays English — the channel package's IM command surface is English-only today; a uniform IM i18n pass is a separate PR.

### 4. Web settings page two-level read-only + i18n
`web/src/views/SettingsView.svelte` + `web/src/lib/{api,i18n}.ts`. New "Channels" section above the existing flat AI Models editor: each endpoint renders as a card with id/name/provider/base_url/key status + its model list (composite ids shown, default/lite/vision tagged). i18n adds `settings.endpoints.*` to `en` + `zh` (§15.1 PR4b subset; CRUD keys like `add`/`delete`/`rename_confirm`/`error.*` land in PR5). `webdist` build artifacts stay gitignored (PR #1595) — only `web/src/` is committed.

## Tests

- **Go**: `TestGetEndpoints_{ReturnsTwoLevelShape,NoKeyReportsAbsent,EmptyConfigReturnsEmptyShape}`; `TestModelPicker_TwoLevelEndpointSwitch` + rewritten picker tests for the two-level shape; `TestCmdModel_ListGroupsByEndpoint`; `TestChannelModelOps_Resolve` updated for composite id; `TestPR4b_Review_VerifyEntryByModelHandlesCompositeID` pins the round-trip invariant an independent code review mis-flagged.
- **Web**: `i18n.endpoints.test.ts` asserts every `settings.endpoints.*` key exists in `en` + `zh` with non-empty string values, and that the two dictionaries carry the same key set.
- All existing tests in `internal/config`, `internal/channel`, `internal/server`, `cmd/octo`, and `web/` still pass.

## Code review

An independent sub-agent review surfaced one 🔴 critical claim (C1: "`EntryByModel` doesn't handle composite ids, so IM `/model` bindings would be lost across turns") — **refuted**: `EntryByModel` at `config.go:614` runs `splitCompositeID` first and resolves against `c.Endpoints`; the reviewer read only the bare-model fallback at line 644. Added `TestPR4b_Review_VerifyEntryByModelHandlesCompositeID` to lock the invariant.

Valid findings fixed in this PR:
- I1: `/model` listing "current" mark was keyed off the bare `sess.Agent.Model`, which double-marks the same model across endpoints. Re-keyed off `sess.AppliedModelConfig` (the composite-id binding).
- I3: TUI picker cursor on a bare active model living under multiple endpoints picked the first in config order; now prefers the default endpoint.
- I4: Web endpoint card had a redundant Default badge at the header level; removed (the per-model badge is enough).
- I5: Misleading test comment about the grouping key; corrected to `(provider, base_url)`.

Deferred:
- I2: TUI picker's `items`/`idx` alias of `endpoints[epIdx].items` is a mild footgun but keeps existing tests' shape; left as tech debt with a comment.

## Next

PR5 will switch `Save` to write the `endpoints:` block, migrate every `Models`-mutating callsite (`SetDefaultEntry`/`SetEntry`/`octo config`/`octo doctor`/`octo config --fix`/`--model --default`), and replace the flat AI Models section with editable two-level CRUD (adding the remaining §15.1 i18n keys: `add`/`delete`/`rename_confirm`/`error.*`).
