### PR TITLE
fix(cli): non-TTY wizard model default must gate on sameProvider (#1641)

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -442,7 +442,11 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 		}
 		fmt.Fprintf(stdout, "Model: %s\n\n", shown)
 	} else {
-		model = strings.TrimSpace(promptDefault(reader, stdout, "Model", firstNonEmpty(existing.Model, defaultModels[provider])))
+		def := defaultModels[provider]
+		if sameProvider && existing.Model != "" {
+			def = existing.Model
+		}
+		model = strings.TrimSpace(promptDefault(reader, stdout, "Model", def))
 	}
 
 	// Base URL / endpoint. Compatible (custom-endpoint) vendors require a

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -236,9 +236,10 @@ func TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Answers: provider=openai, model=(default), set-as-default=y. No
-	// endpoint question for a pinned vendor.
-	in := strings.NewReader("openai\n\ny\n")
+	// Answers: provider=openai, model=(default/blank), store-key=n,
+	// coauthor=y, reasoning=off(blank), set-as-default=y. No endpoint question
+	// for a pinned vendor; no vision question (gpt-5.4 is in the catalogue).
+	in := strings.NewReader("openai\n\nn\ny\n\ny\n")
 	var stdout, stderr bytes.Buffer
 	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
@@ -261,16 +262,28 @@ func TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals(t *testing.T) {
 	if got.PermissionMode != "strict" {
 		t.Errorf("permission_mode lost: %q", got.PermissionMode)
 	}
-	// The new openai endpoint must exist (the wizard added it).
-	var hasOpenai bool
+	// The new openai endpoint must exist (the wizard added it) and, since the
+	// model question was answered blank, must inherit the openai default —
+	// NOT the previous anthropic entry's model.
+	var openaiModel string
 	for _, ep := range got.Endpoints {
 		if ep.Provider == "openai" {
-			hasOpenai = true
+			if len(ep.Models) > 0 {
+				openaiModel = ep.Models[0].Model
+			}
 			break
 		}
 	}
-	if !hasOpenai {
-		t.Errorf("wizard did not add an openai endpoint: %+v", got.Endpoints)
+	if openaiModel == "" {
+		t.Fatalf("wizard did not add an openai endpoint: %+v", got.Endpoints)
+	}
+	if openaiModel != "gpt-5.4" {
+		t.Errorf("blank model answer must default to the openai default, got %q", openaiModel)
+	}
+	// The default composite id must name the openai model, not the leaked
+	// anthropic one.
+	if wantDefault := "openai::gpt-5.4"; got.Default != wantDefault {
+		t.Errorf("Default = %q, want %q", got.Default, wantDefault)
 	}
 }
 
@@ -318,9 +331,10 @@ func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
 
 	// Answers (key now comes right after model): provider=openai,
 	// model=(default), store_key=y, key=new-openai-key, coauthor=y,
-	// reasoning-effort=(off), show-reasoning=(off), set-as-default=y.
-	// No endpoint question for a pinned vendor.
-	in := strings.NewReader("openai\n\ny\nnew-openai-key\ny\n\n\ny\n")
+	// reasoning-effort=(off), set-as-default=y. No endpoint question for a
+	// pinned vendor; no vision question (the blank model defaults to the
+	// openai default gpt-5.4, which the catalogue already knows is vision-capable).
+	in := strings.NewReader("openai\n\ny\nnew-openai-key\ny\n\ny\n")
 	var stdout, stderr bytes.Buffer
 	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())


### PR DESCRIPTION
Fixes #1641.

## Problem

In `runConfigWizard` (`cmd/octo/config.go`), the non-TTY fallback for the model question seeded its default from the existing entry **without** the `sameProvider` gate the TTY select path already applies:

```go
model = strings.TrimSpace(promptDefault(reader, stdout, "Model", firstNonEmpty(existing.Model, defaultModels[provider])))
```

So when the stored default belongs to a different provider and the user re-runs the wizard non-interactively (piped stdin, tests, Windows readline fallback), pressing Enter at the model question inherited the **old provider's** model name — e.g. a new openai endpoint getting `claude-sonnet-4-6` instead of the openai default `gpt-5.4`.

## Fix

Apply the same `sameProvider` gate in the non-TTY branch:

```go
def := defaultModels[provider]
if sameProvider && existing.Model != "" {
    def = existing.Model
}
model = strings.TrimSpace(promptDefault(reader, stdout, "Model", def))
```

Side effect: the blank-model path now resolves to a known catalogue model, so the wizard no longer needs to ask the vision question in that case.

## Tests

- `TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals` — tightened back to the concrete composite id `openai::gpt-5.4` (and asserts the new endpoint's model is `gpt-5.4`, not the leaked anthropic one); scripted input completed so `set-as-default` is actually answered.
- `TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey` — input adjusted for the dropped vision prompt.

`go test ./cmd/octo/`, `go vet ./cmd/octo/`, and `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)