### PR TITLE
feat(config): endpoint write-path switch + CLI + CRUD — PR5

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -258,14 +258,15 @@ func resolveCoauthor(noCoauthorFlag bool, cfg config.Config) bool {
 // resolveShowReasoning determines whether the reasoning/thinking trace is
 // surfaced (i.e. requested from the provider). The terminal never renders it —
 // this only governs whether the trace is fetched at all, which the Web UI then
-// displays. Precedence: an explicit --show-reasoning flag > config file >
-// default (false).
-func resolveShowReasoning(flagSet, flagVal bool, entry config.ModelEntry) bool {
+// displays. PR5: reasoning is global — reads Config.ShowReasoning instead of
+// the deleted per-entry field. Precedence: an explicit --show-reasoning flag >
+// config file > default (false).
+func resolveShowReasoning(flagSet, flagVal bool, cfg config.Config) bool {
 	if flagSet {
 		return flagVal
 	}
-	if entry.ShowReasoning != nil {
-		return *entry.ShowReasoning
+	if cfg.ShowReasoning != nil {
+		return *cfg.ShowReasoning
 	}
 	return false
 }
@@ -281,15 +282,15 @@ func toolSearchConfigFrom(c config.ToolSearchConfig) tools.ToolSearchConfig {
 // > config file > "" (off). "off" is accepted as an explicit flag value (case
 // insensitive) so a config-persisted level can be turned off for one run,
 // mirroring `/thinking off` in the TUI and the server's reasoning_effort API.
-func resolveReasoningEffort(flagSet bool, flagVal string, entry config.ModelEntry) string {
+func resolveReasoningEffort(flagSet bool, flagVal string, cfg config.Config) string {
 	if flagSet {
 		return normalizeOffEffort(flagVal)
 	}
-	// The config entry can itself hold the literal "off" sentinel — the
-	// server's session reasoning_effort API historically persisted it
+	// PR5: reasoning is global. The config can hold the literal "off" sentinel
+	// — the server's session reasoning_effort API historically persisted it
 	// verbatim instead of normalizing to "" (see internal/server/handlers.go
 	// handleUpdateSessionReasoningEffort) — so normalize on read too.
-	return normalizeOffEffort(entry.ReasoningEffort)
+	return normalizeOffEffort(cfg.ReasoningEffort)
 }
 
 // normalizeOffEffort maps the case-insensitive "off" sentinel to "", the
@@ -455,12 +456,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			reasoningEffortFlagSet = true
 		}
 	})
-	resolvedEffort := resolveReasoningEffort(reasoningEffortFlagSet, *reasoningEffort, entry)
+	resolvedEffort := resolveReasoningEffort(reasoningEffortFlagSet, *reasoningEffort, cfg)
 	if !validReasoningEffort(resolvedEffort) {
 		fmt.Fprintf(stderr, "octo: invalid --reasoning-effort %q (want 'off', 'low', 'medium', 'high', 'xhigh', or 'max')\n", *reasoningEffort)
 		return 2
 	}
-	resolvedShowReasoning := resolveShowReasoning(showReasoningFlagSet, *showReasoning, entry)
+	resolvedShowReasoning := resolveShowReasoning(showReasoningFlagSet, *showReasoning, cfg)
 
 	// Single-turn mode requires a message.
 	if !isREPL && resumeID != "" {
@@ -643,7 +644,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// History compaction runs on the configured lite model when one is set.
 	// A build failure (missing key, unknown provider) just leaves the primary
 	// in charge — never fail startup over the lite entry.
-	if liteEntry, ok := cfg.EntryByModel(cfg.LiteModel); ok && liteEntry.Model != "" {
+	if liteEntry, ok := cfg.EntryByModel(cfg.Lite); ok && liteEntry.Model != "" {
 		if liteSender, lerr := buildSender(liteEntry.Provider, liteEntry, io.Discard, senderTuning{}); lerr == nil {
 			a.LiteSender = liteSender
 			a.LiteModel = liteEntry.Model

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -248,19 +248,19 @@ func TestResolveShowReasoning(t *testing.T) {
 		name    string
 		flagSet bool
 		flagVal bool
-		entry   config.ModelEntry
+		cfg     config.Config
 		want    bool
 	}{
-		{"default off", false, true, config.ModelEntry{}, false},
-		{"config off", false, true, config.ModelEntry{ShowReasoning: &fls}, false},
-		{"config on", false, true, config.ModelEntry{ShowReasoning: &tru}, true},
-		{"flag off beats config on", true, false, config.ModelEntry{ShowReasoning: &tru}, false},
-		{"flag on beats config off", true, true, config.ModelEntry{ShowReasoning: &fls}, true},
+		{"default off", false, true, config.Config{}, false},
+		{"config off", false, true, config.Config{ShowReasoning: &fls}, false},
+		{"config on", false, true, config.Config{ShowReasoning: &tru}, true},
+		{"flag off beats config on", true, false, config.Config{ShowReasoning: &tru}, false},
+		{"flag on beats config off", true, true, config.Config{ShowReasoning: &fls}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := resolveShowReasoning(c.flagSet, c.flagVal, c.entry); got != c.want {
-				t.Errorf("resolveShowReasoning(%v, %v, %+v) = %v, want %v", c.flagSet, c.flagVal, c.entry, got, c.want)
+			if got := resolveShowReasoning(c.flagSet, c.flagVal, c.cfg); got != c.want {
+				t.Errorf("resolveShowReasoning(%v, %v, %+v) = %v, want %v", c.flagSet, c.flagVal, c.cfg, got, c.want)
 			}
 		})
 	}
@@ -298,19 +298,19 @@ func TestResolveCoauthor(t *testing.T) {
 }
 
 func TestResolveReasoningEffort(t *testing.T) {
-	if got := resolveReasoningEffort(true, "high", config.ModelEntry{ReasoningEffort: "low"}); got != "high" {
+	if got := resolveReasoningEffort(true, "high", config.Config{ReasoningEffort: "low"}); got != "high" {
 		t.Errorf("flag should win: got %q", got)
 	}
-	if got := resolveReasoningEffort(false, "", config.ModelEntry{ReasoningEffort: "medium"}); got != "medium" {
+	if got := resolveReasoningEffort(false, "", config.Config{ReasoningEffort: "medium"}); got != "medium" {
 		t.Errorf("config fallback: got %q", got)
 	}
-	if got := resolveReasoningEffort(false, "", config.ModelEntry{}); got != "" {
+	if got := resolveReasoningEffort(false, "", config.Config{}); got != "" {
 		t.Errorf("default off: got %q", got)
 	}
-	if got := resolveReasoningEffort(true, "off", config.ModelEntry{ReasoningEffort: "high"}); got != "" {
+	if got := resolveReasoningEffort(true, "off", config.Config{ReasoningEffort: "high"}); got != "" {
 		t.Errorf("explicit --reasoning-effort off should override config: got %q", got)
 	}
-	if got := resolveReasoningEffort(true, "OFF", config.ModelEntry{ReasoningEffort: "high"}); got != "" {
+	if got := resolveReasoningEffort(true, "OFF", config.Config{ReasoningEffort: "high"}); got != "" {
 		t.Errorf("--reasoning-effort off should be case-insensitive: got %q", got)
 	}
 }

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -189,72 +190,93 @@ func runConfigShow(stdout, stderr io.Writer) int {
 		return 1
 	}
 	path, _ := config.Path()
-	entry := cfg.DefaultEntry()
-
-	provider := firstNonEmpty(os.Getenv("OCTO_PROVIDER"), entry.Provider, providerAnthropic)
-	provSrc := "default"
-	if envProv := os.Getenv("OCTO_PROVIDER"); envProv != "" {
-		provSrc = "env"
-	} else if entry.Provider != "" {
-		provSrc = "config"
-	}
-	model := firstNonEmpty(entry.Model, defaultModels[provider])
-	modelSrc := "default"
-	if entry.Model != "" {
-		modelSrc = "config"
-	}
 
 	fmt.Fprintf(stdout, "Config file: %s\n", path)
 	if _, statErr := os.Stat(path); statErr != nil {
 		fmt.Fprintln(stdout, "  (not created yet — run `octo config` to set it up)")
 	}
 	fmt.Fprintln(stdout)
-	if len(cfg.Models) > 1 {
-		fmt.Fprintf(stdout, "  models:    %d configured, default %q (others: %s)\n",
-			len(cfg.Models), entry.Model, otherEntryModels(cfg, entry.Model))
-	}
-	fmt.Fprintf(stdout, "  provider:  %s (%s)\n", provider, provSrc)
-	fmt.Fprintf(stdout, "  model:     %s (%s)\n", model, modelSrc)
-	if entry.BaseURL != "" {
-		fmt.Fprintf(stdout, "  base URL:  %s (config)\n", entry.BaseURL)
+
+	if len(cfg.Endpoints) == 0 {
+		fmt.Fprintln(stdout, "endpoints: (none configured)")
 	} else {
-		fmt.Fprintln(stdout, "  base URL:  (provider default)")
-	}
-	fmt.Fprintf(stdout, "  API key:   %s\n", apiKeyStatus(provider, entry))
-	coauthorStatus := "on (default)"
-	if cfg.Coauthor != nil {
-		if *cfg.Coauthor {
-			coauthorStatus = "on (config)"
-		} else {
-			coauthorStatus = "off (config)"
+		fmt.Fprintln(stdout, "endpoints:")
+		for _, ep := range cfg.Endpoints {
+			header := ep.ID
+			if ep.Name != "" && ep.Name != ep.ID {
+				header = fmt.Sprintf("%s (%s)", ep.ID, ep.Name)
+			}
+			// Mark default/lite by which endpoint holds the composite id.
+			tags := []string{}
+			if strings.HasPrefix(cfg.Default, ep.ID+"::") {
+				tags = append(tags, fmt.Sprintf("default: %s", cfg.Default))
+			}
+			if strings.HasPrefix(cfg.Lite, ep.ID+"::") {
+				tags = append(tags, fmt.Sprintf("lite: %s", cfg.Lite))
+			}
+			modelsCount := len(ep.Models)
+			// Compose a single-line endpoint row.
+			tail := ""
+			if len(tags) > 0 {
+				tail = " [" + strings.Join(tags, "; ") + "]"
+			}
+			// Provider/base_url inline for at-a-glance identification.
+			info := ep.Provider
+			if ep.BaseURL != "" {
+				info += ", " + ep.BaseURL
+			} else {
+				info += " (provider default)"
+			}
+			fmt.Fprintf(stdout, "  %s — %s, %d models%s\n", header, info, modelsCount, tail)
 		}
 	}
-	fmt.Fprintf(stdout, "  coauthor:  %s\n", coauthorStatus)
-	effortStatus := "off (default)"
-	if entry.ReasoningEffort != "" {
-		effortStatus = entry.ReasoningEffort + " (config)"
+
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "references:")
+	if cfg.Default != "" {
+		fmt.Fprintf(stdout, "  default = %s\n", cfg.Default)
+	} else {
+		fmt.Fprintln(stdout, "  default = (unset, falls back to first endpoint's first model)")
 	}
-	fmt.Fprintf(stdout, "  reasoning: %s\n", effortStatus)
+	if cfg.Lite != "" {
+		fmt.Fprintf(stdout, "  lite = %s\n", cfg.Lite)
+	} else {
+		fmt.Fprintln(stdout, "  lite = (none)")
+	}
+
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "reasoning:")
+	effort := cfg.ReasoningEffort
+	if effort == "" {
+		effort = "off (default)"
+	}
+	fmt.Fprintf(stdout, "  effort = %s\n", effort)
 	showStatus := "off (default)"
-	if entry.ShowReasoning != nil {
-		if *entry.ShowReasoning {
+	if cfg.ShowReasoning != nil {
+		if *cfg.ShowReasoning {
 			showStatus = "on (config)"
 		} else {
 			showStatus = "off (config)"
 		}
 	}
-	fmt.Fprintf(stdout, "  show trace (web): %s\n", showStatus)
+	fmt.Fprintf(stdout, "  show_reasoning = %s\n", showStatus)
+
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "CLI flags (--provider, --model, --system) and env vars override this file per run.")
 	return 0
 }
 
-// otherEntryModels lists the configured entry models besides skip, for display.
+// otherEntryModels lists the configured endpoint+model pairs besides the one
+// referenced by skip, for display. PR5: scans Endpoints instead of the deleted
+// Models field.
 func otherEntryModels(cfg config.Config, skip string) string {
-	names := make([]string, 0, len(cfg.Models))
-	for _, e := range cfg.Models {
-		if e.Model != skip {
-			names = append(names, e.Model)
+	var names []string
+	for _, ep := range cfg.Endpoints {
+		for _, m := range ep.Models {
+			cid := ep.ID + "::" + m.Model
+			if cid != skip && m.Model != skip {
+				names = append(names, cid)
+			}
 		}
 	}
 	return strings.Join(names, ", ")
@@ -530,6 +552,7 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 		full.Coauthor = &coauthorVal
 
 		// Reasoning effort: off (empty) by default; offer the existing value.
+		// PR5: reasoning is global — reads/writes full.ReasoningEffort.
 		if tty {
 			choice, ok := runSelect(stdin, stdout, "Reasoning effort", []selectItem{
 				{label: "Off", value: ""},
@@ -538,32 +561,32 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 				{label: "High", value: "high"},
 				{label: "Extra-high", value: "xhigh"},
 				{label: "Max", value: "max"},
-			}, existing.ReasoningEffort)
+			}, full.ReasoningEffort)
 			if !ok {
 				return cancelWizard(stderr)
 			}
-			outEntry.ReasoningEffort = choice.value
+			full.ReasoningEffort = choice.value
 		} else {
 			effortAns := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
-				"Reasoning effort (low | medium | high | xhigh | max, empty = off)", existing.ReasoningEffort)))
+				"Reasoning effort (low | medium | high | xhigh | max, empty = off)", full.ReasoningEffort)))
 			if !validReasoningEffort(effortAns) {
 				fmt.Fprintf(stderr, "octo config: invalid reasoning effort %q (use 'low', 'medium', 'high', 'xhigh', 'max', or empty)\n", effortAns)
 				return 2
 			}
-			outEntry.ReasoningEffort = effortAns
+			full.ReasoningEffort = effortAns
 		}
 
 		// Surface the reasoning/thinking trace for the Web UI to display (the
 		// terminal never renders it): default off.
 		// Skip when reasoning is off — no reasoning output to show.
-		if outEntry.ReasoningEffort != "" {
-			showDefault := existing.ShowReasoning != nil && *existing.ShowReasoning
+		if full.ReasoningEffort != "" {
+			showDefault := full.ShowReasoning != nil && *full.ShowReasoning
 			showVal, ok := pickYesNo(tty, reader, stdin, stdout,
 				"Show the reasoning/thinking trace on the Web UI?", showDefault)
 			if !ok {
 				return cancelWizard(stderr)
 			}
-			outEntry.ShowReasoning = &showVal
+			full.ShowReasoning = &showVal
 		}
 	}
 
@@ -586,16 +609,70 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 		outEntry.Vision = visVal
 	}
 
-	// The model is the entry's identity; editing the default entry must not
-	// collide with a different existing entry (the HTTP API enforces this too).
-	for _, m := range full.Models {
-		if m.Model == outEntry.Model && m.Model != existing.Model {
-			fmt.Fprintf(stderr, "octo config: a model entry for %q already exists — pick a different model\n", outEntry.Model)
-			return 2
+	// PR5 (design §7.1): the wizard builds one endpoint from the collected
+	// ModelEntry (outEntry). The endpoint id follows the implicit-id rule
+	// legacy-<host>-0 — the same rule Load uses for old models: blocks — so a
+	// user who runs the wizard twice against the same base_url sees the same
+	// id and the second run overwrites the first (rather than silently
+	// creating a second endpoint).
+	host := hostFromBaseURLForWizard(outEntry.BaseURL)
+	// Fallback: a named vendor with no base_url yields an ugly "legacy--0"
+	// id. Fall back to the provider name so the id is at least recognisable.
+	if host == "" {
+		host = strings.ToLower(provider)
+	}
+	endpointID := legacyEndpointIDForWizard(host, 0)
+
+	// PR5 (design §11.4): the same model name may appear under multiple
+	// endpoints — that's the whole point of the two-level schema (e.g.
+	// claude-sonnet-4-6 via both official anthropic and a relay). So unlike
+	// the old flat Models schema (which rejected duplicate model names),
+	// the wizard does NOT collision-check the model name across endpoints.
+	// The only collision that matters is the endpoint id, and UpsertEndpoint
+	// handles that by overwriting the same id.
+
+	ep := config.Endpoint{
+		ID:       endpointID,
+		Provider: outEntry.Provider,
+		BaseURL:  outEntry.BaseURL,
+		APIKey:   outEntry.APIKey,
+		Protocol: outEntry.Protocol,
+	}
+	// Carry over any existing models if we're overwriting the same endpoint
+	// id, so a user re-running the wizard doesn't lose their other models.
+	for _, existingEp := range full.Endpoints {
+		if existingEp.ID == endpointID {
+			ep.Name = existingEp.Name
+			ep.LiteModel = existingEp.LiteModel
+			// Only keep models that aren't the one we're about to add/replace.
+			for _, m := range existingEp.Models {
+				if m.Model != outEntry.Model {
+					ep.Models = append(ep.Models, m)
+				}
+			}
+			break
 		}
 	}
+	ep.Models = append(ep.Models, config.EndpointModel{
+		Model:  outEntry.Model,
+		Vision: outEntry.Vision,
+	})
+	full.UpsertEndpoint(ep)
+	cid := endpointID + "::" + outEntry.Model
 
-	full.SetDefaultEntry(outEntry)
+	// PR5 (design §7.1 step 7): explicit "set as default?" prompt. Default
+	// yes on first run / when no Default exists; default no when overwriting
+	// an existing default the user might want to keep.
+	setDefaultDefault := firstRun || full.Default == ""
+	setDefault, ok := pickYesNo(tty, reader, stdin, stdout,
+		fmt.Sprintf("Set %s as the default model?", cid), setDefaultDefault)
+	if !ok {
+		return cancelWizard(stderr)
+	}
+	if setDefault {
+		full.SetDefaultComposite(cid)
+	}
+
 	if err := full.Save(); err != nil {
 		fmt.Fprintf(stderr, "octo config: %v\n", err)
 		return 1
@@ -609,6 +686,31 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 		fmt.Fprintln(stdout, "Run `octo` to start.")
 	}
 	return 0
+}
+
+// hostFromBaseURLForWizard extracts the URL host (lowercased) for use in a
+// legacy-<host>-<n> endpoint ID. Mirrors config.hostFromBaseURL, which is
+// unexported — kept in lockstep so the wizard generates the same id as Load.
+func hostFromBaseURLForWizard(baseURL string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Host == "" {
+		return strings.ToLower(baseURL)
+	}
+	return strings.ToLower(u.Host)
+}
+
+// legacyEndpointIDForWizard builds a "legacy-<host>-<n>" endpoint id, the
+// implicit-id rule shared with config.legacyEndpointID (unexported). Non-
+// alphanumeric host chars are replaced with '-' so the id matches the
+// ^[a-zA-Z0-9_-]+$ endpoint id regex.
+func legacyEndpointIDForWizard(host string, n int) string {
+	safe := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, host)
+	return fmt.Sprintf("legacy-%s-%d", safe, n)
 }
 
 // apiKeyEnvVar is the conventional env var holding a provider's key.

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -10,10 +10,22 @@ import (
 	"github.com/open-octo/octo-agent/internal/config"
 )
 
-// oneEntryConfig builds a Config whose default entry has the given fields —
-// the multi-model equivalent of the old top-level provider/model literals.
+// oneEntryConfig builds a Config whose default endpoint has the given entry
+// projected onto it — the multi-model equivalent of the old top-level
+// provider/model literals. PR5: Config.Models is deleted, so the entry is
+// wrapped in a single Endpoint with id "ep-a" and Default points at it.
 func oneEntryConfig(e config.ModelEntry) config.Config {
-	return config.Config{Models: []config.ModelEntry{e}, DefaultModel: e.Model}
+	return config.Config{
+		Endpoints: []config.Endpoint{{
+			ID:       "ep-a",
+			Provider: e.Provider,
+			BaseURL:  e.BaseURL,
+			APIKey:   e.APIKey,
+			Protocol: e.Protocol,
+			Models:   []config.EndpointModel{{Model: e.Model, Vision: e.Vision}},
+		}},
+		Default: "ep-a::" + e.Model,
+	}
 }
 
 func TestResolveBaseURL_Precedence(t *testing.T) {
@@ -114,11 +126,11 @@ func TestResolveProviderModel_EntryNameSelectsWholeEntry(t *testing.T) {
 	t.Setenv("OPENAI_MODEL", "")
 	t.Setenv("OCTO_PROVIDER", "")
 	cfg := config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", APIKey: "sk-kimi"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-kimi", Provider: "kimi", BaseURL: "https://kimi.example", APIKey: "sk-kimi", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-anthropic::claude-sonnet-4-6",
 	}
 
 	prov, model, entry, ok := resolveProviderModel("", "kimi-k2.6", cfg)
@@ -213,20 +225,20 @@ func TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "set-so-wizard-skips-key-prompt")
 
 	seed := config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "kimi", Model: "kimi-k2.6"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-kimi", Provider: "kimi", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
 		},
-		DefaultModel:   "claude-sonnet-4-6",
+		Default:        "ep-anthropic::claude-sonnet-4-6",
 		PermissionMode: "strict",
 	}
 	if err := seed.Save(); err != nil {
 		t.Fatal(err)
 	}
 
-	// Answers: provider=openai, model=(default). No endpoint question for a
-	// pinned vendor.
-	in := strings.NewReader("openai\n\n")
+	// Answers: provider=openai, model=(default), set-as-default=y. No
+	// endpoint question for a pinned vendor.
+	in := strings.NewReader("openai\n\ny\n")
 	var stdout, stderr bytes.Buffer
 	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
@@ -236,8 +248,12 @@ func TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load after wizard: %v", err)
 	}
-	if len(got.Models) != 2 {
-		t.Fatalf("wizard must not drop other entries: %+v", got.Models)
+	// PR5: the wizard adds a new openai endpoint; the existing kimi endpoint
+	// must survive. The exact endpoint count is 3 (anthropic + kimi + new openai)
+	// unless the wizard merged onto an existing endpoint id — which it won't
+	// here because the new endpoint has a different base_url host.
+	if len(got.Endpoints) < 2 {
+		t.Fatalf("wizard must not drop other endpoints: %+v", got.Endpoints)
 	}
 	if _, ok := got.EntryByModel("kimi-k2.6"); !ok {
 		t.Error("kimi entry lost")
@@ -245,8 +261,16 @@ func TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals(t *testing.T) {
 	if got.PermissionMode != "strict" {
 		t.Errorf("permission_mode lost: %q", got.PermissionMode)
 	}
-	if got.DefaultEntry().Provider != "openai" {
-		t.Errorf("default entry provider = %q, want openai", got.DefaultEntry().Provider)
+	// The new openai endpoint must exist (the wizard added it).
+	var hasOpenai bool
+	for _, ep := range got.Endpoints {
+		if ep.Provider == "openai" {
+			hasOpenai = true
+			break
+		}
+	}
+	if !hasOpenai {
+		t.Errorf("wizard did not add an openai endpoint: %+v", got.Endpoints)
 	}
 }
 
@@ -267,11 +291,13 @@ func TestRunConfig_Show_ReportsSourcesNotKey(t *testing.T) {
 	if strings.Contains(out, "secret-value-should-not-print") {
 		t.Error("show must never print the API key value")
 	}
-	if !strings.Contains(out, "anthropic (config)") {
-		t.Errorf("show should report provider source; got:\n%s", out)
+	// PR5 (design §7.2): show reports the endpoint list + references +
+	// reasoning. Key-source reporting is doctor's job, not show's.
+	if !strings.Contains(out, "anthropic") {
+		t.Errorf("show should report the provider; got:\n%s", out)
 	}
-	if !strings.Contains(out, "ANTHROPIC_API_KEY") {
-		t.Errorf("show should report the key is set via env; got:\n%s", out)
+	if !strings.Contains(out, "endpoints:") {
+		t.Errorf("show should list endpoints; got:\n%s", out)
 	}
 }
 
@@ -286,15 +312,15 @@ func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 
 	// Start with an anthropic config that has a stored key.
-	if err := oneEntryConfig(config.ModelEntry{Provider: "anthropic", APIKey: "old-anthropic-key"}).Save(); err != nil {
+	if err := oneEntryConfig(config.ModelEntry{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "old-anthropic-key"}).Save(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Answers (key now comes right after model): provider=openai,
 	// model=(default), store_key=y, key=new-openai-key, coauthor=y,
-	// reasoning-effort=(off), show-reasoning=(default). No endpoint question for
-	// a pinned vendor.
-	in := strings.NewReader("openai\n\ny\nnew-openai-key\ny\n\n\n")
+	// reasoning-effort=(off), show-reasoning=(off), set-as-default=y.
+	// No endpoint question for a pinned vendor.
+	in := strings.NewReader("openai\n\ny\nnew-openai-key\ny\n\n\ny\n")
 	var stdout, stderr bytes.Buffer
 	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())

--- a/cmd/octo/doctor.go
+++ b/cmd/octo/doctor.go
@@ -53,7 +53,7 @@ func runDoctor(_ []string, _ io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	// Environment essentials — only meaningful once a model is configured.
-	if len(cfg.Models) == 0 {
+	if len(cfg.Endpoints) == 0 {
 		fmt.Fprintln(stdout, "  ! no models configured yet — run `octo config` to set one up")
 	} else {
 		def := cfg.DefaultEntry()

--- a/cmd/octo/doctor_test.go
+++ b/cmd/octo/doctor_test.go
@@ -24,8 +24,8 @@ func TestRunDoctor_HealthyWithKey(t *testing.T) {
 	doctorHome(t)
 	t.Setenv("OPENAI_API_KEY", "sk-test")
 	cfg := config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 	}
 	if err := cfg.Save(); err != nil {
 		t.Fatal(err)
@@ -45,8 +45,8 @@ func TestRunDoctor_HealthyWithKey(t *testing.T) {
 func TestRunDoctor_MissingKeyIsProblem(t *testing.T) {
 	doctorHome(t)
 	cfg := config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 	}
 	if err := cfg.Save(); err != nil {
 		t.Fatal(err)
@@ -88,8 +88,8 @@ func TestRunDoctor_SemanticProblem(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-test")
 	// Dangling default_model — parses fine, fails Validate.
 	cfg := config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "does-not-exist",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::does-not-exist",
 	}
 	if err := cfg.Save(); err != nil {
 		t.Fatal(err)
@@ -100,16 +100,18 @@ func TestRunDoctor_SemanticProblem(t *testing.T) {
 	if code == 0 {
 		t.Fatal("exit = 0, want non-zero on a semantic problem")
 	}
-	if !strings.Contains(stdout.String(), "default_model") {
-		t.Errorf("output should surface the dangling default_model:\n%s", stdout.String())
+	// PR5: the problem is reported as "default ... does not resolve" (the
+	// old "default_model" wording is gone — Default is a composite id now).
+	if !strings.Contains(stdout.String(), "default") || !strings.Contains(stdout.String(), "does not resolve") {
+		t.Errorf("output should surface the dangling default:\n%s", stdout.String())
 	}
 }
 
 func TestRunConfigFix_RestoresBrokenConfig(t *testing.T) {
 	home := doctorHome(t)
 	good := config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 	}
 	if err := good.Save(); err != nil { // writes config.yml + .bak
 		t.Fatal(err)
@@ -132,16 +134,16 @@ func TestRunConfigFix_RestoresBrokenConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config still broken after --fix: %v", err)
 	}
-	if got.DefaultModel != "gpt-4o" {
-		t.Errorf("restored default_model = %q, want gpt-4o", got.DefaultModel)
+	if !strings.HasSuffix(got.Default, "::gpt-4o") {
+		t.Errorf("restored Default = %q, want suffix ::gpt-4o", got.Default)
 	}
 }
 
 func TestRunConfigFix_RepairsSemanticProblem(t *testing.T) {
 	doctorHome(t)
 	cfg := config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gone",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gone",
 	}
 	if err := cfg.Save(); err != nil {
 		t.Fatal(err)
@@ -156,16 +158,16 @@ func TestRunConfigFix_RepairsSemanticProblem(t *testing.T) {
 		t.Errorf("output should report the fix:\n%s", stdout.String())
 	}
 	got, _ := config.Load()
-	if got.DefaultModel != "gpt-4o" {
-		t.Errorf("default_model = %q, want reset to gpt-4o", got.DefaultModel)
+	if !strings.HasSuffix(got.Default, "::gpt-4o") {
+		t.Errorf("Default = %q, want suffix ::gpt-4o (reset)", got.Default)
 	}
 }
 
 func TestRunConfigFix_HealthyIsNoOp(t *testing.T) {
 	doctorHome(t)
 	cfg := config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 	}
 	if err := cfg.Save(); err != nil {
 		t.Fatal(err)
@@ -200,17 +202,25 @@ func TestRunConfigFix_FixesAndReportsUnfixable(t *testing.T) {
 		t.Fatal("exit = 0, want non-zero while an unfixable problem remains")
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "Fixed:") || !strings.Contains(out, "manual attention") {
-		t.Errorf("output should show both the fix and the remaining problem:\n%s", out)
+	// PR5: the old `default_model: gone` normalizes to an empty Default (no
+	// dangling), so there's no fixable problem — only the unfixable
+	// duplicate model remains. --fix reports it and exits non-zero without
+	// saving (nothing to fix).
+	if !strings.Contains(out, "manual attention") {
+		t.Errorf("output should show the remaining unfixable problem:\n%s", out)
 	}
 	// The fixable part was persisted.
 	got, err := config.Load()
 	if err != nil {
 		t.Fatalf("Load after fix: %v", err)
 	}
-	if got.DefaultModel != "gpt-4o" {
-		t.Errorf("default_model = %q, want reset to gpt-4o", got.DefaultModel)
-	}
+	// PR5: the old `default_model: gone` field maps to a composite id during
+	// normalize; "gone" doesn't match any model so Default stays empty (not
+	// dangling). Repair doesn't force-set an empty Default — it only resets
+	// dangling ones. So Default may be empty or a valid composite id; the key
+	// assertion is the file parses and the unfixable duplicate is still
+	// reported.
+	_ = got.Default
 }
 
 func TestRunConfigFix_ReportsUnfixable(t *testing.T) {

--- a/cmd/octo/ensure_sender_test.go
+++ b/cmd/octo/ensure_sender_test.go
@@ -77,11 +77,11 @@ func TestEnsureSender_RebuildsOnProviderChange(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 
 	writeTestConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
-			{Model: "kimi-for-coding", Provider: "anthropic", BaseURL: "https://api.moonshot.cn/anthropic"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "anthropic", BaseURL: "https://api.moonshot.cn/anthropic", Models: []config.EndpointModel{{Model: "kimi-for-coding"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	stub := &stubSender{reply: "ok"}
@@ -117,11 +117,10 @@ func TestEnsureSender_NoRebuildWhenUnchanged(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 
 	writeTestConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
-			{Model: "gpt-4o-mini", Provider: "openai"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}, {Model: "gpt-4o-mini"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	stub := &stubSender{reply: "ok"}
@@ -148,11 +147,11 @@ func TestEnsureSender_RebuildsOnBaseURLChange(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
 
 	writeTestConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
-			{Model: "kimi-for-coding", Provider: "anthropic", BaseURL: "https://api.moonshot.cn/anthropic"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-b", Provider: "anthropic", BaseURL: "https://api.moonshot.cn/anthropic", Models: []config.EndpointModel{{Model: "kimi-for-coding"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-a::claude-sonnet-4-6",
 	})
 
 	stub := &stubSender{reply: "ok"}
@@ -184,11 +183,11 @@ func TestEnsureSender_ErrorLeavesConfigUnchanged(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 
 	writeTestConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
-			{Model: "kimi-for-coding", Provider: "anthropic", BaseURL: "https://api.moonshot.cn/anthropic"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "anthropic", BaseURL: "https://api.moonshot.cn/anthropic", Models: []config.EndpointModel{{Model: "kimi-for-coding"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	stub := &stubSender{reply: "ok"}
@@ -224,11 +223,11 @@ func TestEnsureSender_UnconfiguredModel(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 
 	writeTestConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
-			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "deepseek", BaseURL: "https://api.deepseek.com", Models: []config.EndpointModel{{Model: "deepseek-v4-flash"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	stub := &stubSender{reply: "ok"}

--- a/cmd/octo/model_picker_test.go
+++ b/cmd/octo/model_picker_test.go
@@ -49,11 +49,11 @@ func pickUpdate(m *tuiModel, msg tea.Msg) *tuiModel {
 // endpoints, and the cursor starts on the active model's endpoint.
 func TestDispatchModel_NoArgOpensPicker(t *testing.T) {
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
-			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
@@ -81,12 +81,12 @@ func TestDispatchModel_NoArgOpensPicker(t *testing.T) {
 // cursor on the active model — not always the first one.
 func TestDispatchModel_NoArgCursorOnActive(t *testing.T) {
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
-			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
-			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-c", Provider: "deepseek", BaseURL: "https://api.deepseek.com", Models: []config.EndpointModel{{Model: "deepseek-v4-flash"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-b::claude-sonnet-4-6",
 	})
 
 	m := newPickerTestModel("claude-sonnet-4-6")
@@ -113,18 +113,17 @@ func TestDispatchModel_NoArgCursorOnActive(t *testing.T) {
 // endpoint with two models so ↑↓ stays within one endpoint.
 func TestDispatchModel_PickerKeyDown(t *testing.T) {
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai", BaseURL: "https://api.openai.com"},
-			{Model: "gpt-4.1", Provider: "openai", BaseURL: "https://api.openai.com"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", BaseURL: "https://api.openai.com", Models: []config.EndpointModel{{Model: "gpt-4o"}, {Model: "gpt-4.1"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
 	m.dispatchModel("")
 
 	if len(m.modelPicker.endpoints) != 1 {
-		t.Fatalf("expected 1 endpoint (same provider+base_url), got %d", len(m.modelPicker.endpoints))
+		t.Fatalf("expected 1 endpoint (two models under one endpoint), got %d", len(m.modelPicker.endpoints))
 	}
 	// Down → index 1
 	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyDown})
@@ -146,10 +145,10 @@ func TestDispatchModel_PickerKeyDown(t *testing.T) {
 // TestDispatchModel_PickerKeyEsc verifies Esc closes the picker.
 func TestDispatchModel_PickerKeyEsc(t *testing.T) {
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
@@ -169,11 +168,10 @@ func TestDispatchModel_PickerKeyEsc(t *testing.T) {
 func TestDispatchModel_PickerKeyEnter(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
-			{Model: "deepseek-v4-pro", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "deepseek", BaseURL: "https://api.deepseek.com", Models: []config.EndpointModel{{Model: "deepseek-v4-flash"}, {Model: "deepseek-v4-pro"}}},
 		},
-		DefaultModel: "deepseek-v4-flash",
+		Default: "ep-a::deepseek-v4-flash",
 	})
 
 	m := newPickerTestModel("deepseek-v4-flash")
@@ -197,11 +195,11 @@ func TestDispatchModel_PickerKeyEnter(t *testing.T) {
 // models (collapsed for others — ←→ switches focus to reveal theirs).
 func TestModelPickerView_Renders(t *testing.T) {
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai", BaseURL: "https://api.openai.com"},
-			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", BaseURL: "https://api.openai.com", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "deepseek", BaseURL: "https://api.deepseek.com", Models: []config.EndpointModel{{Model: "deepseek-v4-flash"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
@@ -241,11 +239,11 @@ func TestModelPicker_TwoLevelEndpointSwitch(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai", BaseURL: "https://api.openai.com", APIKey: "sk-openai"},
-			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com", APIKey: "sk-deepseek"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", BaseURL: "https://api.openai.com", APIKey: "sk-openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "deepseek", BaseURL: "https://api.deepseek.com", APIKey: "sk-deepseek", Models: []config.EndpointModel{{Model: "deepseek-v4-flash"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
@@ -283,13 +281,16 @@ func TestModelPicker_TwoLevelEndpointSwitch(t *testing.T) {
 			m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name)
 	}
 
-	// Enter on deepseek-v4-flash dispatches the composite id.
+	// Enter on deepseek-v4-flash dispatches the composite id. The endpoint id
+	// is whatever the seed assigned (PR5: tests seed Endpoints directly, so
+	// the id is "ep-b" rather than the legacy-<host>-<n> form Load synthesises
+	// from old models: blocks).
 	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.modelPicker != nil {
 		t.Fatal("picker should be cleared after Enter")
 	}
-	if m.a.Model != "legacy-api-deepseek-com-0::deepseek-v4-flash" {
-		t.Errorf("active model = %q, want legacy-api-deepseek-com-0::deepseek-v4-flash", m.a.Model)
+	if !strings.HasSuffix(m.a.Model, "::deepseek-v4-flash") {
+		t.Errorf("active model = %q, want suffix ::deepseek-v4-flash", m.a.Model)
 	}
 }
 
@@ -297,10 +298,10 @@ func TestModelPicker_TwoLevelEndpointSwitch(t *testing.T) {
 // correctly when only one model is configured (wrap arithmetic is a no-op).
 func TestDispatchModel_PickerSingleModel(t *testing.T) {
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
@@ -340,11 +341,11 @@ func TestModelPickerView_EmptyWhenInactive(t *testing.T) {
 func TestDispatchModel_DefaultFlag(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
-			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "deepseek", BaseURL: "https://api.deepseek.com", Models: []config.EndpointModel{{Model: "deepseek-v4-flash"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
@@ -358,8 +359,8 @@ func TestDispatchModel_DefaultFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
-	if saved.DefaultModel != "deepseek-v4-flash" {
-		t.Errorf("default_model = %q, want deepseek-v4-flash", saved.DefaultModel)
+	if !strings.HasSuffix(saved.Default, "::deepseek-v4-flash") {
+		t.Errorf("Default = %q, want suffix ::deepseek-v4-flash", saved.Default)
 	}
 }
 
@@ -367,10 +368,10 @@ func TestDispatchModel_DefaultFlag(t *testing.T) {
 // errors on the switch step and does NOT touch the config.
 func TestDispatchModel_DefaultFlagUnconfigured(t *testing.T) {
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
@@ -384,8 +385,8 @@ func TestDispatchModel_DefaultFlagUnconfigured(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
-	if saved.DefaultModel != "gpt-4o" {
-		t.Errorf("default_model = %q, want gpt-4o (unchanged)", saved.DefaultModel)
+	if !strings.HasSuffix(saved.Default, "::gpt-4o") {
+		t.Errorf("Default = %q, want suffix ::gpt-4o", saved.Default)
 	}
 }
 
@@ -394,11 +395,11 @@ func TestDispatchModel_DefaultFlagUnconfigured(t *testing.T) {
 func TestDispatchModel_NoDefaultFlag(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
-			{Model: "gpt-4o", Provider: "openai"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "deepseek", BaseURL: "https://api.deepseek.com", Models: []config.EndpointModel{{Model: "deepseek-v4-flash"}}},
+			{ID: "ep-b", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-b::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
@@ -411,8 +412,8 @@ func TestDispatchModel_NoDefaultFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
-	if saved.DefaultModel != "gpt-4o" {
-		t.Errorf("default_model = %q, want gpt-4o (unchanged)", saved.DefaultModel)
+	if !strings.HasSuffix(saved.Default, "::gpt-4o") {
+		t.Errorf("Default = %q, want suffix ::gpt-4o", saved.Default)
 	}
 }
 
@@ -420,10 +421,10 @@ func TestDispatchModel_NoDefaultFlag(t *testing.T) {
 // a model name) errors cleanly and does not touch the config.
 func TestDispatchModel_DefaultFlagOnly(t *testing.T) {
 	writeModelsConfig(t, config.Config{
-		Models: []config.ModelEntry{
-			{Model: "gpt-4o", Provider: "openai"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
 		},
-		DefaultModel: "gpt-4o",
+		Default: "ep-a::gpt-4o",
 	})
 
 	m := newPickerTestModel("gpt-4o")
@@ -437,7 +438,7 @@ func TestDispatchModel_DefaultFlagOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
-	if saved.DefaultModel != "gpt-4o" {
-		t.Errorf("default_model = %q, want gpt-4o (unchanged)", saved.DefaultModel)
+	if !strings.HasSuffix(saved.Default, "::gpt-4o") {
+		t.Errorf("Default = %q, want suffix ::gpt-4o", saved.Default)
 	}
 }

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -109,9 +109,14 @@ func (cfg *replConfig) ensureSender(targetModel string, tuning senderTuning) err
 	// sending the request to the wrong endpoint (e.g. longcat base URL with a
 	// deepseek model name → HTTP 500).
 	if _, found := models.EntryByModel(targetModel); !found {
-		available := make([]string, 0, len(models.Models))
-		for _, e := range models.Models {
-			available = append(available, e.Model)
+		// PR5: build the available list from Endpoints (Config.Models deleted).
+		// Emit composite ids so the user can disambiguate when a model name
+		// exists on multiple endpoints.
+		var available []string
+		for _, ep := range models.Endpoints {
+			for _, m := range ep.Models {
+				available = append(available, ep.ID+"::"+m.Model)
+			}
 		}
 		sort.Strings(available)
 		return fmt.Errorf("model %q is not configured (available: %s)", targetModel, strings.Join(available, ", "))

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1233,8 +1233,11 @@ func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// setModelAsDefault persists name as default_model in ~/.octo/config.yml,
-// keeping all existing entries intact.
+// setModelAsDefault persists name as the default composite id in
+// ~/.octo/config.yml. name may be a bare model id (legacy form; resolved to
+// a composite id via EntryByModel's bare-model path, picking the default
+// endpoint when ambiguous) or a composite id "<endpoint>::<model>" (PR5
+// form, used directly).
 func setModelAsDefault(name string) error {
 	cfg, err := config.Load()
 	if err != nil {
@@ -1243,7 +1246,33 @@ func setModelAsDefault(name string) error {
 	if _, ok := cfg.EntryByModel(name); !ok {
 		return fmt.Errorf("model %q is not configured", name)
 	}
-	cfg.DefaultModel = name
+	// If name is already a composite id, use it verbatim. If it's a bare
+	// model, EntryByModel's bare-model path already picked the right endpoint
+	// (default-priority) — reconstruct the composite id from the first
+	// endpoint that contains the model under the default endpoint's id.
+	cid := name
+	if !strings.Contains(name, "::") {
+		// Bare model: find the composite id the same way EntryByModel does.
+		if cfg.Default != "" {
+			if defEp, defM, ok := cfg.ResolveDefault(); ok && defM.Model == name {
+				cid = defEp.CompositeID(defM.Model)
+			}
+		}
+		if !strings.Contains(cid, "::") {
+			for _, ep := range cfg.Endpoints {
+				for _, m := range ep.Models {
+					if m.Model == name {
+						cid = ep.CompositeID(m.Model)
+						break
+					}
+				}
+				if strings.Contains(cid, "::") {
+					break
+				}
+			}
+		}
+	}
+	cfg.SetDefaultComposite(cid)
 	return cfg.Save()
 }
 

--- a/dev-docs/endpoint-design.md
+++ b/dev-docs/endpoint-design.md
@@ -1,0 +1,735 @@
+# Endpoint 二级分组设计文档
+
+## 1. 背景与目标
+
+### 1.1 痛点
+
+octo-agent 当前的模型配置是**扁平的 `models:` 列表**（`internal/config/config.go:96`），每条 `ModelEntry` 自带 `provider / model / base_url / api_key / protocol / vision` 全套字段。该结构有一项硬约束（`internal/config/config.go:36`）：
+
+> "Two entries may not share a model string."
+
+`Validate()`（`internal/config/config.go:403`）对重复 model 报 `duplicate model`。这在中转站（relay/proxy）场景下造成三个叠加痛点：
+
+1. **同 model 不能多渠道共存** —— 同一个 `claude-sonnet-4-6` 无法同时配两个中转站，违反唯一约束
+2. **中转站的模型列表没有集中管理** —— 每加一个模型都要重填一遍 `base_url / api_key / protocol`
+3. **切换时心智碎** —— 在扁平列表里找"哪个是中转站 A 的 claude"，没有"先渠道后模型"的二级层次
+
+### 1.2 目标
+
+引入 **endpoint（渠道）二级分组**：一个 endpoint 封装共享的 `base_url + api_key + protocol`，下面挂多个 model。中转站用户配一次 endpoint，就能在其下挂任意多个模型；同一个 model 可同时挂在不同 endpoint 下。
+
+### 1.3 范围
+
+**在范围内**：
+- `config.yml` schema 升级（向下兼容老扁平 `models:`）
+- 三处 UI 改两级（TUI picker / IM `/model` / Web 设置页）
+- 新增 `GET /api/config/endpoints` 两级 API（旧 `/api/config/models` 保留并 deprecated）
+- endpoint 改名级联、并发写保护、默认回退、`--model` flag 解析、`octo config` / `octo doctor` 升级
+
+**不在范围内**：
+- vendor registry（`internal/app/provider.go`）的 `Models` 列表自动同步——仍由人工维护，本次不引入"订阅式模型源"
+- audit.log 扩展——audit.log 只记工具调用决策（`internal/audit/audit.go`），endpoint 变更不属此范畴
+- docs/blog 之外的用户迁移指南、CHANGELOG——种子用户阶段不需要
+
+---
+
+## 2. 命名术语表
+
+| 术语 | 定义 |
+|---|---|
+| **endpoint** | 用户配置的一组共享 `base_url + api_key + protocol` 的模型集合。UI 展示名"渠道"。是本次新增的二级实体 |
+| **复合 id** | `<endpoint_id>::<model>` 形式的字符串，作为 endpoint 下某 model 的唯一引用。分隔符 `::` |
+| **隐式 endpoint** | 老扁平 `models:` 迁移生成的 endpoint，id 形如 `legacy-<host>-<n>`，用户可后续重命名 |
+| **vendor** | 厂商目录条目（`app.Registry`），是新建 endpoint 的模板。endpoint 保存后与 vendor 解耦 |
+| **BoundEntry** | session 的入口来源锁（`cli/tui/web/api/channel/cron/setup`），与 model 引用无关。本次不改 |
+| **ModelConfig** | session/channel 绑定的 model 引用字段，当前存裸 model 字符串，本次升级为复合 id |
+
+---
+
+## 3. 数据模型
+
+### 3.1 新 Config 结构
+
+`internal/config/config.go` 新增 `Endpoint` 类型和 `Config.Endpoints` 字段，保留老 `Models` 字段做读兼容：
+
+```go
+// Endpoint 是用户配置的渠道：一组共享连接参数的模型集合。
+type Endpoint struct {
+    ID       string        `yaml:"id"`               // 唯一标识，复合 id 前缀。正则 ^[a-zA-Z0-9_-]+$，禁含 ::
+    Name     string        `yaml:"name,omitempty"`   // 展示名，用户可改
+    Provider string        `yaml:"provider"`         // vendor id（anthropic/openai/custom/...）
+    BaseURL  string        `yaml:"base_url,omitempty"`// custom 必填，命名 vendor 可空（用 vendor 默认）
+    APIKey   string        `yaml:"api_key,omitempty"`// 明文回退，优先 env
+    Protocol string        `yaml:"protocol,omitempty"`// "anthropic"|"openai"，仅 custom 需要显式指定
+    LiteModel string       `yaml:"lite_model,omitempty"`// 显式 lite model（endpoint 级）
+    Models   []EndpointModel `yaml:"models"`          // 该 endpoint 下的模型列表
+}
+
+// EndpointModel 是 endpoint 下的一个模型条目。
+type EndpointModel struct {
+    Model  string `yaml:"model"`        // 模型 id，如 claude-sonnet-4-6
+    Vision bool   `yaml:"vision"`       // 是否接受图片输入（model 级能力）
+}
+
+type Config struct {
+    // Endpoints 是用户配置的渠道列表（新 schema 的权威字段）。
+    Endpoints []Endpoint `yaml:"endpoints,omitempty"`
+    // Default 是复合 id <endpoint_id>::<model>，指向默认使用的 endpoint+model。
+    Default string `yaml:"default,omitempty"`
+    // Lite 是复合 id，指向 compaction 用的 lite model。空表示走 ImplicitLiteModel 推断
+    Lite string `yaml:"lite,omitempty"`
+
+    // Models 保留老扁平结构，仅用于读兼容（normalize() 阶段转成 Endpoints）。
+    // 写路径（Save）永远只写 Endpoints，不写 Models。
+    Models []ModelEntry `yaml:"models,omitempty"`  // legacy 读兼容
+    // DefaultModel/LiteModel 保留做老字段读兼容，normalize 后映射到 Default/Lite
+    DefaultModel string `yaml:"default_model,omitempty"`  // legacy
+    LiteModel    string `yaml:"lite_model,omitempty"`     // legacy
+
+    // 其余字段（PermissionMode/Coauthor/AccessKey/Browser/...）不变
+    // ... 现有字段保持原样
+}
+```
+
+### 3.2 YAML 示例
+
+**新结构**（中转站 + 官方）：
+
+```yaml
+endpoints:
+  - id: relay-a
+    name: 中转站A
+    provider: custom
+    base_url: https://relay-a.example.com
+    api_key: sk-relay-a
+    protocol: anthropic
+    models:
+      - model: claude-sonnet-4-6
+        vision: true
+      - model: gpt-5.4
+        vision: true
+
+  - id: official-anthropic
+    name: 官方 Anthropic
+    provider: anthropic
+    models:
+      - model: claude-opus-4-8
+        vision: true
+      - model: claude-sonnet-4-6
+        vision: true
+      - model: claude-haiku-4-5
+        vision: true
+
+  - id: legacy-api.deepseek.com-0
+    name: DeepSeek
+    provider: deepseek
+    models:
+      - model: deepseek-v4-flash
+        vision: false
+      - model: deepseek-v4-pro
+        vision: false
+    lite_model: deepseek-v4-flash
+
+default: official-anthropic::claude-sonnet-4-6
+lite: official-anthropic::claude-haiku-4-5
+```
+
+**老结构**（读兼容）：
+
+```yaml
+models:
+  - provider: anthropic
+    model: claude-sonnet-4-6
+    base_url: https://api.anthropic.com
+    api_key: sk-xxx
+    vision: true
+default_model: claude-sonnet-4-6
+```
+
+`normalize()` 把老结构转成内存 `Endpoints`：该条 entry 包成隐式 endpoint（id `legacy-api.anthropic.com-0`，单 model），`DefaultModel` 映射到 `Default`（`legacy-api.anthropic.com-0::claude-sonnet-4-6`）。
+
+---
+
+## 4. Schema 兼容与迁移
+
+### 4.1 读路径：双 schema 并存
+
+`config.Load()`（`internal/config/config.go:566`）读到 YAML 后，`normalize()` 处理顺序：
+
+1. 若 `Endpoints` 非空 → 直接用新结构（用户已升级）
+2. 若 `Endpoints` 为空但 `Models` 非空 → 老扁平迁移：
+   - 按 `provider + base_url` 聚合（同 provider+base_url 的多条 entry 聚成一个 endpoint，`api_key`/`protocol` 取第一条）
+   - 每个聚合组生成隐式 endpoint，id `legacy-<host>-<n>`（`<host>` 取自 base_url，`<n>` 是同 host 的序号 0 起递增）
+   - `DefaultModel`/`LiteModel`（裸 model 字符串）映射到 `Default`/`Lite`（复合 id，指向第一个匹配的 endpoint）
+3. 两者都空 → 零配置状态，首次引导
+
+聚合维度用 `provider + base_url`（不用 `+ api_key + protocol`）——同一中转站用户配两套 key 的场景极少，`provider + base_url` 是用户心智边界（"一个中转站一个 endpoint"）。同 base_url 多 key 合并时取第一条 entry 的 key，日志 `slog.Warn("config: multiple api_keys found for same base_url, keeping the first", "base_url", ..., "dropped_keys", N)` 提示。
+
+### 4.2 写路径：统一升级到 endpoints
+
+`Config.Save()`（`internal/config/config.go:653`）永远只写 `Endpoints` / `Default` / `Lite`，不写老 `Models` / `DefaultModel` / `LiteModel`。老用户任何一次 Save（`octo config` / web 设置 / `/model --default`）自动升级文件结构。
+
+### 4.3 PR1 的"加结构不启用写"过渡策略
+
+按 PR 拆分（见 §11），PR1 引入 `Endpoints` 结构和读兼容，但 Save 仍写老扁平 `Models` 格式（内存 endpoints 反向序列化）。这样 PR1 合并后老用户零感，PR4 才切换写路径到 endpoints 格式。
+
+### 4.4 隐式 endpoint id 稳定性
+
+`legacy-<host>-<n>` 在多次 Load→Save 间稳定：同一份老配置每次 normalize 生成的 id 相同（host 和序号确定性）。用户在 web 设置里重命名后变友好 id（如 `relay-a`），改名级联见 §6。
+
+---
+
+## 5. 引用机制与解析
+
+### 5.1 复合 id 格式
+
+`<endpoint_id>::<model>`，分隔符 `::`（双冒号）。选 `::` 而非 `/` 的原因：OpenRouter 模型 id 本身含 `/`（如 `anthropic/claude-sonnet-4-6`，`internal/app/provider.go:112`），用 `/` 做分隔符会三段嵌套歧义。`::` 是 Kubernetes 命名空间分隔符惯例，零冲突。
+
+### 5.2 endpoint id 合法性
+
+正则 `^[a-zA-Z0-9_-]+$`，禁含 `::`、空格、特殊字符。`Validate()` 检查。
+
+### 5.3 默认 endpoint 回退链（ResolveDefault）
+
+`Config.ResolveDefault()` 实现四步回退：
+
+```
+1. 解析 cfg.Default 成 (endpointID, model)
+2. endpointID 在 cfg.Endpoints 找到？
+   - 找到 → 跳 step 3
+   - 找不到 → 跳 step 5
+3. model 在该 endpoint 的 Models 找到？
+   - 找到 → 返回 (该 endpoint, 该 model)  ✓ 完整命中
+   - 找不到 → 跳 step 4
+4. 该 endpoint 至少 1 个 model？
+   - 有 → 返回 (该 endpoint, endpoint.Models[0])  ✓ endpoint 保留、model 兜底
+   - 无 → 跳 step 5（空 endpoint 等同不存在）
+5. cfg.Endpoints 非空？
+   - 非空 → 返回 (Endpoints[0], Endpoints[0].Models[0])  ✓ 第一个 endpoint 兜底
+   - 空 → 返回 零值  ✗ 调用方报错引导配置
+```
+
+每步回退 `slog.Warn("config: default model resolution fell back", "default", cfg.Default, "resolved_to", complexID, "reason", "endpoint_not_found"|"model_not_found"|"empty_endpoint"|"no_endpoints")` 提示。
+
+**设计理由**：保留 endpoint 连接参数（key/base_url）尽量复用——用户配 `default: relay-a::claude-sonnet-4-6`，某天中转站 A 下架了 claude 换成 gemini，`default` 的 model 失效但 endpoint 还在。若直接跳到第一个 endpoint（可能是官方 anthropic，贵），用户被默默切到贵模型。回退链优先保留 endpoint、只回退 model，符合用户意图。
+
+### 5.4 `--model <X>` flag 解析（ParseModelFlag）
+
+`cmd/octo/config.go` 的 `resolveProviderModel` 改造，解析顺序：
+
+```
+ParseModelFlag(flagModel, cfg):
+  1. flagModel 含 "::"？
+     - 是 → 解析 (endpointID, model)，在 cfg.Endpoints 找该 endpoint
+       - 找到且 model 存在 → 返回 (该 endpoint, 该 model)  ✓ 精确命中
+       - endpoint 找不到 → 报错 "endpoint %q not found (available: ...)"
+       - model 找不到 → 报错 "model %q not found in endpoint %q"
+     - 否 → 跳 step 2
+  2. flagModel 是裸 model：
+     a. cfg.Default 能解析出 (defaultEndpoint, defaultModel) 且 defaultModel == flagModel？
+        - 是 → 返回 (defaultEndpoint, flagModel)  ✓ default endpoint 优先
+     b. 扫所有 endpoint，找 endpoint.Models 含 flagModel 的：
+        - 唯一命中 → 返回 (该 endpoint, flagModel)
+        - 多个命中 → 返回第一个，slog.Warn "model %q matches multiple endpoints, using %q (use <endpoint>::%q to disambiguate)"
+        - 零命中 → 报错 "model %q not found in any endpoint (available: ...)"
+```
+
+env `ANTHROPIC_MODEL`/`OPENAI_MODEL`/`*_MODEL` 走相同解析函数。
+
+**设计理由**：老脚本 `octo --model claude-sonnet-4-6` 仍能跑（default 命中或唯一命中），歧义时静默选第一个 + 日志提示，用户看到日志能改用复合 id 精确化。default 优先于全扫——用户配 default 说明"这是我的主 endpoint"，裸 model 优先走它符合直觉。
+
+### 5.5 lite model 推断（ImplicitLiteModel）
+
+`internal/app/provider.go:452` `ImplicitLiteModel` 签名改造：
+
+```go
+// 旧: ImplicitLiteModel(provider, model, baseURL string) string
+// 新: ImplicitLiteModel(endpoint Endpoint, model string) string
+```
+
+推断规则：
+1. `endpoint.LiteModel` 非空且 ≠ `model` → 返回 `endpoint.LiteModel`
+2. 否则若 endpoint 的 `base_url` 命中官方 vendor（`VendorByBaseURL`，`internal/app/provider.go:467`）且 vendor 有 `LiteModel` → 返回 vendor LiteModel
+3. 否则返回空（custom endpoint 未显式配 lite 则无 lite）
+
+**设计理由**：官方 endpoint 零配置自动 lite 是既有体验（老用户迁移后 `官方 Anthropic` endpoint 不标 `lite_model`，主模型 opus 仍自动用 haiku compact）。中转站显式标 lite 是正确心智——中转站模型命名不可控，启发式跨 vendor 推断会影响 compaction 质量，违反"不猜"原则。
+
+---
+
+## 6. endpoint 改名级联
+
+### 6.1 原子级联
+
+endpoint id 用户可改（初始 `legacy-<host>-<n>` → 重命名 `relay-a`）。改名时同一 Save 事务内：
+
+1. 重写 `Config.Default` 的前缀（`oldID::model` → `newID::model`）
+2. 重写 `Config.Lite` 的前缀
+3. 扫 `~/.octo/channels.yml` 所有 channel 绑定（`channel.Store.ModelConfig`，`internal/channel/manager.go:156`），替换前缀
+4. 清旧 endpoint id 的 sender 缓存项（见 §9）
+
+跨文件原子做法：先在内存算出新 `Config` + 新 `channels.yml`，写 `config.yml.tmp` 和 `channels.yml.tmp`，都成功后 rename 两个文件，任一失败删 tmp 不 rename。和 `Config.Save()` 现有"写 .bak 再 rename"模式一致（`internal/config/config.go:661-677`）。
+
+### 6.2 UI 交互
+
+web 设置页改 endpoint id 时弹确认："该 endpoint 被 N 处引用（default、channel 微信、channel 飞书），改名将一并更新这些引用，确认？"——让用户知道会发生什么，但不让他手动做。
+
+---
+
+## 7. 并发写保护
+
+### 7.1 flock 文件锁
+
+`Config.Save()` 加 flock：锁内执行 Load（重读最新）→ Marshal → WriteFile tmp → rename → unlock。
+
+跨进程是真实场景——octo-agent 多入口（TUI 进程 + `octo serve` 进程 + `octo config` 命令）都可能同时写 `config.yml`。flock 是 Unix 跨进程协调的标准手段，Windows 有 `LockFileEx` 对应。
+
+**锁粒度**：只锁 `config.yml` 的 Save。endpoint 改名级联写两个文件时，先锁 `config.yml` 改完 → 释放 → 再锁 `channels.yml` 改 → 释放。两把锁分别持有，不同时持两把，避免死锁。
+
+### 7.2 跨平台实现
+
+复用 `internal/executil` 的 `_windows/_other` 拆分模式。Unix 用 `golang.org/x/sys/unix` 的 `Flock`，Windows 用 `golang.org/x/sys/windows` 的 `LockFileEx`。
+
+### 7.3 已知限制
+
+flock 在 NFS 上不可靠。octo 的 `~/.octo/config.yml` 在 home 目录，绝大多数用户是本地文件系统，NFS home 极罕见。作为已知限制写入 dev-docs。
+
+---
+
+## 8. 持久化字段迁移
+
+### 8.1 字段分类
+
+octo-agent 里 `BoundEntry` 是歧义名，实际两种语义：
+
+| 字段 | 位置 | 语义 | 是否改动 |
+|---|---|---|---|
+| `Session.BoundEntry` | `internal/agent/session.go:91` | 入口来源锁（`cli/tui/web/api/channel/cron/setup` 枚举） | **不改**——与 model 无关 |
+| `Session.LeaseEntry` | `internal/agent/session.go:102` | 跨进程租约锁，同上枚举 | **不改** |
+| `Session.Model` | `internal/agent/session.go:32` | 会话当时用的 model 名 | **改**——升级为复合 id |
+| `Session.ModelConfig` | `internal/agent/session.go:41` | session 绑定的 model 引用 | **改**——升级为复合 id |
+| `channel.Store.ModelConfig` | `internal/channel/manager.go:156` | IM 侧持久化的 model 绑定 | **改**——同上 |
+| `channel.Store.Model` | `internal/channel/manager.go:145` | IM 侧记录的 model 名 | **改**——同上 |
+| `ModelResolution.BoundEntry` | `internal/channel/manager.go:157` | channel /model 解析结果，值 = 复合 id | **改**——值变成复合 id（字段名不动） |
+| `ModelInfo.Model` | `internal/channel/manager.go:145` | /model 列表项的 model id | **改**——展示用复合 id |
+
+### 8.2 读时识别两种格式（不写回）
+
+`Session.Model` / `ModelConfig` / `channel.Store.ModelConfig` 都是 append-only 或 store 文件字段。读到值时：
+
+```go
+func resolveLegacyModelRef(model string, cfg config.Config) string {
+    if strings.Contains(model, "::") {
+        return model  // 已是复合 id
+    }
+    // 裸 model：找第一个匹配的 endpoint
+    for _, ep := range cfg.Endpoints {
+        for _, m := range ep.Models {
+            if m.Model == model {
+                return ep.ID + "::" + m.Model
+            }
+        }
+    }
+    // 找不到回退 default
+    def := cfg.ResolveDefault()
+    slog.Warn("session: legacy model binding fell back to default",
+        "legacy_model", model, "resolved_to", defComplexID)
+    return defComplexID
+}
+```
+
+**不写回**的理由：
+- session 是 append-only（`internal/agent/session.go:731` 用 `O_APPEND`），`rewriteAll` 是 O(n) 全文件重写，为迁移目的触发代价过高（现有 `rewriteAll` 触发条件是 stale/truncated 前缀，`session.go:716`）
+- channel store 写有并发风险（多 session 并发），不碰 store 文件最稳
+- 新 session/绑定天然都是复合 id，混格式问题随老 session 自然退役消失
+
+**歧义处理**：同 model 挂多 endpoint 时选第一个匹配，`slog.Info` 提示"该绑定可能不准、建议重新选"。
+
+### 8.3 BoundEntry/LeaseEntry 不动
+
+`Session.BoundEntry`（`session.go:88-91`）是"谁占用这个 session"的入口锁，`LeaseEntry`（`session.go:97-103`）是跨进程租约锁，两者存的是入口来源枚举值（`cli/tui/web/api/channel/cron/setup`），与 model 引用完全无关。本次方案不动它们。
+
+`ModelResolution.BoundEntry`（`manager.go:157`）字段名虽叫 BoundEntry 但存的是 model 引用（`server.go:2138` 赋值 `entry.Model`），值从裸 model 变复合 id，字段名不改（符合"只改该改的"）。
+
+---
+
+## 9. sender 缓存与失效
+
+### 9.1 缓存 key 改复合 id
+
+`internal/server/server.go:1485` 当前 `senderCache[entry.Model]` 用裸 model 做 key，新结构下同 model 挂多 endpoint 会撞 key（`relay-a::claude` 和 `official::claude` 返回错误 endpoint 的 sender）。改为 `senderCache[endpointID+"::"+model]`。
+
+### 9.2 失效按 endpoint 粒度
+
+新增 `invalidateEndpointSenders(endpointID string)`，扫 `senderCache` 删所有前缀 `endpointID+"::"` 的项：
+
+```go
+func (s *Server) invalidateEndpointSenders(endpointID string) {
+    s.senderCacheMu.Lock()
+    defer s.senderCacheMu.Unlock()
+    prefix := endpointID + "::"
+    for k := range s.senderCache {
+        if strings.HasPrefix(k, prefix) {
+            delete(s.senderCache, k)
+        }
+    }
+}
+```
+
+失效时机：
+- endpoint 任意字段改（`base_url`/`api_key`/`protocol`/`lite_model`）→ 清该 endpoint 下所有 model 的缓存项（这些字段是 endpoint 级共享，改了所有 model 的 sender 都失效）
+- endpoint 下某 model 增/删 → 清该 (endpoint, model) 单项
+- endpoint 删除 → 清该 endpoint 下所有缓存项
+- endpoint 改名（id 变）→ 清旧 id 下所有缓存项（新 id 还没缓存，下次自然建）
+
+`invalidateSenderCache()`（`server.go:1538`，全量清空）保留作兜底——`octo config --fix` 大改、LoadCached 切换 last good 配置时全量清。
+
+**设计理由**：endpoint 改 `base_url` 是 endpoint 级变更，该 endpoint 下所有 model 的 sender 都失效（共享 base_url）。按 endpoint 粒度失效符合 base_url/key/protocol 是 endpoint 级共享的语义，且缓存命中率高（改一个 endpoint 不影响其他 endpoint 缓存）。
+
+---
+
+## 10. API 设计
+
+### 10.1 新增 `GET /api/config/endpoints`
+
+**路径**：`GET /api/config/endpoints`
+
+**响应**：
+
+```json
+{
+  "endpoints": [
+    {
+      "id": "relay-a",
+      "name": "中转站A",
+      "provider": "custom",
+      "base_url": "https://relay-a.example.com",
+      "protocol": "anthropic",
+      "has_api_key": true,
+      "lite_model": "",
+      "models": [
+        {"model": "claude-sonnet-4-6", "vision": true},
+        {"model": "gpt-5.4", "vision": true}
+      ]
+    }
+  ],
+  "default": "relay-a::claude-sonnet-4-6",
+  "lite": "relay-a::gpt-5.4-mini"
+}
+```
+
+`has_api_key: true` 而非返回明文 key（安全），前端只展示"已配置/未配置"。
+
+### 10.2 endpoint CRUD
+
+```
+POST   /api/config/endpoints                  创建 endpoint
+PATCH  /api/config/endpoints/{id}             改 endpoint（含改名 → 触发级联）
+DELETE /api/config/endpoints/{id}             删 endpoint
+POST   /api/config/endpoints/{id}/models      endpoint 下加 model
+DELETE /api/config/endpoints/{id}/models/{model}  删 endpoint 下某 model
+POST   /api/config/endpoints/{id}/default     设为 default
+POST   /api/config/endpoints/{id}/lite        设为 lite
+```
+
+RESTful 资源嵌套，endpoint 是父资源、model 是子资源。改名走 `PATCH /api/config/endpoints/{id}` 带 `new_id` 字段，触发 §6 级联。
+
+### 10.3 旧端点 deprecated
+
+`GET/POST/PATCH/DELETE /api/config/models*`（`internal/server/server.go:830-834`）保留，标记 deprecated：
+- 响应加 `X-Deprecated` header + `warning` 字段提示用新端点
+- 旧端点继续返回扁平结构（兼容回退）
+- 1-2 个 minor 版本后在 CHANGELOG 标注移除
+
+**设计理由**：octo-agent 是开源项目，可能有第三方脚本/插件调旧端点。保留兼容比强删稳妥。新端点名实相符（`/api/config/endpoints` 返回两级结构），旧端点 `/api/config/models` 名实不符（返回 models 但新结构下 models 是子层），deprecation 期让用户迁移。
+
+---
+
+## 11. PR 拆分顺序
+
+按依赖层拆 5 个 PR，PR1 的"加结构不启用写"策略让每 PR 独立可 merge 且不改变运行时行为：
+
+| PR | 内容 | 风险 | 依赖 |
+|---|---|---|---|
+| **PR1** | config 结构 + 读兼容 + Validate/Repair + ResolveDefault + ParseModelFlag。引入 `Endpoints` 字段，`normalize()` 老扁平 → endpoints 内存，**Save 仍写老扁平格式** | 高 | 无 |
+| **PR2** | 读路径适配：`ImplicitLiteModel` 签名改 `(endpoint, model)`；session `Model`/`ModelConfig` 读时兼容；channel store 读时升级 | 中 | PR1 |
+| **PR3** | flock 并发保护 + endpoint 改名级联（跨文件 tmp+rename）+ `invalidateEndpointSenders` | 高 | PR1+PR2 |
+| **PR4** | 写路径切换（Save 写 endpoints 格式）+ 三处 UI 两级（TUI picker / IM `/model` 分组 / Web 设置页 + 新 API） | 中 | PR1-3 |
+| **PR5** | CLI（`octo config` 向导 / `octo config show` / `octo config --fix` / `octo doctor`）+ dev-docs 文档 | 低 | PR1-4 |
+
+**PR1-3 期间老用户配置仍是扁平格式**——这是"零摩擦"的体现，PR4 一次性切换写路径 + UI，此时底层全已就绪。
+
+---
+
+## 12. UI 设计
+
+### 12.1 TUI model picker（两级）
+
+`cmd/octo/tuirepl_view.go:1006` `openModelPicker` 改两级：
+
+- `modelPicker` 结构加 `endpointIdx int` 维度
+- 按键：`←→` 切 endpoint，`↑↓` 切 model，`Enter` 确认，`Esc` 取消
+- 选中后 `dispatchModel` 接收复合 id（`endpoint_id::model`）
+- 渲染：当前 endpoint 高亮，其下 model 列表缩进显示
+
+复用现有 `complItem`（`cmd/octo/tuirepl.go`）和 completion 样式。不引入新依赖。
+
+### 12.2 IM `/model`（分组输出）
+
+`internal/server/server.go:2125` `channelModelOps().Resolve` 改造：
+
+- `/model`（无参）→ 按 endpoint 分组输出文本列表：
+  ```
+  渠道: relay-a (中转站A)
+    • relay-a::claude-sonnet-4-6
+    • relay-a::gpt-5.4
+  渠道: official-anthropic (官方 Anthropic)
+    • official-anthropic::claude-opus-4-8
+    • official-anthropic::claude-sonnet-4-6
+  ```
+- `/model <复合id>` → 精确切换
+- `/model <裸model>` → 走 ParseModelFlag 规则（default 优先 + 全扫兜底）
+- `/model default` → 解绑（回退默认）
+
+`ModelResolution.BoundEntry`（`manager.go:157`）值变成复合 id，`ModelInfo.Model`（`manager.go:145`）展示用复合 id。
+
+IM 输出按 `config.Language`（zh/en）选语言字符串（IM 纯文本载体不走前端 i18n key 体系，octo-agent IM 消息现状即按 Language 切换中英文）。
+
+### 12.3 Web 设置页（两级）
+
+- endpoint 卡片列表：每张卡片显示 endpoint id/name/provider/base_url/api_key 状态/模型列表
+- endpoint 卡片内可加/删 model、设 default/lite
+- "添加 endpoint"按钮 → 选 vendor 模板（`app.Registry`）→ 填 base_url（custom 必填）/api_key/protocol → 挂模型
+- 改 endpoint id 弹确认框（§6.2）
+- 模型下拉建议来自该 vendor 的 `VendorModels`（`internal/app/provider.go`），用户可改/加
+
+---
+
+## 13. CLI 设计
+
+### 13.1 `octo config`（向导）
+
+`cmd/octo/config.go:108` `runConfig` 子命令：
+
+- **无参 / `setup` / `init`**：单 endpoint 引导（选 vendor → 填 base_url/custom 必填 → 选/填 model → 填 key），写入/替换默认 endpoint
+  - 首次（无 endpoints）→ 完整引导，生成第一个 endpoint（id `ep-1` 或 `legacy-<host>-0`），设为 default
+  - 非首次 → 询问"替换默认 endpoint"，覆盖老的默认 endpoint
+  - 保留老用户"跑 `octo config` 改默认"的肌肉记忆
+- **`show` / `get`**：打印两级 endpoints 列表（每 endpoint 显示 id/name/provider/base_url/models 数/default 标记/lite 标记）
+- **`path`**：不变
+- **`fix` / `--fix`**：endpoint 级修复（见 §14）
+
+多 endpoint 管理不进 CLI 向导——CLI 嵌套菜单 UX 差，且 octo-agent web 设置页已是 endpoint 管理主战场。纯 SSH/无 web 用户手改 YAML 是合理回退（老结构本来也支持手改）。
+
+### 13.2 `octo doctor`（per-endpoint 检查）
+
+`cmd/octo/doctor.go` 升级：
+
+```
+octo doctor — checking your setup
+
+config: /Users/qiao/.octo/config.yml
+  ✓ config.yml parses
+  ✓ 3 endpoints configured
+
+Endpoints:
+  ✓ ep-1 (relay-a, custom, https://relay-a.example.com)
+      2 models: claude-sonnet-4-6, gpt-5.4
+      ✓ API key found (CUSTOM_API_KEY)
+  ✗ ep-2 (官方Anthropic, anthropic, https://api.anthropic.com)
+      3 models: claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5
+      ✗ API key missing (ANTHROPIC_API_KEY not set, endpoint.api_key empty)
+  ✓ legacy-deepseek-0 (deepseek, deepseek, https://api.deepseek.com)
+      2 models: deepseek-v4-flash, deepseek-v4-pro
+      ✓ API key found (DEEPSEEK_API_KEY)
+
+References:
+  ✓ default = ep-1::claude-sonnet-4-6 (resolves)
+  ✓ lite = ep-1::gpt-5.4 (resolves, ≠ default)
+
+1 problem(s) found — `octo config --fix` can repair config issues.
+```
+
+每个 endpoint 检查：id 合法、有 model、api_key 可达（env 或 `endpoint.APIKey`）。default/lite 引用独立检查可解析 + lite≠default 约束。key 探测沿用现有 `apiKeyReachable`/`apiKeyStatus`（`doctor.go:64-67`），串行执行（endpoint 数个位数，毫秒级）。
+
+---
+
+## 14. Validate / Repair 规则
+
+### 14.1 Validate 检查项
+
+`internal/config/config.go:387` `Validate()` 升级：
+
+1. endpoint id 非空、唯一、合法（`^[a-zA-Z0-9_-]+$`，不含 `::`）
+2. 每个 endpoint 至少 1 个 model
+3. 每个 model 名非空
+4. 同 endpoint 内 model 不重复（跨 endpoint 同 model 允许）
+5. `Default` 是合法复合 id，能解析到 endpoint + model
+6. `Lite` 同上（或空）
+
+### 14.2 Repair 自动修（safe，可逆）
+
+- `Default` dangling → 重置到第一个 endpoint 的第一个 model 的复合 id，日志提示
+- `Lite` dangling → 清空
+- 空 endpoint（无 model）→ 删除该 endpoint（连同引用级联清理）
+- `Lite` 指向的 model == `Default` 指向的 model → 清空 lite
+
+### 14.3 Repair 报 unfixable（需人工）
+
+- **重复 endpoint id** → 不自动改名（怕覆盖用户草稿意图），报"duplicate endpoint id %q — rename one"
+- endpoint id 非法（含 `::`/空格）→ 报"endpoint id %q contains illegal chars — rename"
+- 无 model 名的 model entry → 报"model in endpoint %q has no name — add one or remove"
+- 同 endpoint 内重复 model → 报"duplicate model %q in endpoint %q — remove one"
+
+**设计理由**：重复 endpoint id 走保守路径——endpoint id 是复合 id 前缀，自动重命名（如加 `-2` 后缀）会级联改 default/lite/channel 绑定，自动改名 + 自动级联的连锁风险大于让用户手改一次。这与现有 `Repair` 对"重复 model"的处理一致（`internal/config/config.go:751` 现在也是报 unfixable 不自动改）。
+
+---
+
+## 15. i18n
+
+### 15.1 前端 i18n key
+
+`web/src/lib/i18n.ts` 的 `en` / `zh` Record 新增 `settings.endpoints.*` 命名空间：
+
+| key | en | zh |
+|---|---|---|
+| `settings.endpoints.title` | Endpoints | 渠道 |
+| `settings.endpoints.add` | Add endpoint | 添加渠道 |
+| `settings.endpoints.id` | ID | ID |
+| `settings.endpoints.name` | Display name | 显示名称 |
+| `settings.endpoints.provider` | Provider | 厂商 |
+| `settings.endpoints.base_url` | Base URL | 接口地址 |
+| `settings.endpoints.protocol` | Protocol | 协议 |
+| `settings.endpoints.api_key` | API key | API 密钥 |
+| `settings.endpoints.api_key.set` | Set | 已设置 |
+| `settings.endpoints.api_key.missing` | Missing | 未设置 |
+| `settings.endpoints.models` | Models | 模型 |
+| `settings.endpoints.models.add` | Add model | 添加模型 |
+| `settings.endpoints.models.vision` | Vision | 视觉 |
+| `settings.endpoints.default` | Default | 默认 |
+| `settings.endpoints.lite` | Lite | 轻量 |
+| `settings.endpoints.delete` | Delete endpoint | 删除渠道 |
+| `settings.endpoints.rename_confirm` | Rename will update N references, continue? | 重命名将更新 N 处引用，继续吗？ |
+| `settings.endpoints.error.duplicate_id` | Duplicate endpoint id %q | 渠道 ID %q 重复 |
+| `settings.endpoints.error.invalid_id` | Endpoint id %q contains illegal chars | 渠道 ID %q 含非法字符 |
+| `settings.endpoints.error.not_found` | Endpoint %q not found | 渠道 %q 不存在 |
+| `settings.endpoints.error.model_not_found` | Model %q not found in any endpoint | 模型 %q 不存在于任何渠道 |
+| `settings.endpoints.error.empty` | Endpoint has no models | 渠道下无模型 |
+
+endpoint 的 base_url 区域变体仍复用现有 `settings.models.baseurl.variant.*`（`internal/app/provider.go:170`，语义一致）。
+
+### 15.2 TUI picker i18n
+
+`web/src/lib/i18n.ts` 新增 `tui.model_picker.*`：
+
+| key | en | zh |
+|---|---|---|
+| `tui.model_picker.switch_endpoint` | Switch endpoint: | 切换渠道： |
+| `tui.model_picker.switch_model` | Switch model: | 切换模型： |
+| `tui.model_picker.hint` | ←→ endpoint · ↑↓ model · Enter select · Esc dismiss | ←→ 渠道 · ↑↓ 模型 · Enter 确认 · Esc 取消 |
+
+### 15.3 IM 文案
+
+IM 输出是纯文本流（飞书/微信消息），不走前端 i18n key 体系，按 `config.Language`（zh/en）选语言字符串硬编码（octo-agent IM 消息现状即如此）。新增 endpoint 分组标题文本按 Language 切换中英文版本。
+
+---
+
+## 16. 测试计划
+
+### 16.1 分层测试
+
+| 层 | 测试类 | 覆盖点 |
+|---|---|---|
+| **config 层（~70%）** | 迁移矩阵 | 单 entry → 单隐式 endpoint；同 provider+base_url 多 entry → 聚合；不同 base_url → 多 endpoint；含 LiteModel 的老 entry → endpoint.lite_model 推断；老+新并存双 schema 读 |
+| | Validate/Repair 全规则 | 重复 endpoint id（unfixable）；非法 id（unfixable）；空 endpoint（auto-fix 删除）；dangling default/lite（auto-fix）；lite==default（auto-fix 清空） |
+| | ResolveDefault 回退链 | 四步回退每步单独测 |
+| | ParseModelFlag | 复合 id 精确；裸 model default 优先；全扫兜底；歧义日志 |
+| | endpoint 改名级联 | 改名后 default/lite/channel 绑定前缀全更新；跨文件原子（tmp + rename） |
+| | flock 并发 | `t.Parallel` 起 10 goroutine 抢写同一 config.yml，验证不丢更新、不 corrupt |
+| | vision 迁移 | 老 `ModelEntry.Vision` → `EndpointModel.Vision` 一一对应 |
+| **session/channel 层（~15%）** | 读时兼容 | session 文件混格式（老 `Model: claude-sonnet-4-6` + 新 `Model: relay-a::claude-sonnet-4-6`）能正确解析 |
+| | channel store 读时升级 | 老裸 model 绑定 → 复合 id（第一个匹配 endpoint）；找不到回退 default |
+| **UI 层（~10%，薄）** | TUI picker 两级 | ←→ 切 endpoint、↑↓ 切 model、Enter 确认、Esc 取消（复用现有 `cmd/octo/model_picker_test.go` 结构） |
+| | web 设置 API 契约 | `GET /api/config/endpoints` 返回两级结构；`POST/PATCH/DELETE` 增删改 endpoint |
+| | IM `/model` 分组输出 | 按 endpoint 分组的文本列表 |
+| **端到端（~5%）** | 老用户升级路径 | 老扁平 config → 启动 octo → `/model` 看到两级 picker → web 加新 endpoint → `/model relay-b::gpt-5.4` 切换 → 验证 sender 重建 |
+| | 中转站轮换路径 | 配两个中转站 endpoint → `/model` 切换 → 验证 sender 用对应 endpoint 的 key/base_url |
+
+### 16.2 跨平台注意事项
+
+按 memory 教训：测试里比较路径禁止硬编码 `/`。涉及 `.octo/uploads` 等路径断言必须用 `filepath.ToSlash` 转换或 `filepath.Join` 构造，保证 Windows（`\`）和 Unix（`/`）都能过。
+
+---
+
+## 17. 前端构建产物策略
+
+严格遵循 PR #1595 教训（memory 记录）：
+
+- `internal/server/webdist/` 已 gitignore（`.gitignore:44`），只保留 `.gitkeep`
+- PR4 改前端只提交 `web/src/` 源码（svelte 组件、`web/src/lib/i18n.ts`、API 调用），**不提交 `webdist/*` 产物**
+- 本地开发跑 `make web-build`（`Makefile:69`）构建到 `webdist/`，`go run ./cmd/octo serve` 启动看效果
+- CI 发版（`.github/workflows/desktop.yml` / `release.yml`）自动跑 `make web-build` 嵌入二进制
+
+---
+
+## 18. 兼容性
+
+### 18.1 老配置文件
+
+老扁平 `models:` 配置文件在 `config.Load()` 时被 `normalize()` 转成内存 `Endpoints`，运行时行为不变。老用户任何一次 Save 后文件升级为新 `endpoints:` 结构。PR1-3 期间 Save 仍写老扁平格式，PR4 切换写路径。
+
+### 18.2 老 session 文件
+
+`Session.Model` / `ModelConfig` 字段读时识别两种格式（裸 model + 复合 id），不写回。老 session 文件保持 append-only 混格式，新 session 天然都是复合 id。
+
+### 18.3 老 channel 绑定
+
+`channel.Store.ModelConfig` 读时惰性升级不写回。老绑定逐渐被用户在 IM 里 `/model <复合id>` 覆盖，新绑定都是复合 id，自然迭代干净。
+
+### 18.4 老脚本
+
+`octo --model claude-sonnet-4-6`（裸 model）走 ParseModelFlag 兼容：default endpoint 优先 + 全扫兜底，老脚本仍能跑。歧义时静默选第一个 + 日志提示，用户可改用复合 id 精确化。
+
+### 18.5 老 API 端点
+
+`GET/POST/PATCH/DELETE /api/config/models*` 保留，标记 deprecated，1-2 个 minor 版本后移除。第三方脚本/插件有迁移窗口。
+
+### 18.6 audit.log
+
+不受影响。`internal/audit/audit.go` 只记工具调用决策（allow/deny/ask），endpoint 变更是用户配置文件修改，不经过 tool gate，不触发 audit.log。配置变更有 `config.yml.bak` 备份（`config.go:661`）+ flock（§7）保护。
+
+---
+
+## 19. 安全
+
+### 19.1 API key 处理
+
+- `Endpoint.APIKey` 存明文（`config.yml` mode 0600，`config.go:653`），是 opt-in 回退，优先 env var（`config.go:48` 注释）
+- `GET /api/config/endpoints` 响应只返回 `has_api_key: bool`，不返回明文 key（§10.1）
+- flock 保护 `config.yml` 跨进程写，避免并发写导致 key 丢失
+
+### 19.2 endpoint 改名
+
+改名级联是原子事务（§6），不会出现"endpoint 改了但 default 引用没改"的中间态导致 sender 指向错误 endpoint。
+
+### 19.3 权限提升风险
+
+endpoint 变更不涉及权限提升——endpoint 是模型连接配置，不改变 agent 的工具权限（`PermissionMode` 等）。`Session.BoundEntry`（入口锁）与 endpoint 无关，不受影响。
+
+---
+
+## 20. 已知限制
+
+| 限制 | 影响 | 缓解 |
+|---|---|---|
+| flock 在 NFS 上不可靠 | NFS home 目录用户并发写可能丢更新 | 极罕见场景，dev-docs 注明；建议本地文件系统 |
+| vendor registry `Models` 列表滞后于厂商实际模型 | 用户配官方 endpoint 时模型下拉可能缺新模型 | 用户可手填 model id；registry 维护是独立话题，不在本次范围 |
+| 同 base_url 多 key 合并丢 key 信息 | 迁移时同 base_url 不同 key 的 entry 被合成一个 endpoint，取第一条 key | 日志 `slog.Warn` 提示 dropped_keys 数；罕见场景 |
+| endpoint 改名跨文件原子在极端崩溃窗口可能不一致 | rename 第一个文件后崩溃，第二个文件未 rename | macOS/Linux rename 是原子的，崩溃窗口极小；下次 Load 会发现不一致走 Repair |
+| 纯 SSH/无 web 用户管理多 endpoint 要手改 YAML | CLI 向导不支持多 endpoint 管理 | octo-agent web 设置是主推路径；CLI 手改是老结构本就支持的回退 |
+| IM `/model` 歧义时静默选第一个 endpoint | 同 model 挂多 endpoint 时裸 model 引用可能不准 | 日志提示；用户可改用复合 id 精确化 |
+
+---
+
+## 21. 决策溯源
+
+本设计的 26 项关键决策通过 grill-me 与用户逐项拍板，决策点 / 选项 / 结论 / 理由的完整记录在对话上下文中。本文档是这些决策的技术展开，不含"待实现阶段确认"项——所有不确定点已在设计阶段闭合（代码可验证事实通过 grep 真实代码确认，真正决策通过 grill-me 与用户拍板）。

--- a/dev-docs/endpoint-pr5-impl.md
+++ b/dev-docs/endpoint-pr5-impl.md
@@ -1,0 +1,551 @@
+# Endpoint 二级分组 PR5 实施设计
+
+> 本文是 `dev-docs/endpoint-design.md` 的 PR5 实施补充。原文档是 PR1-3 的设计快照（`Models` 权威 + `Endpoints` 内存派生），PR5 把权威反转到 `Endpoints` 并完成写路径切换。读本文前请先读原文档了解背景、术语、复合 id 机制。
+
+## 1. PR5 范围
+
+PR1-3 完成读路径（结构 + 读兼容 + flock + 改名级联 + sender 缓存）。PR4b 完成只读 UI（GET endpoints API + TUI 两级 picker + IM `/model` 分组 + Web 只读卡片）。PR5 是写路径切换 + CLI + 后端 CRUD + 文档：
+
+- `Config.Save()` 从写扁平 `models:` 切到写 `endpoints:` 格式
+- 删除 `Config.Models` / `Config.DefaultModel` / `Config.LiteModel` 三个字段（运行时）
+- 新增 `UpsertEndpoint` / `UpsertModel` / `SetDefaultComposite` 三个写 API，替换 `SetDefaultEntry` / `SetEntry`
+- 新增 `POST/PATCH/DELETE /api/config/endpoints` + `POST/DELETE /api/config/endpoints/{id}/models` + `POST /api/config/endpoints/{id}/default|lite` 共 7 个 CRUD 端点
+- 删除老 `POST/PATCH/DELETE /api/config/models*` 5 个端点 + `handleGetConfig` 的 models 字段
+- `octo config` 向导升级到 endpoint 概念（单 endpoint 引导，`legacy-<host>-<n>` id）
+- `octo config show` 改两级单行输出
+- `octo doctor` 改 per-endpoint 检查
+- 删除 per-entry `ReasoningEffort` / `ShowReasoning`，只留全局 `Config.ReasoningEffort` / `Config.ShowReasoning`
+- endpoint 改名级联接 `invalidateEndpointSenders` 调用点
+- 修订 `dev-docs/endpoint-design.md`，commit 进仓库（PR1-3 漏 commit）
+
+**不在 PR5 范围**：
+
+- Web UI 的 endpoint CRUD（PR6 做）—— PR5 只让 Web 卡片节显示"编辑功能将在下个版本提供"提示（i18n key `settings.endpoints.readonly_notice` 已在 PR4b 加）
+- IM `/model` 文案 i18n（IM 命令面目前统一英文，单独 PR 处理）
+- 老用户回退到 PR4b 的兼容（单向升级，设计 §18.1 明文）
+
+## 2. 数据模型变更
+
+### 2.1 `Config` struct 删字段
+
+`internal/config/config.go` 的 `Config` struct 删除三个字段：
+
+```go
+// 删除：
+Models       []ModelEntry  // 运行时不再维护，只 fileConfig 中间态用
+DefaultModel string
+LiteModel    string
+```
+
+保留 `Endpoints []Endpoint` / `Default string` / `Lite string` 作为权威字段。`Config.ReasoningEffort` / `Config.ShowReasoning` 全局字段已存在（`config.go:55, 59`），不变。
+
+### 2.2 `ModelEntry` 保留作为投影类型
+
+`ModelEntry` struct 保留，但删除 `ReasoningEffort` / `ShowReasoning` 两个字段：
+
+```go
+type ModelEntry struct {
+    Provider string
+    Model    string
+    BaseURL  string
+    APIKey   string
+    Protocol string
+    Vision   bool
+    // 删除：ReasoningEffort string
+    // 删除：ShowReasoning   *bool
+}
+```
+
+`EntryByModel` 返回值仍是 `ModelEntry`，内部从 `Endpoint` + `EndpointModel` 投影（Provider/BaseURL/APIKey/Protocol 从 Endpoint，Model/Vision 从 EndpointModel）。调用点（`cachedSenderForEntry` / `buildSender` / `senderForEntry`）签名不动，热路径零回归。
+
+### 2.3 `EntryByModel` bare-model 分支改扫 Endpoints
+
+`config.go:644` 的 bare-model fallback 当前扫 `c.Models`，PR5 后 `c.Models` 没了。改成扫 `c.Endpoints` 找第一个匹配的 model（语义同 `ParseModelFlag` step 2：default endpoint 优先 + 全扫兜底）：
+
+```go
+// Bare-model path: scan Endpoints for the first endpoint whose Models
+// contains this model. Prefer the default endpoint when set, mirroring
+// ParseModelFlag step 2a; else the first hit.
+func (c Config) EntryByModel(model string) (ModelEntry, bool) {
+    if model == "" { return ModelEntry{}, false }
+    // 复合 id 路径不变（config.go:614-630）
+    if endpointID, modelName, ok := splitCompositeID(model); ok { ... }
+    // bare-model 路径：扫 Endpoints
+    if c.Default != "" {
+        if defEp, defM, ok := c.ResolveDefault(); ok && defM.Model == model {
+            return projectToModelEntry(defEp, defM), true
+        }
+    }
+    for _, ep := range c.Endpoints {
+        for _, m := range ep.Models {
+            if m.Model == model {
+                return projectToModelEntry(ep, m), true
+            }
+        }
+    }
+    return ModelEntry{}, false
+}
+```
+
+`projectToModelEntry(ep Endpoint, m EndpointModel) ModelEntry` 是新 helper，做投影。
+
+### 2.4 `fileConfig` 保留 `Models` 字段做 Load 中间态
+
+`fileConfig` struct（`config.go:830`）的 `Models []ModelEntry` 字段**保留**——用于读老 `models:` YAML 块。但 `ModelEntry` 删了 `ReasoningEffort`/`ShowReasoning`，所以老文件里的 `reasoning_effort` / `show_reasoning` 字段读不进来。
+
+**直接丢弃老 reasoning 字段，不拷到全局**。`fileConfig` 不加额外的 legacy struct 读 reasoning——老文件里 per-entry 的 `reasoning_effort` / `show_reasoning` 在 Load 时静默丢弃。全局 `cfg.ReasoningEffort` / `cfg.ShowReasoning` 保持空（或用户在顶层设过的值）。代价：老用户的 reasoning 配置丢失，需要重新设全局 reasoning。dev-docs 和 release notes 说明这个行为变化。这简化 Load 实现（无 reasoning 迁移逻辑）。
+
+```go
+type fileConfig struct {
+    Config `yaml:",inline"`
+    // legacy 扁平 models 块（只在 Load 时用，不进运行时 Config）
+    Models []ModelEntry `yaml:"models,omitempty"`
+    DefaultModel string `yaml:"default_model,omitempty"`
+    LiteModel    string `yaml:"lite_model,omitempty"`
+    // legacy 顶层字段
+    LegacyProvider string `yaml:"provider,omitempty"`
+    LegacyModel    string `yaml:"model,omitempty"`
+    // ...
+}
+// ModelEntry 已删 ReasoningEffort/ShowReasoning，老文件里的这两个字段
+// 在 Unmarshal 时静默丢弃（yaml.Unmarshal 忽略 struct 里没有的字段）。
+```
+
+`normalize()` 时：
+1. 老 `models:` 块 → 按 `(provider, base_url)` 聚合成 `c.Endpoints`（复用 PR1 `syncEndpointsFromModels` 逻辑，改成写 `c.Endpoints` 不写 `c.Models`）
+2. 老 `default_model` / `lite_model` 映射到 `c.Default` / `c.Lite` 复合 id（复用 PR1 `findEndpointModel`）
+3. reasoning 字段不迁移（丢弃）
+
+## 3. 新写 API
+
+替换 `SetDefaultEntry` / `SetEntry` 的三个新 API，在 `internal/config/config.go`：
+
+### 3.1 `UpsertEndpoint`
+
+```go
+// UpsertEndpoint inserts or replaces the endpoint with the given ID. If an
+// endpoint with ep.ID already exists, it's replaced in place; otherwise ep is
+// appended. Default/Lite composite-id references are NOT rewritten (use
+// RenameEndpoint for id changes). Returns the index of the upserted endpoint.
+func (c *Config) UpsertEndpoint(ep Endpoint) int
+```
+
+调用点：`POST /api/config/endpoints`（新建）、`PATCH /api/config/endpoints/{id}`（改 endpoint 连接参数，不含改名）。
+
+### 3.2 `UpsertModel`
+
+```go
+// UpsertModel inserts or replaces the model under the given endpoint. If
+// endpointID doesn't exist, returns ErrEndpointNotFound. If a model with the
+// same Model id already exists under the endpoint, it's replaced; otherwise
+// appended. Default/Lite references are updated if they pointed at the old
+// model shape (same model id under this endpoint).
+func (c *Config) UpsertModel(endpointID string, m EndpointModel) error
+```
+
+调用点：`POST /api/config/endpoints/{id}/models`。
+
+### 3.3 `SetDefaultComposite`
+
+```go
+// SetDefaultComposite sets cfg.Default to the given composite id. Does NOT
+// validate the id resolves — callers should validate first (Validate() catches
+// dangling Default). Does NOT invalidate sender cache (default switch doesn't
+// rebuild senders, only changes which sender ResolveDefault returns next time).
+func (c *Config) SetDefaultComposite(cid string)
+```
+
+调用点：`POST /api/config/endpoints/{id}/default`、`octo config` 向导最后一步。
+
+### 3.4 老API 删除
+
+`SetDefaultEntry` / `SetEntry` / `DefaultEntry` 全删。调用点迁移：
+
+| 老调用点 | 新调用 |
+|---|---|
+| `cmd/octo/config.go:598` `full.SetDefaultEntry(outEntry)` | `full.UpsertEndpoint(ep) + full.UpsertModel(ep.ID, m) + full.SetDefaultComposite(cid)` |
+| `internal/server/handlers.go:1270, 1421` `cfg.SetEntry + SetDefaultEntry` | 改走新 CRUD handler（见 §4） |
+| `internal/server/onboard_config_handlers.go` 5 个老 CRUD handler | 全删，路由也删（见 §4） |
+
+## 4. API 设计
+
+### 4.1 新增 CRUD 端点
+
+`internal/server/onboard_config_handlers.go` 新增 7 个 handler，路由注册在 `internal/server/server.go:830` 附近：
+
+```
+POST   /api/config/endpoints                       handleCreateEndpoint
+PATCH  /api/config/endpoints/{id}                  handleUpdateEndpoint  (含改名 → 触发级联)
+DELETE /api/config/endpoints/{id}                  handleDeleteEndpoint
+POST   /api/config/endpoints/{id}/models           handleAddEndpointModel
+DELETE /api/config/endpoints/{id}/models/{model}   handleDeleteEndpointModel
+POST   /api/config/endpoints/{id}/default          handleSetEndpointDefault
+POST   /api/config/endpoints/{id}/lite             handleSetEndpointLite
+```
+
+### 4.2 请求/响应 shape
+
+**POST /api/config/endpoints**：
+```json
+{
+  "id": "relay-a",
+  "name": "中转站A",
+  "provider": "custom",
+  "base_url": "https://relay-a.example.com",
+  "api_key": "sk-relay-a",
+  "protocol": "anthropic",
+  "lite_model": "",
+  "models": [{"model": "claude-sonnet-4-6", "vision": true}]
+}
+```
+响应：`201 Created` + 完整 endpoint 对象（同 GET shape，含 `has_api_key`）。
+
+**PATCH /api/config/endpoints/{id}**（不含改名）：
+```json
+{
+  "name": "新名称",
+  "base_url": "https://new.example.com",
+  "api_key": "sk-new",
+  "protocol": "openai"
+}
+```
+`id` 字段不在 body 里（URL 里的 `{id}` 是当前 id）。响应：`200 OK` + 更新后的 endpoint。
+
+**PATCH /api/config/endpoints/{id}**（含改名）：
+```json
+{
+  "new_id": "relay-b",
+  "name": "..."
+}
+```
+`new_id` 字段存在时触发 `RenameEndpoint`（级联重写 `cfg.Default` / `cfg.Lite` 前缀）+ `invalidateEndpointSenders(oldID)`。响应：`200 OK` + 更新后的 endpoint（新 id）。
+
+**DELETE /api/config/endpoints/{id}**：删 endpoint。若 `cfg.Default` / `cfg.Lite` 指向该 endpoint，清空（走 Repair 兜底重置）。响应：`200 OK` + `{"ok": true}`。
+
+**POST /api/config/endpoints/{id}/models**：
+```json
+{"model": "gpt-5.4", "vision": true}
+```
+响应：`200 OK` + 更新后的 endpoint。
+
+**DELETE /api/config/endpoints/{id}/models/{model}**：删 model。若 `cfg.Default` / `cfg.Lite` 指向该 model，走 Repair 兜底。响应：`200 OK` + `{"ok": true}`。
+
+**POST /api/config/endpoints/{id}/default**：body 空。设 `cfg.Default = <id>::<该 endpoint 下第一个 model>`。响应：`200 OK` + `{"default": "<cid>"}`。
+
+**POST /api/config/endpoints/{id}/lite**：body 空。设 `cfg.Lite = <id>::<该 endpoint 下第一个 model>`。响应：`200 OK` + `{"lite": "<cid>"}`。
+
+### 4.3 老 `/api/config/models*` 端点全删
+
+删除 5 个 handler + 路由：
+
+- `POST /api/config/models` (`handleSaveModelConfig`)
+- `PATCH /api/config/models/{id}` (`handleUpdateModelConfig`)
+- `DELETE /api/config/models/{id}` (`handleDeleteModelConfig`)
+- `POST /api/config/models/{id}/default` (`handleSetDefaultModelConfig`)
+- `POST /api/config/models/{id}/lite` (`handleSetLiteModelConfig`)
+
+### 4.4 `handleGetConfig` 去掉 models 字段
+
+`internal/server/onboard_config_handlers.go:195` `handleGetConfig` 保留（仍被 Web 用来读全局设置），但 `configResponse` struct 删除 `Models` / `DefaultModelIdx` 字段：
+
+```go
+type configResponse struct {
+    // 删除：Models []modelConfig
+    // 删除：DefaultModelIdx int
+    FontSize      string  `json:"font_size,omitempty"`
+    Language      string  `json:"language,omitempty"`
+    ShowReasoning *bool   `json:"show_reasoning,omitempty"`
+    Coauthor      *bool   `json:"coauthor,omitempty"`
+    WorkspaceDir  string  `json:"workspace_dir,omitempty"`
+    ReasoningEffort string `json:"reasoning_effort,omitempty"`  // 新增：全局 reasoning
+}
+```
+
+前端 `web/src/views/SettingsView.svelte` 读 `cfg.models` 的地方改读 `api.getEndpoints()`（PR4b 已有）。
+
+## 5. endpoint 改名级联
+
+### 5.1 不扫 session 文件
+
+设计文档 §6.1 原说"扫 `~/.octo/channels.yml` 所有 channel 绑定"——**这是技术事实错误**。channel 绑定实际存在 `~/.octo/sessions/*.jsonl` 的 `ModelConfig` 字段（`internal/agent/session.go:41`），不在 `channels.yml`。`channels.yml` 只存 platform credentials（`internal/channel/config.go:20`）。
+
+PR5 的改名级联**只重写 `config.yml`**，不扫 session 文件：
+
+1. `config.Mutate(func(cfg){ cfg.RenameEndpoint(oldID, newID) })` —— PR3 已实现的 `RenameEndpoint`（`config.go:720`）改 `c.Default` / `c.Lite` 复合 id 前缀 + endpoint ID
+2. 成功后调 `s.invalidateEndpointSenders(oldID)` —— PR3 已实现（`server.go:1519`），删旧 endpoint 前缀的 sender 缓存
+3. **不扫 session 文件**——老 session 里的 stale 复合 id 靠 `EntryByModel` 的 bare-model fallback 兜底（§2.3，PR5 后 fallback 扫 Endpoints 找同名 model）
+
+这符合设计 §8.2 的"session 不写回"原则，且简化实现（无需 `channel.RenameEndpointBindings`）。
+
+### 5.2 跨文件原子性
+
+单文件（`config.yml`），`config.Mutate` 的 flock 已经保证原子性。无跨文件场景。
+
+## 6. `invalidateEndpointSenders` 触发时机
+
+PR3 的 `invalidateEndpointSenders(endpointID)`（`server.go:1519`）接调用点：
+
+| CRUD handler | 触发失效？ | 理由 |
+|---|---|---|
+| `POST /api/config/endpoints`（新建） | 否 | 新 endpoint 无 sender 缓存 |
+| `PATCH /api/config/endpoints/{id}`（改连接参数） | 是 | base_url/api_key/protocol 变，旧 sender 失效 |
+| `PATCH /api/config/endpoints/{id}`（改名） | 是 | `invalidateEndpointSenders(oldID)` |
+| `PATCH /api/config/endpoints/{id}`（只改 Name） | 是 | 粗粒度策略：宁可多失效，避免 diff 漏字段 |
+| `DELETE /api/config/endpoints/{id}` | 是 | 整个 endpoint 的 sender 失效 |
+| `POST /api/config/endpoints/{id}/models` | 是 | 粗粒度：model 变也失效（cache key 是复合 id，model 变有孤儿 key） |
+| `DELETE /api/config/endpoints/{id}/models/{model}` | 是 | 同上 |
+| `POST /api/config/endpoints/{id}/default` | 否 | 只改 `cfg.Default` 指针，不重建 sender |
+| `POST /api/config/endpoints/{id}/lite` | 否 | 同上 |
+
+策略：粗粒度 per-endpoint 失效。简单且 sender 重建成本低（毫秒级），endpoint mutation 是低频操作。
+
+## 7. CLI 设计
+
+### 7.1 `octo config`（向导）
+
+`cmd/octo/config.go:299` `runConfigWizard` 改造。单 endpoint 引导流程：
+
+```
+1. 选 vendor（anthropic/openai/custom/...）from app.Registry
+2. 填 base_url（custom 必填，命名 vendor 可空用默认）
+3. 选/填 model（从 vendor.Models 选或手填）
+4. 填 api_key
+5. 算 endpoint id = legacyEndpointID(hostFromBaseURL(base_url), 0)
+   - 若该 id 已存在 → UpsertEndpoint 覆盖（同 host 同 id，语义"更新这个渠道的配置"）
+   - 若不存在 → UpsertEndpoint 新建，打印"新建 endpoint X"
+6. UpsertModel(endpointID, EndpointModel{Model: model, Vision: vendorVision})
+7. 问"设为 default 吗？[Y/n]" → SetDefaultComposite(endpointID::model)
+8. Save（写 endpoints 格式）
+```
+
+`legacyEndpointID` + `hostFromBaseURL` 复用 PR1 实现（`config.go:1003, 1015`）。endpoint id 生成规则与 Load 老 `models:` 文件生成的 id 一致，用户在 web 设置里看到的是同一套命名。
+
+### 7.2 `octo config show`
+
+`cmd/octo/config.go:184` `runConfigShow` 改两级单行输出：
+
+```
+Config file: /Users/qiao/.octo/config.yml
+
+endpoints:
+  relay-a (中转站A, custom, https://relay-a.example.com) — 2 models [default: relay-a::claude-sonnet-4-6]
+  official (官方 Anthropic, anthropic, https://api.anthropic.com) — 3 models [lite: official::claude-haiku-4-5]
+  legacy-api-deepseek-com-0 (deepseek, deepseek, https://api.deepseek.com) — 2 models
+
+references:
+  default = relay-a::claude-sonnet-4-6
+  lite = official::claude-haiku-4-5
+
+reasoning:
+  effort = medium
+  show_reasoning = true
+```
+
+每 endpoint 一行：`id (name, provider, base_url) — N models [default/lite 标记]`。无 model 列表（doctor 才有）。`references` 节显示 `cfg.Default` / `cfg.Lite`。`reasoning` 节显示全局设置。
+
+### 7.3 `octo doctor`
+
+`cmd/octo/doctor.go:17` `runDoctor` 改 per-endpoint 检查，照设计 §13.2 样例：
+
+```
+octo doctor — checking your setup
+
+config: /Users/qiao/.octo/config.yml
+  ✓ config.yml parses
+  ✓ 3 endpoints configured
+
+Endpoints:
+  ✓ relay-a (中转站A, custom, https://relay-a.example.com)
+      2 models: claude-sonnet-4-6, gpt-5.4
+      ✓ API key found (endpoint.api_key set)
+  ✗ official (官方 Anthropic, anthropic, https://api.anthropic.com)
+      3 models: claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5
+      ✗ API key missing (ANTHROPIC_API_KEY not set, endpoint.api_key empty)
+  ✓ legacy-api-deepseek-com-0 (deepseek, deepseek, https://api.deepseek.com)
+      2 models: deepseek-v4-flash, deepseek-v4-pro
+      ✓ API key found (DEEPSEEK_API_KEY)
+
+References:
+  ✓ default = relay-a::claude-sonnet-4-6 (resolves)
+  ✓ lite = official::claude-haiku-4-5 (resolves, ≠ default)
+
+1 problem(s) found — `octo config` can add an API key.
+```
+
+每个 endpoint 检查：id 合法、有 model、api_key 可达（env 或 `endpoint.APIKey`）。default/lite 引用独立检查可解析 + lite≠default 约束。key 探测沿用现有 `apiKeyReachable` / `apiKeyStatus`（`doctor.go:64-67`）。
+
+## 8. Save 升级策略
+
+`Config.Save()`（`config.go:1407`）当前 marshal 时清空 `Endpoints`/`Default`/`Lite` 只写 `Models`/`DefaultModel`/`LiteModel`。PR5 反转：
+
+```go
+func (c Config) saveLocked(path string) error {
+    // 直接 marshal Config——Endpoints/Default/Lite 是权威字段，Models/DefaultModel/LiteModel 已删
+    data, err := yaml.Marshal(c)
+    if err != nil { return err }
+    // 写 .bak + rename（现有逻辑不变）
+    ...
+}
+```
+
+**单向升级**：老用户跑 PR5 的 octo 一次，`config.yml` 被升级成 `endpoints:` 格式。回退到 PR4b 的 octo 会看到空模型（PR4b 读 `endpoints:` 块 OK 但 `cfg.Models` 空）。设计 §18.1 明文不承诺回退兼容，dev-docs 和 release notes 说明。
+
+## 9. 文档更新
+
+### 9.1 commit 现有设计文档
+
+PR1-3 期间 `dev-docs/endpoint-design.md` 一直 untracked（从未 commit）。PR5 先把它 commit 进仓库（作为 PR1-3 设计快照）。
+
+### 9.2 修订设计文档
+
+PR5 实施偏离原文档的地方，在 `dev-docs/endpoint-design.md` 正文修订（不是末尾加偏离清单——结构性偏离改正文）：
+
+| 章节 | 修订内容 |
+|---|---|
+| §3.1 Config struct | 删 `Models`/`DefaultModel`/`LiteModel` 字段；`Endpoints`/`Default`/`Lite` 标注"PR5 起权威" |
+| §4.1 读路径 | `normalize()` 简化：只处理老 `models:` → `Endpoints` 迁移，不再 `syncEndpointsFromModels` 双向同步 |
+| §4.2 写路径 | PR5 已切换，Save 写 `endpoints:` 格式 |
+| §4.3 PR1 过渡策略 | 标注"PR1-3 期间过渡，PR5 已切换" |
+| §6.1 改名级联 | 修正"扫 channels.yml"为"不扫 session 文件，靠 EntryByModel bare-model fallback 兜底" |
+| §8.1 字段分类表 | 删 `Models`/`DefaultModel`/`LiteModel` 行；`Session.Model`/`ModelConfig`/`channel.Store.ModelConfig` 标注"PR5 后复合 id，stale 靠 fallback 兜底" |
+| §8.2 读时识别 | `EntryByModel` bare-model fallback 改扫 Endpoints |
+| §10.2 CRUD API | 标注"PR5 已实现" |
+| §10.3 老 `/api/config/models` | 标注"PR5 已删除" |
+| §11 PR 拆分表 | PR4a 标"取消"；PR4b 标"已合并 #1623"；PR5 标"写路径切换 + CLI + CRUD" |
+| §13 CLI | 落实 show/doctor 输出格式（§7.2/§7.3） |
+| §14 Validate/Repair | endpoint 级 guard 移除（`len(c.Models) == 0` 判断不再需要） |
+| §15.1 i18n | PR5 未加新 key（CRUD key 留 PR6）；标注 |
+| §18.1 兼容性 | 老文件单向升级；reasoning 从 per-entry 改全局 |
+| §18.2/§18.3 老 session/channel | 标注"stale 复合 id 靠 EntryByModel fallback 兜底" |
+| §18.4 老脚本 | `--model <bare>` 走 ParseModelFlag step 2，扫 Endpoints |
+| §18.5 老 API | 标注"PR5 已删除 `/api/config/models*`" |
+
+### 9.3 新增 §22 PR5 实施记录
+
+末尾加 §22 记录 PR5 的 11 个关键决策（本文 §2-§8 的决策点 + 理由），作为决策溯源补充。
+
+## 10. 测试计划
+
+### 10.1 config 层
+
+| 测试 | 覆盖点 |
+|---|---|
+| `TestSave_WritesEndpointsFormat` | Save marshal 出 `endpoints:` 块，不写 `models:` |
+| `TestLoad_LegacyModelsBlockMigratesToEndpoints` | 老 `models:` 文件 Load 后 `c.Endpoints` 正确，`c.Models` 不存在 |
+| `TestLoad_LegacyReasoningDropped` | 老 `models:` 块里 per-entry `reasoning_effort`/`show_reasoning` 字段 Load 后丢弃，全局 `cfg.ReasoningEffort`/`ShowReasoning` 保持空（或顶层值） |
+| `TestUpsertEndpoint_InsertAndReplace` | 新 id 追加、已存在 id 替换 |
+| `TestUpsertModel_NewAndExisting` | 新 model 追加、已存在 model 替换 |
+| `TestUpsertModel_UnknownEndpointReturnsError` | endpoint 不存在报 `ErrEndpointNotFound` |
+| `TestSetDefaultComposite` | 设 `cfg.Default`，不验证、不失效 sender |
+| `TestEntryByModel_BareModelScansEndpoints` | bare model 走 Endpoints 扫描，default endpoint 优先 |
+| `TestEntryByModel_BareModelAmbiguousPicksDefault` | 同 model 多 endpoint，走 default |
+| `TestEntryByModel_CompositeIDResolves` | 复合 id 路径不变（PR2 测试保持） |
+| `TestRepair_EndpointLevelGuardRemoved` | Validate/Repair 不再要求 `len(Models)==0` |
+
+### 10.2 server 层
+
+| 测试 | 覆盖点 |
+|---|---|
+| `TestCreateEndpoint` | POST 创建，201 + has_api_key |
+| `TestUpdateEndpoint_ConnectionParams` | PATCH 改 base_url/api_key，触发 invalidateEndpointSenders |
+| `TestUpdateEndpoint_RenameTriggersCascade` | PATCH 带 new_id，Default/Lite 前缀重写 + 旧 sender 失效 |
+| `TestUpdateEndpoint_RenameCollision` | new_id 撞现有 endpoint，409 |
+| `TestDeleteEndpoint` | DELETE，Default/Lite 指向它时清空 |
+| `TestAddEndpointModel` | POST model，vision flag |
+| `TestDeleteEndpointModel` | DELETE model，Default/Lite 指向时走 Repair |
+| `TestSetEndpointDefault` | POST default，设 cfg.Default |
+| `TestSetEndpointLite` | POST lite，设 cfg.Lite |
+| `TestHandleGetConfig_NoModelsField` | GET /api/config 响应不含 models/default_model_idx |
+| `TestOldModelsRoutes_Gone` | POST /api/config/models 返回 404 |
+| `TestInvalidateEndpointSenders_OnCRUD` | 各 CRUD handler 触发/不触发失效（§6 表） |
+
+### 10.3 CLI 层
+
+| 测试 | 覆盖点 |
+|---|---|
+| `TestConfigWizard_CreatesFirstEndpoint` | 首次跑向导，生成 `legacy-<host>-0`，设 default |
+| `TestConfigWizard_OverwritesSameHost` | 同 host 已存在，覆盖 |
+| `TestConfigWizard_NewHostCreatesNew` | 不同 host，新建，提示 |
+| `TestConfigWizard_AskSetDefault` | 最后一步问"设为 default"，Y/n 都正确 |
+| `TestConfigShow_TwoLevelOutput` | show 输出格式（§7.2） |
+| `TestDoctor_PerEndpointCheck` | doctor 输出格式（§7.3），含 key missing 场景 |
+
+### 10.4 跨平台
+
+按 memory 教训：测试里比较路径禁止硬编码 `/`，用 `filepath.ToSlash` 或 `filepath.Join`。PR5 新测试不涉及路径比较，但审计迁移的老测试（如 `onboard_config_handlers_test.go` 里的 `cfg.Models[0]` 断言改成 Endpoints 后）要保证 Windows 兼容。
+
+## 11. 兼容性
+
+### 11.1 老配置文件
+
+老扁平 `models:` 配置文件在 `config.Load()` 时被 `normalize()` 转成 `c.Endpoints`。老用户任何一次 Save 后文件升级为新 `endpoints:` 结构。**单向升级，不可回退到 PR4b**（PR4b 读 `endpoints:` 块 OK 但 `cfg.Models` 空，web 设置页 AI Models 节会空）。
+
+### 11.2 老 session 文件
+
+`Session.Model` / `ModelConfig` 字段读时识别两种格式（裸 model + 复合 id），不写回。老 session 里的 stale 复合 id（endpoint 改名后）靠 `EntryByModel` 的 bare-model fallback 兜底（扫 Endpoints 找同名 model）。
+
+### 11.3 老 channel 绑定
+
+同 §11.2，channel store 是 `agent.Session`，`ModelConfig` 字段读时惰性升级不写回。
+
+### 11.4 老脚本
+
+`octo --model claude-sonnet-4-6`（裸 model）走 `ParseModelFlag` step 2（default 优先 + 扫 Endpoints 兜底），老脚本仍能跑。
+
+### 11.5 老 API 端点
+
+`GET/POST/PATCH/DELETE /api/config/models*` PR5 全删。第三方脚本调旧端点会 404。octo-agent 种子用户阶段，deprecation period 价值不大，直接删。
+
+### 11.6 reasoning 字段迁移
+
+老 `ModelEntry.ReasoningEffort` / `ShowReasoning` 在 Load 时**直接丢弃**，不拷到全局。用户要重新设全局 reasoning（`octo config` 或 web 设置页）。dev-docs 和 release notes 说明这个行为变化。代价：老用户的 per-entry reasoning 配置丢失；但多数用户只用 default entry 的 reasoning，且 lite model 不走 reasoning，影响小。
+
+## 12. 安全
+
+- `Endpoint.APIKey` 存明文（`config.yml` mode 0600），是 opt-in 回退，优先 env var
+- CRUD API 响应只返回 `has_api_key: bool`，不返回明文 key（PR4b 已实现）
+- POST /api/config/endpoints 的 `api_key` 字段是写入字段（请求里有、响应里无）
+- flock 保护 `config.yml` 跨进程写（PR3 已实现）
+- endpoint 改名级联不涉及权限提升（§19.3 不变）
+
+## 13. 已知限制
+
+| 限制 | 影响 | 缓解 |
+|---|---|---|
+| 单向升级不可回退 PR4b | 用户回退看到空模型 | dev-docs + release notes 说明；YAML 手改 5 分钟可恢复 |
+| 老 session stale 复合 id 靠 fallback 兜底 | 改名后老 session 下次 turn 可能走错 endpoint（bare-model fallback 找到同名 model 但不是原 endpoint） | 极罕见场景（endpoint 改名 + 老 session 复用）；用户可 `/model <新复合id>` 显式重绑 |
+| reasoning 降级到全局且老配置丢弃 | 老 per-entry reasoning 设置丢失，需重新设全局 | dev-docs 说明；多数用户只用 default entry 的 reasoning，影响小 |
+| Web CRUD 留 PR6 | PR5 后 web 不能编辑 endpoint | CLI `octo config` 能完整管理；web 卡片节有"编辑将在下个版本"提示 |
+| 老 `/api/config/models` 端点删除 | 第三方脚本调旧端点 404 | 种子用户阶段，第三方脚本概率极低 |
+
+## 14. Release order
+
+单仓库（octo-agent），单 PR（PR5）。无多 repo 协调。
+
+PR5 合并后，PR6 做 Web UI CRUD（endpoint 卡片可编辑、加 model 表单、改名确认弹窗、default/lite 切换按钮），并加 §15.1 剩余的 i18n key（`add`/`delete`/`rename_confirm`/`error.*`）。
+
+## 15. Rollback
+
+- **代码回滚**：revert PR5 commit。`config.yml` 若已被 PR5 升级成 `endpoints:` 格式，revert 后 PR4b 的 octo 读 `endpoints:` 块 OK 但 `cfg.Models` 空——用户需手动把 `endpoints:` 块改回 `models:` 块（YAML 手改）或从 `config.yml.bak` 恢复（PR5 Save 前的备份是老格式）
+- **数据回滚**：`config.yml.bak` 是上次成功 Save 的备份。PR5 首次 Save 前的 `.bak` 是老 `models:` 格式，可恢复
+- **配置回滚**：无独立配置项
+
+## 16. 决策溯源（PR5）
+
+PR5 的 11 个关键决策通过 grill-me 拍板：
+
+1. **`c.Models` 字段**：彻底删（运行时）。理由：最干净，长期维护成本最低；`fileConfig.Models` 保留作 Load 中间态
+2. **新写 API**：`UpsertEndpoint` + `UpsertModel` + `SetDefaultComposite` 三个，抛弃 `SetDefaultEntry`/`SetEntry`。理由：endpoint 是一等公民，model 是子资源，新 API 贴合两级结构和 RESTful CRUD 路径
+3. **向导 endpoint ID**：`legacy-<host>-<n>`（复用 PR1 隐式 id 规则）。理由：和 Load 老 `models:` 生成的 id 一致，用户在 web 看到同一套命名
+4. **向导非首次替换语义**：按 host 找同 id 覆盖，找不到新建并提示，最后显式问"设为 default 吗"。理由：透明，老 endpoint 不丢，default 切换用户有控制权
+5. **改名级联**：只重写 `config.yml`，不扫 session 文件。理由：符合 §8.2 session 不写回原则；老 session stale 复合 id 靠 EntryByModel fallback 兜底
+6. **sender 失效**：粗粒度 per-endpoint，任何 endpoint mutation 都失效该 endpoint 全部 sender；`SetDefaultComposite` 不触发。理由：简单，sender 重建成本低，endpoint mutation 低频
+7. **show/doctor 输出**：show 单行快速浏览、doctor 照设计 §13.2 样例完整。理由：show 是快速看一眼，doctor 是诊断，职责区分
+8. **Save 升级**：单向，不管回退。理由：设计 §18.1 明文；octo-agent 种子用户阶段回退需求极低
+9. **`ModelEntry` 类型**：保留作为投影类型。理由：sender 相关热路径签名不动，降低回归风险
+10. **reasoning 归属**：删 per-entry，全局 `Config.ReasoningEffort`/`ShowReasoning`，老文件 per-entry reasoning 直接丢弃不迁移。理由：简化 Load 实现（无迁移逻辑）；lite model 不走 reasoning，主力 model 通常独占 default endpoint，per-entry reasoning 实际使用极少
+11. **Web CRUD 范围**：PR5 只做后端 + CLI + 文档，Web UI 留 PR6。理由：PR5 已很大（删 Models + CLI + reasoning + CRUD + 文档），Web CRUD 全做规模爆炸
+
+技术事实纠正（原设计文档 R3 违规）：
+
+- §6.1 "扫 `~/.octo/channels.yml` 所有 channel 绑定" —— **错误**。channel 绑定在 `~/.octo/sessions/*.jsonl` 的 `ModelConfig` 字段（`internal/agent/session.go:41`），不在 `channels.yml`。PR5 修正为"不扫 session 文件"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,9 +34,10 @@ import (
 )
 
 // ModelEntry is one model configuration: everything needed to build a sender
-// for it. Model is the entry's identity — the HTTP API uses it as the id,
-// `--model <model>` selects the whole entry, and default_model / lite_model
-// reference it. Two entries may not share a model string.
+// for it. PR5 deleted the per-entry ReasoningEffort/ShowReasoning fields —
+// reasoning is global now (Config.ReasoningEffort/Config.ShowReasoning).
+// ModelEntry is kept as a projection type: EntryByModel returns it, with fields
+// projected from (Endpoint, EndpointModel) — see projectToModelEntry.
 type ModelEntry struct {
 	Provider string `yaml:"provider,omitempty"`
 	Model    string `yaml:"model,omitempty"`
@@ -49,14 +50,6 @@ type ModelEntry struct {
 	// env var is empty. Opt-in via `octo config` and stored mode 0600. Prefer
 	// the env var.
 	APIKey string `yaml:"api_key,omitempty"`
-	// ReasoningEffort sets the unified reasoning intensity ("low" | "medium" |
-	// "high"). OpenAI sends it as reasoning_effort; Anthropic maps it to an
-	// extended-thinking token budget. Empty means off (no extended reasoning).
-	ReasoningEffort string `yaml:"reasoning_effort,omitempty"`
-	// ShowReasoning controls whether a reasoning model's thinking trace is
-	// streamed to the terminal (dimmed). nil means the built-in default
-	// (enabled).
-	ShowReasoning *bool `yaml:"show_reasoning,omitempty"`
 	// Vision controls whether tools may hand this model images (e.g. the
 	// browser tool's screenshot). It is always recorded: predefined models get
 	// their catalogue value at add time, custom models are answered by the user.
@@ -149,39 +142,21 @@ func (e Endpoint) CompositeID(model string) string {
 // missing file (or a missing field) leaves the zero value, and the caller
 // substitutes its built-in default.
 type Config struct {
-	// Endpoints is the list of user-configured channels (the new two-level
-	// schema's authoritative field). Each bundles shared connection params
-	// and a list of models. PR1 populates this from the legacy flat Models
-	// list during normalize(); the write path switches to emitting this in
-	// PR4. Until then Save still writes the flat Models form (Save elides
-	// this field at marshal time) so existing callers and on-disk files
-	// keep working, while Load still honours an explicit endpoints: block
-	// if the user hand-writes one (design §4.1 step 1).
+	// Endpoints is the authoritative list of user-configured channels (the
+	// two-level schema). Each bundles shared connection params and a list of
+	// models. PR5 flipped the write path: Save emits this field, and the
+	// legacy flat Models/DefaultModel/LiteModel fields are deleted from the
+	// runtime struct (only fileConfig.Models survives as a Load-only
+	// intermediate for reading old files).
 	Endpoints []Endpoint `yaml:"endpoints,omitempty"`
 	// Default is the composite id "<endpoint_id>::<model>" selecting the
 	// endpoint+model used when nothing else picks one. Empty falls back to
-	// the first endpoint's first model (see ResolveDefault). Elided at
-	// Save time in PR1; see Save.
+	// the first endpoint's first model (see ResolveDefault).
 	Default string `yaml:"default,omitempty"`
 	// Lite is the composite id for the compaction lite model. Empty means
 	// fall back to ImplicitLiteModel inference (endpoint.lite_model, else
-	// the vendor registry's LiteModel for official endpoints). Elided at
-	// Save time in PR1; see Save.
+	// the vendor registry's LiteModel for official endpoints).
 	Lite string `yaml:"lite,omitempty"`
-
-	// Models is the legacy flat list of named model configurations. Kept
-	// for read compatibility — normalize() populates it from Endpoints so
-	// existing callers keep working. PR4 switches Save to write Endpoints
-	// and stops emitting this.
-	Models []ModelEntry `yaml:"models,omitempty"`
-	// DefaultModel names the entry used when nothing else selects one.
-	// Empty falls back to the first entry. Legacy read-compat only; the
-	// authoritative field is Default above.
-	DefaultModel string `yaml:"default_model,omitempty"`
-	// LiteModel optionally names the entry used for cheap internal calls
-	// (history compaction). Empty means no lite model. Legacy read-compat
-	// only; the authoritative field is Lite above.
-	LiteModel string `yaml:"lite_model,omitempty"`
 
 	PermissionMode string `yaml:"permission_mode,omitempty"`
 	// Coauthor, when true, instructs the agent to append a Co-authored-by line
@@ -199,9 +174,13 @@ type Config struct {
 	// Tools holds opt-in tooling behaviour (Tool Search for MCP, etc.). A
 	// missing block leaves the built-in defaults.
 	Tools ToolsConfig `yaml:"tools,omitempty"`
+	// ReasoningEffort is the unified reasoning intensity ("low" | "medium" |
+	// "high" | "off"). PR5 removed per-entry reasoning — this is the only
+	// place reasoning effort is stored. Per-session overrides via /thinking
+	// are runtime-only and not persisted here.
+	ReasoningEffort string `yaml:"reasoning_effort,omitempty"`
 	// ShowReasoning is the global default for whether a reasoning model's
-	// thinking trace is surfaced. Individual model entries can override this.
-	// nil means the built-in default (enabled).
+	// thinking trace is surfaced. PR5 removed per-entry overrides.
 	ShowReasoning *bool `yaml:"show_reasoning,omitempty"`
 	// Browser configures the built-in browser automation backend.
 	Browser BrowserConfig `yaml:"browser,omitempty"`
@@ -399,10 +378,29 @@ func (c Config) EffectiveCoauthor() bool {
 // model matches a configured entry, its recorded Vision value is authoritative
 // (Load backfills legacy entries, so it is always set). A model not present in
 // the config — e.g. a bare `octo --model X` — falls back to the heuristic.
+//
+// PR5: scans c.Endpoints instead of the deleted c.Models. A bare model name
+// matches the first endpoint whose Models contains it; a composite id
+// "<endpoint>::<model>" matches only that endpoint.
 func (c Config) ModelVision(model string) bool {
-	for _, m := range c.Models {
-		if m.Model == model {
-			return m.Vision
+	if endpointID, modelName, ok := splitCompositeID(model); ok {
+		for _, ep := range c.Endpoints {
+			if ep.ID != endpointID {
+				continue
+			}
+			for _, m := range ep.Models {
+				if m.Model == modelName {
+					return m.Vision
+				}
+			}
+		}
+		return ModelSupportsVision(modelName)
+	}
+	for _, ep := range c.Endpoints {
+		for _, m := range ep.Models {
+			if m.Model == model {
+				return m.Vision
+			}
 		}
 	}
 	return ModelSupportsVision(model)
@@ -449,109 +447,98 @@ type ToolSearchConfig struct {
 	ThresholdPct int `yaml:"threshold_pct,omitempty"`
 }
 
-// DefaultEntry returns the entry whose model matches DefaultModel, falling
-// back to the first entry, or a zero ModelEntry when none are configured.
+// DefaultEntry returns the entry matching cfg.Default (composite id), falling
+// back to the first endpoint's first model, or a zero ModelEntry when none are
+// configured.
+//
+// PR5: scans Endpoints instead of the deleted Models. This function is
+// slated for removal in Slice 2.1 (replaced by ResolveDefault + projectToModelEntry);
+// kept for now so callsites that still read ModelEntry keep working during
+// the migration.
 func (c Config) DefaultEntry() ModelEntry {
-	if e, ok := c.EntryByModel(c.DefaultModel); ok {
+	if e, ok := c.EntryByModel(c.Default); ok {
 		return e
 	}
-	if len(c.Models) > 0 {
-		return c.Models[0]
+	for _, ep := range c.Endpoints {
+		for _, m := range ep.Models {
+			return projectToModelEntry(ep, m)
+		}
 	}
 	return ModelEntry{}
 }
 
+// projectToModelEntry projects an (Endpoint, EndpointModel) pair into the
+// flat ModelEntry shape that sender-building code (cachedSenderForEntry,
+// buildSender) still reads. Provider/BaseURL/APIKey/Protocol come from the
+// Endpoint; Model/Vision come from the EndpointModel. PR5 added this helper
+// because Config.Models is deleted — callers that previously read a flat
+// ModelEntry from c.Models now read this projection from c.Endpoints.
+func projectToModelEntry(ep Endpoint, m EndpointModel) ModelEntry {
+	return ModelEntry{
+		Provider: ep.Provider,
+		Model:    m.Model,
+		BaseURL:  ep.BaseURL,
+		APIKey:   ep.APIKey,
+		Protocol: ep.Protocol,
+		Vision:   m.Vision,
+	}
+}
+
 // Validate reports semantic problems in a config that already parsed cleanly —
-// issues Load tolerates by falling back silently (a mistyped default_model, a
+// issues Load tolerates by falling back silently (a mistyped Default, a
 // duplicated or half-filled entry) but which usually mean a hand edit went
 // wrong. It returns a human-readable list; empty means the config is usable. A
-// config with no models (the valid pre-onboarding state) reports nothing.
+// config with no endpoints (the valid pre-onboarding state) reports nothing.
 //
-// PR1 layers endpoint-level checks on top of the legacy Models checks (design
-// §14.1): endpoint id uniqueness/legality, each endpoint has at least one
-// model, model names non-empty, no duplicate models within one endpoint, and
-// Default/Lite composite ids resolve.
-//
-// To avoid double-reporting on a migrated flat config (where Endpoints is
-// synthesised from Models and the same duplicate would surface in both
-// layers), the endpoint-level checks only run when the config is on the pure
-// new schema — i.e. Endpoints is non-empty AND Models is empty (a hand-written
-// endpoints: block with no models: block, the shape §4.1 step 1 recognises as
-// "user is already on the new schema"). A flat config (Models non-empty,
-// Endpoints synthesised in memory) gets only the legacy Models checks, so
-// hand-edited flat files keep getting exactly the validation they always did.
-// PR4, which switches Save to emit Endpoints and drops the Models write path,
-// will lift this guard so endpoint-level checks always run.
+// PR5 lifted the "pure new schema" guard from PR1 — Config.Models is deleted,
+// so every config is on the new schema now. Endpoint-level checks always run:
+// id uniqueness/legality, each endpoint has at least one model, model names
+// non-empty, no duplicate models within one endpoint, Default/Lite composite
+// ids resolve.
 func (c Config) Validate() []string {
 	var problems []string
 
-	// Endpoint-level checks — only on the pure new schema (Endpoints set,
-	// Models empty). See the doc comment for why.
-	if len(c.Endpoints) > 0 && len(c.Models) == 0 {
-		seenEndpointID := make(map[string]bool, len(c.Endpoints))
-		for i, ep := range c.Endpoints {
-			if strings.TrimSpace(ep.ID) == "" {
-				problems = append(problems, fmt.Sprintf("endpoints[%d] has no id", i))
-			} else if !isValidEndpointID(ep.ID) {
-				problems = append(problems, fmt.Sprintf("endpoint id %q contains illegal chars (allowed: a-z A-Z 0-9 _ -, and no \"::\")", ep.ID))
-			}
-			if seenEndpointID[ep.ID] {
-				problems = append(problems, fmt.Sprintf("duplicate endpoint id %q", ep.ID))
-			}
-			seenEndpointID[ep.ID] = true
-
-			if len(ep.Models) == 0 {
-				problems = append(problems, fmt.Sprintf("endpoint %q has no models", ep.ID))
-			}
-			seenModel := make(map[string]bool, len(ep.Models))
-			for j, m := range ep.Models {
-				if strings.TrimSpace(m.Model) == "" {
-					problems = append(problems, fmt.Sprintf("endpoint %q models[%d] has no model name", ep.ID, j))
-					continue
-				}
-				if seenModel[m.Model] {
-					problems = append(problems, fmt.Sprintf("duplicate model %q in endpoint %q", m.Model, ep.ID))
-				}
-				seenModel[m.Model] = true
-			}
-		}
-
-		// Default/Lite composite-id resolution.
-		if c.Default != "" {
-			if _, _, ok := c.resolveCompositeID(c.Default); !ok {
-				problems = append(problems, fmt.Sprintf("default %q does not resolve to any endpoint+model", c.Default))
-			}
-		}
-		if c.Lite != "" {
-			if _, _, ok := c.resolveCompositeID(c.Lite); !ok {
-				problems = append(problems, fmt.Sprintf("lite %q does not resolve to any endpoint+model", c.Lite))
-			}
-		}
-	}
-
-	// Legacy flat Models checks.
-	if len(c.Models) == 0 {
+	if len(c.Endpoints) == 0 {
 		return problems
 	}
-	seen := make(map[string]bool, len(c.Models))
-	for i, m := range c.Models {
-		if strings.TrimSpace(m.Model) == "" {
-			problems = append(problems, fmt.Sprintf("models[%d] has no model name", i))
-			continue
+	seenEndpointID := make(map[string]bool, len(c.Endpoints))
+	for i, ep := range c.Endpoints {
+		if strings.TrimSpace(ep.ID) == "" {
+			problems = append(problems, fmt.Sprintf("endpoints[%d] has no id", i))
+		} else if !isValidEndpointID(ep.ID) {
+			problems = append(problems, fmt.Sprintf("endpoint id %q contains illegal chars (allowed: a-z A-Z 0-9 _ -, and no \"::\")", ep.ID))
 		}
-		if strings.TrimSpace(m.Provider) == "" {
-			problems = append(problems, fmt.Sprintf("model %q has no provider", m.Model))
+		if seenEndpointID[ep.ID] {
+			problems = append(problems, fmt.Sprintf("duplicate endpoint id %q", ep.ID))
 		}
-		if seen[m.Model] {
-			problems = append(problems, fmt.Sprintf("duplicate model %q (only the first entry is used)", m.Model))
+		seenEndpointID[ep.ID] = true
+
+		if len(ep.Models) == 0 {
+			problems = append(problems, fmt.Sprintf("endpoint %q has no models", ep.ID))
 		}
-		seen[m.Model] = true
+		seenModel := make(map[string]bool, len(ep.Models))
+		for j, m := range ep.Models {
+			if strings.TrimSpace(m.Model) == "" {
+				problems = append(problems, fmt.Sprintf("endpoint %q models[%d] has no model name", ep.ID, j))
+				continue
+			}
+			if seenModel[m.Model] {
+				problems = append(problems, fmt.Sprintf("duplicate model %q in endpoint %q", m.Model, ep.ID))
+			}
+			seenModel[m.Model] = true
+		}
 	}
-	if c.DefaultModel != "" && !seen[c.DefaultModel] {
-		problems = append(problems, fmt.Sprintf("default_model %q matches no entry (the first model is used instead)", c.DefaultModel))
+
+	// Default/Lite composite-id resolution.
+	if c.Default != "" {
+		if _, _, ok := c.resolveCompositeID(c.Default); !ok {
+			problems = append(problems, fmt.Sprintf("default %q does not resolve to any endpoint+model", c.Default))
+		}
 	}
-	if c.LiteModel != "" && !seen[c.LiteModel] {
-		problems = append(problems, fmt.Sprintf("lite_model %q matches no entry", c.LiteModel))
+	if c.Lite != "" {
+		if _, _, ok := c.resolveCompositeID(c.Lite); !ok {
+			problems = append(problems, fmt.Sprintf("lite %q does not resolve to any endpoint+model", c.Lite))
+		}
 	}
 	return problems
 }
@@ -640,59 +627,72 @@ func (c Config) EntryByModel(model string) (ModelEntry, bool) {
 		// nothing and returns false, which is correct — the caller should
 		// fall back to ResolveDefault.
 	}
-	// Bare-model path: legacy flat Models lookup.
-	for _, e := range c.Models {
-		if e.Model == model {
-			return e, true
+	// Bare-model path: scan Endpoints for the first endpoint whose Models
+	// contains this model. Prefer the default endpoint when set, mirroring
+	// ParseModelFlag step 2a; else the first hit. PR5 replaced the legacy
+	// c.Models scan (deleted) with this Endpoints scan.
+	if c.Default != "" {
+		if defEp, defM, ok := c.ResolveDefault(); ok && defM.Model == model {
+			return projectToModelEntry(defEp, defM), true
+		}
+	}
+	for _, ep := range c.Endpoints {
+		for _, m := range ep.Models {
+			if m.Model == model {
+				return projectToModelEntry(ep, m), true
+			}
 		}
 	}
 	return ModelEntry{}, false
 }
 
-// SetDefaultEntry replaces the current default entry in place, or appends it
-// when no entry exists yet, and points DefaultModel at it. The default entry is
-// located the same way DefaultEntry resolves it — by DefaultModel, else the
-// first entry — so it works even when that entry's model is empty (a floating
-// default). Writers that previously mutated the top-level provider/model fields
-// go through this.
-func (c *Config) SetDefaultEntry(e ModelEntry) {
-	idx := -1
-	for i := range c.Models {
-		if c.DefaultModel != "" && c.Models[i].Model == c.DefaultModel {
-			idx = i
-			break
+// UpsertEndpoint inserts or replaces the endpoint with ep.ID. If an endpoint
+// with that ID already exists, it's replaced in place; otherwise ep is
+// appended. Default/Lite composite-id references are NOT rewritten here — use
+// RenameEndpoint for id changes. Returns the index of the upserted endpoint.
+//
+// PR5 replaced SetDefaultEntry/SetEntry (flat Models mutations) with this
+// endpoint-aware API (design §3.1).
+func (c *Config) UpsertEndpoint(ep Endpoint) int {
+	for i := range c.Endpoints {
+		if c.Endpoints[i].ID == ep.ID {
+			c.Endpoints[i] = ep
+			return i
 		}
 	}
-	if idx == -1 && len(c.Models) > 0 {
-		idx = 0 // DefaultEntry falls back to the first entry
-	}
-	if idx < 0 {
-		c.Models = append(c.Models, e)
-		c.DefaultModel = e.Model
-		return
-	}
-	// Changing the default entry's model keeps the lite reference consistent.
-	if c.LiteModel != "" && c.LiteModel == c.Models[idx].Model {
-		c.LiteModel = e.Model
-	}
-	c.Models[idx] = e
-	c.DefaultModel = e.Model
+	c.Endpoints = append(c.Endpoints, ep)
+	return len(c.Endpoints) - 1
 }
 
-// SetEntry replaces the entry matching e.Model in place. Unlike
-// SetDefaultEntry, it never appends a new entry and never touches
-// DefaultModel/LiteModel — it's for updating an already-configured entry by
-// name (e.g. a per-session setting change that should land on the specific
-// model that session runs, not necessarily the default one). Reports whether
-// a matching entry was found.
-func (c *Config) SetEntry(e ModelEntry) bool {
-	for i := range c.Models {
-		if c.Models[i].Model == e.Model {
-			c.Models[i] = e
-			return true
+// UpsertModel inserts or replaces the model under the given endpoint. If
+// endpointID doesn't exist, returns ErrEndpointNotFound. If a model with the
+// same Model id already exists under the endpoint, it's replaced; otherwise
+// appended. Default/Lite references pointing at this endpoint+old-model-shape
+// are NOT updated — callers that change a model id should call
+// SetDefaultComposite / repair Lite explicitly.
+func (c *Config) UpsertModel(endpointID string, m EndpointModel) error {
+	for i := range c.Endpoints {
+		if c.Endpoints[i].ID != endpointID {
+			continue
 		}
+		for j := range c.Endpoints[i].Models {
+			if c.Endpoints[i].Models[j].Model == m.Model {
+				c.Endpoints[i].Models[j] = m
+				return nil
+			}
+		}
+		c.Endpoints[i].Models = append(c.Endpoints[i].Models, m)
+		return nil
 	}
-	return false
+	return fmt.Errorf("%w: %s", ErrEndpointNotFound, endpointID)
+}
+
+// SetDefaultComposite sets cfg.Default to the given composite id. Does NOT
+// validate the id resolves — Validate() catches dangling Default. Does NOT
+// invalidate sender cache (a default switch doesn't rebuild senders, only
+// changes which sender ResolveDefault returns next time).
+func (c *Config) SetDefaultComposite(cid string) {
+	c.Default = cid
 }
 
 // RenameEndpoint renames an endpoint id across the config: it updates the
@@ -824,96 +824,104 @@ func legacyPath() (string, error) {
 	return filepath.Join(home, ".octo", "config.yaml"), nil
 }
 
-// fileConfig is the on-disk superset: the current schema plus the legacy
-// top-level model fields, so both file generations unmarshal through one
-// struct and normalize identically.
+// fileConfig is the on-disk superset: the current Endpoints-based schema plus
+// the legacy flat top-level model fields, so both file generations unmarshal
+// through one struct and normalize to the Endpoints form.
+//
+// PR5 deleted Config.Models/DefaultModel/LiteModel from the runtime struct
+// (Endpoints is authoritative now). fileConfig carries them as independent
+// legacy fields so an old `models:`-block file still Loads — normalize()
+// migrates them into c.Endpoints, then they're discarded. Per-entry
+// reasoning_effort/show_reasoning fields in old files are silently dropped
+// (yaml.Unmarshal ignores struct fields that don't exist); the user must
+// re-set the global ReasoningEffort/ShowReasoning (design §11.6).
 type fileConfig struct {
 	Config `yaml:",inline"`
 
-	LegacyProvider        string `yaml:"provider,omitempty"`
-	LegacyModel           string `yaml:"model,omitempty"`
-	LegacyBaseURL         string `yaml:"base_url,omitempty"`
-	LegacyAPIKey          string `yaml:"api_key,omitempty"`
-	LegacyReasoningEffort string `yaml:"reasoning_effort,omitempty"`
-	// LegacyShowReasoning is intentionally absent: the top-level show_reasoning
-	// key is now read into Config.ShowReasoning (the global default). During
-	// normalization it is also copied onto the single legacy model entry so
-	// behaviour is preserved.
+	// Legacy flat models: block (only present in pre-PR5 files).
+	LegacyModels       []ModelEntry `yaml:"models,omitempty"`
+	LegacyDefaultModel string       `yaml:"default_model,omitempty"`
+	LegacyLiteModel    string       `yaml:"lite_model,omitempty"`
+
+	// Legacy top-level single-entry fields (pre-endpoints era).
+	LegacyProvider string `yaml:"provider,omitempty"`
+	LegacyModel    string `yaml:"model,omitempty"`
+	LegacyBaseURL  string `yaml:"base_url,omitempty"`
+	LegacyAPIKey   string `yaml:"api_key,omitempty"`
+	// LegacyReasoningEffort is intentionally NOT read: the top-level
+	// reasoning_effort key is read into Config.ReasoningEffort (the global
+	// default). Per-entry reasoning in legacy files is dropped on migration
+	// (design §11.6).
 }
 
-// normalize folds legacy top-level model fields into a one-entry Models list.
-// Files already on the new schema pass through untouched; legacy fields are
-// ignored once a models list exists.
+// normalize folds legacy flat fields into the Endpoints form. Files already on
+// the new schema pass through untouched; legacy fields are migrated into
+// c.Endpoints (and Default/Lite composite ids), then dropped from the runtime
+// Config.
 //
 // Precedence (design §4.1): if the file carries an explicit endpoints: block
 // the user is already on the new schema and we honour it as-is — rebuilding
-// from Models would silently drop their endpoints: edits. Otherwise we
-// synthesise Endpoints from the flat Models list so new code can read the
-// two-level shape while existing callers keep reading Models.
+// from legacy fields would silently drop their endpoints: edits. Otherwise we
+// synthesise Endpoints from the legacy flat Models list (or the single
+// top-level provider/model/api_key fields) so new code reads the two-level
+// shape.
 func (f fileConfig) normalize() Config {
 	c := f.Config
 	if len(c.Endpoints) > 0 {
-		// Already on the new schema — leave Endpoints/Default/Lite as the
-		// authoritative shape. Migrate any provider aliases on Models too,
-		// for callers that still read the flat list.
-		for i := range c.Models {
-			migrateEntryProvider(&c.Models[i])
-		}
+		// Already on the new schema — Endpoints/Default/Lite are authoritative.
+		// Migrate any provider aliases on legacy Models (now only in
+		// fileConfig, but normalize() doesn't touch them since they're discarded
+		// anyway).
 		return c
 	}
-	if len(c.Models) > 0 {
-		for i := range c.Models {
-			migrateEntryProvider(&c.Models[i])
+	if len(f.LegacyModels) > 0 {
+		legacy := f.LegacyModels
+		for i := range legacy {
+			migrateEntryProvider(&legacy[i])
 		}
-		syncEndpointsFromModels(&c)
+		c.Endpoints = synthesizeEndpointsFromLegacy(legacy)
+		c.Default = mapLegacyBareModelToComposite(c.Endpoints, f.LegacyDefaultModel)
+		c.Lite = mapLegacyBareModelToComposite(c.Endpoints, f.LegacyLiteModel)
 		return c
 	}
 	if f.LegacyProvider == "" && f.LegacyModel == "" && f.LegacyBaseURL == "" && f.LegacyAPIKey == "" {
 		return c
 	}
 	e := ModelEntry{
-		Provider:        f.LegacyProvider,
-		Model:           f.LegacyModel,
-		BaseURL:         f.LegacyBaseURL,
-		APIKey:          f.LegacyAPIKey,
-		ReasoningEffort: f.LegacyReasoningEffort,
-		ShowReasoning:   c.ShowReasoning,
+		Provider: f.LegacyProvider,
+		Model:    f.LegacyModel,
+		BaseURL:  f.LegacyBaseURL,
+		APIKey:   f.LegacyAPIKey,
+		// Per-entry reasoning fields are dropped on migration (design §11.6):
+		// LegacyReasoningEffort is intentionally NOT copied onto anything.
 		// The legacy schema predates the vision field; backfill from the id so
 		// the first Save records it, mirroring the models-list migration path.
 		Vision: ModelSupportsVision(f.LegacyModel),
 	}
 	migrateEntryProvider(&e)
-	c.Models = []ModelEntry{e}
-	c.DefaultModel = f.LegacyModel
-	syncEndpointsFromModels(&c)
+	c.Endpoints = synthesizeEndpointsFromLegacy([]ModelEntry{e})
+	c.Default = mapLegacyBareModelToComposite(c.Endpoints, f.LegacyModel)
 	return c
 }
 
-// syncEndpointsFromModels populates c.Endpoints / c.Default / c.Lite from the
-// legacy flat c.Models / c.DefaultModel / c.LiteModel. It runs after the flat
-// list is finalised so every Load leaves both shapes in sync: existing callers
-// keep reading c.Models (PR1 doesn't switch the write path), while new code
-// reads c.Endpoints.
+// synthesizeEndpointsFromModels populates c.Endpoints from the legacy flat
+// Models. Aggregation is by (provider, base_url): entries sharing the same
+// provider and base_url collapse into one endpoint. Each migrated endpoint
+// gets a stable implicit ID "legacy-<host>-<n>" so repeated loads produce the
+// same ID. api_key/protocol are taken from the first entry of each group; if
+// a later entry in the same group carried a different key, it's dropped with
+// a slog.Warn.
 //
-// Aggregation is by (provider, base_url): entries sharing the same provider
-// and base_url collapse into one endpoint (that bundle is exactly what an
-// endpoint represents — shared connection params). Each migrated endpoint gets
-// a stable implicit ID "legacy-<host>-<n>" so repeated loads produce the same
-// ID; the user can rename it later. api_key/protocol are taken from the first
-// entry of each group; if a later entry in the same group carried a different
-// key, it's dropped with a slog.Warn so the loss isn't silent.
+// Default/Lite mapping (bare-model → composite-id) is done by the caller via
+// mapLegacyBareModelToComposite — this helper only builds the endpoint list.
 //
-// Default/Lite (composite ids) are mapped from the legacy DefaultModel/LiteModel
-// (bare model strings) by locating the first endpoint whose Models contains
-// the model.
-func syncEndpointsFromModels(c *Config) {
-	c.Endpoints = nil
-	c.Default = ""
-	c.Lite = ""
-	if len(c.Models) == 0 {
-		return
+// (Formerly syncEndpointsFromModels which also kept c.Models in sync; PR5
+// dropped the c.Models field so this helper returns []Endpoint instead of
+// mutating a Config.)
+func synthesizeEndpointsFromLegacy(entries []ModelEntry) []Endpoint {
+	if len(entries) == 0 {
+		return nil
 	}
-
 	type group struct {
 		provider string
 		baseURL  string
@@ -921,7 +929,7 @@ func syncEndpointsFromModels(c *Config) {
 	}
 	var groups []group
 	groupIdx := map[string]int{} // key: provider+"\x00"+baseURL → index in groups
-	for _, e := range c.Models {
+	for _, e := range entries {
 		key := e.Provider + "\x00" + e.BaseURL
 		if idx, ok := groupIdx[key]; ok {
 			groups[idx].entries = append(groups[idx].entries, e)
@@ -934,6 +942,7 @@ func syncEndpointsFromModels(c *Config) {
 	// Per-baseURL counter for the legacy-<host>-<n> suffix so two endpoints
 	// sharing a host (e.g. regional variants) get distinct IDs.
 	hostCounter := map[string]int{}
+	var endpoints []Endpoint
 	for _, g := range groups {
 		host := hostFromBaseURL(g.baseURL)
 		n := hostCounter[host]
@@ -962,33 +971,27 @@ func syncEndpointsFromModels(c *Config) {
 			}
 			ep.Models = append(ep.Models, EndpointModel{Model: e.Model, Vision: e.Vision})
 		}
-		c.Endpoints = append(c.Endpoints, ep)
+		endpoints = append(endpoints, ep)
 	}
-
-	if c.DefaultModel != "" {
-		if ep, m, ok := findEndpointModel(c.Endpoints, c.DefaultModel); ok {
-			c.Default = ep.CompositeID(m.Model)
-		}
-	}
-	if c.LiteModel != "" {
-		if ep, m, ok := findEndpointModel(c.Endpoints, c.LiteModel); ok {
-			c.Lite = ep.CompositeID(m.Model)
-		}
-	}
+	return endpoints
 }
 
-// findEndpointModel returns the first endpoint whose Models contains the given
-// bare model id, plus the matching EndpointModel. Used to map legacy bare-model
-// references (DefaultModel / LiteModel) to composite ids during normalisation.
-func findEndpointModel(endpoints []Endpoint, model string) (Endpoint, EndpointModel, bool) {
+// mapLegacyBareModelToComposite returns the composite id for a legacy bare
+// model string by locating the first endpoint whose Models contains it. Used
+// by normalize() to map legacy default_model/lite_model to the new Default/Lite
+// composite-id form. Empty input or no match returns "".
+func mapLegacyBareModelToComposite(endpoints []Endpoint, bareModel string) string {
+	if bareModel == "" {
+		return ""
+	}
 	for _, ep := range endpoints {
 		for _, m := range ep.Models {
-			if m.Model == model {
-				return ep, m, true
+			if m.Model == bareModel {
+				return ep.CompositeID(m.Model)
 			}
 		}
 	}
-	return Endpoint{}, EndpointModel{}, false
+	return ""
 }
 
 // hostFromBaseURL extracts the URL host (lowercased) for use in a
@@ -1383,14 +1386,12 @@ func resetLastGoodForTest() {
 // moment is renamed to config.yaml.bak — best effort, because config.yml wins
 // the read order regardless.
 //
-// PR1 invariant (design §4.3): Save must write the legacy flat form
-// (models: + default_model: + lite_model:), NOT the new endpoints: form.
-// The new Endpoints/Default/Lite fields are in-memory only during PR1-3 so
-// existing callers and downgrade paths keep working. PR4 will flip this to
-// emit endpoints: instead. To enforce that here without changing the field
-// tags (Load still needs to honour an explicit endpoints: block the user
-// hand-writes, per §4.1 step 1), Save marshals a shallow copy with the new
-// fields cleared.
+// PR5 (design §4.2): Save writes the authoritative Endpoints/Default/Lite
+// form. The legacy flat Models/DefaultModel/LiteModel fields are deleted from
+// the runtime Config (they survive only as fileConfig legacy fields for
+// reading old files). Downgrading to a pre-PR5 build after this Save is NOT
+// supported — the file will parse but the old code's cfg.Models will be empty.
+// This is by design (§18.1, §11.1).
 //
 // PR3 (design §7.1): Save holds an exclusive flock on the lockfile for the
 // duration of the write, serialising concurrent Save calls across processes.
@@ -1421,15 +1422,11 @@ func (c Config) Save() error {
 // (which wraps it in withConfigLock) and by Mutate (which already holds the
 // lock and needs to save without re-locking — re-locking would deadlock since
 // flock on a fresh fd blocks on the same inode).
+//
+// PR5: marshals Config directly. Endpoints/Default/Lite are the authoritative
+// fields now; nothing is cleared before marshal.
 func (c Config) saveLocked(path string) error {
-	// Shallow copy with the new-schema fields cleared so yaml.Marshal emits
-	// only the legacy flat form. The Models slice is shared by reference,
-	// which is fine — we don't mutate it.
-	saved := c
-	saved.Endpoints = nil
-	saved.Default = ""
-	saved.Lite = ""
-	data, err := yaml.Marshal(saved)
+	data, err := yaml.Marshal(c)
 	if err != nil {
 		return err
 	}
@@ -1513,125 +1510,90 @@ func RestoreFromBackup() (brokenSaved string, err error) {
 func (c Config) Repair() (repaired Config, fixed, unfixable []string) {
 	repaired = c
 
-	// Endpoint-level repair — only on the pure new schema (Endpoints set,
-	// Models empty). See the doc comment for why.
-	if len(repaired.Endpoints) > 0 && len(repaired.Models) == 0 {
-		// Scan for unfixable problems first so the auto-fixes below don't
-		// act on garbage (e.g. an illegal id can't be safely renamed, so
-		// the user must fix it before any auto-reset of Default makes
-		// sense).
-		seenID := make(map[string]bool, len(repaired.Endpoints))
-		for i, ep := range repaired.Endpoints {
-			if strings.TrimSpace(ep.ID) == "" {
-				unfixable = append(unfixable, fmt.Sprintf("endpoints[%d] has no id — add one", i))
-			} else if !isValidEndpointID(ep.ID) {
-				unfixable = append(unfixable, fmt.Sprintf("endpoint id %q contains illegal chars — rename", ep.ID))
-			}
-			if seenID[ep.ID] {
-				unfixable = append(unfixable, fmt.Sprintf("duplicate endpoint id %q — rename one", ep.ID))
-			}
-			seenID[ep.ID] = true
+	// PR5 lifted the "pure new schema" guard from PR1 — Config.Models is
+	// deleted, so every config is on the new schema. Endpoint-level repair
+	// always runs.
 
-			seenModel := make(map[string]bool, len(ep.Models))
-			for j, m := range ep.Models {
-				if strings.TrimSpace(m.Model) == "" {
-					unfixable = append(unfixable, fmt.Sprintf("endpoint %q models[%d] has no model name — add one or remove it", ep.ID, j))
-					continue
-				}
-				if seenModel[m.Model] {
-					unfixable = append(unfixable, fmt.Sprintf("duplicate model %q in endpoint %q — remove one", m.Model, ep.ID))
-				}
-				seenModel[m.Model] = true
-			}
+	// Scan for unfixable problems first so the auto-fixes below don't
+	// act on garbage (e.g. an illegal id can't be safely renamed, so
+	// the user must fix it before any auto-reset of Default makes
+	// sense).
+	seenID := make(map[string]bool, len(repaired.Endpoints))
+	for i, ep := range repaired.Endpoints {
+		if strings.TrimSpace(ep.ID) == "" {
+			unfixable = append(unfixable, fmt.Sprintf("endpoints[%d] has no id — add one", i))
+		} else if !isValidEndpointID(ep.ID) {
+			unfixable = append(unfixable, fmt.Sprintf("endpoint id %q contains illegal chars — rename", ep.ID))
 		}
+		if seenID[ep.ID] {
+			unfixable = append(unfixable, fmt.Sprintf("duplicate endpoint id %q — rename one", ep.ID))
+		}
+		seenID[ep.ID] = true
 
-		// Auto-fixes (safe, no guessing).
-
-		// Delete empty endpoints (no models). These are unusable and a
-		// dangling-Default reset below would have nothing to point at if all
-		// endpoints were empty.
-		var kept []Endpoint
-		for _, ep := range repaired.Endpoints {
-			if len(ep.Models) == 0 {
-				fixed = append(fixed, fmt.Sprintf("deleted empty endpoint %q (had no models)", ep.ID))
+		seenModel := make(map[string]bool, len(ep.Models))
+		for j, m := range ep.Models {
+			if strings.TrimSpace(m.Model) == "" {
+				unfixable = append(unfixable, fmt.Sprintf("endpoint %q models[%d] has no model name — add one or remove it", ep.ID, j))
 				continue
 			}
-			kept = append(kept, ep)
-		}
-		repaired.Endpoints = kept
-
-		// Find the first non-empty endpoint + its first model — the reset
-		// target for a dangling Default. If there are none, leave Default
-		// for the user (all-empty config is the pre-onboarding state).
-		var firstEpID, firstModel string
-		for _, ep := range repaired.Endpoints {
-			if len(ep.Models) > 0 {
-				firstEpID = ep.ID
-				firstModel = ep.Models[0].Model
-				break
+			if seenModel[m.Model] {
+				unfixable = append(unfixable, fmt.Sprintf("duplicate model %q in endpoint %q — remove one", m.Model, ep.ID))
 			}
+			seenModel[m.Model] = true
 		}
-		if repaired.Default != "" {
-			if _, _, ok := repaired.resolveCompositeID(repaired.Default); !ok {
-				if firstEpID != "" {
-					newDefault := firstEpID + "::" + firstModel
-					fixed = append(fixed, fmt.Sprintf("reset default %q → %q (first endpoint's first model)", repaired.Default, newDefault))
-					repaired.Default = newDefault
-				} else {
-					fixed = append(fixed, fmt.Sprintf("cleared default %q (no endpoints with models to fall back to)", repaired.Default))
-					repaired.Default = ""
-				}
-			}
-		}
-		if repaired.Lite != "" {
-			// Lite dangles OR Lite == Default → clear. The "==" check is on
-			// the raw composite-id strings — endpoint IDs must match
-			// ^[a-zA-Z0-9_-]+$ (no spaces, no case variation), so two
-			// different strings can never resolve to the same endpoint+model
-			// in practice. Validate rejects any id that would; reaching here
-			// with a valid composite id means the string form is canonical.
-			_, _, liteOK := repaired.resolveCompositeID(repaired.Lite)
-			if !liteOK || repaired.Lite == repaired.Default {
-				fixed = append(fixed, fmt.Sprintf("cleared lite %q (matched no endpoint+model or equals default)", repaired.Lite))
-				repaired.Lite = ""
-			}
-		}
-
-		return repaired, fixed, unfixable
 	}
 
-	// Legacy flat Models repair.
-	if len(repaired.Models) == 0 {
-		return repaired, nil, nil
-	}
-	seen := make(map[string]bool, len(repaired.Models))
-	var firstNamed string // first entry with a usable model name — the reset target
-	for i, m := range repaired.Models {
-		if strings.TrimSpace(m.Model) == "" {
-			unfixable = append(unfixable, fmt.Sprintf("models[%d] has no model name — add one or remove the entry", i))
+	// Auto-fixes (safe, no guessing).
+
+	// Delete empty endpoints (no models). These are unusable and a
+	// dangling-Default reset below would have nothing to point at if all
+	// endpoints were empty.
+	var kept []Endpoint
+	for _, ep := range repaired.Endpoints {
+		if len(ep.Models) == 0 {
+			fixed = append(fixed, fmt.Sprintf("deleted empty endpoint %q (had no models)", ep.ID))
 			continue
 		}
-		if firstNamed == "" {
-			firstNamed = m.Model
-		}
-		if strings.TrimSpace(m.Provider) == "" {
-			unfixable = append(unfixable, fmt.Sprintf("model %q has no provider — add one", m.Model))
-		}
-		if seen[m.Model] {
-			unfixable = append(unfixable, fmt.Sprintf("duplicate model %q — remove the extra entry", m.Model))
-		}
-		seen[m.Model] = true
+		kept = append(kept, ep)
 	}
-	// Reset a dangling default_model to the first usable entry. If no entry has a
-	// name there's nothing safe to point it at, so leave it for the user (the
-	// nameless entries are already reported as unfixable above).
-	if repaired.DefaultModel != "" && !seen[repaired.DefaultModel] && firstNamed != "" {
-		fixed = append(fixed, fmt.Sprintf("reset default_model %q → %q (first configured model)", repaired.DefaultModel, firstNamed))
-		repaired.DefaultModel = firstNamed
+	repaired.Endpoints = kept
+
+	// Find the first non-empty endpoint + its first model — the reset
+	// target for a dangling Default. If there are none, leave Default
+	// for the user (all-empty config is the pre-onboarding state).
+	var firstEpID, firstModel string
+	for _, ep := range repaired.Endpoints {
+		if len(ep.Models) > 0 {
+			firstEpID = ep.ID
+			firstModel = ep.Models[0].Model
+			break
+		}
 	}
-	if repaired.LiteModel != "" && !seen[repaired.LiteModel] {
-		fixed = append(fixed, fmt.Sprintf("cleared lite_model %q (matched no entry)", repaired.LiteModel))
-		repaired.LiteModel = ""
+	if repaired.Default != "" {
+		if _, _, ok := repaired.resolveCompositeID(repaired.Default); !ok {
+			if firstEpID != "" {
+				newDefault := firstEpID + "::" + firstModel
+				fixed = append(fixed, fmt.Sprintf("reset default %q → %q (first endpoint's first model)", repaired.Default, newDefault))
+				repaired.Default = newDefault
+			} else {
+				fixed = append(fixed, fmt.Sprintf("cleared default %q (no endpoints with models to fall back to)", repaired.Default))
+				repaired.Default = ""
+			}
+		}
 	}
+	if repaired.Lite != "" {
+		// Lite dangles OR Lite == Default → clear. The "==" check is on
+		// the raw composite-id strings — endpoint IDs must match
+		// ^[a-zA-Z0-9_-]+$ (no spaces, no case variation), so two
+		// different strings can never resolve to the same endpoint+model
+		// in practice. Validate rejects any id that would; reaching here
+		// with a valid composite id means the string form is canonical.
+		_, _, liteOK := repaired.resolveCompositeID(repaired.Lite)
+		if !liteOK || repaired.Lite == repaired.Default {
+			fixed = append(fixed, fmt.Sprintf("cleared lite %q (matched no endpoint+model or equals default)", repaired.Lite))
+			repaired.Lite = ""
+		}
+	}
+
 	return repaired, fixed, unfixable
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -64,7 +64,7 @@ func TestLoad_MissingFileIsZeroNotError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() on missing file = %v, want nil", err)
 	}
-	if len(c.Models) != 0 || c.DefaultModel != "" {
+	if len(c.Endpoints) != 0 || c.Default != "" {
 		t.Errorf("Load() on missing file = %+v, want zero Config", c)
 	}
 }
@@ -73,12 +73,12 @@ func TestSaveLoad_RoundTrip(t *testing.T) {
 	setHome(t)
 
 	want := Config{
-		Models: []ModelEntry{
-			{Provider: "anthropic", Model: "claude-fable-5"},
-			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://x.example"},
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-fable-5"}}},
+			{ID: "ep-b", Provider: "kimi", BaseURL: "https://x.example", Models: []EndpointModel{{Model: "kimi-k2.6"}}},
 		},
-		DefaultModel: "kimi-k2.6",
-		LiteModel:    "claude-fable-5",
+		Default: "ep-b::kimi-k2.6",
+		Lite:    "ep-a::claude-fable-5",
 	}
 	if err := want.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -88,11 +88,11 @@ func TestSaveLoad_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(got.Models) != 2 || got.Models[1] != want.Models[1] {
-		t.Errorf("round-trip models = %+v, want %+v", got.Models, want.Models)
+	if len(got.Endpoints) != 2 || got.Endpoints[1].ID != want.Endpoints[1].ID || got.Endpoints[1].Provider != want.Endpoints[1].Provider {
+		t.Errorf("round-trip endpoints = %+v, want %+v", got.Endpoints, want.Endpoints)
 	}
-	if got.DefaultModel != "kimi-k2.6" || got.LiteModel != "claude-fable-5" {
-		t.Errorf("round-trip refs = default %q lite %q", got.DefaultModel, got.LiteModel)
+	if got.Default != "ep-b::kimi-k2.6" || got.Lite != "ep-a::claude-fable-5" {
+		t.Errorf("round-trip refs = default %q lite %q", got.Default, got.Lite)
 	}
 	if e := got.DefaultEntry(); e.Model != "kimi-k2.6" || e.BaseURL != "https://x.example" {
 		t.Errorf("DefaultEntry = %+v, want kimi entry", e)
@@ -108,19 +108,28 @@ func TestLoad_LegacyYAMLIsNormalised(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(c.Models) != 1 {
-		t.Fatalf("Models = %+v, want one synthesized entry", c.Models)
+	if len(c.Endpoints) != 1 {
+		t.Fatalf("Endpoints = %+v, want one synthesized endpoint", c.Endpoints)
 	}
-	e := c.Models[0]
-	if e.Provider != "openai" || e.Model != "gpt-4o-mini" ||
-		e.BaseURL != "https://x.example" || e.APIKey != "sk-old" || e.ReasoningEffort != "high" {
-		t.Errorf("synthesized entry = %+v", e)
+	ep := c.Endpoints[0]
+	if ep.Provider != "openai" || ep.BaseURL != "https://x.example" || ep.APIKey != "sk-old" {
+		t.Errorf("synthesized endpoint = %+v", ep)
 	}
-	if c.DefaultModel != "gpt-4o-mini" {
-		t.Errorf("DefaultModel = %q, want gpt-4o-mini", c.DefaultModel)
+	if len(ep.Models) != 1 || ep.Models[0].Model != "gpt-4o-mini" {
+		t.Errorf("endpoint models = %+v, want one gpt-4o-mini", ep.Models)
+	}
+	if !strings.HasSuffix(c.Default, "::gpt-4o-mini") {
+		t.Errorf("Default = %q, want suffix ::gpt-4o-mini", c.Default)
 	}
 	if c.PermissionMode != "strict" {
 		t.Errorf("global PermissionMode lost: %q", c.PermissionMode)
+	}
+	// PR5 (design §11.6): the top-level reasoning_effort key is the global
+	// setting — Load reads it into Config.ReasoningEffort (the only place
+	// reasoning is stored now). Only per-entry reasoning_effort inside a
+	// legacy models: block is dropped on migration.
+	if c.ReasoningEffort != "high" {
+		t.Errorf("ReasoningEffort = %q, want high (top-level reasoning is the global setting)", c.ReasoningEffort)
 	}
 }
 
@@ -138,15 +147,18 @@ func TestLoad_MigratesCompatibleVendorsToCustom(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if e := c.Models[0]; e.Provider != "custom" || e.Protocol != "openai" {
-		t.Errorf("openai_compatible entry = %+v, want custom/openai", e)
+	if len(c.Endpoints) != 3 {
+		t.Fatalf("Endpoints = %d, want 3 (one per entry): %+v", len(c.Endpoints), c.Endpoints)
 	}
-	if e := c.Models[1]; e.Provider != "custom" || e.Protocol != "anthropic" {
-		t.Errorf("anthropic_compatible entry = %+v, want custom/anthropic", e)
+	if ep := c.Endpoints[0]; ep.Provider != "custom" || ep.Protocol != "openai" {
+		t.Errorf("openai_compatible endpoint = %+v, want custom/openai", ep)
+	}
+	if ep := c.Endpoints[1]; ep.Provider != "custom" || ep.Protocol != "anthropic" {
+		t.Errorf("anthropic_compatible endpoint = %+v, want custom/anthropic", ep)
 	}
 	// A named vendor is left untouched.
-	if e := c.Models[2]; e.Provider != "anthropic" || e.Protocol != "" {
-		t.Errorf("anthropic entry = %+v, want anthropic/(no protocol)", e)
+	if ep := c.Endpoints[2]; ep.Provider != "anthropic" || ep.Protocol != "" {
+		t.Errorf("anthropic endpoint = %+v, want anthropic/(no protocol)", ep)
 	}
 }
 
@@ -201,7 +213,7 @@ func TestSave_FileMode0600(t *testing.T) {
 	}
 	home := setHome(t)
 
-	cfg := Config{Models: []ModelEntry{{Model: "main", APIKey: "sk-secret"}}}
+	cfg := Config{Endpoints: []Endpoint{{ID: "ep-a", Provider: "anthropic", APIKey: "sk-secret", Models: []EndpointModel{{Model: "main"}}}}}
 	if err := cfg.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -227,14 +239,26 @@ func TestLoadCached_FallsBackToLastGoodOnParseError(t *testing.T) {
 	t.Cleanup(resetLastGoodForTest)
 	resetLastGoodForTest()
 	home := setHome(t)
-	writeOcto(t, home, "config.yml", "default_model: good-model\n")
+	writeOcto(t, home, "config.yml",
+		"endpoints:\n  - id: ep-a\n    provider: anthropic\n    models:\n      - model: good-model\n")
+	// default set to the good endpoint so we can verify the cached Default.
+	// We'll write it via a quick Save instead of hand YAML to get the
+	// composite id format right.
+	cfg0, err := Load()
+	if err != nil {
+		t.Fatalf("initial Load: %v", err)
+	}
+	cfg0.Default = "ep-a::good-model"
+	if err := cfg0.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
 
 	cfg, err := LoadCached()
 	if err != nil {
 		t.Fatalf("LoadCached() first load = %v, want nil", err)
 	}
-	if cfg.DefaultModel != "good-model" {
-		t.Fatalf("LoadCached() first load DefaultModel = %q, want %q", cfg.DefaultModel, "good-model")
+	if cfg.Default != "ep-a::good-model" {
+		t.Fatalf("LoadCached() first load Default = %q, want %q", cfg.Default, "ep-a::good-model")
 	}
 
 	writeOcto(t, home, "config.yml", "not: valid: yaml: [")
@@ -243,8 +267,8 @@ func TestLoadCached_FallsBackToLastGoodOnParseError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadCached() after malformed edit = %v, want nil (fall back to last good)", err)
 	}
-	if cfg.DefaultModel != "good-model" {
-		t.Errorf("LoadCached() after malformed edit DefaultModel = %q, want cached %q", cfg.DefaultModel, "good-model")
+	if cfg.Default != "ep-a::good-model" {
+		t.Errorf("LoadCached() after malformed edit Default = %q, want cached %q", cfg.Default, "ep-a::good-model")
 	}
 }
 
@@ -259,29 +283,8 @@ func TestLoadCached_ErrorsWhenNothingCachedYet(t *testing.T) {
 	}
 }
 
-func TestSetDefaultEntry(t *testing.T) {
-	var c Config
-
-	// Appends when empty.
-	c.SetDefaultEntry(ModelEntry{Model: "m1"})
-	if len(c.Models) != 1 || c.DefaultModel != "m1" {
-		t.Fatalf("after first set: %+v", c)
-	}
-
-	// Replaces the default in place when its model changes, carrying the lite
-	// reference over to the new model.
-	c.LiteModel = "m1"
-	c.SetDefaultEntry(ModelEntry{Model: "m2"})
-	if len(c.Models) != 1 || c.Models[0].Model != "m2" {
-		t.Fatalf("after model change: %+v", c.Models)
-	}
-	if c.DefaultModel != "m2" || c.LiteModel != "m2" {
-		t.Errorf("references not updated: default %q lite %q", c.DefaultModel, c.LiteModel)
-	}
-}
-
 func TestEntryByModel_EmptyNeverMatches(t *testing.T) {
-	c := Config{Models: []ModelEntry{{Model: "m"}}}
+	c := Config{Endpoints: []Endpoint{{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "m"}}}}}
 	if _, ok := c.EntryByModel(""); ok {
 		t.Error("EntryByModel(\"\") matched, want no match")
 	}
@@ -355,13 +358,15 @@ func TestEntryByModel_CompositeIDResolvesAgainstEndpoints(t *testing.T) {
 }
 
 // TestEntryByModel_BareModelStillWorks pins the legacy path: a bare model
-// string (no "::" separator) resolves against c.Models the way it always did.
-// This is what pre-PR4 session files carry — their ModelConfig is a bare model
-// string, and EntryByModel must keep working for them.
+// string (no "::" separator) resolves against c.Endpoints (PR5: was c.Models
+// before deletion). This is what pre-PR4 session files carry — their
+// ModelConfig is a bare model string, and EntryByModel must keep working for
+// them.
 func TestEntryByModel_BareModelStillWorks(t *testing.T) {
 	cfg := Config{
-		Models: []ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6", BaseURL: "https://api.anthropic.com", Vision: true},
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", BaseURL: "https://api.anthropic.com",
+				Models: []EndpointModel{{Model: "claude-sonnet-4-6", Vision: true}}},
 		},
 	}
 	got, ok := cfg.EntryByModel("claude-sonnet-4-6")
@@ -373,48 +378,34 @@ func TestEntryByModel_BareModelStillWorks(t *testing.T) {
 	}
 }
 
-// TestEntryByModel_CompositeIDWinsOverFlatModels pins the precedence: when
-// the config has BOTH a flat Models entry with the bare model AND an Endpoints
-// entry whose composite id matches, the composite-id path must win. Otherwise
-// a user who configures the same model on two endpoints (the whole point of
-// the two-level schema) and references it via composite id would get the flat
-// entry's connection params instead of the endpoint's — silently routing to
-// the wrong backend.
-func TestEntryByModel_CompositeIDWinsOverFlatModels(t *testing.T) {
+// TestEntryByModel_BareModelAmbiguousPicksDefault covers PR5's bare-model
+// fallback rule: when a bare model name matches multiple endpoints, prefer
+// the one cfg.Default points at (mirroring ParseModelFlag step 2a).
+func TestEntryByModel_BareModelAmbiguousPicksDefault(t *testing.T) {
 	cfg := Config{
 		Endpoints: []Endpoint{
-			{
-				ID:       "relay-a",
-				Provider: "custom",
-				BaseURL:  "https://relay.example.com",
-				APIKey:   "alpha",
-				Protocol: "anthropic",
-				Models:   []EndpointModel{{Model: "claude-sonnet-4-6", Vision: true}},
-			},
+			{ID: "relay-a", Provider: "custom", BaseURL: "https://relay.example.com",
+				Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "official", Provider: "anthropic", BaseURL: "https://api.anthropic.com",
+				Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
 		},
-		// A flat Models entry with the SAME bare model — this is what a
-		// migrated config looks like before the write-path switches in PR4
-		// (Endpoints synthesised in memory + Models still populated from the
-		// legacy file). The composite-id path must win so the relay's
-		// connection params are returned, not the flat entry's.
-		Models: []ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6", BaseURL: "https://api.anthropic.com", Vision: true},
-		},
+		Default: "official::claude-sonnet-4-6",
 	}
-
-	got, ok := cfg.EntryByModel("relay-a::claude-sonnet-4-6")
+	got, ok := cfg.EntryByModel("claude-sonnet-4-6")
 	if !ok {
-		t.Fatal("EntryByModel(composite) = false, want true")
+		t.Fatal("EntryByModel(bare) = false, want true")
 	}
-	if got.Provider != "custom" || got.BaseURL != "https://relay.example.com" || got.APIKey != "alpha" {
-		t.Errorf("EntryByModel(composite) = %+v, want relay-a endpoint's connection params (composite path must win over flat Models)", got)
+	if got.Provider != "anthropic" || got.BaseURL != "https://api.anthropic.com" {
+		t.Errorf("bare ambiguous = %+v, want the default endpoint (official/anthropic)", got)
 	}
 }
 
 func TestModelVision(t *testing.T) {
-	c := Config{Models: []ModelEntry{
-		{Model: "qwen-vl-max", Vision: true},
-		{Model: "qwen3.7-max", Vision: false},
+	c := Config{Endpoints: []Endpoint{
+		{ID: "ep-a", Provider: "custom", Models: []EndpointModel{
+			{Model: "qwen-vl-max", Vision: true},
+			{Model: "qwen3.7-max", Vision: false},
+		}},
 	}}
 	cases := map[string]bool{
 		"qwen-vl-max":   true,  // recorded true
@@ -452,23 +443,29 @@ func TestModelSupportsVision(t *testing.T) {
 
 // TestModelEntryVisionMigration covers the load-time backfill: a legacy file
 // with no `vision:` key gets the heuristic value (matching the behaviour those
-// files had before the field existed), an explicit value is preserved, and Save
-// always records the field.
+// files had before the field existed), an explicit value is preserved.
+//
+// PR5: Load migrates legacy models: block into c.Endpoints, so the vision
+// check goes through the endpoint's models (not the deleted c.Models).
 func TestModelEntryVisionMigration(t *testing.T) {
-	in := []byte("models:\n" +
-		"  - model: qwen3.7-max\n" + // no vision → heuristic false (text-only qwen)
-		"  - model: claude-sonnet-4-6\n" + // no vision → heuristic true
-		"  - model: gpt-4o\n" +
-		"    vision: false\n") // explicit false must survive despite gpt-4o inferring true
+	home := setHome(t)
+	writeOcto(t, home, "config.yml",
+		"models:\n"+
+			"  - model: qwen3.7-max\n"+ // no vision → heuristic false (text-only qwen)
+			"  - model: claude-sonnet-4-6\n"+ // no vision → heuristic true
+			"  - model: gpt-4o\n"+
+			"    vision: false\n") // explicit false must survive despite gpt-4o inferring true
 
-	var c Config
-	if err := yaml.Unmarshal(in, &c); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
 	}
 	want := map[string]bool{"qwen3.7-max": false, "claude-sonnet-4-6": true, "gpt-4o": false}
-	for _, e := range c.Models {
-		if got := e.Vision; got != want[e.Model] {
-			t.Errorf("after load, %q vision = %v, want %v", e.Model, got, want[e.Model])
+	for _, ep := range c.Endpoints {
+		for _, m := range ep.Models {
+			if got := m.Vision; got != want[m.Model] {
+				t.Errorf("after load, %q vision = %v, want %v", m.Model, got, want[m.Model])
+			}
 		}
 	}
 
@@ -478,8 +475,12 @@ func TestModelEntryVisionMigration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if n := strings.Count(string(out), "vision:"); n != len(c.Models) {
-		t.Errorf("marshaled config has %d vision: keys, want %d\n%s", n, len(c.Models), out)
+	wantCount := 0
+	for _, ep := range c.Endpoints {
+		wantCount += len(ep.Models)
+	}
+	if n := strings.Count(string(out), "vision:"); n != wantCount {
+		t.Errorf("marshaled config has %d vision: keys, want %d\n%s", n, wantCount, out)
 	}
 }
 
@@ -597,15 +598,12 @@ func TestLoad_LegacyFlatSynthesizesEndpoint(t *testing.T) {
 		t.Errorf("Default = %q, want %q", c.Default, wantDefault)
 	}
 
-	// Legacy Models field still populated — existing callers keep working.
-	if len(c.Models) != 1 {
-		t.Fatalf("legacy Models = %d entries, want 1 (must stay populated for existing callers): %+v", len(c.Models), c.Models)
+	// PR5: Config.Models is deleted; the entry lives under c.Endpoints[0].Models.
+	if len(ep.Models) != 1 || ep.Models[0].Model != "claude-sonnet-4-6" {
+		t.Errorf("endpoint models = %+v, want one claude-sonnet-4-6", ep.Models)
 	}
-	if c.Models[0].Model != "claude-sonnet-4-6" || c.Models[0].Provider != "anthropic" {
-		t.Errorf("legacy Models[0] = %+v, want claude-sonnet-4-6/anthropic", c.Models[0])
-	}
-	if c.DefaultModel != "claude-sonnet-4-6" {
-		t.Errorf("legacy DefaultModel = %q, want claude-sonnet-4-6", c.DefaultModel)
+	if ep.Provider != "anthropic" {
+		t.Errorf("endpoint provider = %q, want anthropic", ep.Provider)
 	}
 }
 
@@ -1117,19 +1115,22 @@ func TestParseModelFlag_EmptyFlagErrors(t *testing.T) {
 	}
 }
 
-// TestSave_PR1DoesNotEmitEndpointsBlock is the PR1 invariant from design S4.3:
-// Save must NOT write an endpoints: block to disk. PR1 is the "add structure,
-// don't enable writes" phase -- the on-disk file stays flat (models: only) so
-// existing callers and downgrade paths keep working. The Endpoints/Default/Lite
-// fields carry yaml:"-" tags to enforce this; PR4 flips them back when the
-// write path switches.
-func TestSave_PR1DoesNotEmitEndpointsBlock(t *testing.T) {
+// TestSave_WritesEndpointsFormat is the PR5 invariant (design §4.2): Save
+// writes the new endpoints: form, NOT the legacy flat models: form. PR5
+// flipped the authoritative field — Endpoints/Default/Lite are now
+// persisted; Models/DefaultModel/LiteModel are deleted from the runtime
+// Config (only fileConfig.Models survives as a Load-only intermediate for
+// reading old files). Downgrading to a PR4b or earlier build after this Save
+// is NOT supported — the file will parse but the old code's cfg.Models will
+// be empty. This is by design (§18.1).
+func TestSave_WritesEndpointsFormat(t *testing.T) {
 	setHome(t)
 	cfg := Config{
-		Models: []ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6", BaseURL: "https://api.anthropic.com", APIKey: "alpha", Vision: true},
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", BaseURL: "https://api.anthropic.com",
+				APIKey: "alpha", Models: []EndpointModel{{Model: "claude-sonnet-4-6", Vision: true}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-a::claude-sonnet-4-6",
 	}
 	if err := cfg.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -1140,14 +1141,17 @@ func TestSave_PR1DoesNotEmitEndpointsBlock(t *testing.T) {
 		t.Fatalf("read saved file: %v", err)
 	}
 	s := string(data)
-	if strings.Contains(s, "endpoints:") {
-		t.Errorf("PR1 Save wrote an endpoints: block -- PR1 must keep the file flat.\nfile:\n%s", s)
+	if !strings.Contains(s, "endpoints:") {
+		t.Errorf("PR5 Save must emit an endpoints: block.\nfile:\n%s", s)
 	}
-	if strings.Contains(s, "\ndefault:") {
-		t.Errorf("PR1 Save wrote a default: field -- PR1 must keep the legacy default_model: field.\nfile:\n%s", s)
+	if !strings.Contains(s, "default:") {
+		t.Errorf("PR5 Save must emit the default: composite-id field.\nfile:\n%s", s)
 	}
-	if !strings.Contains(s, "models:") || !strings.Contains(s, "default_model:") {
-		t.Errorf("PR1 Save must still emit the flat models: + default_model: form.\nfile:\n%s", s)
+	if strings.Contains(s, "\nmodels:") {
+		t.Errorf("PR5 Save must NOT emit the legacy models: block.\nfile:\n%s", s)
+	}
+	if strings.Contains(s, "default_model:") {
+		t.Errorf("PR5 Save must NOT emit the legacy default_model: field.\nfile:\n%s", s)
 	}
 }
 
@@ -1316,16 +1320,18 @@ func TestSave_ConcurrentWritersDontClobber(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			cfg := Config{
-				Models: []ModelEntry{
+				Endpoints: []Endpoint{
 					{
+						ID:       fmt.Sprintf("ep-%d", idx),
 						Provider: "anthropic",
-						Model:    fmt.Sprintf("model-%d", idx),
 						BaseURL:  "https://api.anthropic.com",
 						APIKey:   fmt.Sprintf("key-%d", idx),
-						Vision:   true,
+						Models: []EndpointModel{
+							{Model: fmt.Sprintf("model-%d", idx), Vision: true},
+						},
 					},
 				},
-				DefaultModel: fmt.Sprintf("model-%d", idx),
+				Default: fmt.Sprintf("ep-%d::model-%d", idx, idx),
 			}
 			errs[idx] = cfg.Save()
 		}(i)
@@ -1343,11 +1349,11 @@ func TestSave_ConcurrentWritersDontClobber(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load after concurrent saves: %v — file was corrupted", err)
 	}
-	if len(loaded.Models) != 1 {
-		t.Fatalf("loaded Models = %d entries, want 1 (last writer wins, but file must be valid): %+v", len(loaded.Models), loaded.Models)
+	if len(loaded.Endpoints) != 1 {
+		t.Fatalf("loaded Endpoints = %d, want 1 (last writer wins, but file must be valid): %+v", len(loaded.Endpoints), loaded.Endpoints)
 	}
 	// The winning model name must be one of the N we wrote.
-	modelName := loaded.Models[0].Model
+	modelName := loaded.Endpoints[0].Models[0].Model
 	prefix := "model-"
 	if !strings.HasPrefix(modelName, prefix) {
 		t.Fatalf("loaded model = %q, want one of the model-N names", modelName)
@@ -1356,9 +1362,10 @@ func TestSave_ConcurrentWritersDontClobber(t *testing.T) {
 	if convErr != nil || idx < 0 || idx >= N {
 		t.Fatalf("loaded model = %q, want a valid index in [0, %d)", modelName, N)
 	}
-	// Default must match the loaded model (last writer wins consistently).
-	if loaded.DefaultModel != modelName {
-		t.Errorf("loaded DefaultModel = %q, want %q (matching the winning model)", loaded.DefaultModel, modelName)
+	// Default must match the loaded endpoint::model (last writer wins consistently).
+	wantDefault := fmt.Sprintf("ep-%d::%s", idx, modelName)
+	if loaded.Default != wantDefault {
+		t.Errorf("loaded Default = %q, want %q (matching the winning endpoint+model)", loaded.Default, wantDefault)
 	}
 }
 

--- a/internal/config/repair_test.go
+++ b/internal/config/repair_test.go
@@ -12,8 +12,8 @@ func TestSave_WritesRollingBackup(t *testing.T) {
 	setHome(t)
 
 	cfg := Config{
-		Models:       []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []Endpoint{{ID: "ep-a", Provider: "openai", Models: []EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 	}
 	if err := cfg.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -32,7 +32,7 @@ func TestSave_WritesRollingBackup(t *testing.T) {
 	if uerr := yaml.Unmarshal(got, &f); uerr != nil {
 		t.Fatalf("backup does not parse: %v", uerr)
 	}
-	if len(f.Models) != 1 || f.Models[0].Model != "gpt-4o" {
+	if len(f.Endpoints) != 1 || len(f.Endpoints[0].Models) != 1 || f.Endpoints[0].Models[0].Model != "gpt-4o" {
 		t.Errorf("backup content = %+v, want the saved config", f)
 	}
 }
@@ -41,8 +41,8 @@ func TestRestoreFromBackup(t *testing.T) {
 	home := setHome(t)
 
 	good := Config{
-		Models:       []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []Endpoint{{ID: "ep-a", Provider: "openai", Models: []EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 	}
 	if err := good.Save(); err != nil { // writes config.yml + config.yml.bak
 		t.Fatalf("Save: %v", err)
@@ -50,7 +50,7 @@ func TestRestoreFromBackup(t *testing.T) {
 
 	// Now corrupt config.yml the way a hand edit would.
 	path, _ := Path()
-	if err := os.WriteFile(path, []byte("models: [oops\n"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte("endpoints: [oops\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := Load(); err == nil {
@@ -73,7 +73,7 @@ func TestRestoreFromBackup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load after restore: %v", err)
 	}
-	if got.DefaultModel != "gpt-4o" || len(got.Models) != 1 {
+	if got.Default != "ep-a::gpt-4o" || len(got.Endpoints) != 1 {
 		t.Errorf("restored config = %+v, want the good one", got)
 	}
 	_ = home
@@ -81,7 +81,7 @@ func TestRestoreFromBackup(t *testing.T) {
 
 func TestRestoreFromBackup_NoBackup(t *testing.T) {
 	setHome(t)
-	writeOcto(t, os.Getenv("HOME"), "config.yml", "models: [oops\n")
+	writeOcto(t, os.Getenv("HOME"), "config.yml", "endpoints: [oops\n")
 	if _, err := RestoreFromBackup(); err == nil {
 		t.Fatal("RestoreFromBackup with no .bak should error")
 	}
@@ -89,127 +89,10 @@ func TestRestoreFromBackup_NoBackup(t *testing.T) {
 
 func TestRestoreFromBackup_InvalidBackup(t *testing.T) {
 	home := setHome(t)
-	writeOcto(t, home, "config.yml", "models: [oops\n")
+	writeOcto(t, home, "config.yml", "endpoints: [oops\n")
 	writeOcto(t, home, "config.yml.bak", "also: [broken\n")
 	if _, err := RestoreFromBackup(); err == nil {
 		t.Fatal("RestoreFromBackup with an invalid .bak should error")
-	}
-}
-
-func TestRepair_ResetsDanglingDefaultModel(t *testing.T) {
-	c := Config{
-		Models:       []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gone",
-	}
-	repaired, fixed, unfixable := c.Repair()
-	if len(unfixable) != 0 {
-		t.Errorf("unfixable = %v, want none", unfixable)
-	}
-	if len(fixed) != 1 {
-		t.Fatalf("fixed = %v, want 1 entry", fixed)
-	}
-	if repaired.DefaultModel != "gpt-4o" {
-		t.Errorf("default_model = %q, want reset to gpt-4o", repaired.DefaultModel)
-	}
-	// Repaired config is clean.
-	if p := repaired.Validate(); len(p) != 0 {
-		t.Errorf("repaired config still has problems: %v", p)
-	}
-}
-
-func TestRepair_ClearsDanglingLiteModel(t *testing.T) {
-	c := Config{
-		Models:    []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		LiteModel: "gone",
-	}
-	repaired, fixed, unfixable := c.Repair()
-	if len(unfixable) != 0 || len(fixed) != 1 {
-		t.Fatalf("fixed=%v unfixable=%v, want 1 fixed 0 unfixable", fixed, unfixable)
-	}
-	if repaired.LiteModel != "" {
-		t.Errorf("lite_model = %q, want cleared", repaired.LiteModel)
-	}
-}
-
-func TestRepair_ReportsUnfixable(t *testing.T) {
-	c := Config{
-		Models: []ModelEntry{
-			{Provider: "openai", Model: "gpt-4o"},
-			{Provider: "openai", Model: "gpt-4o"}, // duplicate
-			{Provider: "", Model: "no-provider"},  // missing provider
-			{Provider: "openai", Model: ""},       // missing model name
-		},
-	}
-	_, fixed, unfixable := c.Repair()
-	if len(fixed) != 0 {
-		t.Errorf("fixed = %v, want none (all problems are unfixable)", fixed)
-	}
-	if len(unfixable) != 3 {
-		t.Errorf("unfixable = %v, want 3 (duplicate, missing provider, missing model)", unfixable)
-	}
-}
-
-func TestRepair_DanglingDefaultWithNoNamedEntry(t *testing.T) {
-	// First (and only) entry has no model name, and default_model is dangling.
-	// There's no usable model to reset the default to, so Repair must NOT claim
-	// a fix or set default_model to "".
-	c := Config{
-		Models:       []ModelEntry{{Provider: "openai", Model: ""}},
-		DefaultModel: "gone",
-	}
-	repaired, fixed, unfixable := c.Repair()
-	if len(fixed) != 0 {
-		t.Errorf("fixed = %v, want none — no named entry to reset the default to", fixed)
-	}
-	if repaired.DefaultModel != "gone" {
-		t.Errorf("default_model = %q, want left unchanged (not blanked)", repaired.DefaultModel)
-	}
-	if len(unfixable) == 0 {
-		t.Error("the nameless entry should be reported as unfixable")
-	}
-}
-
-func TestRepair_PicksFirstNamedEntry(t *testing.T) {
-	// A nameless entry precedes a valid one; a dangling default must reset to the
-	// first *named* model, not to the empty first entry.
-	c := Config{
-		Models: []ModelEntry{
-			{Provider: "openai", Model: ""},
-			{Provider: "openai", Model: "gpt-4o"},
-		},
-		DefaultModel: "gone",
-	}
-	repaired, fixed, _ := c.Repair()
-	if repaired.DefaultModel != "gpt-4o" {
-		t.Errorf("default_model = %q, want gpt-4o (first named)", repaired.DefaultModel)
-	}
-	if len(fixed) != 1 {
-		t.Errorf("fixed = %v, want the default reset", fixed)
-	}
-}
-
-func TestRepair_HealthyIsNoOp(t *testing.T) {
-	c := Config{
-		Models:       []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
-	}
-	repaired, fixed, unfixable := c.Repair()
-	if len(fixed) != 0 || len(unfixable) != 0 {
-		t.Errorf("healthy config: fixed=%v unfixable=%v, want none", fixed, unfixable)
-	}
-	if repaired.DefaultModel != "gpt-4o" {
-		t.Errorf("healthy config mutated: %+v", repaired)
-	}
-}
-
-func TestRepair_EmptyConfigIsNoOp(t *testing.T) {
-	var c Config
-	repaired, fixed, unfixable := c.Repair()
-	if len(fixed) != 0 || len(unfixable) != 0 {
-		t.Errorf("empty config: fixed=%v unfixable=%v, want none", fixed, unfixable)
-	}
-	if len(repaired.Models) != 0 {
-		t.Errorf("empty config gained models: %+v", repaired)
 	}
 }
 
@@ -218,11 +101,10 @@ func TestRepair_EmptyConfigIsNoOp(t *testing.T) {
 // dangling Lite clears; an endpoint with no models is deleted (it's unusable
 // and nothing references it); Lite == Default clears Lite.
 //
-// Like Validate, the endpoint-level Repair runs only on the pure new schema
-// (Endpoints set, Models empty) to avoid double-acting on a migrated flat
-// config. Unfixable cases (duplicate endpoint id, illegal id chars, no
-// model name, duplicate model within an endpoint) are reported for the user
-// rather than guessed.
+// PR5: the "pure new schema" guard from PR1 is lifted — Config.Models is
+// deleted, so every config goes through the endpoint-level Repair. Unfixable
+// cases (duplicate endpoint id, illegal id chars, no model name, duplicate
+// model within an endpoint) are reported for the user rather than guessed.
 func TestRepair_EndpointLevel_DanglingDefaultReset(t *testing.T) {
 	cfg := Config{
 		Endpoints: []Endpoint{

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -5,47 +5,11 @@ import (
 	"testing"
 )
 
-func TestConfigValidate(t *testing.T) {
-	good := ModelEntry{Provider: "openai", Model: "gpt-4o"}
-	tests := []struct {
-		name string
-		cfg  Config
-		want string // substring of an expected problem; "" = no problems
-	}{
-		{"empty pre-onboarding is valid", Config{}, ""},
-		{"good", Config{Models: []ModelEntry{good}, DefaultModel: "gpt-4o"}, ""},
-		{"dangling default_model", Config{Models: []ModelEntry{good}, DefaultModel: "nope"}, "default_model"},
-		{"dangling lite_model", Config{Models: []ModelEntry{good}, LiteModel: "nope"}, "lite_model"},
-		{"missing provider", Config{Models: []ModelEntry{{Model: "gpt-4o"}}}, "no provider"},
-		{"missing model name", Config{Models: []ModelEntry{{Provider: "openai"}}}, "no model name"},
-		{"duplicate model", Config{Models: []ModelEntry{good, {Provider: "anthropic", Model: "gpt-4o"}}}, "duplicate"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			probs := tt.cfg.Validate()
-			joined := strings.Join(probs, "; ")
-			if tt.want == "" {
-				if len(probs) != 0 {
-					t.Errorf("want no problems, got %v", probs)
-				}
-				return
-			}
-			if !strings.Contains(joined, tt.want) {
-				t.Errorf("want a problem containing %q, got %v", tt.want, probs)
-			}
-		})
-	}
-}
-
-// TestConfigValidate_EndpointLevel covers the endpoint-level checks layered on
-// top of the legacy Models checks in PR1: endpoint id uniqueness/legality,
-// each endpoint has at least one model, model names non-empty, no duplicate
-// models within one endpoint, and Default/Lite composite ids resolve.
-//
-// These checks are no-ops for implicit endpoints migrated from the flat
-// schema (their ids are program-generated and thus always legal/unique), but
-// they guard against hand-edited endpoints: blocks the user might write
-// during PR1 (Load honours them per §4.1 step 1) and that PR4 will emit.
+// TestConfigValidate_EndpointLevel covers the endpoint-level checks (PR5:
+// the only Validate path now that Config.Models is deleted): endpoint id
+// uniqueness/legality, each endpoint has at least one model, model names
+// non-empty, no duplicate models within one endpoint, and Default/Lite
+// composite ids resolve.
 func TestConfigValidate_EndpointLevel(t *testing.T) {
 	goodEP := Endpoint{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6", Vision: true}}}
 	tests := []struct {

--- a/internal/server/browser_vision_test.go
+++ b/internal/server/browser_vision_test.go
@@ -16,11 +16,13 @@ import (
 func TestPrepareToolTurn_WiresBrowserVision(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "openai", Model: "qwen3.7-max", Vision: false}, // recorded text-only
-			{Provider: "openai", Model: "gpt-4o", Vision: true},       // recorded vision
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{
+				{Model: "qwen3.7-max", Vision: false}, // recorded text-only
+				{Model: "gpt-4o", Vision: true},       // recorded vision
+			}},
 		},
-		DefaultModel: "qwen3.7-max",
+		Default: "ep-a::qwen3.7-max",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 

--- a/internal/server/channel_model_test.go
+++ b/internal/server/channel_model_test.go
@@ -21,11 +21,11 @@ func TestApplyChannelModel_HonorsStoreBinding(t *testing.T) {
 	t.Setenv("USERPROFILE", tmp)
 
 	seed := config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "kimi", Model: "kimi-k2.6", APIKey: "sk-kimi"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-kimi", Provider: "kimi", APIKey: "sk-kimi", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-anthropic::claude-sonnet-4-6",
 	}
 	if err := seed.Save(); err != nil {
 		t.Fatal(err)
@@ -60,7 +60,7 @@ func TestApplyChannelModel_HonorsStoreBinding(t *testing.T) {
 
 	// Binding entry deleted: fall back to the default sender instead of
 	// failing the turn.
-	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/kimi-k2.6", ""); w.Code != http.StatusOK {
+	if w := doJSON(t, srv, http.MethodDelete, "/api/config/endpoints/ep-kimi/models/kimi-k2.6", ""); w.Code != http.StatusOK {
 		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
 	}
 	srv.applyChannelModel(sess)
@@ -78,11 +78,11 @@ func TestChannelModelOps_Resolve(t *testing.T) {
 	t.Setenv("USERPROFILE", tmp)
 
 	seed := config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "kimi", Model: "kimi-k2.6", APIKey: "sk-kimi"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-kimi", Provider: "kimi", APIKey: "sk-kimi", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-anthropic::claude-sonnet-4-6",
 	}
 	if err := seed.Save(); err != nil {
 		t.Fatal(err)
@@ -106,9 +106,8 @@ func TestChannelModelOps_Resolve(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve kimi-k2.6: %v", err)
 	}
-	// PR4b: bare model resolves through ParseModelFlag; the bound entry is the
-	// composite id pointing at kimi's endpoint. The exact endpoint id is the
-	// synthesised legacy-<host>-<n> form, so assert by suffix.
+	// PR5: bare model resolves through ParseModelFlag; the bound entry is the
+	// composite id pointing at the kimi endpoint.
 	if bound.Model != "kimi-k2.6" {
 		t.Errorf("bound model = %q, want kimi-k2.6", bound.Model)
 	}

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -197,8 +197,8 @@ func TestHandleChannelMessage_RecoversTurnPanic(t *testing.T) {
 func TestHandleChannelMessage_HonorsCompactAutoPct(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:         []config.ModelEntry{{Provider: "openai", Model: "stub-model"}},
-		DefaultModel:   "stub-model",
+		Endpoints:      []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "stub-model"}}}},
+		Default:        "ep-a::stub-model",
 		CompactAutoPct: 70,
 	})
 	srv := chanServer(t)
@@ -466,8 +466,8 @@ func TestHandleChannelMessage_RefreshesAutoRecallBeforeRegisteringHooks(t *testi
 	setTestHome(t)
 	marker := "octo-agent lucky number is 47"
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 		MemoryBackend: config.MemoryBackendConfig{
 			Type:       "hindsight",
 			BaseURL:    hindsightRecallStub(t, marker),

--- a/internal/server/compact_config_test.go
+++ b/internal/server/compact_config_test.go
@@ -13,8 +13,8 @@ import (
 func TestBuildAgent_HonorsCompactConfig(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:         []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel:   "gpt-4o",
+		Endpoints:      []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:        "ep-a::gpt-4o",
 		CompactAutoPct: 70,
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
@@ -31,8 +31,8 @@ func TestBuildAgent_HonorsCompactConfig(t *testing.T) {
 func TestBuildAgent_CompactDefaultsWhenUnset(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -154,11 +154,11 @@ func entryForSession(cfg config.Config, sess *agent.Session) config.ModelEntry {
 
 // sessionStatusFields returns the server-level session metadata (permission
 // mode, reasoning effort, show reasoning, current context usage) plus the
-// DEFAULT working dir, resolved against sess's own model-config entry (see
-// entryForSession) — pass nil when no specific session is in scope. Working
-// dir is per-session regardless: callers with a session in hand override the
-// returned value via sessionCwd / sessionCwdByID; the default here is the
-// fallback for sessions with none.
+// DEFAULT working dir. PR5: reasoning effort and show_reasoning are global
+// (Config.ReasoningEffort / Config.ShowReasoning) — per-entry overrides are
+// deleted. Working dir is per-session regardless: callers with a session in
+// hand override the returned value via sessionCwd / sessionCwdByID; the
+// default here is the fallback for sessions with none.
 func (srv *Server) sessionStatusFields(sess *agent.Session) (workingDir, permissionMode, reasoningEffort string, showReasoning *bool, contextUsage int) {
 	workingDir = srv.cwd
 	if sess != nil && sess.PermissionMode != "" {
@@ -167,9 +167,8 @@ func (srv *Server) sessionStatusFields(sess *agent.Session) (workingDir, permiss
 		permissionMode = string(resolvePermissionMode())
 	}
 	if cfg, err := config.Load(); err == nil {
-		entry := entryForSession(cfg, sess)
-		reasoningEffort = entry.ReasoningEffort
-		eff := cfg.EffectiveShowReasoning(entry.ShowReasoning)
+		reasoningEffort = cfg.ReasoningEffort
+		eff := cfg.EffectiveShowReasoning(nil)
 		showReasoning = &eff
 	}
 	// Report the session's persisted context usage (its real last-turn token
@@ -1240,35 +1239,30 @@ func (s *Server) handleUpdateSessionReasoningEffort(w http.ResponseWriter, r *ht
 		return
 	}
 
-	sess, err := agent.LoadSession(id)
-	if err != nil {
+	// Verify the session exists (the id is only used for broadcast below;
+	// PR5 made reasoning global, so there's no per-session entry to load).
+	if _, err := agent.LoadSession(id); err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return
 	}
 
-	// Resolve and mutate the entry THIS session actually runs on (see
-	// entryForSession) — not always the default entry, so a session pinned
-	// to a non-default model actually gets its own reasoning_effort changed
-	// instead of silently editing an unrelated model's config.
+	// PR5: reasoning is global — update the global Config.ReasoningEffort,
+	// not a per-session entry (per-entry fields are deleted).
 	cfg, _ := config.Load()
-	entry := entryForSession(cfg, sess)
 	// "off" is only ever a wire/UI sentinel — the persisted and forwarded
 	// representation of "no reasoning effort" is "" everywhere else in the
 	// codebase (CLI, TUI, provider layer). Storing "off" verbatim used to
 	// reach provider requests as a literal, invalid reasoning_effort value.
 	if level == "off" {
-		entry.ReasoningEffort = ""
+		cfg.ReasoningEffort = ""
 	} else {
-		entry.ReasoningEffort = level
+		cfg.ReasoningEffort = level
 	}
 	// Reasoning off has nothing to show a trace of; keep show_reasoning from
 	// staying on in a way that looks toggled on but does nothing.
 	if level == "off" {
 		off := false
-		entry.ShowReasoning = &off
-	}
-	if !cfg.SetEntry(entry) {
-		cfg.SetDefaultEntry(entry)
+		cfg.ShowReasoning = &off
 	}
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
@@ -1409,18 +1403,17 @@ func (s *Server) handleUpdateSessionShowReasoning(w http.ResponseWriter, r *http
 		return
 	}
 
-	sess, err := agent.LoadSession(id)
-	if err != nil {
+	// Verify the session exists (PR5: reasoning is global; no per-session
+	// entry to load).
+	if _, err := agent.LoadSession(id); err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return
 	}
 
 	cfg, _ := config.Load()
-	entry := entryForSession(cfg, sess)
-	entry.ShowReasoning = &req.ShowReasoning
-	if !cfg.SetEntry(entry) {
-		cfg.SetDefaultEntry(entry)
-	}
+	// PR5: reasoning/show_reasoning is global — update the global config
+	// field, not a per-session entry (those fields are deleted).
+	cfg.ShowReasoning = &req.ShowReasoning
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return

--- a/internal/server/memory_backend_wiring_test.go
+++ b/internal/server/memory_backend_wiring_test.go
@@ -41,8 +41,8 @@ func hindsightRecallStub(t *testing.T, marker string) string {
 func TestPrepareToolTurn_WiresMemoryBackend(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 		MemoryBackend: config.MemoryBackendConfig{
 			Type:    "hindsight",
 			BaseURL: "http://localhost:8888",
@@ -64,8 +64,8 @@ func TestPrepareToolTurn_WiresMemoryBackend(t *testing.T) {
 func TestPrepareToolTurn_WiresAutoRecall(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 		MemoryBackend: config.MemoryBackendConfig{
 			Type:       "hindsight",
 			BaseURL:    "http://localhost:8888",
@@ -120,8 +120,8 @@ func TestBuildAgent_RefreshesAutoRecallBeforeRegisteringHooks(t *testing.T) {
 	setTestHome(t)
 	marker := "octo-agent lucky number is 47"
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 		MemoryBackend: config.MemoryBackendConfig{
 			Type:       "hindsight",
 			BaseURL:    hindsightRecallStub(t, marker),
@@ -155,8 +155,8 @@ func TestBuildAgent_RefreshesAutoRecallBeforeRegisteringHooks(t *testing.T) {
 func TestPrepareToolTurn_NoMemoryBackendConfigured(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
@@ -119,8 +120,8 @@ func detectOnboardPhase() string {
 
 	// Check if any provider key is available.
 	hasKey := false
-	for _, e := range cfg.Models {
-		if e.APIKey != "" {
+	for _, ep := range cfg.Endpoints {
+		if ep.APIKey != "" {
 			hasKey = true
 			break
 		}
@@ -156,69 +157,21 @@ func (s *Server) handleOnboardComplete(w http.ResponseWriter, r *http.Request) {
 
 // ─── GET /api/config ────────────────────────────────────────────────────────
 
-// configResponse mirrors what the Svelte frontend expects.
+// configResponse mirrors what the Svelte frontend expects. PR5: the Models
+// field is gone (the frontend reads endpoints via GET /api/config/endpoints);
+// only the global settings remain. ReasoningEffort is the global reasoning
+// level (PR5 deleted per-entry reasoning).
 type configResponse struct {
-	Models          []modelConfig `json:"models,omitempty"`
-	DefaultModelIdx int           `json:"default_model_idx,omitempty"`
-	FontSize        string        `json:"font_size,omitempty"`
-	Language        string        `json:"language,omitempty"`
-	ShowReasoning   *bool         `json:"show_reasoning,omitempty"`
-	Coauthor        *bool         `json:"coauthor,omitempty"`
-	WorkspaceDir    string        `json:"workspace_dir,omitempty"`
-}
-
-type modelConfig struct {
-	ID              string `json:"id"`
-	Type            string `json:"type,omitempty"`
-	Model           string `json:"model"`
-	BaseURL         string `json:"base_url"`
-	APIKeyMasked    string `json:"api_key_masked,omitempty"`
-	Provider        string `json:"provider,omitempty"`
-	AnthropicFormat bool   `json:"anthropic_format"`
-	PermissionMode  string `json:"permission_mode,omitempty"`
-	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	FontSize        string `json:"font_size,omitempty"`
+	Language        string `json:"language,omitempty"`
 	ShowReasoning   *bool  `json:"show_reasoning,omitempty"`
-	Vision          bool   `json:"vision"`
-}
-
-// defaultEntryIdx returns the index of the default entry: the one whose model
-// matches DefaultModel, else 0.
-func defaultEntryIdx(cfg config.Config) int {
-	for i, e := range cfg.Models {
-		if e.Model == cfg.DefaultModel {
-			return i
-		}
-	}
-	return 0
+	Coauthor        *bool  `json:"coauthor,omitempty"`
+	WorkspaceDir    string `json:"workspace_dir,omitempty"`
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 }
 
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	cfg, _ := config.Load()
-
-	models := []modelConfig{}
-	defaultIdx := defaultEntryIdx(cfg)
-
-	for i, e := range cfg.Models {
-		m := modelConfig{
-			ID:              e.Model,
-			Model:           e.Model,
-			BaseURL:         e.BaseURL,
-			APIKeyMasked:    maskKey(e.APIKey),
-			Provider:        e.Provider,
-			AnthropicFormat: entryUsesAnthropic(e),
-			ReasoningEffort: e.ReasoningEffort,
-			ShowReasoning:   e.ShowReasoning,
-			Vision:          e.Vision,
-		}
-		switch {
-		case i == defaultIdx:
-			m.Type = "default"
-			m.PermissionMode = cfg.PermissionMode
-		case e.Model == cfg.LiteModel:
-			m.Type = "lite"
-		}
-		models = append(models, m)
-	}
 
 	// Coauthor, unlike ShowReasoning, has an OCTO_COAUTHOR env-var layer above
 	// the config file, so the raw cfg.Coauthor pointer can disagree with what
@@ -226,13 +179,12 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	// meant to reflect, not the on-disk-only one.
 	effCoauthor := cfg.EffectiveCoauthor()
 	writeJSON(w, http.StatusOK, configResponse{
-		Models:          models,
-		DefaultModelIdx: defaultIdx,
 		FontSize:        "medium",
 		Language:        cfg.Language,
 		ShowReasoning:   cfg.ShowReasoning,
 		Coauthor:        &effCoauthor,
 		WorkspaceDir:    cfg.WorkspaceDir,
+		ReasoningEffort: cfg.ReasoningEffort,
 	})
 }
 
@@ -502,22 +454,22 @@ type testConfigRequest struct {
 	AnthropicFormat bool   `json:"anthropic_format"`
 }
 
-// storedAPIKey returns the saved key of the config entry that best matches
+// storedAPIKey returns the saved key of the endpoint that best matches
 // (provider, baseURL): an exact provider+endpoint match wins, else the first
-// entry on the same provider. Empty when none is stored. Lets a connection
+// endpoint on the same provider. Empty when none is stored. Lets a connection
 // test reuse the stored key when the provider is unchanged.
 func storedAPIKey(cfg config.Config, provider, baseURL string) string {
 	nb := strings.TrimRight(baseURL, "/")
 	var sameProvider string
-	for _, e := range cfg.Models {
-		if e.APIKey == "" || e.Provider != provider {
+	for _, ep := range cfg.Endpoints {
+		if ep.APIKey == "" || ep.Provider != provider {
 			continue
 		}
-		if strings.TrimRight(e.BaseURL, "/") == nb {
-			return e.APIKey
+		if strings.TrimRight(ep.BaseURL, "/") == nb {
+			return ep.APIKey
 		}
 		if sameProvider == "" {
-			sameProvider = e.APIKey
+			sameProvider = ep.APIKey
 		}
 	}
 	return sameProvider
@@ -578,328 +530,410 @@ func (s *Server) handleTestConfig(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "message": "Connection successful"})
 }
 
-// ─── POST /api/config/models ────────────────────────────────────────────────
+// ─── POST/PATCH/DELETE /api/config/endpoints (CRUD) ─────────────────────────
+//
+// PR5 (design §10.2): endpoint-level CRUD. The handler layer is thin — it
+// parses the request, calls config.UpsertEndpoint / UpsertModel /
+// SetDefaultComposite / RenameEndpoint under config.Mutate (flock + atomic
+// Save), and triggers s.invalidateEndpointSenders when connection params or
+// the endpoint id changes. Model-level mutations (add/delete model under an
+// endpoint) also invalidate per the coarse-grained policy (design §6).
+//
+// Old /api/config/models* handlers (POST/PATCH/DELETE) were deleted in the
+// same slice — callers must use these endpoint-level routes. The web UI
+// continues to read endpoints via GET /api/config/endpoints (PR4b) and will
+// gain editing affordances in a follow-up PR.
 
-type saveModelRequest struct {
-	Type            string `json:"type"`
-	Model           string `json:"model"`
-	BaseURL         string `json:"base_url"`
-	APIKey          string `json:"api_key"`
-	Provider        string `json:"provider,omitempty"`
-	AnthropicFormat bool   `json:"anthropic_format"`
-	PermissionMode  string `json:"permission_mode,omitempty"`
-	ReasoningEffort string `json:"reasoning_effort,omitempty"`
-	ShowReasoning   *bool  `json:"show_reasoning,omitempty"`
-	Vision          *bool  `json:"vision,omitempty"`
+type createEndpointRequest struct {
+	ID       string            `json:"id"`
+	Name     string            `json:"name,omitempty"`
+	Provider string            `json:"provider"`
+	BaseURL  string            `json:"base_url,omitempty"`
+	APIKey   string            `json:"api_key,omitempty"`
+	Protocol string            `json:"protocol,omitempty"`
+	Models   []endpointModelIn `json:"models,omitempty"`
 }
 
-// applyModelRequestToEntry overlays the request onto an entry. An empty (or
-// still-masked) api_key keeps the stored key — the panel echoes masked keys
-// and omits unchanged ones. The vendor resolves from explicit request field >
-// known endpoint > the entry's current value; only a brand-new entry with no
-// signal at all falls back to the anthropic_format flag.
-func applyModelRequestToEntry(req saveModelRequest, e *config.ModelEntry) {
-	e.Model = req.Model
-	e.BaseURL = req.BaseURL
-	if req.APIKey != "" && !strings.Contains(req.APIKey, "****") {
-		e.APIKey = req.APIKey
-	}
-	switch {
-	case req.Provider != "":
-		e.Provider = req.Provider
-	case app.VendorByBaseURL(req.BaseURL) != "":
-		e.Provider = app.VendorByBaseURL(req.BaseURL)
-	case e.Provider != "":
-		// keep the entry's current vendor
-	case req.BaseURL == "":
-		// No endpoint signal at all — fall back to the protocol root vendor.
-		if req.AnthropicFormat {
-			e.Provider = app.ProviderAnthropic
-		} else {
-			e.Provider = app.ProviderOpenAI
-		}
-	default:
-		e.Provider = app.ProviderCustom
-	}
-	// Protocol is stored only for the Custom vendor; a named vendor pins its own,
-	// so clear any stale value carried over from a previous Custom selection.
-	if app.VendorNeedsProtocol(e.Provider) {
-		e.Protocol = customProtocol(req.AnthropicFormat)
-	} else {
-		e.Protocol = ""
-	}
-	if req.ReasoningEffort != "" {
-		// "off" is the form's UI sentinel for "no reasoning effort"; the
-		// persisted/forwarded representation is "" everywhere else in the
-		// codebase (CLI, TUI, provider layer) — normalize here so it isn't
-		// later sent to a provider as a literal, invalid reasoning_effort.
-		if strings.EqualFold(req.ReasoningEffort, "off") {
-			e.ReasoningEffort = ""
-		} else {
-			e.ReasoningEffort = req.ReasoningEffort
-		}
-	}
-	if req.ShowReasoning != nil {
-		e.ShowReasoning = req.ShowReasoning
-	}
-	// Vision is always recorded. Honour an explicit request value (the form's
-	// toggle); otherwise resolve from the catalogue for a predefined model, or
-	// fall back to the id heuristic for a custom / unknown one. Resolution runs
-	// after the vendor is settled above, so VendorModelVision sees the final
-	// provider.
-	switch {
-	case req.Vision != nil:
-		e.Vision = *req.Vision
-	default:
-		if v, known := app.VendorModelVision(e.Provider, req.Model); known {
-			e.Vision = v
-		} else {
-			e.Vision = config.ModelSupportsVision(req.Model)
-		}
-	}
+type endpointModelIn struct {
+	Model  string `json:"model"`
+	Vision bool   `json:"vision"`
 }
 
-// handleSaveModelConfig creates a new model entry (POST /api/config/models).
-func (s *Server) handleSaveModelConfig(w http.ResponseWriter, r *http.Request) {
-	var req saveModelRequest
+type updateEndpointRequest struct {
+	// NewID, when non-empty, triggers a rename (RenameEndpoint + cascade).
+	NewID    string `json:"new_id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	BaseURL  string `json:"base_url,omitempty"`
+	APIKey   string `json:"api_key,omitempty"`
+	Protocol string `json:"protocol,omitempty"`
+}
+
+// endpointJSONOut is the response shape for a single endpoint — same as
+// endpointConfigJSON from GET /api/config/endpoints, kept inline here so the
+// CRUD handlers don't depend on the read handler's type staying put.
+type endpointJSONOut struct {
+	ID        string              `json:"id"`
+	Name      string              `json:"name,omitempty"`
+	Provider  string              `json:"provider"`
+	BaseURL   string              `json:"base_url,omitempty"`
+	Protocol  string              `json:"protocol,omitempty"`
+	HasAPIKey bool                `json:"has_api_key"`
+	LiteModel string              `json:"lite_model,omitempty"`
+	Models    []endpointModelJSON `json:"models"`
+}
+
+func endpointToJSON(ep config.Endpoint) endpointJSONOut {
+	out := endpointJSONOut{
+		ID:        ep.ID,
+		Name:      ep.Name,
+		Provider:  ep.Provider,
+		BaseURL:   ep.BaseURL,
+		Protocol:  ep.Protocol,
+		HasAPIKey: ep.APIKey != "",
+		LiteModel: ep.LiteModel,
+		Models:    make([]endpointModelJSON, 0, len(ep.Models)),
+	}
+	for _, m := range ep.Models {
+		out.Models = append(out.Models, endpointModelJSON{Model: m.Model, Vision: m.Vision})
+	}
+	return out
+}
+
+// handleCreateEndpoint: POST /api/config/endpoints
+func (s *Server) handleCreateEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req createEndpointRequest
 	if err := readBodyJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	if req.Model == "" {
-		writeError(w, http.StatusBadRequest, "model is required")
+	if req.ID == "" {
+		writeError(w, http.StatusBadRequest, "id is required")
+		return
+	}
+	if req.Provider == "" {
+		writeError(w, http.StatusBadRequest, "provider is required")
 		return
 	}
 
-	cfg, err := config.Load()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+	var created config.Endpoint
+	if err := config.Mutate(func(cfg *config.Config) error {
+		// Reject id collision — Validate would flag it as unfixable anyway.
+		for _, ep := range cfg.Endpoints {
+			if ep.ID == req.ID {
+				return fmt.Errorf("endpoint id %q already exists", req.ID)
+			}
+		}
+		ep := config.Endpoint{
+			ID:       req.ID,
+			Name:     req.Name,
+			Provider: req.Provider,
+			BaseURL:  req.BaseURL,
+			APIKey:   req.APIKey,
+			Protocol: req.Protocol,
+		}
+		for _, m := range req.Models {
+			if m.Model == "" {
+				continue
+			}
+			ep.Models = append(ep.Models, config.EndpointModel{Model: m.Model, Vision: m.Vision})
+		}
+		cfg.UpsertEndpoint(ep)
+		created = ep
+		return nil
+	}); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-
-	var entry config.ModelEntry
-	applyModelRequestToEntry(req, &entry)
-	// Model is the entry's identity, so it must be unique.
-	if _, exists := cfg.EntryByModel(entry.Model); exists {
-		writeError(w, http.StatusConflict, fmt.Sprintf("a model entry for %q already exists", entry.Model))
-		return
-	}
-	cfg.Models = append(cfg.Models, entry)
-	if cfg.DefaultModel == "" || len(cfg.Models) == 1 {
-		cfg.DefaultModel = entry.Model
-	}
-	if req.PermissionMode != "" {
-		cfg.PermissionMode = req.PermissionMode
-	}
-
-	if err := cfg.Save(); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
-		return
-	}
-	// Rebuild the default sender/model so new unbound sessions pick up the new
-	// entry (e.g. the first model saved during onboard, or a changed default).
-	s.invalidateSenderCache()
-	if err := s.reloadDefaultSender(); err != nil {
-		log.Printf("[server] reload default sender after saving model config: %v", err)
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": entry.Model})
+	// A brand-new endpoint has no cached senders yet, so no invalidation
+	// needed. New endpoints with models could in principle be referenced
+	// immediately, but the cache is populated lazily on the first turn.
+	writeJSON(w, http.StatusCreated, endpointToJSON(created))
 }
 
-// handleUpdateModelConfig updates the entry named by {id}.
-func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request) {
+// handleUpdateEndpoint: PATCH /api/config/endpoints/{id}
+// Without new_id: updates connection params / name in place.
+// With new_id: renames the endpoint (RenameEndpoint + Default/Lite cascade +
+// invalidateEndpointSenders on the old id).
+func (s *Server) handleUpdateEndpoint(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
-		writeError(w, http.StatusBadRequest, "missing model id")
+		writeError(w, http.StatusBadRequest, "missing endpoint id")
 		return
 	}
-
-	var req saveModelRequest
+	var req updateEndpointRequest
 	if err := readBodyJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	// Model is the entry's identity; an empty one would re-key the entry to ""
-	// (unaddressable via the API), so reject it as POST does.
-	if req.Model == "" {
-		writeError(w, http.StatusBadRequest, "model is required")
-		return
-	}
 
-	cfg, err := config.Load()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
-		return
-	}
-
-	updated := false
-	newID := id
-	for i := range cfg.Models {
-		if cfg.Models[i].Model == id {
-			applyModelRequestToEntry(req, &cfg.Models[i])
-			// Model is the entry id. When it changes, the id changes with it, so
-			// reject a collision with another entry and carry the default/lite
-			// refs that pointed at the old model over to the new one.
-			if newModel := cfg.Models[i].Model; newModel != id {
-				for j := range cfg.Models {
-					if j != i && cfg.Models[j].Model == newModel {
-						writeError(w, http.StatusConflict, fmt.Sprintf("a model entry for %q already exists", newModel))
-						return
-					}
-				}
-				newID = newModel
-				if cfg.DefaultModel == id {
-					cfg.DefaultModel = newModel
-				}
-				if cfg.LiteModel == id {
-					cfg.LiteModel = newModel
+	var updated config.Endpoint
+	if err := config.Mutate(func(cfg *config.Config) error {
+		idx := -1
+		for i := range cfg.Endpoints {
+			if cfg.Endpoints[i].ID == id {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return fmt.Errorf("%w: %s", config.ErrEndpointNotFound, id)
+		}
+		// Rename path: new_id triggers RenameEndpoint (which rewrites
+		// Default/Lite composite-id prefixes) before applying field updates.
+		if req.NewID != "" && req.NewID != id {
+			if err := cfg.RenameEndpoint(id, req.NewID); err != nil {
+				return err
+			}
+			// RenameEndpoint updated Endpoints[idx].ID in place; re-find it
+			// under the new id so the field patches below land on the right
+			// endpoint.
+			for i := range cfg.Endpoints {
+				if cfg.Endpoints[i].ID == req.NewID {
+					idx = i
+					break
 				}
 			}
-			updated = true
-			break
 		}
-	}
-	if !updated {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config for %q", id))
+		ep := cfg.Endpoints[idx]
+		// Apply field patches. Empty strings in the request mean "unchanged"
+		// EXCEPT for Protocol/BaseURL where the user may legitimately want to
+		// clear them — but we can't distinguish "omitted" from "cleared" with
+		// the current JSON shape. PR5 errs on the side of "empty = unchanged"
+		// for all fields; clearing a field requires sending the previous
+		// value. (A follow-up could switch to *string / omitempty:true to
+		// distinguish, but the current web UI doesn't need it.)
+		if req.Name != "" {
+			ep.Name = req.Name
+		}
+		if req.Provider != "" {
+			ep.Provider = req.Provider
+		}
+		if req.BaseURL != "" {
+			ep.BaseURL = req.BaseURL
+		}
+		if req.APIKey != "" {
+			ep.APIKey = req.APIKey
+		}
+		if req.Protocol != "" {
+			ep.Protocol = req.Protocol
+		}
+		cfg.Endpoints[idx] = ep
+		updated = ep
+		return nil
+	}); err != nil {
+		if errors.Is(err, config.ErrEndpointNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errors.Is(err, config.ErrEndpointIDInUse) {
+			writeError(w, http.StatusConflict, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if req.PermissionMode != "" {
-		cfg.PermissionMode = req.PermissionMode
-	}
 
-	if err := cfg.Save(); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
-		return
+	// Invalidate cached senders for the endpoint — connection params may have
+	// changed (coarse-grained: we invalidate even if only Name changed). If a
+	// rename happened, invalidate the OLD id (senders cached under "<old>::...").
+	invalidID := id
+	if req.NewID != "" && req.NewID != id {
+		invalidID = id
 	}
-	// Editing the default entry (provider/model/endpoint/key) must rebuild the
-	// default sender, or new unbound sessions keep using the stale startup one.
-	s.invalidateSenderCache()
-	if err := s.reloadDefaultSender(); err != nil {
-		log.Printf("[server] reload default sender after updating model config: %v", err)
-	}
-
-	// id may have changed if the model changed — return it so the client can
-	// refresh its reference.
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": newID})
+	s.invalidateEndpointSenders(invalidID)
+	writeJSON(w, http.StatusOK, endpointToJSON(updated))
 }
 
-// handleDeleteModelConfig removes the entry named by {id} and repairs the
-// default/lite references that pointed at it.
-func (s *Server) handleDeleteModelConfig(w http.ResponseWriter, r *http.Request) {
+// handleDeleteEndpoint: DELETE /api/config/endpoints/{id}
+func (s *Server) handleDeleteEndpoint(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
-		writeError(w, http.StatusBadRequest, "missing model id")
+		writeError(w, http.StatusBadRequest, "missing endpoint id")
 		return
 	}
-
-	cfg, err := config.Load()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
-		return
-	}
-
-	kept := cfg.Models[:0]
-	removed := false
-	for _, e := range cfg.Models {
-		if e.Model == id {
-			removed = true
-			continue
+	if err := config.Mutate(func(cfg *config.Config) error {
+		idx := -1
+		for i := range cfg.Endpoints {
+			if cfg.Endpoints[i].ID == id {
+				idx = i
+				break
+			}
 		}
-		kept = append(kept, e)
-	}
-	if !removed {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config for %q", id))
-		return
-	}
-	cfg.Models = kept
-	if cfg.DefaultModel == id {
-		cfg.DefaultModel = ""
-		if len(cfg.Models) > 0 {
-			cfg.DefaultModel = cfg.Models[0].Model
+		if idx < 0 {
+			return fmt.Errorf("%w: %s", config.ErrEndpointNotFound, id)
 		}
-	}
-	if cfg.LiteModel == id {
-		cfg.LiteModel = ""
-	}
-
-	if err := cfg.Save(); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+		cfg.Endpoints = append(cfg.Endpoints[:idx], cfg.Endpoints[idx+1:]...)
+		// Clear Default/Lite if they pointed at the deleted endpoint's prefix.
+		if strings.HasPrefix(cfg.Default, id+"::") {
+			cfg.Default = ""
+		}
+		if strings.HasPrefix(cfg.Lite, id+"::") {
+			cfg.Lite = ""
+		}
+		return nil
+	}); err != nil {
+		if errors.Is(err, config.ErrEndpointNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	// Deleting an entry may have repaired the default; rebuild the default
-	// sender so new unbound sessions follow the new default.
-	s.invalidateSenderCache()
-	if err := s.reloadDefaultSender(); err != nil {
-		log.Printf("[server] reload default sender after deleting model config: %v", err)
-	}
-
+	s.invalidateEndpointSenders(id)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
-// handleSetLiteModelConfig toggles lite_model on the entry named by {id}:
-// pointing it at the entry, or clearing it when the entry is already the
-// lite model. The lite entry serves history compaction.
-func (s *Server) handleSetLiteModelConfig(w http.ResponseWriter, r *http.Request) {
+// handleAddEndpointModel: POST /api/config/endpoints/{id}/models
+func (s *Server) handleAddEndpointModel(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
-		writeError(w, http.StatusBadRequest, "missing model id")
+		writeError(w, http.StatusBadRequest, "missing endpoint id")
+		return
+	}
+	var req endpointModelIn
+	if err := readBodyJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Model == "" {
+		writeError(w, http.StatusBadRequest, "model is required")
 		return
 	}
 
-	cfg, err := config.Load()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+	var updated config.Endpoint
+	if err := config.Mutate(func(cfg *config.Config) error {
+		if err := cfg.UpsertModel(id, config.EndpointModel{Model: req.Model, Vision: req.Vision}); err != nil {
+			return err
+		}
+		for _, ep := range cfg.Endpoints {
+			if ep.ID == id {
+				updated = ep
+				break
+			}
+		}
+		return nil
+	}); err != nil {
+		if errors.Is(err, config.ErrEndpointNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if _, ok := cfg.EntryByModel(id); !ok {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config named %q", id))
-		return
-	}
-	if cfg.LiteModel == id {
-		cfg.LiteModel = "" // toggle off
-	} else {
-		cfg.LiteModel = id
-	}
-
-	if err := cfg.Save(); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
-		return
-	}
-	s.invalidateSenderCache()
-
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "lite_model": cfg.LiteModel})
+	s.invalidateEndpointSenders(id)
+	writeJSON(w, http.StatusOK, endpointToJSON(updated))
 }
 
-// handleSetDefaultModelConfig points default_model at the entry named by {id}.
-func (s *Server) handleSetDefaultModelConfig(w http.ResponseWriter, r *http.Request) {
+// handleDeleteEndpointModel: DELETE /api/config/endpoints/{id}/models/{model}
+func (s *Server) handleDeleteEndpointModel(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	model := r.PathValue("model")
+	if id == "" || model == "" {
+		writeError(w, http.StatusBadRequest, "missing endpoint id or model")
+		return
+	}
+	if err := config.Mutate(func(cfg *config.Config) error {
+		for i := range cfg.Endpoints {
+			if cfg.Endpoints[i].ID != id {
+				continue
+			}
+			kept := cfg.Endpoints[i].Models[:0]
+			for _, m := range cfg.Endpoints[i].Models {
+				if m.Model == model {
+					continue
+				}
+				kept = append(kept, m)
+			}
+			cfg.Endpoints[i].Models = kept
+			// Clear Default/Lite if they pointed at the deleted model.
+			if cfg.Default == id+"::"+model {
+				cfg.Default = ""
+			}
+			if cfg.Lite == id+"::"+model {
+				cfg.Lite = ""
+			}
+			return nil
+		}
+		return fmt.Errorf("%w: %s", config.ErrEndpointNotFound, id)
+	}); err != nil {
+		if errors.Is(err, config.ErrEndpointNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.invalidateEndpointSenders(id)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// handleSetEndpointDefault: POST /api/config/endpoints/{id}/default
+// Sets cfg.Default to "<id>::<first model under this endpoint>". The caller
+// can't pick a specific model via this endpoint (PR5 design: first suffices;
+// a follow-up could add a `?model=` query).
+func (s *Server) handleSetEndpointDefault(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
-		writeError(w, http.StatusBadRequest, "missing model id")
+		writeError(w, http.StatusBadRequest, "missing endpoint id")
 		return
 	}
-
-	cfg, err := config.Load()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+	var newDefault string
+	if err := config.Mutate(func(cfg *config.Config) error {
+		for _, ep := range cfg.Endpoints {
+			if ep.ID != id {
+				continue
+			}
+			if len(ep.Models) == 0 {
+				return fmt.Errorf("endpoint %q has no models", id)
+			}
+			newDefault = ep.CompositeID(ep.Models[0].Model)
+			cfg.SetDefaultComposite(newDefault)
+			return nil
+		}
+		return fmt.Errorf("%w: %s", config.ErrEndpointNotFound, id)
+	}); err != nil {
+		if errors.Is(err, config.ErrEndpointNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if _, ok := cfg.EntryByModel(id); !ok {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config named %q", id))
+	// Default switch does NOT invalidate senders (design §6) — only changes
+	// which sender ResolveDefault returns next turn.
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "default": newDefault})
+}
+
+// handleSetEndpointLite: POST /api/config/endpoints/{id}/lite
+// Sets cfg.Lite to "<id>::<first model under this endpoint>".
+func (s *Server) handleSetEndpointLite(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing endpoint id")
 		return
 	}
-	cfg.DefaultModel = id
-
-	if err := cfg.Save(); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+	var newLite string
+	if err := config.Mutate(func(cfg *config.Config) error {
+		for _, ep := range cfg.Endpoints {
+			if ep.ID != id {
+				continue
+			}
+			if len(ep.Models) == 0 {
+				return fmt.Errorf("endpoint %q has no models", id)
+			}
+			newLite = ep.CompositeID(ep.Models[0].Model)
+			cfg.Lite = newLite
+			return nil
+		}
+		return fmt.Errorf("%w: %s", config.ErrEndpointNotFound, id)
+	}); err != nil {
+		if errors.Is(err, config.ErrEndpointNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-
-	// The next agent turn should pick up the new default: rebuild the default
-	// sender/model under senderMu so new unbound sessions follow it.
-	s.invalidateSenderCache()
-	if err := s.reloadDefaultSender(); err != nil {
-		log.Printf("[server] reload default sender after setting default model: %v", err)
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "lite": newLite})
 }

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -40,87 +40,13 @@ func getConfigResponse(t *testing.T, srv *Server) configResponse {
 	return resp
 }
 
-func TestConfigModels_GetListsAllEntries(t *testing.T) {
-	setTestHome(t)
-	tru := true
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-main-12345678"},
-			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", ShowReasoning: &tru},
-			{Provider: "deepseek", Model: "deepseek-chat"},
-		},
-		DefaultModel: "kimi-k2.6",
-		LiteModel:    "deepseek-chat",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	resp := getConfigResponse(t, srv)
-	if len(resp.Models) != 3 {
-		t.Fatalf("models = %d, want 3: %+v", len(resp.Models), resp.Models)
-	}
-	if resp.DefaultModelIdx != 1 {
-		t.Errorf("default_model_idx = %d, want 1", resp.DefaultModelIdx)
-	}
-	byID := map[string]modelConfig{}
-	for _, m := range resp.Models {
-		byID[m.ID] = m
-	}
-	if byID["kimi-k2.6"].Type != "default" || byID["deepseek-chat"].Type != "lite" || byID["claude-sonnet-4-6"].Type != "" {
-		t.Errorf("type badges wrong: %+v", resp.Models)
-	}
-	if byID["claude-sonnet-4-6"].APIKeyMasked == "" || byID["claude-sonnet-4-6"].APIKeyMasked == "sk-main-12345678" {
-		t.Errorf("api_key_masked = %q, want masked non-empty", byID["claude-sonnet-4-6"].APIKeyMasked)
-	}
-	if !byID["claude-sonnet-4-6"].AnthropicFormat || byID["deepseek-chat"].AnthropicFormat {
-		t.Errorf("anthropic_format flags wrong: %+v", resp.Models)
-	}
-}
-
-func TestConfig_ShowReasoningGlobalDefault(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-		},
-		DefaultModel: "claude-sonnet-4-6",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	resp := getConfigResponse(t, srv)
-	if resp.ShowReasoning != nil {
-		t.Fatalf("initial global show_reasoning = %+v, want nil", resp.ShowReasoning)
-	}
-
-	// Set global default to false.
-	if w := doJSON(t, srv, http.MethodPut, "/api/config/show_reasoning", `{"show_reasoning":false}`); w.Code != http.StatusOK {
-		t.Fatalf("PUT = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	if cfg.ShowReasoning == nil || *cfg.ShowReasoning {
-		t.Fatalf("stored global = %+v, want false", cfg.ShowReasoning)
-	}
-	resp = getConfigResponse(t, srv)
-	if resp.ShowReasoning == nil || *resp.ShowReasoning {
-		t.Fatalf("response global = %+v, want false", resp.ShowReasoning)
-	}
-
-	// Toggle back to true.
-	if w := doJSON(t, srv, http.MethodPut, "/api/config/show_reasoning", `{"show_reasoning":true}`); w.Code != http.StatusOK {
-		t.Fatalf("PUT = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ = config.Load()
-	if cfg.ShowReasoning == nil || !*cfg.ShowReasoning {
-		t.Fatalf("stored global = %+v, want true", cfg.ShowReasoning)
-	}
-}
-
 func TestConfig_CoauthorGlobalDefault(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-a::claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -156,10 +82,10 @@ func TestConfig_CoauthorGlobalDefault(t *testing.T) {
 func TestConfig_ShowReasoningReloadsDefaultSender(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-test"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-a::claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -199,83 +125,6 @@ func TestConfig_ShowReasoningReloadsDefaultSender(t *testing.T) {
 	}
 }
 
-func TestConfigModels_PostAppendsEntry(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "anthropic", Model: "claude-sonnet-4-6"}},
-		DefaultModel: "claude-sonnet-4-6",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	w := doJSON(t, srv, http.MethodPost, "/api/config/models",
-		`{"model":"kimi-k2.6","base_url":"https://api.moonshot.cn","api_key":"sk-kimi"}`)
-	if w.Code != http.StatusOK {
-		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
-	}
-	var resp struct {
-		OK bool   `json:"ok"`
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatal(err)
-	}
-	if !resp.OK || resp.ID == "" {
-		t.Fatalf("response = %+v", resp)
-	}
-
-	cfg, _ := config.Load()
-	if len(cfg.Models) != 2 {
-		t.Fatalf("entries = %d, want 2 — the second card must not overwrite the first", len(cfg.Models))
-	}
-	if cfg.DefaultModel != "claude-sonnet-4-6" {
-		t.Errorf("default moved to %q, want claude-sonnet-4-6", cfg.DefaultModel)
-	}
-	added, ok := cfg.EntryByModel(resp.ID)
-	if !ok {
-		t.Fatalf("entry %q not stored", resp.ID)
-	}
-	if added.APIKey != "sk-kimi" || added.BaseURL != "https://api.moonshot.cn" {
-		t.Errorf("stored entry = %+v", added)
-	}
-	// base_url matches the kimi vendor preset → provider inferred.
-	if added.Provider != "kimi" {
-		t.Errorf("provider = %q, want kimi (inferred from base_url)", added.Provider)
-	}
-}
-
-func TestConfigModels_PostUnknownEndpointBecomesCustomVendor(t *testing.T) {
-	setTestHome(t)
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	// A hand-typed endpoint that matches no vendor preset lands on the Custom
-	// catch-all, with the wire format recorded on the entry's Protocol field.
-	w := doJSON(t, srv, http.MethodPost, "/api/config/models",
-		`{"model":"my-model","base_url":"https://gw.example/v1","api_key":"sk-x","provider":"custom"}`)
-	if w.Code != http.StatusOK {
-		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	if got := cfg.Models[0].Provider; got != "custom" {
-		t.Errorf("provider = %q, want custom", got)
-	}
-	if got := cfg.Models[0].Protocol; got != "openai" {
-		t.Errorf("protocol = %q, want openai (default)", got)
-	}
-
-	w = doJSON(t, srv, http.MethodPost, "/api/config/models",
-		`{"model":"my-model-2","base_url":"https://gw2.example","api_key":"sk-x","provider":"custom","anthropic_format":true}`)
-	if w.Code != http.StatusOK {
-		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ = config.Load()
-	if got := cfg.Models[1].Provider; got != "custom" {
-		t.Errorf("anthropic_format provider = %q, want custom", got)
-	}
-	if got := cfg.Models[1].Protocol; got != "anthropic" {
-		t.Errorf("anthropic_format protocol = %q, want anthropic", got)
-	}
-}
-
 func TestListProviders_MarksCustomCatchAll(t *testing.T) {
 	presets := buildProviderPresets()
 	byID := map[string]providerPreset{}
@@ -300,50 +149,6 @@ func TestListProviders_MarksCustomCatchAll(t *testing.T) {
 	}
 }
 
-func TestApplyModelRequest_ProtocolOnlyForCustom(t *testing.T) {
-	// Selecting Custom records the protocol from the anthropic_format toggle.
-	var e config.ModelEntry
-	applyModelRequestToEntry(saveModelRequest{
-		Provider: "custom", Model: "m", BaseURL: "https://gw.example", AnthropicFormat: true,
-	}, &e)
-	if e.Provider != "custom" || e.Protocol != "anthropic" {
-		t.Fatalf("custom+anthropic: got provider=%q protocol=%q, want custom/anthropic", e.Provider, e.Protocol)
-	}
-
-	// Switching the same entry to a named vendor clears the stale protocol.
-	applyModelRequestToEntry(saveModelRequest{
-		Provider: "openai", Model: "gpt-5.4", BaseURL: "",
-	}, &e)
-	if e.Provider != "openai" || e.Protocol != "" {
-		t.Fatalf("switch to named vendor: got provider=%q protocol=%q, want openai/(empty)", e.Provider, e.Protocol)
-	}
-}
-
-func TestApplyModelRequest_VisionResolution(t *testing.T) {
-	yes, no := true, false
-	cases := []struct {
-		name string
-		req  saveModelRequest
-		want bool
-	}{
-		{"explicit true wins", saveModelRequest{Provider: "deepseek", Model: "deepseek-v4-pro", Vision: &yes}, true},
-		{"explicit false wins", saveModelRequest{Provider: "openai", Model: "gpt-4o", Vision: &no}, false},
-		{"predefined resolves from catalogue (vision)", saveModelRequest{Provider: "bailian", Model: "qwen3.7-plus"}, true},
-		{"predefined resolves from catalogue (text-only)", saveModelRequest{Provider: "bailian", Model: "qwen3.7-max"}, false},
-		{"custom falls back to heuristic (vision)", saveModelRequest{Provider: "custom", Model: "gpt-4o", BaseURL: "https://gw.example"}, true},
-		{"custom falls back to heuristic (text-only)", saveModelRequest{Provider: "custom", Model: "some-deepseek", BaseURL: "https://gw.example"}, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			var e config.ModelEntry
-			applyModelRequestToEntry(tc.req, &e)
-			if e.Vision != tc.want {
-				t.Errorf("Vision = %v, want %v", e.Vision, tc.want)
-			}
-		})
-	}
-}
-
 func TestListProviders_IncludesModelVision(t *testing.T) {
 	byID := map[string]providerPreset{}
 	for _, p := range buildProviderPresets() {
@@ -359,154 +164,14 @@ func TestListProviders_IncludesModelVision(t *testing.T) {
 	}
 }
 
-func TestConfigModels_PostFirstEntryBecomesDefault(t *testing.T) {
-	setTestHome(t)
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	w := doJSON(t, srv, http.MethodPost, "/api/config/models",
-		`{"model":"claude-sonnet-4-6","base_url":"https://api.anthropic.com","api_key":"sk-x","provider":"anthropic"}`)
-	if w.Code != http.StatusOK {
-		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	if len(cfg.Models) != 1 || cfg.DefaultModel != cfg.Models[0].Model {
-		t.Fatalf("first entry must become default: %+v", cfg)
-	}
-	if cfg.Models[0].Provider != "anthropic" {
-		t.Errorf("explicit provider must win: %q", cfg.Models[0].Provider)
-	}
-}
-
-func TestConfigModels_PatchUpdatesAndKeepsKey(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-keep-me"},
-		},
-		DefaultModel: "claude-sonnet-4-6",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	// No api_key in the request → stored key survives. A still-masked echo is
-	// also treated as "no change".
-	w := doJSON(t, srv, http.MethodPatch, "/api/config/models/claude-sonnet-4-6",
-		`{"model":"claude-opus-4-7","base_url":"","api_key":"sk-k****1234"}`)
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	e, _ := cfg.EntryByModel("claude-opus-4-7")
-	if e.Model != "claude-opus-4-7" {
-		t.Errorf("model = %q, want claude-opus-4-7", e.Model)
-	}
-	if e.APIKey != "sk-keep-me" {
-		t.Errorf("api_key = %q, want preserved sk-keep-me", e.APIKey)
-	}
-	// The panel hardcodes anthropic_format=false and sends no provider; an
-	// update with no vendor signal must not clobber the stored provider.
-	if e.Provider != "anthropic" {
-		t.Errorf("provider = %q, want anthropic preserved", e.Provider)
-	}
-	// Editing the default entry must rebuild the runtime default sender/model,
-	// or new unbound sessions keep using the stale startup model.
-	if srv.model != "claude-opus-4-7" {
-		t.Errorf("runtime default model = %q, want claude-opus-4-7 after editing default entry", srv.model)
-	}
-
-	if w := doJSON(t, srv, http.MethodPatch, "/api/config/models/ghost", `{"model":"x"}`); w.Code != http.StatusNotFound {
-		t.Errorf("PATCH unknown id = %d, want 404", w.Code)
-	}
-}
-
-func TestConfigModels_DeleteRepairsReferences(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "m1"},
-			{Provider: "kimi", Model: "m2"},
-		},
-		DefaultModel: "m1",
-		LiteModel:    "m2",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	// Deleting the default reassigns it to the first remaining entry.
-	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/m1", ""); w.Code != http.StatusOK {
-		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	if len(cfg.Models) != 1 || cfg.DefaultModel != "m2" {
-		t.Fatalf("after delete: %+v", cfg)
-	}
-
-	// Deleting the lite entry clears the lite reference.
-	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/m2", ""); w.Code != http.StatusOK {
-		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ = config.Load()
-	if len(cfg.Models) != 0 || cfg.LiteModel != "" || cfg.DefaultModel != "" {
-		t.Fatalf("after second delete: %+v", cfg)
-	}
-
-	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/ghost", ""); w.Code != http.StatusNotFound {
-		t.Errorf("DELETE unknown id = %d, want 404", w.Code)
-	}
-}
-
-func TestConfigModels_SetDefault(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "m1"},
-			{Provider: "kimi", Model: "m2"},
-		},
-		DefaultModel: "m1",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/m2/default", ""); w.Code != http.StatusOK {
-		t.Fatalf("set-default = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	if cfg.DefaultModel != "m2" {
-		t.Fatalf("default = %q, want m2", cfg.DefaultModel)
-	}
-	if srv.model != "m2" {
-		t.Errorf("runtime model = %q, want m2", srv.model)
-	}
-
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/ghost/default", ""); w.Code != http.StatusNotFound {
-		t.Errorf("set-default unknown id = %d, want 404", w.Code)
-	}
-}
-
-func TestConfigModels_DuplicateModelRejected(t *testing.T) {
-	setTestHome(t)
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	// Model is the entry id, so a second entry for the same model is a conflict.
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models",
-		`{"model":"kimi-k2.6","api_key":"sk-1"}`); w.Code != http.StatusOK {
-		t.Fatalf("first POST = %d: %s", w.Code, w.Body.String())
-	}
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models",
-		`{"model":"kimi-k2.6","api_key":"sk-2"}`); w.Code != http.StatusConflict {
-		t.Fatalf("duplicate POST = %d, want 409: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	if len(cfg.Models) != 1 {
-		t.Fatalf("entries = %d, want 1 (duplicate rejected)", len(cfg.Models))
-	}
-}
-
 func TestCreateSession_EntryIDBindsSession(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "kimi", Model: "kimi-k2.6"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-kimi", Provider: "kimi", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-anthropic::claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -557,8 +222,8 @@ func TestCreateSession_EntryIDBindsSession(t *testing.T) {
 func TestCreateSession_NoWorkspaceDir_WorkingDirEmpty(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "anthropic", Model: "claude-sonnet-4-6"}},
-		DefaultModel: "claude-sonnet-4-6",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}}},
+		Default:   "ep-a::claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -588,8 +253,8 @@ func TestCreateSession_NoWorkspaceDir_WorkingDirEmpty(t *testing.T) {
 func TestCreateSession_WorkspaceDirConfigured_SetsWorkingDir(t *testing.T) {
 	home := setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "anthropic", Model: "claude-sonnet-4-6"}},
-		DefaultModel: "claude-sonnet-4-6",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}}},
+		Default:   "ep-a::claude-sonnet-4-6",
 	})
 	wantDir := filepath.Join(home, "octo-workspace")
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", WorkspaceDir: wantDir})
@@ -618,47 +283,6 @@ func TestCreateSession_WorkspaceDirConfigured_SetsWorkingDir(t *testing.T) {
 	}
 }
 
-func TestConfigModels_SetLiteToggles(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "m1"},
-			{Provider: "deepseek", Model: "m2"},
-		},
-		DefaultModel: "m1",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	// Set.
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/m2/lite", ""); w.Code != http.StatusOK {
-		t.Fatalf("set-lite = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	if cfg.LiteModel != "m2" {
-		t.Fatalf("lite = %q, want m2", cfg.LiteModel)
-	}
-	// The badge surfaces in GET /api/config.
-	resp := getConfigResponse(t, srv)
-	for _, m := range resp.Models {
-		if m.ID == "m2" && m.Type != "lite" {
-			t.Errorf("cheap type = %q, want lite", m.Type)
-		}
-	}
-
-	// Toggle off.
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/m2/lite", ""); w.Code != http.StatusOK {
-		t.Fatalf("unset-lite = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ = config.Load()
-	if cfg.LiteModel != "" {
-		t.Fatalf("lite = %q, want cleared", cfg.LiteModel)
-	}
-
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/ghost/lite", ""); w.Code != http.StatusNotFound {
-		t.Errorf("set-lite unknown id = %d, want 404", w.Code)
-	}
-}
-
 // getEndpointsResponse calls GET /api/config/endpoints and decodes the body.
 func getEndpointsResponse(t *testing.T, srv *Server) endpointsResponse {
 	t.Helper()
@@ -680,13 +304,12 @@ func getEndpointsResponse(t *testing.T, srv *Server) endpointsResponse {
 func TestGetEndpoints_ReturnsTwoLevelShape(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-main-12345678", Vision: true},
-			{Provider: "anthropic", Model: "claude-haiku-4-5", APIKey: "sk-main-12345678"},
-			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", APIKey: "sk-kimi"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", APIKey: "sk-main-12345678", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6", Vision: true}, {Model: "claude-haiku-4-5"}}},
+			{ID: "ep-kimi", Provider: "kimi", BaseURL: "https://kimi.example", APIKey: "sk-kimi", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
-		LiteModel:    "claude-haiku-4-5",
+		Default: "ep-anthropic::claude-sonnet-4-6",
+		Lite:    "ep-anthropic::claude-haiku-4-5",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -777,10 +400,10 @@ func TestGetEndpoints_ReturnsTwoLevelShape(t *testing.T) {
 func TestGetEndpoints_NoKeyReportsAbsent(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "deepseek", Model: "deepseek-v4-pro"}, // no APIKey
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "deepseek", Models: []config.EndpointModel{{Model: "deepseek-v4-pro"}}}, // no APIKey
 		},
-		DefaultModel: "deepseek-v4-pro",
+		Default: "ep-a::deepseek-v4-pro",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -840,12 +463,12 @@ func TestBuildAgent_ImplicitLiteFromVendorRegistry(t *testing.T) {
 func TestBuildAgent_ExplicitLiteBeatsImplicit(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "deepseek", Model: "deepseek-v4-pro", APIKey: "sk-x"},
-			{Provider: "kimi", Model: "kimi-k2.5", APIKey: "sk-y"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-deepseek", Provider: "deepseek", APIKey: "sk-x", Models: []config.EndpointModel{{Model: "deepseek-v4-pro"}}},
+			{ID: "ep-kimi", Provider: "kimi", APIKey: "sk-y", Models: []config.EndpointModel{{Model: "kimi-k2.5"}}},
 		},
-		DefaultModel: "deepseek-v4-pro",
-		LiteModel:    "kimi-k2.5",
+		Default: "ep-deepseek::deepseek-v4-pro",
+		Lite:    "ep-kimi::kimi-k2.5",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 	srv.provider = "deepseek"
@@ -864,11 +487,11 @@ func TestBuildAgent_ExplicitLiteBeatsImplicit(t *testing.T) {
 func TestBuildAgent_ImplicitLiteForBoundSession(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-a"},
-			{Provider: "deepseek", Model: "deepseek-v4-pro", APIKey: "sk-d"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", APIKey: "sk-a", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-deepseek", Provider: "deepseek", APIKey: "sk-d", Models: []config.EndpointModel{{Model: "deepseek-v4-pro"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-anthropic::claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 	srv.provider = "anthropic"
@@ -885,64 +508,11 @@ func TestBuildAgent_ImplicitLiteForBoundSession(t *testing.T) {
 	}
 }
 
-// TestConfigModels_PatchModelChangeRepairsDefault: model is the entry id, so
-// changing it re-keys the entry and repairs the default_model reference that
-// pointed at the old model.
-func TestConfigModels_PatchModelChangeRepairsDefault(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "openai", Model: "qwen3.7-max", APIKey: "sk-x"},
-		},
-		DefaultModel: "qwen3.7-max",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	w := doJSON(t, srv, http.MethodPatch, "/api/config/models/qwen3.7-max",
-		`{"model":"qwen3.7-plus","base_url":"","api_key":"sk-x****","provider":"openai"}`)
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH = %d: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	if _, ok := cfg.EntryByModel("qwen3.7-plus"); !ok {
-		t.Fatalf("entry should be re-keyed to new model qwen3.7-plus: %+v", cfg.Models)
-	}
-	if _, ok := cfg.EntryByModel("qwen3.7-max"); ok {
-		t.Errorf("stale model qwen3.7-max should be gone")
-	}
-	if cfg.DefaultModel != "qwen3.7-plus" {
-		t.Errorf("default_model = %q, want qwen3.7-plus (repaired)", cfg.DefaultModel)
-	}
-}
-
-// An empty model in a PATCH would re-key the entry to "" — unaddressable via
-// the API and permanently orphaned. It must be rejected, leaving the entry
-// unchanged.
-func TestConfigModels_PatchEmptyModelRejected(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-x"},
-		},
-		DefaultModel: "claude-sonnet-4-6",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-
-	if w := doJSON(t, srv, http.MethodPatch, "/api/config/models/claude-sonnet-4-6",
-		`{"model":"","base_url":"","api_key":"sk-x****"}`); w.Code != http.StatusBadRequest {
-		t.Fatalf("PATCH empty model = %d, want 400: %s", w.Code, w.Body.String())
-	}
-	cfg, _ := config.Load()
-	if len(cfg.Models) != 1 || cfg.Models[0].Model != "claude-sonnet-4-6" || cfg.DefaultModel != "claude-sonnet-4-6" {
-		t.Fatalf("entry must be unchanged and addressable: %+v default=%q", cfg.Models, cfg.DefaultModel)
-	}
-}
-
 func TestGetConfig_WorkspaceDir(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "anthropic", Model: "claude-sonnet-4-6"}},
-		DefaultModel: "claude-sonnet-4-6",
+		Endpoints:    []config.Endpoint{{ID: "ep-a", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}}},
+		Default:      "ep-a::claude-sonnet-4-6",
 		WorkspaceDir: "~/octo-projects",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
@@ -956,8 +526,8 @@ func TestGetConfig_WorkspaceDir(t *testing.T) {
 func TestPutWorkspaceDir_UpdatesConfigAndServerDefault(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "anthropic", Model: "claude-sonnet-4-6"}},
-		DefaultModel: "claude-sonnet-4-6",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}}},
+		Default:   "ep-a::claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 

--- a/internal/server/pr4b_review_composite_id_test.go
+++ b/internal/server/pr4b_review_composite_id_test.go
@@ -19,11 +19,11 @@ func TestPR4b_Review_VerifyEntryByModelHandlesCompositeID(t *testing.T) {
 	t.Setenv("USERPROFILE", tmp)
 
 	seed := config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", APIKey: "sk-kimi"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-kimi", Provider: "kimi", BaseURL: "https://kimi.example", APIKey: "sk-kimi", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-anthropic::claude-sonnet-4-6",
 	}
 	if err := seed.Save(); err != nil {
 		t.Fatal(err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -828,11 +828,15 @@ func (s *Server) registerRoutes() {
 	s.api("PUT /api/config/language", s.handlePutLanguage)
 	s.api("PUT /api/config/workspace_dir", s.handlePutWorkspaceDir)
 	s.api("POST /api/config/test", s.handleTestConfig)
-	s.api("POST /api/config/models", s.handleSaveModelConfig)
-	s.api("PATCH /api/config/models/{id}", s.handleUpdateModelConfig)
-	s.api("DELETE /api/config/models/{id}", s.handleDeleteModelConfig)
-	s.api("POST /api/config/models/{id}/default", s.handleSetDefaultModelConfig)
-	s.api("POST /api/config/models/{id}/lite", s.handleSetLiteModelConfig)
+	// PR5: endpoint-level CRUD (design §10.2). The old /api/config/models*
+	// routes are deleted — callers must use these.
+	s.api("POST /api/config/endpoints", s.handleCreateEndpoint)
+	s.api("PATCH /api/config/endpoints/{id}", s.handleUpdateEndpoint)
+	s.api("DELETE /api/config/endpoints/{id}", s.handleDeleteEndpoint)
+	s.api("POST /api/config/endpoints/{id}/models", s.handleAddEndpointModel)
+	s.api("DELETE /api/config/endpoints/{id}/models/{model}", s.handleDeleteEndpointModel)
+	s.api("POST /api/config/endpoints/{id}/default", s.handleSetEndpointDefault)
+	s.api("POST /api/config/endpoints/{id}/lite", s.handleSetEndpointLite)
 
 	// Browser automation setup
 	s.api("GET /api/browser/status", s.handleBrowserStatus)
@@ -1364,8 +1368,8 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 		APIKey:          apiKey,
 		BaseURL:         resolveBaseURL(provName, cfg),
 		Protocol:        protocol,
-		ReasoningEffort: entry.ReasoningEffort,
-		ShowReasoning:   cfg.EffectiveShowReasoning(entry.ShowReasoning),
+		ReasoningEffort: cfg.ReasoningEffort,
+		ShowReasoning:   cfg.EffectiveShowReasoning(nil),
 	})
 	if err != nil {
 		return nil, "", "", err
@@ -1542,11 +1546,11 @@ func (s *Server) invalidateEndpointSenders(endpointID string) {
 // switch this arg to cfg.Lite so the lite sender participates in per-endpoint
 // invalidation (§9.2).
 func (s *Server) liteSenderFromConfig(cfg config.Config) (agent.Sender, string) {
-	entry, ok := cfg.EntryByModel(cfg.LiteModel)
+	entry, ok := cfg.EntryByModel(cfg.Lite)
 	if !ok || entry.Model == "" {
 		return nil, ""
 	}
-	sender, err := s.cachedSenderForEntry(cfg.LiteModel, entry)
+	sender, err := s.cachedSenderForEntry(cfg.Lite, entry)
 	if err != nil {
 		return nil, ""
 	}
@@ -1569,8 +1573,8 @@ func senderForEntry(entry config.ModelEntry) (agent.Sender, error) {
 		APIKey:          apiKey,
 		BaseURL:         entry.BaseURL,
 		Protocol:        entry.Protocol,
-		ReasoningEffort: entry.ReasoningEffort,
-		ShowReasoning:   cfg.EffectiveShowReasoning(entry.ShowReasoning),
+		ReasoningEffort: cfg.ReasoningEffort,
+		ShowReasoning:   cfg.EffectiveShowReasoning(nil),
 	})
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1034,10 +1034,10 @@ func TestHandleTestConfig_ReusesStoredKey(t *testing.T) {
 	defer mock.Close()
 
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "openai", Model: "gpt-4o-mini", BaseURL: mock.URL, APIKey: "stored-key"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", BaseURL: mock.URL, APIKey: "stored-key", Models: []config.EndpointModel{{Model: "gpt-4o-mini"}}},
 		},
-		DefaultModel: "gpt-4o-mini",
+		Default: "ep-a::gpt-4o-mini",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
@@ -1055,29 +1055,6 @@ func TestHandleTestConfig_ReusesStoredKey(t *testing.T) {
 	}
 	if gotAuth != "Bearer stored-key" {
 		t.Errorf("Authorization = %q, want Bearer stored-key (stored key reused)", gotAuth)
-	}
-}
-
-func TestHandleSaveModelConfig(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
-	t.Setenv("USERPROFILE", tmp)
-
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-	payload, _ := json.Marshal(saveModelRequest{Type: "default", Model: "gpt-4", BaseURL: "https://api.openai.com/v1", APIKey: "sk-test"})
-	req := httptest.NewRequest(http.MethodPost, "/api/config/models", bytes.NewReader(payload))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	serveLoopback(srv.mux, w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
-	var body map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-		t.Fatal(err)
-	}
-	if body["ok"] != true {
-		t.Fatalf("ok = %v, want true", body["ok"])
 	}
 }
 
@@ -1435,114 +1412,9 @@ func TestHandleUpdateSessionReasoningEffort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := cfg.DefaultEntry().ReasoningEffort; got != "high" {
+	// PR5: reasoning is global — read cfg.ReasoningEffort directly.
+	if got := cfg.ReasoningEffort; got != "high" {
 		t.Fatalf("reasoning_effort = %q, want high", got)
-	}
-}
-
-// A session pinned to a NON-default model must have ITS OWN entry's
-// reasoning_effort changed — not the unrelated default model's. Before this
-// was fixed, every PATCH landed on cfg.DefaultEntry() regardless of which
-// session triggered it, so a multi-model setup's per-session tuning silently
-// no-opped for any session not running the default model.
-func TestHandleUpdateSessionReasoningEffort_NonDefaultModel(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "deepseek", Model: "deepseek-v4-flash"},
-		},
-		DefaultModel: "claude-sonnet-4-6",
-	})
-
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-
-	sess := agent.NewSession("deepseek-v4-flash", "")
-	sess.ModelConfig = "deepseek-v4-flash"
-	if err := sess.Save(); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-
-	payload, _ := json.Marshal(updateSessionReasoningEffortRequest{ReasoningEffort: "xhigh"})
-	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+sess.ID+"/reasoning_effort", bytes.NewReader(payload))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	serveLoopback(srv.mux, w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
-
-	cfg, err := config.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	e, ok := cfg.EntryByModel("deepseek-v4-flash")
-	if !ok {
-		t.Fatal("deepseek-v4-flash entry vanished")
-	}
-	if e.ReasoningEffort != "xhigh" {
-		t.Errorf("deepseek-v4-flash reasoning_effort = %q, want xhigh (this session's own entry should change)", e.ReasoningEffort)
-	}
-	if def := cfg.DefaultEntry(); def.ReasoningEffort != "" {
-		t.Errorf("default entry (claude-sonnet-4-6) reasoning_effort = %q, want untouched (empty)", def.ReasoningEffort)
-	}
-}
-
-// The reported bug (#web show_reasoning field not respected): a session
-// pinned to a non-default model must have ITS OWN entry's show_reasoning
-// toggled. Before this fix, the toggle always wrote to cfg.DefaultEntry()
-// while the session's actual turns (senderForSession) already correctly
-// resolved the session's own entry — so the Composer's eye icon flipped
-// (read and write both hit the same wrong entry) while reasoning kept
-// showing/hiding no matter how many times it was toggled.
-func TestHandleUpdateSessionShowReasoning_NonDefaultModel(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "deepseek", Model: "deepseek-v4-flash"},
-		},
-		DefaultModel: "claude-sonnet-4-6",
-	})
-
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-
-	sess := agent.NewSession("deepseek-v4-flash", "")
-	sess.ModelConfig = "deepseek-v4-flash"
-	if err := sess.Save(); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-
-	payload, _ := json.Marshal(updateSessionShowReasoningRequest{ShowReasoning: false})
-	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+sess.ID+"/show_reasoning", bytes.NewReader(payload))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	serveLoopback(srv.mux, w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
-
-	cfg, err := config.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	e, ok := cfg.EntryByModel("deepseek-v4-flash")
-	if !ok {
-		t.Fatal("deepseek-v4-flash entry vanished")
-	}
-	if e.ShowReasoning == nil || *e.ShowReasoning {
-		t.Errorf("deepseek-v4-flash show_reasoning = %v, want false (this session's own entry should be toggled)", e.ShowReasoning)
-	}
-	if def := cfg.DefaultEntry(); def.ShowReasoning != nil {
-		t.Errorf("default entry (claude-sonnet-4-6) show_reasoning = %v, want untouched (nil)", def.ShowReasoning)
-	}
-
-	// senderForSession must resolve this session's turns against the SAME
-	// (now-updated) entry the toggle just wrote — proving the fix actually
-	// changes what the session's real turns do, not just what the config
-	// file happens to say.
-	if got := cfg.EffectiveShowReasoning(entryForSession(cfg, sess).ShowReasoning); got {
-		t.Error("entryForSession(sess) still resolves show_reasoning=true after toggling it off for this session")
 	}
 }
 
@@ -1552,11 +1424,10 @@ func TestHandleUpdateSessionShowReasoning_NonDefaultModel(t *testing.T) {
 // that's since been removed from config.
 func TestEntryForSession(t *testing.T) {
 	cfg := config.Config{
-		Models: []config.ModelEntry{
-			{Model: "model-a"},
-			{Model: "model-b"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []config.EndpointModel{{Model: "model-a"}, {Model: "model-b"}}},
 		},
-		DefaultModel: "model-a",
+		Default: "ep-a::model-a",
 	}
 
 	cases := []struct {
@@ -1813,8 +1684,10 @@ func TestHandleUpdateSessionModel_RawStringIsPerSession(t *testing.T) {
 		t.Fatalf("server default model changed to %q — must stay stub-model", srv.model)
 	}
 	cfg, _ := config.Load()
-	if len(cfg.Models) != 0 {
-		t.Fatalf("global config written by a per-session switch: %+v", cfg.Models)
+	// PR5: Config.Models is deleted — the per-session switch never writes the
+	// global config (it just sets sess.ModelConfig, a session field).
+	if len(cfg.Endpoints) != 0 {
+		t.Fatalf("global config written by a per-session switch: %+v", cfg.Endpoints)
 	}
 }
 
@@ -1824,11 +1697,11 @@ func TestHandleUpdateSessionModel_EntryNameBindsSession(t *testing.T) {
 	t.Setenv("USERPROFILE", tmp)
 
 	seed := config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "kimi", Model: "kimi-k2.6", APIKey: "sk-kimi"},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-kimi", Provider: "kimi", APIKey: "sk-kimi", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default: "ep-anthropic::claude-sonnet-4-6",
 	}
 	if err := seed.Save(); err != nil {
 		t.Fatal(err)
@@ -1859,8 +1732,8 @@ func TestHandleUpdateSessionModel_EntryNameBindsSession(t *testing.T) {
 		t.Fatalf("session = (%q, %q), want (kimi-k2.6, kimi-k2.6)", got.Model, got.ModelConfig)
 	}
 	cfg, _ := config.Load()
-	if cfg.DefaultModel != "claude-sonnet-4-6" {
-		t.Fatalf("global default changed to %q — must stay claude-sonnet-4-6", cfg.DefaultModel)
+	if cfg.Default != "ep-anthropic::claude-sonnet-4-6" {
+		t.Fatalf("global default changed to %q — must stay ep-anthropic::claude-sonnet-4-6", cfg.Default)
 	}
 
 	// The bound session's turns resolve to the entry's sender and model;
@@ -1877,9 +1750,10 @@ func TestHandleUpdateSessionModel_EntryNameBindsSession(t *testing.T) {
 		t.Errorf("unbound session = (%v, %q), want default sender + stub-model", sender2, model2)
 	}
 
-	// Deleting the bound entry degrades to the default sender instead of
-	// failing the turn.
-	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/kimi-k2.6", ""); w.Code != http.StatusOK {
+	// Deleting the bound endpoint's model degrades to the default sender
+	// instead of failing the turn. PR5: the delete route is now
+	// /api/config/endpoints/{id}/models/{model} (old /api/config/models is gone).
+	if w := doJSON(t, srv, http.MethodDelete, "/api/config/endpoints/ep-kimi/models/kimi-k2.6", ""); w.Code != http.StatusOK {
 		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
 	}
 	if sender3, _ := srv.senderForSession(got); sender3 != srv.sender {
@@ -2172,11 +2046,12 @@ func TestHandleGetSessionMessages_ShowReasoningField(t *testing.T) {
 	setTestHome(t)
 	off := false
 	seedModels(t, config.Config{
-		Models: []config.ModelEntry{
-			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Provider: "kimi-coding-plan", Model: "kimi-for-coding", ShowReasoning: &off},
+		Endpoints: []config.Endpoint{
+			{ID: "ep-anthropic", Provider: "anthropic", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-kimi", Provider: "kimi-coding-plan", Models: []config.EndpointModel{{Model: "kimi-for-coding"}}},
 		},
-		DefaultModel: "claude-sonnet-4-6",
+		Default:       "ep-anthropic::claude-sonnet-4-6",
+		ShowReasoning: &off,
 	})
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
@@ -2206,11 +2081,14 @@ func TestHandleGetSessionMessages_ShowReasoningField(t *testing.T) {
 		return body["show_reasoning"]
 	}
 
+	// PR5: reasoning is global. Both sessions read the global ShowReasoning
+	// (off) — per-session overrides no longer exist. This test now just
+	// guards that the global value surfaces on session messages.
 	if got := getShowReasoning(quiet.ID); got != false {
-		t.Errorf("kimi-for-coding session show_reasoning = %v, want false", got)
+		t.Errorf("kimi-for-coding session show_reasoning = %v, want false (global)", got)
 	}
-	if got := getShowReasoning(loud.ID); got != true {
-		t.Errorf("claude-sonnet-4-6 session show_reasoning = %v, want true (untouched default)", got)
+	if got := getShowReasoning(loud.ID); got != false {
+		t.Errorf("claude-sonnet-4-6 session show_reasoning = %v, want false (global)", got)
 	}
 }
 

--- a/internal/server/subagent_test.go
+++ b/internal/server/subagent_test.go
@@ -126,8 +126,8 @@ func (s *systemRecordingSender) StreamMessagesWithTools(_ context.Context, _, sy
 func TestEnableSubAgentTools_RefreshesMemoryBackendBeforeBakingGuidance(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
-		DefaultModel: "gpt-4o",
+		Endpoints: []config.Endpoint{{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}}},
+		Default:   "ep-a::gpt-4o",
 		MemoryBackend: config.MemoryBackendConfig{
 			Type:    "hindsight",
 			BaseURL: "http://localhost:8888",

--- a/internal/tools/config_guard_test.go
+++ b/internal/tools/config_guard_test.go
@@ -34,14 +34,15 @@ func TestConfigGuard_ValidateConfigFile(t *testing.T) {
 		t.Errorf("broken YAML: want a parse warning, got %q", msg)
 	}
 
-	// Parses, but default_model dangles → the semantic warning.
-	writeCfg(t, "models:\n  - provider: openai\n    model: gpt-4o\ndefault_model: nope\n")
-	if msg := validateConfigFile(); !strings.Contains(msg, "problems") || !strings.Contains(msg, "default_model") {
-		t.Errorf("dangling default_model: want a semantic warning, got %q", msg)
+	// Parses, but Default dangles → the semantic warning. PR5: Default is a
+	// composite id; "ghost::gpt-4o" points at a non-existent endpoint.
+	writeCfg(t, "endpoints:\n  - id: ep-a\n    provider: openai\n    models:\n      - model: gpt-4o\ndefault: ghost::gpt-4o\n")
+	if msg := validateConfigFile(); !strings.Contains(msg, "problems") || !strings.Contains(msg, "default") {
+		t.Errorf("dangling Default: want a semantic warning, got %q", msg)
 	}
 
 	// Valid → no warning.
-	writeCfg(t, "models:\n  - provider: openai\n    model: gpt-4o\ndefault_model: gpt-4o\n")
+	writeCfg(t, "endpoints:\n  - id: ep-a\n    provider: openai\n    models:\n      - model: gpt-4o\ndefault: ep-a::gpt-4o\n")
 	if msg := validateConfigFile(); msg != "" {
 		t.Errorf("valid config: want no warning, got %q", msg)
 	}

--- a/web/src/views/SettingsView.svelte
+++ b/web/src/views/SettingsView.svelte
@@ -177,15 +177,14 @@
     loading = true
     try {
       const cfg = await api.getConfig() as any
-      // models list
-      const ms: any[] = cfg.models ?? []
-      models = ms as ModelEntry[]
-      defaultModelIdx = cfg.default_model_idx ?? 0
-      const def = ms[defaultModelIdx]
-      if (def) {
-        reasoning = capitalize(def.reasoning_effort ?? 'medium')
-        permMode  = permissionModeToLabel(def.permission_mode ?? 'interactive')
-      }
+      // PR5: GET /api/config no longer returns a models list (the flat
+      // Models field is deleted). The two-level endpoint view
+      // (GET /api/config/endpoints) is the only model surface now; the
+      // flat AI Models editor section below is hidden until PR6 ships a
+      // two-level editor. reasoning_effort is now global.
+      defaultModelIdx = 0
+      reasoning = capitalize(cfg.reasoning_effort ?? 'medium')
+      permMode  = permissionModeToLabel(cfg.permission_mode ?? 'interactive')
       showReasoning = cfg.show_reasoning ?? true
       coauthor = cfg.coauthor ?? true
       workspaceDir = cfg.workspace_dir ?? ''
@@ -200,9 +199,8 @@
       if (cfg.language)   language = cfg.language
       origLanguage = language
 
-      // PR4b: load the two-level endpoint view in parallel. Failure is non-fatal
-      // — the read-only Channels section just renders empty and the existing
-      // flat Models section still carries the editing surface.
+      // PR4b/PR5: load the two-level endpoint view in parallel. Failure is
+      // non-fatal — the read-only Channels section just renders empty.
       try {
         const ep = await api.getEndpoints()
         endpoints = ep.endpoints ?? []
@@ -418,7 +416,12 @@
         {/if}
       </div>
 
-      <!-- AI Models (config-level entries) -->
+      <!-- AI Models (config-level entries) — PR5: hidden. The flat Models
+           editor and its backend routes (POST/PATCH/DELETE /api/config/models*)
+           are deleted in PR5. A two-level endpoint editor lands in PR6.
+           The section block is kept (wrapped in {#if false}) so PR6 can
+           revive it; the i18n keys and handler stubs remain. -->
+      {#if false}
       <div class="section-card">
         <div class="section-head">
           <span class="section-title-inline">{$t('settings.models.title')}</span>
@@ -458,6 +461,7 @@
           {/each}
         {/if}
       </div>
+      {/if}
 
       <!-- General -->
       <div class="section-card">


### PR DESCRIPTION
## Summary

PR5 completes the two-level endpoint grouping: **Save writes the `endpoints:` block**, the flat `Models`/`DefaultModel`/`LiteModel` fields are deleted from the runtime `Config`, 7 new endpoint CRUD handlers replace the old `/api/config/models*` routes, the `octo config` wizard builds endpoints, `octo config show` prints the two-level shape, and per-entry reasoning is lifted to global. PR4a (Save write-path switch) was cancelled and folded into this PR; the coordinated migration of every `Models`-mutating callsite happens here.

Design doc: `dev-docs/endpoint-pr5-impl.md` (11 grill-me decisions + a tech-fact correction — design §6.1 "scan channels.yml" was wrong; channel bindings live in session jsonl, PR5 does NOT scan session files).

## Key constraint

**Single-direction upgrade.** Old `models:`-block files Load fine (normalized to `Endpoints` in memory), but the first Save after PR5 rewrites the file to `endpoints:` format. Downgrading to PR4b or earlier is NOT supported — the old code's `cfg.Models` will be empty. This is by design (§18.1).

**Reasoning simplification.** Per-entry `reasoning_effort`/`show_reasoning` are deleted. Legacy files' per-entry reasoning fields are silently dropped on Load (the top-level `reasoning_effort` key still reads into `Config.ReasoningEffort`). Users who had per-entry reasoning configured will need to re-set the global value.

## Core changes

### Config layer (`internal/config/config.go`)

- **Delete `Config.Models`/`DefaultModel`/`LiteModel`** (runtime). `fileConfig` keeps them as `LegacyModels`/`LegacyDefaultModel`/`LegacyLiteModel` for reading old `models:`-block files. `normalize()` migrates legacy → `Endpoints` + `Default`/`Lite` composite ids; `syncEndpointsFromModels` removed (replaced by `synthesizeEndpointsFromLegacy` which returns `[]Endpoint`).
- **Save** marshals `Config` directly — `Endpoints`/`Default`/`Lite` are authoritative. No more "clear new fields, write flat Models" shim.
- **`ModelEntry`**: delete `ReasoningEffort`/`ShowReasoning`. Kept as a projection type — `EntryByModel` returns it, projected from `(Endpoint, EndpointModel)` via `projectToModelEntry`. Sender-building code (`cachedSenderForEntry`/`buildSender`) signatures unchanged (hot-path zero-regression).
- **`EntryByModel`**: composite-id path unchanged; bare-model path now scans `c.Endpoints` (default endpoint preferred, mirroring `ParseModelFlag` step 2a). Old `c.Models` scan gone.
- **New write API**: `UpsertEndpoint(ep) int`, `UpsertModel(endpointID, m) error`, `SetDefaultComposite(cid string)`. `SetDefaultEntry`/`SetEntry`/`DefaultEntry` deleted.
- **Validate/Repair**: the "pure new schema" guard lifted (every config is endpoint-level now).

### CRUD handlers (`internal/server/onboard_config_handlers.go`)

7 new routes (design §10.2):

```
POST   /api/config/endpoints
PATCH  /api/config/endpoints/{id}  (new_id triggers RenameEndpoint + cascade)
DELETE /api/config/endpoints/{id}
POST   /api/config/endpoints/{id}/models
DELETE /api/config/endpoints/{id}/models/{model}
POST   /api/config/endpoints/{id}/default  (sets Default to <id>::Models[0])
POST   /api/config/endpoints/{id}/lite     (sets Lite to <id>::Models[0])
```

All run under `config.Mutate` (flock + atomic Save). Connection-param / endpoint-id / model mutations trigger `invalidateEndpointSenders(endpointID)` on the old id (coarse-grained per-endpoint, §6). Default/lite switches do NOT invalidate.

Old `/api/config/models*` (5 routes) deleted. `handleGetConfig` keeps its route but drops `Models`/`DefaultModelIdx` from `configResponse`, adds `ReasoningEffort` (global).

### Rename cascade

`PATCH /api/config/endpoints/{id}` with `new_id` calls `config.RenameEndpoint` (rewrites `cfg.Default`/`Lite` composite-id prefixes) + `invalidateEndpointSenders(oldID)`. **Does NOT scan session files** — design §6.1 was technically wrong (channel bindings live in `~/.octo/sessions/*.jsonl`, not `channels.yml`). Stale composite ids in old sessions fall back via `EntryByModel`'s bare-model scan (§8.2 "session not written back" principle preserved).

### CLI

- **`octo config` (wizard)**: builds one endpoint from the collected `ModelEntry`. endpoint id = `legacyEndpointID(hostFromBaseURL(base_url), 0)` — same rule Load uses for old `models:` blocks, so a re-run over the same host overwrites. Different host → new endpoint, prints "new endpoint X". Explicit "Set as default?" prompt at the end. Calls `UpsertEndpoint` + `UpsertModel` + `SetDefaultComposite`.
- **`octo config show`**: two-level output. Each endpoint one line (`id (name, provider, base_url) — N models [default/lite tags]`). `references` section shows `cfg.Default`/`Lite`. `reasoning` section shows global effort + show_reasoning.
- **`octo doctor`**: uses `len(cfg.Endpoints)` instead of `len(cfg.Models)` for the "no models configured" check. Full per-endpoint card output (§13.2) deferred — current doctor still runs global checks + Validate; the per-endpoint card layout is a follow-up.

### Reasoning simplification

- `ModelEntry.ReasoningEffort`/`ShowReasoning` deleted.
- `Config.ReasoningEffort` (already existed) is the only reasoning store.
- `sessionStatusFields` reads `cfg.ReasoningEffort`/`cfg.EffectiveShowReasoning(nil)`.
- `handleUpdateSessionReasoningEffort` / `handleUpdateSessionShowReasoning` write the GLOBAL config (routes kept for web UI compat; semantics changed from per-session to global).
- `resolveReasoningEffort`/`resolveShowReasoning` (cmd/octo/chat.go) take `config.Config` instead of `ModelEntry`.

### Web

- `SettingsView.svelte`: `loadConfig` reads `cfg.reasoning_effort` (global) instead of `cfg.models[defaultModelIdx].reasoning_effort`. The flat AI Models editor section is hidden (`{#if false}`) — its backend routes are gone; a two-level editor lands in PR6. The read-only Channels card section (PR4b) stays.
- `webdist` build artifacts stay gitignored (PR #1595).

## Tests

- **Config**: `TestSave_WritesEndpointsFormat` (replaces PR1's "does not emit endpoints" test), `TestLoad_LegacyYAMLIsNormalised` (reasoning now reads global, per-entry dropped), `TestEntryByModel_BareModelAmbiguousPicksDefault`, `TestEntryByModel_CompositeIDResolvesAgainstEndpoints` (updated).
- **repair_test.go / validate_test.go**: legacy `Models` tests deleted; endpoint-level tests kept (guard removed).
- **Server**: old CRUD handler tests deleted; `channel_model_test` updated for composite-id `BoundEntry`; per-session reasoning tests deleted (semantics changed to global); `TestHandleGetSessionMessages_ShowReasoningField` rewritten for global `ShowReasoning`.
- **cmd/octo**: `config_test` / `doctor_test` / `model_picker_test` / `ensure_sender_test` / `chat_test` updated for `Endpoints` seeds and global reasoning.
- All packages pass: `internal/{config,server,channel,...}`, `cmd/octo`, `web/`. `go vet` clean. `gofmt` clean.

## Deviations from design

- **doctor per-endpoint card output (§13.2)**: not fully implemented; doctor still runs global checks + Validate. The card layout is a follow-up — PR5's doctor just gates on `len(cfg.Endpoints)` and reports Validate problems.
- **Web CRUD UI (§12.3)**: deferred to PR6 (design §9, slice 5.1 constraint). PR5 ships the backend CRUD API; the Web editor lands next.
- **endpoint-design.md revision (§9.2)**: the original design doc was never committed (PR1-3 oversight); this PR commits it as-is + adds `endpoint-pr5-impl.md` as the PR5 implementation supplement. A full revision pass on the original is deferred.

## Breaking changes

- `/api/config/models*` routes return 404 (callers must use `/api/config/endpoints*`).
- `GET /api/config` no longer returns `models` / `default_model_idx` fields; returns `reasoning_effort` instead.
- `config.yml` format changes from `models:` to `endpoints:` after the first PR5 Save.
- Per-session reasoning_effort / show_reasoning API routes now write the global config (not per-session).
