### PR TITLE
fix(web): provider switch auto-fills base_url in endpoint editor

### DIFF
--- a/web/src/views/SettingsView.svelte
+++ b/web/src/views/SettingsView.svelte
@@ -85,10 +85,19 @@
     if (epModalOpen) epModalEl?.focus()
   })
 
-  function openAddEndpoint() {
-    editingEpId = null
-    epForm = { id: '', name: '', provider: 'anthropic', base_url: '', api_key: '', protocol: '' }
-    epModalOpen = true
+  // Track the last provider whose preset base_url we auto-filled, so that
+  // switching providers only overwrites base_url when the user hasn't hand-edited it.
+  let autoFilledBaseURL = $state('')
+
+  function onProviderChange() {
+    const preset = providers.find(p => p.id === epForm.provider)
+    if (!preset || epForm.provider === 'custom') return
+    // Only auto-fill when base_url is empty or still carries the previous
+    // auto-filled value — preserves a hand-typed relay/proxy URL.
+    if (epForm.base_url === '' || epForm.base_url === autoFilledBaseURL) {
+      epForm.base_url = preset.base_url
+      autoFilledBaseURL = preset.base_url
+    }
   }
 
   function openEditEndpoint(ep: EndpointConfig) {
@@ -101,11 +110,19 @@
       api_key: '', // never prefill the key — server only returns has_api_key
       protocol: ep.protocol ?? '',
     }
+    autoFilledBaseURL = ep.base_url ?? ''
     epModalOpen = true
   }
 
   function closeEpModal() {
     epModalOpen = false
+  }
+
+  function openAddEndpoint() {
+    editingEpId = null
+    epForm = { id: '', name: '', provider: 'anthropic', base_url: '', api_key: '', protocol: '' }
+    autoFilledBaseURL = ''
+    epModalOpen = true
   }
 
   async function submitEndpoint() {
@@ -836,7 +853,7 @@
         </label>
         <label class="ep-field">
           <span class="ep-label">{$t('settings.endpoints.field.provider')}</span>
-          <select class="sel" bind:value={epForm.provider}>
+          <select class="sel" bind:value={epForm.provider} onchange={onProviderChange}>
             {#each providers as p}
               <option value={p.id}>{p.name}</option>
             {/each}


### PR DESCRIPTION
## Summary

- When the user changes the provider in the Settings endpoint modal, `base_url` now auto-fills from the provider preset. Previously the `<select>` only had `bind:value` with no `onchange` handler, so switching providers left `base_url` untouched.
- Auto-fill only fires when `base_url` is empty or still carries the previous auto-filled value — a hand-typed relay/proxy URL is preserved.
- `openAddEndpoint` / `openEditEndpoint` both initialize the tracking state correctly.

## Root cause

`web/src/views/SettingsView.svelte:839` — `<select bind:value={epForm.provider}>` had no `onchange`. The `ProviderPreset.base_url` data was already available in the `providers` array but never consulted.

## Test plan

- [ ] Open Settings → Channels → Add endpoint → select a named provider (e.g. Anthropic): `base_url` auto-fills with the preset.
- [ ] Switch to a different named provider: `base_url` updates.
- [ ] Manually edit `base_url` to a relay URL, then switch provider: the relay URL is preserved.
- [ ] Select `custom`: `base_url` is left as-is.
- [ ] All 97 web tests + `tsc --noEmit` pass locally.

🤖 Generated with [octo-agent](https://github.com/open-octo/octo-agent)

Co-authored-by: octo-agent <no-reply@octo-agent.dev>