### PR TITLE
feat(memory): support cloud mode for the hindsight backend

### DIFF
--- a/docs/src/content/docs/guides/memory-backends.md
+++ b/docs/src/content/docs/guides/memory-backends.md
@@ -84,6 +84,19 @@ Unlike the self-hosted default, Hindsight Cloud requires the API key — generat
 dashboard and set it here. octo sends it as `Authorization: Bearer <api_key>`, matching what the
 cloud API expects.
 
+You can also drop the `base_url` and set `mode: cloud` instead — octo then fills in
+`https://api.hindsight.vectorize.io` for you. Because the cloud API is identical to self-hosted in
+auth and route shape, `mode: cloud` is purely this base_url shortcut here (unlike mem0, where it also
+switches paths and headers):
+
+```yaml
+memory_backend:
+  type: hindsight
+  mode: cloud            # fills base_url = https://api.hindsight.vectorize.io
+  api_key: "<your Hindsight Cloud API key>"
+  namespace: octo-agent
+```
+
 ### mem0
 
 Needs Postgres (with pgvector) — the official `server/` stack bundles it via Docker Compose.
@@ -213,7 +226,7 @@ Add a `memory_backend` block to `~/.octo/config.yml`:
 ```yaml
 memory_backend:
   type: hindsight        # hindsight | mem0 | agentmemory
-  mode: ""               # only meaningful for mem0: "cloud" or "" (self-hosted, default)
+  mode: ""               # meaningful for mem0 & hindsight: "cloud" or "" (self-hosted, default)
   base_url: http://localhost:8888
   api_key: ""            # optional — see per-backend notes below
   namespace: my-project  # scopes stored/recalled memories; defaults to "default"
@@ -222,12 +235,15 @@ memory_backend:
 
 - **`type`** selects the backend. Leaving it unset (or omitting the whole block) disables the
   feature entirely — no tool is advertised, nothing is sent anywhere.
-- **`mode`** only matters for `type: mem0`: set it to `cloud` to talk to the hosted mem0 Platform
-  instead of a self-hosted server (see "mem0 Cloud" above) — the two use different endpoint paths
-  and auth headers, so this isn't inferred from `base_url`. Ignored by hindsight and agentmemory.
+- **`mode`** matters for `type: mem0` and `type: hindsight`: set it to `cloud` to talk to the
+  vendor's hosted Platform instead of a self-hosted server (see "mem0 Cloud" / "Hindsight Cloud"
+  above). For mem0 the cloud and self-hosted APIs differ in endpoint paths and auth headers, so this
+  isn't inferred from `base_url`; for hindsight they're identical, so `mode: cloud` just fills in the
+  cloud `base_url`. Ignored by agentmemory.
 - **`base_url`** is the backend's REST endpoint — wherever you're running its server (`http://localhost:8888`
-  for hindsight/mem0 as set up above, `http://localhost:3111` for agentmemory). Can be omitted for
-  `mem0` with `mode: cloud`, which defaults it to `https://api.mem0.ai`.
+  for hindsight/mem0 as set up above, `http://localhost:3111` for agentmemory). Can be omitted with
+  `mode: cloud`, which defaults it to `https://api.mem0.ai` (mem0) or
+  `https://api.hindsight.vectorize.io` (hindsight).
 - **`api_key`** is optional and backend-dependent:
   - self-hosted hindsight has no auth by default; set an API key only if you've enabled
     `HINDSIGHT_API_TENANT_API_KEY` on the server. Hindsight Cloud is the exception — it always

--- a/docs/src/content/docs/zh/guides/memory-backends.md
+++ b/docs/src/content/docs/zh/guides/memory-backends.md
@@ -78,6 +78,18 @@ memory_backend:
 跟自托管默认情况不同，Hindsight Cloud 是强制要求 API key 的——去它的控制台生成一个填在这里。
 octo 会把它当作 `Authorization: Bearer <api_key>` 发出去，正好是云端 API 要求的格式。
 
+你也可以不填 `base_url`，改成设 `mode: cloud`——octo 会自动帮你填上
+`https://api.hindsight.vectorize.io`。因为云端 API 在鉴权和路径结构上跟自托管完全一致，这里的
+`mode: cloud` 纯粹就是这个 base_url 快捷方式（不像 mem0，它的 `cloud` 还会切换路径和 header）：
+
+```yaml
+memory_backend:
+  type: hindsight
+  mode: cloud            # 自动填 base_url = https://api.hindsight.vectorize.io
+  api_key: "<你的 Hindsight Cloud API key>"
+  namespace: octo-agent
+```
+
 ### mem0
 
 需要 Postgres（带 pgvector）——官方的 `server/` 那套栈用 Docker Compose 把它一起打包了。
@@ -200,7 +212,7 @@ curl http://localhost:3111/agentmemory/health
 ```yaml
 memory_backend:
   type: hindsight        # hindsight | mem0 | agentmemory
-  mode: ""               # 只对 mem0 有意义："cloud" 或 ""（自托管，默认）
+  mode: ""               # 对 mem0 和 hindsight 有意义："cloud" 或 ""（自托管，默认）
   base_url: http://localhost:8888
   api_key: ""            # 可选——具体看下面每个后端的说明
   namespace: my-project  # 限定存储/召回的记忆范围；不填默认是 "default"
@@ -209,12 +221,14 @@ memory_backend:
 
 - **`type`** 选择用哪个后端。不填（或者整段都不写）就是彻底关掉这个功能——不会向模型
   暴露任何工具，也不会往外发任何东西。
-- **`mode`** 只对 `type: mem0` 有意义：设成 `cloud` 就会走托管的 mem0 Platform，而不是自托管
-  server（见上文「mem0 Cloud」）——两者端点路径和鉴权 header 都不一样，不会根据 `base_url`
-  自动判断。hindsight 和 agentmemory 不看这个字段。
+- **`mode`** 对 `type: mem0` 和 `type: hindsight` 有意义：设成 `cloud` 就会走对应厂商托管的
+  Platform，而不是自托管 server（见上文「mem0 Cloud」/「Hindsight Cloud」）。mem0 的云端和自托管
+  端点路径、鉴权 header 都不一样，不会根据 `base_url` 自动判断；hindsight 两者完全一致，`mode: cloud`
+  只是帮你填上云端 `base_url`。agentmemory 不看这个字段。
 - **`base_url`** 是后端的 REST 端点——也就是你把它的 server 跑在哪（照上面的方式搭的话，
-  hindsight/mem0 是 `http://localhost:8888`，agentmemory 是 `http://localhost:3111`）。`mem0` 配合
-  `mode: cloud` 时可以不填，会自动用 `https://api.mem0.ai`。
+  hindsight/mem0 是 `http://localhost:8888`，agentmemory 是 `http://localhost:3111`）。配合
+  `mode: cloud` 时可以不填，会自动用 `https://api.mem0.ai`（mem0）或
+  `https://api.hindsight.vectorize.io`（hindsight）。
 - **`api_key`** 是可选的，具体看后端：
   - 自托管 hindsight 默认不需要鉴权；只有在 server 上开了 `HINDSIGHT_API_TENANT_API_KEY` 时才
     需要填一个 API key。Hindsight Cloud 是例外——它始终要求填控制台生成的 API key。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -303,10 +303,10 @@ type MemoryBackendConfig struct {
 	// Namespace scopes stored/recalled memories (hindsight bank_id, mem0
 	// user_id, agentmemory project). Defaults to "default" when empty.
 	Namespace string `yaml:"namespace,omitempty"`
-	// Mode selects between deployment variants of the same Type. Currently
-	// only meaningful for "mem0": "cloud" talks to the hosted mem0 Platform
-	// API instead of a self-hosted server — see the memory-backends guide.
-	// Ignored by other backend types.
+	// Mode selects between deployment variants of the same Type. Meaningful for
+	// "mem0" and "hindsight": "cloud" talks to the vendor's hosted Platform API
+	// (auto-filling its fixed base_url) instead of a self-hosted server — see the
+	// memory-backends guide. Ignored by other backend types.
 	Mode string `yaml:"mode,omitempty"`
 	// AutoRecall, when true, automatically calls Recall with the user's
 	// message before every turn and injects the result as context —

--- a/internal/memorybackend/backend.go
+++ b/internal/memorybackend/backend.go
@@ -64,8 +64,17 @@ type Backend interface {
 // unreachable or misconfigured backend surface on the first Store/Recall
 // call.
 func New(cfg Config) (Backend, error) {
-	if cfg.Type == "mem0" && cfg.Mode == "cloud" && cfg.BaseURL == "" {
-		cfg.BaseURL = mem0CloudBaseURL
+	// "cloud" mode auto-fills the fixed hosted base_url when the user leaves it
+	// blank. mem0 and hindsight each run a single managed Platform, so there's
+	// one canonical URL per backend (unlike self-hosted, which needs an explicit
+	// address). agentmemory has no hosted service, so it's not listed here.
+	if cfg.Mode == "cloud" && cfg.BaseURL == "" {
+		switch cfg.Type {
+		case "mem0":
+			cfg.BaseURL = mem0CloudBaseURL
+		case "hindsight":
+			cfg.BaseURL = hindsightCloudBaseURL
+		}
 	}
 	if cfg.BaseURL == "" {
 		return nil, fmt.Errorf("memorybackend: base_url is required")

--- a/internal/memorybackend/backend_test.go
+++ b/internal/memorybackend/backend_test.go
@@ -65,6 +65,31 @@ func TestNewDoesNotOverrideExplicitBaseURLForMem0Cloud(t *testing.T) {
 	}
 }
 
+func TestNewDefaultsBaseURLForHindsightCloud(t *testing.T) {
+	b, err := New(Config{Type: "hindsight", Mode: "cloud"})
+	if err != nil {
+		t.Fatalf("New(hindsight cloud, no base_url): unexpected error: %v", err)
+	}
+	h, ok := b.(*hindsightBackend)
+	if !ok {
+		t.Fatalf("New(hindsight cloud) returned %T, want *hindsightBackend", b)
+	}
+	if h.cfg.BaseURL != hindsightCloudBaseURL {
+		t.Errorf("BaseURL = %q, want the Hindsight Cloud default %q", h.cfg.BaseURL, hindsightCloudBaseURL)
+	}
+}
+
+func TestNewDoesNotOverrideExplicitBaseURLForHindsightCloud(t *testing.T) {
+	b, err := New(Config{Type: "hindsight", Mode: "cloud", BaseURL: "https://staging.hindsight.example"})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+	h := b.(*hindsightBackend)
+	if h.cfg.BaseURL != "https://staging.hindsight.example" {
+		t.Errorf("BaseURL = %q, want the explicitly configured value preserved", h.cfg.BaseURL)
+	}
+}
+
 func TestConfigNamespaceDefault(t *testing.T) {
 	if got := (Config{}).namespace(); got != "default" {
 		t.Errorf("empty Namespace: got %q, want %q", got, "default")

--- a/internal/memorybackend/hindsight.go
+++ b/internal/memorybackend/hindsight.go
@@ -9,8 +9,18 @@ import (
 	"strings"
 )
 
+// hindsightCloudBaseURL is the fixed hosted-Platform endpoint, used when Mode
+// is "cloud" and BaseURL is left blank — there's only one, unlike self-hosted
+// deployments which need an explicit address. Unlike mem0, hindsight's hosted
+// API is identical to self-hosted in auth (Authorization: Bearer) and route
+// shape (/v1/default/banks/{bank}/...), so cloud mode only swaps the base_url;
+// no path/header branching is needed. Verified against
+// https://docs.hindsight.vectorize.io/api-reference/hindsight-cloud-api/.
+const hindsightCloudBaseURL = "https://api.hindsight.vectorize.io"
+
 // hindsightBackend talks to a self-hosted github.com/vectorize-io/hindsight
-// server. Endpoints and auth verified against
+// server, or — when Mode is "cloud" — the hosted Platform at
+// hindsightCloudBaseURL. Endpoints and auth verified against
 // https://hindsight.vectorize.io/api-reference and
 // https://hindsight.vectorize.io/developer/configuration.
 type hindsightBackend struct {


### PR DESCRIPTION
## Why

Hindsight has a hosted Platform ([Hindsight Cloud](https://docs.hindsight.vectorize.io/), `api.hindsight.vectorize.io`) alongside the self-hosted container. Users could already point octo at it by setting `base_url` explicitly, but mem0 has a nicer `mode: cloud` shortcut that auto-fills its hosted URL. This gives hindsight the same shortcut.

## What

`mode: cloud` for a `hindsight` backend now auto-fills `base_url = https://api.hindsight.vectorize.io` when the user leaves it blank:

```yaml
memory_backend:
  type: hindsight
  mode: cloud            # fills base_url = https://api.hindsight.vectorize.io
  api_key: "<Hindsight Cloud API key>"
```

**Key difference from mem0:** mem0's cloud API differs from self-hosted in endpoint paths (`/v3/memories/...`), auth header (`Token` vs `X-API-Key`), and search body — so mem0's `cloud()` branches on all three. Hindsight Cloud is **identical** to self-hosted: same `Authorization: Bearer`, same `/v1/default/banks/{bank}/...` routes (verified against docs.hindsight.vectorize.io). So for hindsight, `mode: cloud` is *purely* a base_url auto-fill — no path/header branching needed.

- `memorybackend/backend.go` — generalize `New`'s cloud base_url auto-fill from mem0-only to `{mem0, hindsight}`.
- `memorybackend/hindsight.go` — add `hindsightCloudBaseURL` const + doc note on why cloud mode is base_url-only here.
- `config/config.go` — `Mode` field comment: now meaningful for mem0 **and** hindsight.
- docs — document the `mode: cloud` shortcut in the memory-backends guide (EN + ZH).

## Note on the sibling PR

The `Config.Validate()` `memory_backend.base_url` check that exempts cloud-auto-fill backends lives in #1643 (config-validation), which I've already updated there to cover hindsight cloud too. That PR should merge alongside this one so a `type: hindsight, mode: cloud` config with no `base_url` passes doctor.

## Test

- `TestNewDefaultsBaseURLForHindsightCloud` + `TestNewDoesNotOverrideExplicitBaseURLForHindsightCloud`, mirroring the existing mem0-cloud tests.
- `go test ./internal/memorybackend/ ./internal/config/ ./internal/app/`, `go vet`, `gofmt` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)