### PR TITLE
fix(web): Agent Defaults save was broken — reasoning_effort + permission_mode now persist

### DIFF
--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -436,6 +436,127 @@ func (s *Server) handlePutWorkspaceDir(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "workspace_dir": req.WorkspaceDir})
 }
 
+// ─── PUT /api/config/reasoning_effort ────────────────────────────────────────
+
+type putReasoningEffortRequest struct {
+	ReasoningEffort string `json:"reasoning_effort"`
+}
+
+// handlePutReasoningEffort updates the global default reasoning effort. Valid
+// levels: "off", "low", "medium", "high", "xhigh", "max". The server's default
+// sender is rebuilt so unbound existing sessions pick up the new value on their
+// next turn. Because reasoning_effort is baked into cached senders, the cache is
+// invalidated and per-session WS broadcasts push the new effective level.
+func (s *Server) handlePutReasoningEffort(w http.ResponseWriter, r *http.Request) {
+	var req putReasoningEffortRequest
+	if err := readBodyJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	level := strings.ToLower(req.ReasoningEffort)
+	if level == "" {
+		level = "off"
+	}
+	if level != "off" && level != "low" && level != "medium" && level != "high" && level != "xhigh" && level != "max" {
+		writeError(w, http.StatusBadRequest, "reasoning_effort must be off, low, medium, high, xhigh, or max")
+		return
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+		return
+	}
+
+	cfg.ReasoningEffort = level
+	if err := cfg.Save(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+		return
+	}
+
+	s.invalidateSenderCache()
+	if err := s.reloadDefaultSender(); err != nil {
+		log.Printf("[server] reload default sender after reasoning_effort change: %v", err)
+	}
+
+	sessions, _ := agent.ListSessions(50)
+	for _, sess := range sessions {
+		_, pm, re, sr, ctxUsage := s.sessionStatusFields(sess)
+		if sr == nil {
+			continue
+		}
+		s.wsHub.broadcast(sess.ID, map[string]any{
+			"type":             "session_update",
+			"session_id":       sess.ID,
+			"working_dir":      s.sessionCwd(sess),
+			"permission_mode":  pm,
+			"reasoning_effort": re,
+			"show_reasoning":   *sr,
+			"context_usage":    ctxUsage,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "reasoning_effort": level})
+}
+
+// ─── PUT /api/config/permission_mode ─────────────────────────────────────────
+
+type putPermissionModeRequest struct {
+	PermissionMode string `json:"permission_mode"`
+}
+
+// handlePutPermissionMode updates the global default permission mode. Valid
+// values: "interactive", "auto", "strict". New sessions inherit this value.
+// Per-session overrides (set via PATCH /api/sessions/{id}/permission_mode)
+// are untouched — this only changes the global default.
+func (s *Server) handlePutPermissionMode(w http.ResponseWriter, r *http.Request) {
+	var req putPermissionModeRequest
+	if err := readBodyJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	mode := strings.ToLower(req.PermissionMode)
+	if mode != "interactive" && mode != "auto" && mode != "strict" {
+		writeError(w, http.StatusBadRequest, "permission_mode must be interactive, auto, or strict")
+		return
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+		return
+	}
+
+	cfg.PermissionMode = mode
+	if err := cfg.Save(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+		return
+	}
+
+	// Push the new default to all sessions so the UI reflects it immediately.
+	// Sessions with a per-session override keep their own value.
+	sessions, _ := agent.ListSessions(50)
+	for _, sess := range sessions {
+		_, pm, re, sr, ctxUsage := s.sessionStatusFields(sess)
+		if sr == nil {
+			continue
+		}
+		s.wsHub.broadcast(sess.ID, map[string]any{
+			"type":             "session_update",
+			"session_id":       sess.ID,
+			"working_dir":      s.sessionCwd(sess),
+			"permission_mode":  pm,
+			"reasoning_effort": re,
+			"show_reasoning":   *sr,
+			"context_usage":    ctxUsage,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "permission_mode": mode})
+}
+
 // maskKey masks most of an API key, keeping the first and last four runes
 // visible. It measures by runes so it never splits a multi-byte UTF-8 character.
 func maskKey(k string) string {

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -552,3 +552,91 @@ func TestPutWorkspaceDir_UpdatesConfigAndServerDefault(t *testing.T) {
 		t.Errorf("server.workspaceDir = %q, want %q", srv.workspaceDir, wantDir)
 	}
 }
+
+func TestPutReasoningEffort_ValidLevel_SavesAndReturns(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	reqBody, err := json.Marshal(map[string]string{"reasoning_effort": "xhigh"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := doJSON(t, srv, http.MethodPut, "/api/config/reasoning_effort", string(reqBody))
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT /api/config/reasoning_effort = %d: %s", w.Code, w.Body.String())
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ReasoningEffort != "xhigh" {
+		t.Errorf("config.ReasoningEffort = %q, want %q", cfg.ReasoningEffort, "xhigh")
+	}
+}
+
+func TestPutReasoningEffort_InvalidLevel_Rejects(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	reqBody, err := json.Marshal(map[string]string{"reasoning_effort": "ultra"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := doJSON(t, srv, http.MethodPut, "/api/config/reasoning_effort", string(reqBody))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("PUT /api/config/reasoning_effort (invalid) = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ReasoningEffort != "" {
+		t.Errorf("config.ReasoningEffort = %q, want empty (reject should not save)", cfg.ReasoningEffort)
+	}
+}
+
+func TestPutPermissionMode_ValidMode_SavesAndReturns(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	reqBody, err := json.Marshal(map[string]string{"permission_mode": "strict"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := doJSON(t, srv, http.MethodPut, "/api/config/permission_mode", string(reqBody))
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT /api/config/permission_mode = %d: %s", w.Code, w.Body.String())
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.PermissionMode != "strict" {
+		t.Errorf("config.PermissionMode = %q, want %q", cfg.PermissionMode, "strict")
+	}
+}
+
+func TestPutPermissionMode_InvalidMode_Rejects(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	reqBody, err := json.Marshal(map[string]string{"permission_mode": "yes"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := doJSON(t, srv, http.MethodPut, "/api/config/permission_mode", string(reqBody))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("PUT /api/config/permission_mode (invalid) = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.PermissionMode != "" {
+		t.Errorf("config.PermissionMode = %q, want empty (reject should not save)", cfg.PermissionMode)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -827,6 +827,8 @@ func (s *Server) registerRoutes() {
 	s.api("PUT /api/config/coauthor", s.handlePutCoauthor)
 	s.api("PUT /api/config/language", s.handlePutLanguage)
 	s.api("PUT /api/config/workspace_dir", s.handlePutWorkspaceDir)
+	s.api("PUT /api/config/reasoning_effort", s.handlePutReasoningEffort)
+	s.api("PUT /api/config/permission_mode", s.handlePutPermissionMode)
 	s.api("POST /api/config/test", s.handleTestConfig)
 	// PR5: endpoint-level CRUD (design §10.2). The old /api/config/models*
 	// routes are deleted — callers must use these.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -854,6 +854,20 @@ export async function updateWorkspaceDir(workspaceDir: string): Promise<{ ok: bo
   })
 }
 
+export async function updateReasoningEffort(effort: string): Promise<{ ok: boolean; reasoning_effort?: string }> {
+  return request<{ ok: boolean; reasoning_effort?: string }>('/api/config/reasoning_effort', {
+    method: 'PUT',
+    ...json({ reasoning_effort: effort }),
+  })
+}
+
+export async function updatePermissionMode(mode: string): Promise<{ ok: boolean; permission_mode?: string }> {
+  return request<{ ok: boolean; permission_mode?: string }>('/api/config/permission_mode', {
+    method: 'PUT',
+    ...json({ permission_mode: mode }),
+  })
+}
+
 export async function getVersion(): Promise<unknown> {
   return request<unknown>('/api/version', { cache: 'no-store' })
 }

--- a/web/src/views/SettingsView.svelte
+++ b/web/src/views/SettingsView.svelte
@@ -473,29 +473,17 @@
   async function handleSave() {
     saving = true
     try {
-      // Agent Defaults (Reasoning Effort + Permission Mode) — the default
-      // model entry's own settings, saved the same way the Models section
-      // below saves any entry: api.updateModel(id, ...the full entry...).
-      // No session is involved; this is config, not session state. update-
-      // Model isn't a partial PATCH, so the rest of the entry's fields (base
-      // URL, key, provider, vision) are resent unchanged alongside the two
-      // that actually changed — dropping them would blank those fields out.
-      if (reasoning !== origReasoning || permMode !== origPermMode) {
-        const def = models[defaultModelIdx]
-        if (def) {
-          await api.updateModel(def.id, {
-            model: def.model,
-            base_url: def.base_url ?? '',
-            api_key: def.api_key_masked ?? '',
-            provider: def.provider,
-            anthropic_format: def.anthropic_format,
-            vision: def.vision,
-            reasoning_effort: effortMap[reasoning] ?? 'medium',
-            permission_mode: labelToPermissionMode(permMode),
-          })
-          origReasoning = reasoning
-          origPermMode = permMode
-        }
+      // Reasoning Effort + Permission Mode: PR5 made these global config
+      // (PUT /api/config/reasoning_effort + PUT /api/config/permission_mode),
+      // not per-entry. The old api.updateModel call was deleted — save each
+      // changed field through its own global endpoint.
+      if (reasoning !== origReasoning) {
+        await api.updateReasoningEffort(effortMap[reasoning] ?? 'medium')
+        origReasoning = reasoning
+      }
+      if (permMode !== origPermMode) {
+        await api.updatePermissionMode(labelToPermissionMode(permMode))
+        origPermMode = permMode
       }
 
       // Show Reasoning is a separate global fallback (PUT


### PR DESCRIPTION
## Summary

- **Root cause**: PR5 deleted the flat `/api/config/models*` routes and made `reasoning_effort` + `permission_mode` global config, but `SettingsView.svelte`'s `handleSave` still called the removed `api.updateModel` stub (which throws). Any change to Reasoning Effort or Permission Mode threw inside the try block — meaning **nothing** got saved (showReasoning, coauthor, language, workspaceDir all silently failed behind the "Save failed" toast).
- **Backend**: add `PUT /api/config/reasoning_effort` and `PUT /api/config/permission_mode` handlers — validation, `Save()`, sender cache invalidation, per-session WS broadcast. Registered both routes in `server.go`.
- **Frontend**: add `updateReasoningEffort` + `updatePermissionMode` in `api.ts`.
- **SettingsView.svelte**: replace the dead `api.updateModel` block with the two new global endpoints, each saving independently when changed.

## Test plan

- [ ] Open Settings → change Reasoning Effort → Save → reload: value persists.
- [ ] Open Settings → change Permission Mode → Save → reload: value persists.
- [ ] Change any other Agent Defaults field (showReasoning, coauthor, language, workspaceDir) → Save: still works (was broken before).
- [ ] 4 new Go handler tests pass (valid + invalid input for each endpoint).
- [ ] All 97 web tests + `tsc --noEmit` pass.

🤖 Generated with [octo-agent](https://github.com/open-octo/octo-agent)

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
