### PR TITLE
fix(tui): ask_user_question missing from TUI tool surface

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -79,6 +79,13 @@ func runTUI(cfg replConfig) int {
 		cfg.a.Gate = newCLIGate(cfg.permEngine, sink)
 	}
 	tools.SetAsker(newREPLAsker(sink))
+	// Recompute cfg.tools now that the asker is registered — DefaultToolsFor
+	// gates ask_user_question on activeAsker != nil, and chat.go computed
+	// cfg.tools BEFORE this SetAsker ran, so the tool was silently absent
+	// for the whole TUI session. Mirrors what mcpReadyMsg does below.
+	if cfg.executor != nil {
+		cfg.tools = tools.DefaultToolsFor(cfg.modelName)
+	}
 
 	// Sub-agent manager: wire the onExit hook so completion notifications ride
 	// the same inbox path as background-process notices, and send a TUI msg

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.24"
+var Version = "1.12.25"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## 问题

TUI 模式下 `ask_user_question` 工具不存在于 agent 的可用工具列表中，导致 onboard 等依赖该工具的流程失败。agent 明确回复"不在我当前可用的工具列表里"。

## 根因

时序 bug。`chat.go:999` 在 `cfg.tools = tools.DefaultToolsFor(resolvedModel)` 时，`activeAsker` 还是 `nil`（`SetAsker` 要等到 `turepl.go:81` 才被调用）。`DefaultToolsFor` 用 `activeAsker != nil` 来 gate `ask_user_question`，所以整个 TUI session 里这个工具都被静默过滤掉了。

相比之下 headless 路径顺序正确（先 `SetAsker` 再 `DefaultToolsFor`）。

## 修复

`turepl.go` 的 `SetAsker` 之后重算 `cfg.tools`，与下方 `mcpReadyMsg` 的处理逻辑一致。

## 验证

- `go build ./cmd/octo/` ✅
- `go test ./internal/tools/ -run 'AskUserQuestion|DefaultTools_AskGatedOnAsker'` ✅
- `go test ./cmd/octo/ -run 'TUI|Ask|Repl|Onboard'` ✅