### PR TITLE
fix(web): restore typed text to the composer when a turn errors

### DIFF
--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -804,6 +804,23 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
         tools: [],
         todos: [],
       })
+      // A first-round failure (usage limit, network, bad key) rolls the user
+      // message back past history on the server (see the history_reload that
+      // follows), and send() already cleared the composer optimistically — so
+      // the text the user typed is gone from both places. Pull it back into the
+      // composer so a long prompt isn't lost to a transient error; the user can
+      // fix the cause and resend. Only for a non-steer send: a steer's text
+      // belongs to the running turn, not a fresh compose. Mirrors the
+      // steer_retracted restore above, including forgetting the rollback entry
+      // (a rolled-back message is never confirmed by history_user_message).
+      const errQueue = pendingSends.get(sid)
+      const errMeta = errQueue && errQueue.length ? errQueue[errQueue.length - 1] : undefined
+      if (errQueue && errMeta && !errMeta.wasStreaming) {
+        const next = errQueue.filter(m => m.pendingId !== errMeta.pendingId)
+        if (next.length) pendingSends.set(sid, next)
+        else pendingSends.delete(sid)
+        composer?.restore(errMeta.text, errMeta.files)
+      }
     }))
 
     cleanups.push(ws.on('tool_stdout', (ev) => {

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -809,13 +809,17 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       // follows), and send() already cleared the composer optimistically — so
       // the text the user typed is gone from both places. Pull it back into the
       // composer so a long prompt isn't lost to a transient error; the user can
-      // fix the cause and resend. Only for a non-steer send: a steer's text
-      // belongs to the running turn, not a fresh compose. Mirrors the
-      // steer_retracted restore above, including forgetting the rollback entry
-      // (a rolled-back message is never confirmed by history_user_message).
+      // fix the cause and resend. The fresh message that started this turn is
+      // the queue's single non-streaming entry (a follow-up sent mid-turn is
+      // classified as a steer, wasStreaming:true, and its text belongs to the
+      // running turn — not a fresh compose). Find it by that flag rather than by
+      // position: a leaked steer from an earlier turn can sit ahead of it, and a
+      // trailing steer can sit after it. Mirrors the steer_retracted restore
+      // above, including forgetting the rollback entry (a rolled-back message is
+      // never confirmed by history_user_message).
       const errQueue = pendingSends.get(sid)
-      const errMeta = errQueue && errQueue.length ? errQueue[errQueue.length - 1] : undefined
-      if (errQueue && errMeta && !errMeta.wasStreaming) {
+      const errMeta = errQueue?.find(m => !m.wasStreaming)
+      if (errQueue && errMeta) {
         const next = errQueue.filter(m => m.pendingId !== errMeta.pendingId)
         if (next.length) pendingSends.set(sid, next)
         else pendingSends.delete(sid)


### PR DESCRIPTION
## Problem

When the first turn of a message fails at the LLM call — e.g. a Kimi `HTTP 403 (permission_error): You've reached your usage limit` (see report), a network blip, or a bad key — the long prompt the user just typed vanishes completely:

- `Composer.send()` clears the textarea **optimistically** the moment you hit Enter.
- On a first-round failure the server rolls the user message back past history (`ws_handlers.go` `runLoop` / `appendUserInput` error-path contract) and broadcasts `history_reload`, so the optimistic user bubble disappears from the transcript too.

Net result: the text is gone from both the input box and the transcript, leaving only the red error banner. A user who typed several paragraphs loses all of it.

## Fix

In the `turn_error` WS handler, pull the failed send's text (and attachments) back into the composer via the existing `composer.restore()` path — the same one `steer_retracted` already uses to reload a retracted steer. The user can fix the cause (buy quota, switch model, reconnect) and resend without retyping.

- Only restores a **non-steer** send: a steer's text belongs to the running turn, not a fresh compose.
- Drops the send's rollback entry from `pendingSends` (a rolled-back message is never confirmed by `history_user_message`, so it would otherwise leak).
- `history_reload` (which follows) clears the transcript but never touches the composer, and the `turnError` banner is independent state — so the restored text and the error message coexist cleanly.

## Test

- `svelte-check` clean (0 errors).
- `vite build` + `go build ./internal/server/` (go:embed webdist) both succeed.
- webdist is gitignored in this repo (CI rebuilds it), so only the `.svelte` source is committed.

Manual: send a message on a session whose provider returns 403/usage-limit → the error banner shows **and** the typed text is back in the (focused) composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)