### PR TITLE
fix: web onboard 后首个会话模型不匹配导致 500

### DIFF
--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -907,8 +907,16 @@ func (s *Server) handleSetEndpointDefault(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	// Default switch does NOT invalidate senders (design §6) — only changes
-	// which sender ResolveDefault returns next turn.
+	// Default switch does NOT invalidate the per-entry sender cache (design §6)
+	// — it only changes which sender ResolveDefault returns next turn. However it
+	// MUST update s.model immediately so that handleCreateSession (which reads
+	// s.model directly) picks up the new default, not the stale startup fallback
+	// (e.g. claude-sonnet-4-6 on a fresh install). Without this, the first
+	// onboard session is created with the wrong model and fails with 500 because
+	// senderForSession later pairs the reconfigured sender with a stale model.
+	if err := s.reloadDefaultSender(); err != nil {
+		log.Printf("[server] reload default sender after default change: %v", err)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "default": newDefault})
 }
 


### PR DESCRIPTION
## 问题

升级到 v1.12.24 后，用户首次通过 web onboard 时，第一个 onboard 会话报 500 错误。页面底部显示模型为 claude-sonnet-4-6（内置回退值），而非用户配置的模型。

## 根因

`handleSetEndpointDefault` 设置默认模型后没有调用 `reloadDefaultSender()`，导致 `s.model` 停留在启动时的内置回退值 `claude-sonnet-4-6`。

链路：
1. 服务启动（config 为空）→ `s.model = "claude-sonnet-4-6"`
2. Web 端保存模型 → `cfg.Default` 正确写入 config.yml
3. 但 `s.model` 未更新，仍为 `claude-sonnet-4-6`
4. `handleCreateSession` 用 `s.model` 创建会话 → 模型错误
5. 首个 turn：`ensureSender` 从 config 重建了正确的 sender，但 `senderForSession` 返回的 model 是 session 里存的 `claude-sonnet-4-6` → sender 和 model 不匹配 → 500

## 修复

`handleSetEndpointDefault` 成功后调用 `s.reloadDefaultSender()`，与 `handlePutShowReasoning` 采用相同模式。

终端 onboarding 不受影响，因为终端 wizard 保存 config 后退出，下次启动时重新加载。