### PR TITLE
fix(tui): actually deliver ask_user_question to the TUI session

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -79,12 +79,12 @@ func runTUI(cfg replConfig) int {
 		cfg.a.Gate = newCLIGate(cfg.permEngine, sink)
 	}
 	tools.SetAsker(newREPLAsker(sink))
-	// Recompute cfg.tools now that the asker is registered — DefaultToolsFor
+	// Recompute m.cfg.tools now that the asker is registered — DefaultToolsFor
 	// gates ask_user_question on activeAsker != nil, and chat.go computed
 	// cfg.tools BEFORE this SetAsker ran, so the tool was silently absent
 	// for the whole TUI session. Mirrors what mcpReadyMsg does below.
 	if cfg.executor != nil {
-		cfg.tools = tools.DefaultToolsFor(cfg.modelName)
+		m.cfg.tools = tools.DefaultToolsFor(cfg.modelName)
 	}
 
 	// Sub-agent manager: wire the onExit hook so completion notifications ride


### PR DESCRIPTION
## Summary
- The previous fix (#1636) updated the local `cfg.tools`, but `newTUIModel(cfg)` had already copied `cfg` by value — so `m.cfg.tools` (what `runTurn` actually uses) never saw `ask_user_question`. This writes the recomputed list straight to `m.cfg.tools`, mirroring what `mcpReadyMsg` already does on MCP connect.

## Root cause
`runTUI` flow:
1. `m := newTUIModel(cfg)` — copies `cfg.tools` into the model (no `ask_user_question` yet, `SetAsker` not called)
2. `tools.SetAsker(...)` — registers the asker
3. `cfg.tools = tools.DefaultToolsFor(...)` — updates the **local** variable, but `m.cfg` is already a separate copy
4. `runTurn(ctx, m.a, m.cfg, ...)` — uses the model's stale `m.cfg.tools`

## Test plan
- [x] `make build` passes
- [x] `make test` (full suite) green
- [x] `make vet` / `make fmt-check` clean
- [ ] Verify in a live TUI session that `ask_user_question` now appears in the tool surface (manual)

🤖 Generated with [octo-agent](https://github.com/open-octo/octo-agent)
