### PR TITLE
chore(version): bump internal default to v1.12.24

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.23"
+var Version = "1.12.24"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
goreleaser already injects the tag via -ldflags; this keeps the local-`go build` fallback in sync with the released tag.