### PR TITLE
fix(web): unify endpoint editor with ModelConfigForm styles + cleanup dead code

### DIFF
--- a/web/src/views/SettingsView.svelte
+++ b/web/src/views/SettingsView.svelte
@@ -956,10 +956,12 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 }
 .ep-add-model-input { flex: 1; min-width: 140px; }
 .ep-vision-toggle { display: flex; align-items: center; gap: 4px; font-size: 12px; color: var(--text-tertiary); }
-.ep-form { display: flex; flex-direction: column; gap: 12px; }
-.ep-field { display: flex; flex-direction: column; gap: 4px; }
-.ep-label { font-size: 12px; color: var(--text-tertiary); }
+.ep-form { display: flex; flex-direction: column; gap: 16px; }
+.ep-field { display: flex; flex-direction: column; gap: 6px; }
+.ep-label { font-size: 13px; font-weight: 500; color: var(--text-secondary); }
 .ep-form-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
+.ep-form-actions .btn-secondary,
+.ep-form-actions .btn-primary { height: 34px; }
 
 .btn-add {
   height: 30px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container);


### PR DESCRIPTION
## Summary

- **Endpoint modal now matches ModelConfigForm's visual language** — field height, border radius, label weight, gap, and button height are aligned between the Settings panel and the first-run onboard form.
- **API key field**: fixed broken class `"inp"` (was using browser default styles) → `"ep-input mono"`, plus a show/hide toggle button.
- **base_url auto-fill** on provider switch now also resets `epShowKey` and clears `autoFilledBaseURL` when switching to Custom.
- **Named vendors lock `base_url`** (readonly) — the URL is resolved from the preset at runtime; only Custom takes free-form entry.
- **Providers with `endpoint_variants`** (MiniMax, Kimi, …) render chips to pick between regional URLs.
- **"Get API key" link** opens the vendor's key-management page.

## Visual fixes

- New `.ep-input` full-width class — modal fields stretch to fill the 520px modal body instead of being pinned to the 220px settings-row width.
- Labels now 13px / 500-weight / secondary-color (was 12px / tertiary).
- Form gap 12px → 16px, field gap 4px → 6px, button height 30/32px → 34px.

## Cleanup

- Delete the hidden `{#if false}` flat-AI-Models section, its `modelModal`, and all model-related state/handlers — PR5 deleted the Models field and the per-model CRUD routes; `ModelConfigForm` is no longer imported.
- Remove the dead `reasoning`/`permMode` save block in `handleSave` (referenced `models[]` which PR5 emptied).

## Before → After

The endpoint editor looked like a different system: 32px inputs, 12px tertiary labels, 30px buttons, 220px-wide fields floating in a 520px modal, no key toggle, no variant chips, no "Get API key" link. Now it matches the onboard form.

## Test plan

- [ ] Open Settings → Channels → Add endpoint: fields are full-width, labels are styled consistently with the onboard form.
- [ ] Select a named provider (e.g. Anthropic): `base_url` auto-fills and becomes readonly; "Get API key" link appears.
- [ ] Select a provider with variants (e.g. MiniMax): variant chips appear; clicking one updates `base_url`.
- [ ] API key field: eye icon toggles visibility.
- [ ] Select `custom`: `base_url` unlocks for free-form entry.
- [ ] All 97 web tests + `tsc --noEmit` pass locally.

🤖 Generated with [octo-agent](https://github.com/open-octo/octo-agent)

Co-authored-by: octo-agent <no-reply@octo-agent.dev>