### PR TITLE
feat(browser): clean up throwaway Chrome profile on Close

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -19,6 +20,13 @@ type Browser struct {
 	cli         *cdpClient
 	ownsProcess bool
 
+	// tempUserDataDir is the throwaway profile this process launched Chrome with
+	// (via Launch with empty LaunchOptions.UserDataDir). Close removes it so
+	// test runs don't leak octo-chrome-* directories in /tmp. Empty when
+	// attached to a user-owned Chrome (Connect*) — those profiles must never be
+	// deleted by us.
+	tempUserDataDir string
+
 	// oopifs maps a cross-origin (out-of-process) iframe's frameId to its CDP
 	// session, populated by the target watcher. Cross-origin iframes live in a
 	// separate renderer, so their DOM is unreachable via the parent's
@@ -29,16 +37,21 @@ type Browser struct {
 
 // Launch starts a Chrome and connects to it.
 func Launch(ctx context.Context, opts LaunchOptions) (*Browser, error) {
-	cmd, wsURL, err := launchChrome(ctx, opts)
+	cmd, wsURL, tempDir, err := launchChrome(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 	cli, err := dial(ctx, wsURL)
 	if err != nil {
 		killProcessGroup(cmd)
+		if tempDir != "" {
+			os.RemoveAll(tempDir)
+		}
 		return nil, err
 	}
-	return wrapBrowser(cli, cmd, true), nil
+	b := wrapBrowser(cli, cmd, true)
+	b.tempUserDataDir = tempDir
+	return b, nil
 }
 
 // wrapBrowser wraps a live CDP connection and starts the cross-origin iframe
@@ -136,12 +149,17 @@ func dial(ctx context.Context, wsURL string) (*cdpClient, error) {
 func (b *Browser) OwnsProcess() bool { return b.ownsProcess }
 
 // Close tears down the connection and, if this process launched Chrome, the
-// Chrome process too.
+// Chrome process too. It also removes any throwaway profile directory created
+// for a Launch with an empty UserDataDir, so test runs don't leak octo-chrome-*
+// directories in /tmp.
 func (b *Browser) Close() error {
 	b.cli.close()
 	if b.ownsProcess && b.cmd != nil && b.cmd.Process != nil {
 		killProcessGroup(b.cmd)
 		b.cmd.Wait()
+	}
+	if b.tempUserDataDir != "" {
+		os.RemoveAll(b.tempUserDataDir)
 	}
 	return nil
 }

--- a/internal/browser/chrome.go
+++ b/internal/browser/chrome.go
@@ -144,19 +144,21 @@ func findChrome(override string) (string, error) {
 	return "", fmt.Errorf("chrome not found; set LaunchOptions.ExecPath")
 }
 
-// launchChrome starts Chrome and returns the running process plus the browser-
-// level CDP websocket URL.
-func launchChrome(ctx context.Context, opts LaunchOptions) (*exec.Cmd, string, error) {
+// launchChrome starts Chrome and returns the running process, the browser-level
+// CDP websocket URL, and the path of any throwaway profile it created (empty when
+// opts.UserDataDir was set — the caller owns that dir). The caller is responsible
+// for removing the returned temp dir once the browser is no longer needed.
+func launchChrome(ctx context.Context, opts LaunchOptions) (*exec.Cmd, string, string, error) {
 	exe, err := findChrome(opts.ExecPath)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	dataDir := opts.UserDataDir
 	tempDir := ""
 	if dataDir == "" {
 		tempDir, err = os.MkdirTemp("", "octo-chrome-")
 		if err != nil {
-			return nil, "", err
+			return nil, "", "", err
 		}
 		dataDir = tempDir
 	}
@@ -186,7 +188,7 @@ func launchChrome(ctx context.Context, opts LaunchOptions) (*exec.Cmd, string, e
 		if tempDir != "" {
 			os.RemoveAll(tempDir)
 		}
-		return nil, "", fmt.Errorf("start chrome: %w", err)
+		return nil, "", "", fmt.Errorf("start chrome: %w", err)
 	}
 
 	port := opts.Port
@@ -194,15 +196,21 @@ func launchChrome(ctx context.Context, opts LaunchOptions) (*exec.Cmd, string, e
 		port, err = readDevToolsPort(ctx, dataDir)
 		if err != nil {
 			killProcessGroup(cmd)
-			return nil, "", err
+			if tempDir != "" {
+				os.RemoveAll(tempDir)
+			}
+			return nil, "", "", err
 		}
 	}
 	wsURL, err := browserWebSocketURL(ctx, port)
 	if err != nil {
 		killProcessGroup(cmd)
-		return nil, "", err
+		if tempDir != "" {
+			os.RemoveAll(tempDir)
+		}
+		return nil, "", "", err
 	}
-	return cmd, wsURL, nil
+	return cmd, wsURL, tempDir, nil
 }
 
 // readDevToolsPort waits for Chrome to write its chosen debug port to the

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -93,6 +93,9 @@ func TestBrowserTool_SearchDownloadFlow(t *testing.T) {
 	// a code defect. Skip on the known flake signatures; any other failure stays
 	// fatal so real regressions fail the build.
 	skipOnBrowserFlake(t, "launch", err)
+	if b != nil {
+		t.Cleanup(func() { b.Close() })
+	}
 	page, err := b.NewPage(ctx, "about:blank")
 	skipOnBrowserFlake(t, "new page", err)
 	SetBrowserSession(b, page)
@@ -155,6 +158,9 @@ func TestBrowserTool_RecordRunRoundTrip(t *testing.T) {
 	// a code defect. Skip on the known flake signatures; any other failure stays
 	// fatal so real regressions fail the build.
 	skipOnBrowserFlake(t, "launch", err)
+	if b != nil {
+		t.Cleanup(func() { b.Close() })
+	}
 	page, err := b.NewPage(ctx, srv.URL)
 	skipOnBrowserFlake(t, "new page", err)
 	SetBrowserSession(b, page)
@@ -209,6 +215,9 @@ func TestBrowserTool_RecordCancel(t *testing.T) {
 	}
 	b, err := browser.Launch(ctx, browser.LaunchOptions{Headless: true})
 	skipOnBrowserFlake(t, "launch", err)
+	if b != nil {
+		t.Cleanup(func() { b.Close() })
+	}
 	page, err := b.NewPage(ctx, "about:blank")
 	skipOnBrowserFlake(t, "new page", err)
 	SetBrowserSession(b, page)
@@ -376,6 +385,9 @@ func TestBrowserTool_CookiesIncludesHttpOnly(t *testing.T) {
 	// a code defect. Skip on the known flake signatures; any other failure stays
 	// fatal so real regressions fail the build.
 	skipOnBrowserFlake(t, "launch", err)
+	if b != nil {
+		t.Cleanup(func() { b.Close() })
+	}
 	page, err := b.NewPage(ctx, "about:blank")
 	skipOnBrowserFlake(t, "new page", err)
 	SetBrowserSession(b, page)
@@ -414,6 +426,9 @@ func TestBrowserTool_ObserveAndScreenshotVision(t *testing.T) {
 	// a code defect. Skip on the known flake signatures; any other failure stays
 	// fatal so real regressions fail the build.
 	skipOnBrowserFlake(t, "launch", err)
+	if b != nil {
+		t.Cleanup(func() { b.Close() })
+	}
 	page, err := b.NewPage(ctx, "about:blank")
 	skipOnBrowserFlake(t, "new page", err)
 	SetBrowserSession(b, page)


### PR DESCRIPTION
## Problem

`Browser.Launch` with an empty `UserDataDir` creates a temp dir (`octo-chrome-*`) for the headless Chrome profile, but `Close()` never removed it. Every test that launched a browser leaked one of these directories in `/tmp` — over a hundred accumulated across a couple of days (`ls /tmp/PKInstallSandbox.*/tmp/octo-chrome-* | wc -l` showed ~170 dirs, ~120 MB).

## Root cause

- `launchChrome` created the temp dir internally and never returned its path, so the caller had no way to clean it up.
- `Browser.Close()` only killed the process and closed the WebSocket — no filesystem cleanup.
- The five browser tests in `browser_test.go` called `Launch` but never `Close`d the browser.

## Fix

- `launchChrome` now returns the temp dir path (empty when `UserDataDir` was caller-supplied).
- `Launch` stores it in the new `Browser.tempUserDataDir` field and removes it if `dial` fails after a successful launch.
- `Browser.Close` removes `tempUserDataDir` when set. When attached to a user-owned Chrome (`Connect*`), the field stays empty — user profiles are never touched.
- The five browser tests now register `t.Cleanup(func() { b.Close() })` so their profiles are removed at test end. (`workflow_skill_test.go` already had a deferred `Close`.)

## Verification

Wrote a throwaway test confirming the temp dir exists before `Close()` and is gone after; deleted it after passing. `go build`, `go vet`, and `go test -count=1 -run TestNothing ./internal/browser/... ./internal/tools/...` all pass.