### PR TITLE
fix(web): Composer model picker reads endpoints, not deleted cfg.models

### DIFF
--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -168,6 +168,12 @@ type configResponse struct {
 	Coauthor        *bool  `json:"coauthor,omitempty"`
 	WorkspaceDir    string `json:"workspace_dir,omitempty"`
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	// PermissionMode is the global default permission mode. PR5 lifted
+	// per-entry permission_mode to global (per-entry reasoning was deleted;
+	// permission_mode was always global in practice — the old default entry
+	// carried it). The Composer reads this to seed its no-active-session
+	// fallback.
+	PermissionMode string `json:"permission_mode,omitempty"`
 }
 
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
@@ -185,6 +191,7 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 		Coauthor:        &effCoauthor,
 		WorkspaceDir:    cfg.WorkspaceDir,
 		ReasoningEffort: cfg.ReasoningEffort,
+		PermissionMode:  cfg.PermissionMode,
 	})
 }
 

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -109,8 +109,9 @@
     // shows the real configured default instead of a hardcoded guess.
     api.getConfig().then(cfg => {
       if (cfg.language) setLocale(cfg.language)
-      const def = cfg.models?.find(m => m.type === 'default')
-      if (def?.permission_mode) globalPermissionMode.set(def.permission_mode)
+      // PR5: permission_mode is global (was per-default-entry before). The
+      // Composer reads this to seed its no-active-session fallback.
+      if (cfg.permission_mode) globalPermissionMode.set(cfg.permission_mode)
     }).catch(() => { /* non-critical */ })
 
     ws.on('session_list', (ev: any) => {

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -561,7 +561,12 @@
   }
 
   // ── model + reasoning pickers ──────────────────────────────────────────────
-  let models = $state<api.ModelEntry[]>([])
+  // PR5/PR6: the flat ModelEntry list is gone — read the two-level endpoint
+  // view and flatten it into model rows the picker can show. Each row carries
+  // the composite id "<endpoint>::<model>" so pickModel can pass it to
+  // updateSessionModel, which resolves it via cfg.EntryByModel (composite-id
+  // aware since PR2).
+  let models = $state<{ id: string; model: string; endpoint: string }[]>([])
   let modelMenu = $state(false)
   let reasonMenu = $state(false)
   let dirMenu = $state(false)
@@ -573,7 +578,16 @@
   const showReasoningIcon = $derived(showReasoning ? 'ant-design:eye-outlined' : 'ant-design:eye-invisible-outlined')
 
   onMount(async () => {
-    try { models = (await api.getConfig()).models ?? [] } catch { /* leave empty */ }
+    try {
+      const ep = await api.getEndpoints()
+      const flat: { id: string; model: string; endpoint: string }[] = []
+      for (const e of ep.endpoints) {
+        for (const m of e.models) {
+          flat.push({ id: `${e.id}::${m.model}`, model: m.model, endpoint: e.id })
+        }
+      }
+      models = flat
+    } catch { /* leave empty */ }
     try { skills = await api.listSkills() } catch { /* leave empty */ }
     try { workflows = await api.listWorkflows() } catch { /* leave empty */ }
     try {
@@ -584,10 +598,13 @@
     } catch { /* leave empty */ }
   })
 
-  async function pickModel(m: api.ModelEntry) {
+  async function pickModel(m: { id: string; model: string; endpoint: string }) {
     modelMenu = false
     if (!sid) return
     try {
+      // m.id is the composite id "<endpoint>::<model>" — the backend's
+      // handleUpdateSessionModel resolves it via cfg.EntryByModel (composite-
+      // id aware since PR2), binding the session to that endpoint's sender.
       const res = await api.updateSessionModel(sid, m.id)
       sessions.update(list => list.map((s: any) => s.id === sid ? { ...s, model: res.model, model_id: res.model_id } : s))
       chatModel.update(mx => ({ ...mx, [sid]: res.model }))
@@ -869,8 +886,8 @@
           {:else}
             {#each models as m (m.id)}
               <button class="menu-item" onclick={() => pickModel(m)}>
-                <span class="mi-name">{m.id}</span>
-                <span class="mi-model mono">{m.model}</span>
+                <span class="mi-name mono">{m.id}</span>
+                <span class="mi-model mono">{m.endpoint}</span>
               </button>
             {/each}
           {/if}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -706,13 +706,15 @@ export interface ModelEntry {
   vision?: boolean
 }
 export interface ConfigResponse {
-  models?: ModelEntry[]
-  default_model_idx?: number
+  // PR5: Models/DefaultModelIdx deleted (flat Models field gone). The
+  // two-level endpoint view is served by GET /api/config/endpoints.
   font_size?: string
   language?: string
   show_reasoning?: boolean
   coauthor?: boolean
   workspace_dir?: string
+  reasoning_effort?: string   // PR5: global reasoning effort
+  permission_mode?: string    // PR6: global permission mode (was per-default-entry)
 }
 
 export async function getConfig(): Promise<ConfigResponse> {


### PR DESCRIPTION
PR5 deleted the Models field from GET /api/config's response (configResponse), but two front-end call sites still read it:

- Composer.svelte onMount: models = (await api.getConfig()).models ?? [] → always empty → the model picker showed '未配置模型' (chat.no_models) even with endpoints configured. Fixed by reading GET /api/config/endpoints and flattening into {id: '<endpoint>::<model>', model, endpoint} rows. pickModel now passes the composite id, which handleUpdateSessionModel resolves via cfg.EntryByModel (composite-id aware since PR2).

- App.svelte bootMain: looked for cfg.models.find(m => m.type === 'default') to seed globalPermissionMode. PR5 made permission_mode global — added PermissionMode to configResponse + handleGetConfig, and App.svelte now reads cfg.permission_mode directly.

Also cleaned ConfigResponse interface (deleted models/default_model_idx, added reasoning_effort + permission_mode) to match the PR5 server shape.

<!-- Write this PR description in English. -->

## What

<!-- One or two sentences: what does this PR change? -->

## Why

<!-- The need this addresses, and who benefits. -->

## User-visible impact

<!-- Default behavior changes? New config? Breaking changes? "None" is a valid answer. -->

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [ ] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [ ] No new dependencies (or justified below)
- [ ] Fits the existing design / naming / layering

### 2. Need

- [ ] Common need that benefits most users, **or** scope and side effects are explained below
- [ ] No unintended impact on other users' workflows or defaults

### 3. Code

- [ ] All tests pass
- [ ] Coverage does not drop; new code has new tests
- [ ] Commit messages and this PR are written in English
- [ ] This branch was created from the latest `main` and is currently up to date with it

### Bonus

- [ ] This PR was authored using Octo itself

---

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs you considered, or follow-ups planned. -->
