### PR TITLE
fix(provider): avoid double /v1 when base URL already contains it

### DIFF
--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -233,12 +233,23 @@ func hasToolUseBlock(blocks []agent.ContentBlock) bool {
 
 // endpointURL returns BaseURL + MessagesPath, applying defaults and trimming
 // any trailing slash on BaseURL so the join is exactly one slash.
+//
+// Most Anthropic-style gateways (api.anthropic.com, the …/anthropic Bailian
+// endpoints) ship a bare base and expect the client to append the full
+// "/v1/messages". A handful of relays bake "/v1" into the base the same way
+// OpenAI-compatible ones do — detect the trailing "/v1" and drop the redundant
+// segment so both shapes resolve.
 func (c *Client) endpointURL() string {
 	base := c.BaseURL
 	if base == "" {
 		base = DefaultBaseURL
 	}
-	return strings.TrimRight(base, "/") + MessagesPath
+	base = strings.TrimRight(base, "/")
+	suffix := MessagesPath // "/v1/messages"
+	if strings.HasSuffix(base, "/v1") {
+		suffix = "/messages"
+	}
+	return base + suffix
 }
 
 // staticPrefixCache picks the cache_control marker for the static system+tools

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -348,6 +348,36 @@ func TestSend_AppendsMessagesPath(t *testing.T) {
 	}
 }
 
+func TestSend_BaseAlreadyHasV1_StripsDuplicate(t *testing.T) {
+	// Mirrors the OpenAI client test: if a relay bakes "/v1" into its base
+	// URL, the client must detect it and only append "/messages" so the final
+	// URL is not ".../v1/v1/messages". Defensive parity with openai.Client.
+	cases := []struct {
+		name string
+		base string
+	}{
+		{"base ends with /v1", "https://gw.example.com/v1"},
+		{"base ends with /v1/", "https://gw.example.com/v1/"},
+		{"base ends with longer path + /v1", "https://gw.example.com/anthropic/v1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cl, _ := New("k")
+			cl.BaseURL = c.base
+			got := cl.endpointURL()
+
+			// Must NOT contain "/v1/v1".
+			if strings.Contains(got, "/v1/v1") {
+				t.Errorf("endpointURL() = %q, must not contain /v1/v1", got)
+			}
+			// Must end with exactly "/v1/messages".
+			if !strings.HasSuffix(got, "/v1/messages") {
+				t.Errorf("endpointURL() = %q, must end with /v1/messages", got)
+			}
+		})
+	}
+}
+
 // Compile-time assertion: *Client implements provider.Provider.
 var _ provider.Provider = (*Client)(nil)
 

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -407,12 +407,25 @@ func (c *Client) promptCacheKey(key string) string {
 
 // endpointURL returns BaseURL + ChatCompletionsPath, applying defaults and
 // trimming any trailing slash on BaseURL so the join is exactly one slash.
+//
+// OpenAI-compatible gateway conventions split on where the "/v1" goes: OpenAI
+// itself and Alibaba Bailian bake "/v1" into the documented base (e.g.
+// "https://dashscope.aliyuncs.com/compatible-mode/v1"), then the client only
+// appends "/chat/completions". Other gateways (api.deepseek.com, api.moonshot.cn,
+// …) ship a bare host and expect the client to append the full
+// "/v1/chat/completions". To accept both without making the user trim, detect
+// a trailing "/v1" on the base and drop the redundant segment.
 func (c *Client) endpointURL() string {
 	base := c.BaseURL
 	if base == "" {
 		base = DefaultBaseURL
 	}
-	return strings.TrimRight(base, "/") + ChatCompletionsPath
+	base = strings.TrimRight(base, "/")
+	suffix := ChatCompletionsPath // "/v1/chat/completions"
+	if strings.HasSuffix(base, "/v1") {
+		suffix = "/chat/completions"
+	}
+	return base + suffix
 }
 
 // toAPITools converts []agent.ToolDefinition to []apiTool (function format).

--- a/internal/provider/openai/client_test.go
+++ b/internal/provider/openai/client_test.go
@@ -290,6 +290,37 @@ func TestSend_AppendsChatCompletionsPath(t *testing.T) {
 	}
 }
 
+func TestSend_BaseAlreadyHasV1_StripsDuplicate(t *testing.T) {
+	// Bailian (Alibaba) and OpenAI itself bake "/v1" into the documented base
+	// (e.g. "https://dashscope.aliyuncs.com/compatible-mode/v1"). The client
+	// must detect the trailing "/v1" and only append "/chat/completions" so the
+	// final URL is not ".../v1/v1/chat/completions". See issue #1625.
+	cases := []struct {
+		name string
+		base string
+	}{
+		{"base ends with /v1", "https://coding.dashscope.aliyuncs.com/v1"},
+		{"base ends with /v1/", "https://coding.dashscope.aliyuncs.com/v1/"},
+		{"base ends with longer path + /v1", "https://dashscope.aliyuncs.com/compatible-mode/v1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cl, _ := New("k")
+			cl.BaseURL = c.base
+			got := cl.endpointURL()
+
+			// Must NOT contain "/v1/v1".
+			if strings.Contains(got, "/v1/v1") {
+				t.Errorf("endpointURL() = %q, must not contain /v1/v1", got)
+			}
+			// Must end with exactly "/v1/chat/completions".
+			if !strings.HasSuffix(got, "/v1/chat/completions") {
+				t.Errorf("endpointURL() = %q, must end with /v1/chat/completions", got)
+			}
+		})
+	}
+}
+
 func TestSend_NoChoices(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"x","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`))


### PR DESCRIPTION
## Problem

Bailian (Alibaba) documents its OpenAI-compatible base as `https://coding.dashscope.aliyuncs.com/v1` — with `/v1` baked in. `openai.Client.endpointURL()` blindly appended `/v1/chat/completions`, producing `.../v1/v1/chat/completions` and a 404.

Same shape applies to OpenAI's own `https://api.openai.com/v1` convention. Users copying these documented base URLs directly into the Custom endpoint form hit the double-`/v1` bug.

## Fix

Both `openai.Client.endpointURL()` and `anthropic.Client.endpointURL()` now detect a trailing `/v1` on the base and only append the rest (`/chat/completions` / `/messages`). Bases without `/v1` (e.g. `api.deepseek.com`) keep the old behavior unchanged.

## Files

- `internal/provider/openai/client.go` — `endpointURL()` `/v1` detection
- `internal/provider/anthropic/client.go` — parity fix
- `internal/provider/openai/client_test.go` — `TestSend_BaseAlreadyHasV1_StripsDuplicate`
- `internal/provider/anthropic/client_test.go` — `TestSend_BaseAlreadyHasV1_StripsDuplicate`

## Test

All new and existing tests pass; `go build ./...` clean.

Fixes #1625.
