### PR TITLE
fix(config): validate global scalar fields in Config.Validate

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -494,24 +494,28 @@ func projectToModelEntry(ep Endpoint, m EndpointModel) ModelEntry {
 // so every config is on the new schema now. Endpoint-level checks always run:
 // id uniqueness/legality, each endpoint has at least one model, model names
 // non-empty, no duplicate models within one endpoint, Default/Lite composite
-// ids resolve. Global scalar fields that moved from per-model to top-level
-// (permission_mode, reasoning_effort, compact_auto_pct) are value-checked too,
-// so a hand edit that bypasses the CLI/API write-path validation still shows up
-// in `octo doctor` and the post-edit config guard.
+// ids resolve. Global scalar fields with a bounded value set are value-checked
+// too (permission_mode, reasoning_effort, compact_auto_pct, language,
+// tools.tool_search.enabled/threshold_pct, memory_backend.type/base_url), so a
+// hand edit that bypasses the CLI/API write-path validation still shows up in
+// `octo doctor` and the post-edit config guard.
 func (c Config) Validate() []string {
 	var problems []string
 
-	// Global scalar fields moved from per-model to top-level (PR5:
-	// permission_mode / reasoning_effort). Their write-path entries — CLI flags
-	// and the server PUT handlers — reject a bad value, but a hand edit of
-	// config.yml bypasses those and then falls back silently at runtime. Check
-	// the value legality here so `octo doctor` and the post-edit config guard
-	// surface a typo. These run regardless of endpoints (a config may carry only
-	// global settings pre-onboarding), so they sit before the no-endpoints early
-	// return below. config is a leaf package, so the accepted sets are spelled
-	// out rather than imported from permission/ (which would cycle). show_reasoning
-	// is a *bool: a bad value fails YAML decode and is caught by Load, so it needs
-	// no value check here.
+	// Global scalar fields with a bounded value set (permission_mode /
+	// reasoning_effort moved here from per-model in PR5; language, the
+	// tool_search knobs and memory_backend were always global). Their write-path
+	// entries — CLI flags and the server PUT handlers — reject a bad value, but a
+	// hand edit of config.yml bypasses those and then falls back silently at
+	// runtime. Check the value legality here so `octo doctor` and the post-edit
+	// config guard surface a typo. These run regardless of endpoints (a config
+	// may carry only global settings pre-onboarding), so they sit before the
+	// no-endpoints early return below. The accepted sets mirror those write-path
+	// entries; config is a leaf package, so the literals are spelled out rather
+	// than imported from permission/ or memorybackend/ (which would cycle). Bool
+	// and free-form string fields need no check: a bad bool fails YAML decode
+	// (caught by Load), and a free-form string (access_key, paths, namespaces)
+	// has nothing to validate against.
 	if pm := strings.ToLower(strings.TrimSpace(c.PermissionMode)); pm != "" &&
 		pm != "interactive" && pm != "auto" && pm != "strict" {
 		problems = append(problems, fmt.Sprintf("permission_mode %q is not one of interactive, auto, strict", c.PermissionMode))
@@ -522,6 +526,27 @@ func (c Config) Validate() []string {
 	}
 	if c.CompactAutoPct < 0 || c.CompactAutoPct > 100 {
 		problems = append(problems, fmt.Sprintf("compact_auto_pct %d is out of range (0–100; 0 means the built-in default)", c.CompactAutoPct))
+	}
+	if lang := strings.ToLower(strings.TrimSpace(c.Language)); lang != "" && lang != "en" && lang != "zh" {
+		problems = append(problems, fmt.Sprintf("language %q is not one of en, zh", c.Language))
+	}
+	if ts := strings.ToLower(strings.TrimSpace(c.Tools.ToolSearch.Enabled)); ts != "" && ts != "auto" && ts != "on" && ts != "off" {
+		problems = append(problems, fmt.Sprintf("tools.tool_search.enabled %q is not one of auto, on, off", c.Tools.ToolSearch.Enabled))
+	}
+	if pct := c.Tools.ToolSearch.ThresholdPct; pct < 0 || pct > 100 {
+		problems = append(problems, fmt.Sprintf("tools.tool_search.threshold_pct %d is out of range (0–100; 0 means the built-in default)", pct))
+	}
+	// memory_backend: an empty Type disables the feature (nothing to check).
+	// When set, Type must be a known backend and base_url is required — except
+	// mem0 in "cloud" mode, which auto-fills base_url (mirrors memorybackend.New).
+	if mt := strings.ToLower(strings.TrimSpace(c.MemoryBackend.Type)); mt != "" {
+		if mt != "hindsight" && mt != "mem0" && mt != "agentmemory" {
+			problems = append(problems, fmt.Sprintf("memory_backend.type %q is not one of hindsight, mem0, agentmemory", c.MemoryBackend.Type))
+		}
+		mem0Cloud := mt == "mem0" && strings.ToLower(strings.TrimSpace(c.MemoryBackend.Mode)) == "cloud"
+		if c.MemoryBackend.BaseURL == "" && !mem0Cloud {
+			problems = append(problems, "memory_backend.base_url is required when memory_backend.type is set")
+		}
 	}
 
 	if len(c.Endpoints) == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -494,9 +494,35 @@ func projectToModelEntry(ep Endpoint, m EndpointModel) ModelEntry {
 // so every config is on the new schema now. Endpoint-level checks always run:
 // id uniqueness/legality, each endpoint has at least one model, model names
 // non-empty, no duplicate models within one endpoint, Default/Lite composite
-// ids resolve.
+// ids resolve. Global scalar fields that moved from per-model to top-level
+// (permission_mode, reasoning_effort, compact_auto_pct) are value-checked too,
+// so a hand edit that bypasses the CLI/API write-path validation still shows up
+// in `octo doctor` and the post-edit config guard.
 func (c Config) Validate() []string {
 	var problems []string
+
+	// Global scalar fields moved from per-model to top-level (PR5:
+	// permission_mode / reasoning_effort). Their write-path entries — CLI flags
+	// and the server PUT handlers — reject a bad value, but a hand edit of
+	// config.yml bypasses those and then falls back silently at runtime. Check
+	// the value legality here so `octo doctor` and the post-edit config guard
+	// surface a typo. These run regardless of endpoints (a config may carry only
+	// global settings pre-onboarding), so they sit before the no-endpoints early
+	// return below. config is a leaf package, so the accepted sets are spelled
+	// out rather than imported from permission/ (which would cycle). show_reasoning
+	// is a *bool: a bad value fails YAML decode and is caught by Load, so it needs
+	// no value check here.
+	if pm := strings.ToLower(strings.TrimSpace(c.PermissionMode)); pm != "" &&
+		pm != "interactive" && pm != "auto" && pm != "strict" {
+		problems = append(problems, fmt.Sprintf("permission_mode %q is not one of interactive, auto, strict", c.PermissionMode))
+	}
+	if re := strings.ToLower(strings.TrimSpace(c.ReasoningEffort)); re != "" &&
+		re != "off" && re != "low" && re != "medium" && re != "high" && re != "xhigh" && re != "max" {
+		problems = append(problems, fmt.Sprintf("reasoning_effort %q is not one of off, low, medium, high, xhigh, max", c.ReasoningEffort))
+	}
+	if c.CompactAutoPct < 0 || c.CompactAutoPct > 100 {
+		problems = append(problems, fmt.Sprintf("compact_auto_pct %d is out of range (0–100; 0 means the built-in default)", c.CompactAutoPct))
+	}
 
 	if len(c.Endpoints) == 0 {
 		return problems

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -538,13 +538,14 @@ func (c Config) Validate() []string {
 	}
 	// memory_backend: an empty Type disables the feature (nothing to check).
 	// When set, Type must be a known backend and base_url is required — except
-	// mem0 in "cloud" mode, which auto-fills base_url (mirrors memorybackend.New).
+	// in "cloud" mode for backends that auto-fill a fixed hosted URL (mem0 and
+	// hindsight), which mirrors memorybackend.New.
 	if mt := strings.ToLower(strings.TrimSpace(c.MemoryBackend.Type)); mt != "" {
 		if mt != "hindsight" && mt != "mem0" && mt != "agentmemory" {
 			problems = append(problems, fmt.Sprintf("memory_backend.type %q is not one of hindsight, mem0, agentmemory", c.MemoryBackend.Type))
 		}
-		mem0Cloud := mt == "mem0" && strings.ToLower(strings.TrimSpace(c.MemoryBackend.Mode)) == "cloud"
-		if c.MemoryBackend.BaseURL == "" && !mem0Cloud {
+		cloudAutoFill := strings.ToLower(strings.TrimSpace(c.MemoryBackend.Mode)) == "cloud" && (mt == "mem0" || mt == "hindsight")
+		if c.MemoryBackend.BaseURL == "" && !cloudAutoFill {
 			problems = append(problems, "memory_backend.base_url is required when memory_backend.type is set")
 		}
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -72,6 +72,18 @@ func TestConfigValidate_GlobalScalars(t *testing.T) {
 		{"in-range compact_auto_pct", Config{CompactAutoPct: 75}, ""},
 		{"negative compact_auto_pct", Config{CompactAutoPct: -1}, "compact_auto_pct"},
 		{"over-100 compact_auto_pct", Config{CompactAutoPct: 150}, "compact_auto_pct"},
+		{"empty language is fine", Config{}, ""},
+		{"valid language zh", Config{Language: "zh"}, ""},
+		{"bad language", Config{Language: "fr"}, "language"},
+		{"valid tool_search enabled off", Config{Tools: ToolsConfig{ToolSearch: ToolSearchConfig{Enabled: "off"}}}, ""},
+		{"bad tool_search enabled", Config{Tools: ToolsConfig{ToolSearch: ToolSearchConfig{Enabled: "yes"}}}, "tool_search.enabled"},
+		{"in-range tool_search threshold_pct", Config{Tools: ToolsConfig{ToolSearch: ToolSearchConfig{ThresholdPct: 10}}}, ""},
+		{"over-100 tool_search threshold_pct", Config{Tools: ToolsConfig{ToolSearch: ToolSearchConfig{ThresholdPct: 200}}}, "threshold_pct"},
+		{"empty memory_backend is fine", Config{}, ""},
+		{"valid memory_backend", Config{MemoryBackend: MemoryBackendConfig{Type: "hindsight", BaseURL: "http://localhost:8888"}}, ""},
+		{"bad memory_backend type", Config{MemoryBackend: MemoryBackendConfig{Type: "pinecone", BaseURL: "http://x"}}, "memory_backend.type"},
+		{"memory_backend missing base_url", Config{MemoryBackend: MemoryBackendConfig{Type: "mem0"}}, "base_url"},
+		{"mem0 cloud mode needs no base_url", Config{MemoryBackend: MemoryBackendConfig{Type: "mem0", Mode: "cloud"}}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -48,3 +48,44 @@ func TestConfigValidate_EndpointLevel(t *testing.T) {
 		})
 	}
 }
+
+// TestConfigValidate_GlobalScalars covers the top-level scalar fields that moved
+// from per-model to global (permission_mode, reasoning_effort, compact_auto_pct).
+// Hand edits bypass the CLI/API write-path validation, so Validate is the only
+// thing standing between a typo and a silent runtime fallback. These checks run
+// independently of endpoints — a config with no endpoints must still flag them.
+func TestConfigValidate_GlobalScalars(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"empty permission_mode is fine", Config{}, ""},
+		{"valid permission_mode", Config{PermissionMode: "strict"}, ""},
+		{"permission_mode case-insensitive", Config{PermissionMode: "Auto"}, ""},
+		{"bad permission_mode", Config{PermissionMode: "strikt"}, "permission_mode"},
+		{"empty reasoning_effort is fine", Config{}, ""},
+		{"valid reasoning_effort off", Config{ReasoningEffort: "off"}, ""},
+		{"valid reasoning_effort xhigh", Config{ReasoningEffort: "xhigh"}, ""},
+		{"bad reasoning_effort", Config{ReasoningEffort: "ultra"}, "reasoning_effort"},
+		{"zero compact_auto_pct is the default", Config{CompactAutoPct: 0}, ""},
+		{"in-range compact_auto_pct", Config{CompactAutoPct: 75}, ""},
+		{"negative compact_auto_pct", Config{CompactAutoPct: -1}, "compact_auto_pct"},
+		{"over-100 compact_auto_pct", Config{CompactAutoPct: 150}, "compact_auto_pct"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probs := tt.cfg.Validate()
+			joined := strings.Join(probs, "; ")
+			if tt.want == "" {
+				if len(probs) != 0 {
+					t.Errorf("want no problems, got %v", probs)
+				}
+				return
+			}
+			if !strings.Contains(joined, tt.want) {
+				t.Errorf("want a problem containing %q, got %v", tt.want, probs)
+			}
+		})
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -84,6 +84,7 @@ func TestConfigValidate_GlobalScalars(t *testing.T) {
 		{"bad memory_backend type", Config{MemoryBackend: MemoryBackendConfig{Type: "pinecone", BaseURL: "http://x"}}, "memory_backend.type"},
 		{"memory_backend missing base_url", Config{MemoryBackend: MemoryBackendConfig{Type: "mem0"}}, "base_url"},
 		{"mem0 cloud mode needs no base_url", Config{MemoryBackend: MemoryBackendConfig{Type: "mem0", Mode: "cloud"}}, ""},
+		{"hindsight cloud mode needs no base_url", Config{MemoryBackend: MemoryBackendConfig{Type: "hindsight", Mode: "cloud"}}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Why

The model-config refactor (flat `models` → two-level `endpoints → models`) moved `permission_mode`, `reasoning_effort` and `show_reasoning` from per-model entries to **top-level global settings**. But `Config.Validate()` was only updated for the new endpoint structure — it never validates global scalar *values*. The same blind spot already existed for several always-global fields.

Their write-path entries validate them (CLI flags, server `PUT /api/config/*`), but a **hand edit of `~/.octo/config.yml` bypasses those** and then falls back silently at runtime. Both `octo doctor` and the post-edit `ConfigGuard` hook (`internal/tools/config_guard.go`) delegate to `Config.Validate()`, so those two "hand-edit safety net" paths were blind to every global field.

## What

Add value checks to `Config.Validate()` for all global scalars with a bounded value set, mirroring the sets used at the existing write-path entries:

| field | accepted | write-path check existed? |
|---|---|---|
| `permission_mode` | interactive / auto / strict | ✅ CLI + server |
| `reasoning_effort` | off / low / medium / high / xhigh / max | ✅ CLI + server |
| `compact_auto_pct` | 0–100 (0 = default) | ❌ |
| `language` | en / zh | ✅ server |
| `tools.tool_search.enabled` | auto / on / off | ✅ server |
| `tools.tool_search.threshold_pct` | 0–100 (0 = default) | ❌ nowhere |
| `memory_backend.type` | hindsight / mem0 / agentmemory | ❌ (errors at first use) |
| `memory_backend.base_url` | required when type set, except mem0 `cloud` mode | ❌ |

- Placed **before** the `len(c.Endpoints) == 0` early return so a config carrying only global settings is still checked.
- `config` is a leaf package, so the accepted sets are spelled out inline rather than imported from `permission/` or `memorybackend/` (which would cycle).
- The `memory_backend` check mirrors `memorybackend.New` exactly, including the mem0-cloud base_url auto-fill exception — so doctor flags a bad backend config before it errors on the first Store/Recall.

### Deliberately not validated
- **bool / `*bool`** (`coauthor`, `show_reasoning`, `notify`, `terminal_title`, `goal.enabled`, `trash.overwrite_backup`, `memory_backend.auto_recall`) — a bad value fails YAML decode and is already caught by `Load` / `ConfigGuard`.
- **free-form strings** (`access_key`, `workspace_dir`, `browser.*` paths, `memory_backend.api_key/namespace`, `tools.disabled_skills`) — no enum to check against.
- **`trash.retention_days` / `trash.max_size_mb`** — negative is *meaningful* (disables), 0 = default; every int is valid.
- **`memory_backend.mode`** — only meaningful for mem0, ignored elsewhere; not a silent-fallback failure.

## Test

- `TestConfigValidate_GlobalScalars` — valid / invalid / boundary / no-endpoint / mem0-cloud-exception cases for every added field.
- `go test ./internal/config/ ./cmd/octo/ ./internal/tools/`, `go vet`, `gofmt` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)