### PR TITLE
fix(tools): read_file refuses images for non-vision models instead of feeding hallucination

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -79,11 +79,12 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 	tools.SetBrowserRecordingGenerator(MakeRecordingGenerator(a.GetSender(), a.Model))
 	tools.SetBrowserHealer(MakeBrowserHealer(a.GetSender(), a.Model))
 
-	// Gate image content (browser screenshots) on the active model's vision
-	// capability so a text-only model isn't handed images its endpoint rejects.
+	// Gate image content (browser screenshots, read_file) on the active model's
+	// vision capability so a text-only model isn't handed images its endpoint
+	// rejects.
 	cfg, cfgErr := config.Load()
 	if cfgErr == nil {
-		tools.SetBrowserVision(cfg.ModelVision(a.Model))
+		tools.SetModelVision(cfg.ModelVision(a.Model))
 	}
 
 	// Optional external semantic memory backend (hindsight/mem0/agentmemory) — the
@@ -95,7 +96,7 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 		tools.SetSpawner(nil)
 		tools.SetBrowserRecordingGenerator(nil)
 		tools.SetBrowserHealer(nil)
-		tools.SetBrowserVision(true)
+		tools.SetModelVision(true)
 		tools.ResetBrowserSession()
 		tools.SetMemoryBackend(nil)
 		tools.SetMemoryBackendAutoRecall(false)

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -52,16 +52,17 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 		ctx = tools.WithGoalStore(ctx, sess)
 	}
 
-	// Gate browser image content on the active model's vision capability. Unlike
-	// the CLI (which goes through app.WireTools), the server wires tools here, so
-	// this is the only place serve learns whether the model can take images — a
-	// text-only model would otherwise be handed a screenshot it rejects (HTTP
-	// 400). Re-evaluated per turn so a mid-session model switch takes effect.
-	// LoadCached so a config.yml that's momentarily invalid mid-edit keeps
-	// the last vision setting that parsed instead of silently going stale.
+	// Gate image-handing tools (browser, read_file) on the active model's vision
+	// capability. Unlike the CLI (which goes through app.WireTools), the server
+	// wires tools here, so this is the only place serve learns whether the model
+	// can take images — a text-only model would otherwise be handed a screenshot
+	// or image block it rejects (HTTP 400). Re-evaluated per turn so a mid-session
+	// model switch takes effect. LoadCached so a config.yml that's momentarily
+	// invalid mid-edit keeps the last vision setting that parsed instead of
+	// silently going stale.
 	cfg, cfgErr := config.LoadCached()
 	if cfgErr == nil {
-		tools.SetBrowserVision(cfg.ModelVision(a.Model))
+		tools.SetModelVision(cfg.ModelVision(a.Model))
 	}
 
 	// Same omission for the LLM-backed browser helpers: record_stop's

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -53,17 +53,13 @@ var (
 	browserRecordingGen browser.RecordingGenerator
 )
 
-// browserVision gates whether the browser tool hands the model images. Default
-// true (vision-capable); app.WireTools sets it from the active model's config
-// so a text-only model (e.g. qwen-max) gets a text note instead of an image
-// content block that its endpoint would reject.
-var browserVision = func() *atomic.Bool { b := &atomic.Bool{}; b.Store(true); return b }()
-
 // SetBrowserVision enables/disables handing images to the model.
-func SetBrowserVision(on bool) { browserVision.Store(on) }
+// Deprecated: alias of SetModelVision, kept for existing callers — the flag
+// is model capability, not browser state.
+func SetBrowserVision(on bool) { SetModelVision(on) }
 
 // BrowserVisionEnabled reports the current setting (for tests/diagnostics).
-func BrowserVisionEnabled() bool { return browserVision.Load() }
+func BrowserVisionEnabled() bool { return ModelVisionEnabled() }
 
 // BrowserHealerSet / BrowserRecordingGeneratorSet report whether the LLM-backed
 // browser helpers are wired (for tests/diagnostics).
@@ -523,7 +519,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 			return agent.ToolResult{}, err
 		}
 		path := saveScreenshot(shot)
-		if !browserVision.Load() {
+		if !ModelVisionEnabled() {
 			// Text-only model: handing it an image block would be rejected by the
 			// endpoint. Return the path and steer the model to the text channels.
 			return agent.ToolResult{Text: "screenshot saved to " + path + " (the current model can't view images — use observe/eval/ax to read the page instead)"}, nil

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -58,7 +58,8 @@ func (ReadFileTool) Definition() agent.ToolDefinition {
 			"working directory. Refuses binary extensions (executables, archives, " +
 			"PDFs, DBs) and blocking device files (/dev/random, /dev/tty etc). " +
 			"Image files (.png, .jpg, .jpeg, .gif, .webp, .bmp, .tiff, .heic, .ico) " +
-			"are returned as image content for multimodal model consumption.",
+			"are returned as image content for multimodal model consumption, or a " +
+			"refusal if the active model does not accept image input.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -103,8 +103,16 @@ func (ReadFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 		return agent.ToolResult{}, fmt.Errorf("read_file: refusing to read %s — device file would block or stream indefinitely", path)
 	}
 
-	// Check for image files first — multimodal models can consume them.
+	// Check for image files first — multimodal models can consume them. A
+	// text-only model gets a refusal instead: its provider silently drops
+	// image blocks, and a model that believes it "read" an image it cannot
+	// see confidently hallucinates the contents.
 	if mimeType := imageMIMEType(abs); mimeType != "" {
+		if !ModelVisionEnabled() {
+			return agent.ToolResult{
+				Text: fmt.Sprintf("%s is an image file (%s) and the active model does not accept image input — the contents cannot be read or described. Do not guess what the image shows; tell the user to switch to a vision-capable model if they need it analyzed.", path, mimeType),
+			}, nil
+		}
 		return readImageFile(abs, path, mimeType)
 	}
 

--- a/internal/tools/read_file_test.go
+++ b/internal/tools/read_file_test.go
@@ -189,6 +189,33 @@ func TestReadFile_RejectsBinaryExtensions(t *testing.T) {
 	}
 }
 
+// TestReadFile_ImageNonVisionModel verifies that when the active model has no
+// image input, read_file refuses with an instructive message instead of
+// returning an image block the provider would silently drop — a text-only
+// model that "successfully reads" an image it cannot see confidently
+// hallucinates its contents.
+func TestReadFile_ImageNonVisionModel(t *testing.T) {
+	SetModelVision(false)
+	t.Cleanup(func() { SetModelVision(true) })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shot.png")
+	if err := os.WriteFile(path, []byte("\x89PNG\r\n\x1a\nfake"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	res, err := ReadFileTool{}.Execute(context.Background(), "", map[string]any{"path": path})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(res.Blocks) != 0 {
+		t.Errorf("expected no image blocks for non-vision model, got %+v", res.Blocks)
+	}
+	if !strings.Contains(res.Text, "does not accept image input") {
+		t.Errorf("expected refusal text, got: %q", res.Text)
+	}
+}
+
 func TestReadFile_ReadsImage(t *testing.T) {
 	// A valid PNG header: 89 50 4E 47 0D 0A 1A 0A
 	pngHeader := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}

--- a/internal/tools/vision.go
+++ b/internal/tools/vision.go
@@ -1,0 +1,18 @@
+package tools
+
+import "sync/atomic"
+
+// modelVision gates whether tools hand the model image content. Set per turn
+// from the active model's capability (config.ModelVision) by every entry
+// point that prepares a tool turn; defaults to true so embedders that never
+// set it keep the historical behavior. Shared by the browser tool and
+// read_file: an image block sent to a text-only model is silently dropped at
+// the provider, and a model that believes it "read" an image it cannot see
+// hallucinates its contents.
+var modelVision = func() *atomic.Bool { b := &atomic.Bool{}; b.Store(true); return b }()
+
+// SetModelVision records whether the active model accepts image input.
+func SetModelVision(on bool) { modelVision.Store(on) }
+
+// ModelVisionEnabled reports the current setting.
+func ModelVisionEnabled() bool { return modelVision.Load() }


### PR DESCRIPTION
## Summary

A text-only model that `read_file`s an image hallucinates its contents.

The image branch of `read_file` unconditionally returns an image content block plus the one-line receipt `Image: <path> (<mime>, <size>)`. For a model without image input the provider silently drops the image block (e.g. LongCat-2.0's OpenAI-compatible endpoint returns 200 and ignores `image_url` parts), so the model sees only the receipt — it believes the read succeeded and confidently invents what the image shows. Reproduced with LongCat-2.0: it "described" a chat screenshot as a terminal test run that never existed.

## Fix

Gate `read_file`'s image branch on the active model's vision capability, the same way the browser tool already gates screenshots:

- New shared flag `tools.SetModelVision` / `ModelVisionEnabled` (`internal/tools/vision.go`), generalized from the browser-specific `browserVision`. `SetBrowserVision` / `BrowserVisionEnabled` remain as thin aliases so existing callers and tests are untouched.
- The two call sites that already set the flag per turn (`internal/app/bootstrap.go`, `internal/server/handlers_prepare_toolturn.go`) now call the new name; comments updated to reflect the broader scope.
- With vision off, `read_file` on an image returns an instructive refusal: the contents cannot be read or described, do not guess, suggest switching to a vision-capable model. Vision-model behavior is byte-identical.

## Tests

- New `TestReadFile_ImageNonVisionModel`: vision off → no image blocks, refusal text (with `t.Cleanup` restoring the flag).
- Existing `TestReadFile_ReadsImage` unchanged and passing (vision on).
- `go test -race ./internal/tools/ ./internal/app/ ./internal/server/` pass on top of current main; `gofmt` / `go vet` clean.

Follow-up candidate (not in this PR): the TUI paste path (`cmd/octo/tuirepl_view.go`) builds user-message image blocks without a vision check — same failure class, different entry point.

Extracted from #1537 per review feedback; the upload-path commits there are superseded by #1530.

