### PR TITLE
style(blog,docs): unify blog and docs theme with landing page

### DIFF
--- a/blog/public/octo-nav.js
+++ b/blog/public/octo-nav.js
@@ -21,6 +21,13 @@
  *               page can delete its own inline nav + language script.
  */
 (() => {
+	// Both attrs (`alt`) and same-document data-attrs (`data-href-en/zh`) are
+	// treated as untrusted: escape before splicing into innerHTML, and refuse
+	// dangerous URL schemes before handing a value to setAttribute('href', …).
+	const escapeHtml = (s) =>
+		String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+	const safeHref = (s) => (/^\s*(javascript|data|vbscript):/i.test(String(s)) ? '' : s);
+
 	const BLUE = '#1677FF',
 		HOVER = '#4096FF';
 	const MARK = (s) =>
@@ -81,7 +88,7 @@
 		});
 		document.querySelectorAll('[data-href-en],[data-href-zh]').forEach((el) => {
 			const v = el.getAttribute(isZh ? 'data-href-zh' : 'data-href-en');
-			if (v != null) el.setAttribute('href', v);
+			if (v != null) el.setAttribute('href', safeHref(v));
 		});
 		document.querySelectorAll('octo-site-nav[lang-toggle],octo-site-footer[lang-toggle]').forEach((el) => {
 			el.setAttribute('locale', lang);
@@ -99,7 +106,7 @@
 			const t = T[loc];
 			const blogHome = isZh ? '/blog/' : '/blog/en/';
 			const docsHref = isZh ? '/docs/zh/' : '/docs/';
-			const alt = this.getAttribute('alt') || (isZh ? '/blog/en/' : '/blog/');
+			const alt = escapeHtml(safeHref(this.getAttribute('alt')) || (isZh ? '/blog/en/' : '/blog/'));
 			const releases = 'https://github.com/open-octo/octo-agent/releases/latest';
 			const repo = 'https://github.com/open-octo/octo-agent';
 			const sections =

--- a/blog/public/octo-nav.js
+++ b/blog/public/octo-nav.js
@@ -1,0 +1,160 @@
+/*
+ * octo shared chrome — one source of truth for the top nav + footer across
+ * the landing page (static HTML) and the blog (Astro). Drop this one file in
+ * anywhere and use the custom elements; styles are self-contained (shadow DOM)
+ * so the nav looks identical regardless of the host page's CSS.
+ *
+ *   <script src="/octo-nav.js" defer></script>
+ *   <octo-site-nav variant="landing" active="home" locale="en"></octo-site-nav>
+ *   <octo-site-nav variant="site" active="blog" locale="en" alt="/blog/"></octo-site-nav>
+ *   <octo-site-footer locale="en"></octo-site-footer>
+ *
+ * Attributes:
+ *   variant     "landing" (adds in-page section anchors) | "site" (default)
+ *   active      "home" | "docs" | "blog"
+ *   locale      "en" | "zh"
+ *   alt         URL of the alternate-language version of the current page
+ *   lang-toggle present → the EN/中文 pill flips text in place (for the landing
+ *               page's bilingual single-page toggle) instead of navigating.
+ *               It updates every [data-en]/[data-zh] and [data-href-en]/
+ *               [data-href-zh] element in the host document, so the landing
+ *               page can delete its own inline nav + language script.
+ */
+(() => {
+	const BLUE = '#1677FF',
+		HOVER = '#4096FF';
+	const MARK = (s) =>
+		`<svg width="${s}" height="${s}" viewBox="0 0 100 100" aria-hidden="true"><rect width="100" height="100" rx="22" fill="${BLUE}"/><path fill="#fff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/><circle cx="40" cy="42" r="5" fill="${BLUE}"/><circle cx="60" cy="42" r="5" fill="${BLUE}"/></svg>`;
+	const GH =
+		'<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>';
+	const DL =
+		'<svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.5a.75.75 0 01.75.75v6.19l1.72-1.72a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 111.06-1.06l1.72 1.72V2.25A.75.75 0 018 1.5zM2.75 12a.75.75 0 01.75.75v.75c0 .14.11.25.25.25h8.5a.25.25 0 00.25-.25v-.75a.75.75 0 011.5 0v.75A1.75 1.75 0 0112.25 15h-8.5A1.75 1.75 0 012 13.5v-.75a.75.75 0 01.75-.75z"/></svg>';
+
+	const T = {
+		en: { docs: 'Docs', blog: 'Blog', star: 'Star', dl: 'Download', legal: 'MIT licensed',
+			s: [['#arms', 'Interfaces'], ['#features', 'Features'], ['#demo', 'Demo'], ['#faq', 'FAQ']] },
+		zh: { docs: '文档', blog: '博客', star: 'Star', dl: '下载', legal: 'MIT 许可',
+			s: [['#arms', '界面'], ['#features', '特性'], ['#demo', '演示'], ['#faq', '常见问题']] },
+	};
+
+	const BASE = `
+		:host{display:block;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"PingFang SC","Microsoft YaHei",sans-serif;}
+		a{text-decoration:none;color:inherit;}
+		.nav{position:sticky;top:0;z-index:100;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);border-bottom:1px solid #EEEFF1;}
+		.inner{max-width:1080px;margin:0 auto;display:flex;align-items:center;gap:24px;height:60px;padding:0 24px;}
+		.brand{display:flex;align-items:center;gap:10px;color:rgba(0,0,0,.88);font-weight:600;font-size:17px;}
+		.brand svg{display:block;}
+		.links{flex:1;display:flex;gap:24px;margin-left:16px;font-size:14px;}
+		.links a{color:rgba(0,0,0,.65);}
+		.links a:hover{color:${BLUE};}
+		.links a.active{color:${BLUE};font-weight:600;}
+		.ghost{display:inline-flex;align-items:center;gap:8px;padding:5px 14px;border:1px solid #D9D9D9;border-radius:6px;font-size:13px;font-weight:600;color:rgba(0,0,0,.88);}
+		.ghost:hover{border-color:${HOVER};color:${BLUE};}
+		.lang{display:inline-flex;align-items:center;border:1px solid #D9D9D9;border-radius:9999px;padding:2px;font-size:12px;font-weight:600;}
+		.lang .seg{color:rgba(0,0,0,.45);padding:3px 12px;border-radius:9999px;line-height:1;}
+		.lang .seg.active{background:${BLUE};color:#fff;}
+		.lang a.seg:hover{color:${BLUE};}
+		.lang a.seg.active:hover{color:#fff;}
+		.cta{display:inline-flex;align-items:center;gap:8px;padding:6px 16px;background:${BLUE};border-radius:6px;color:#fff;font-size:14px;font-weight:600;}
+		.cta:hover{background:${HOVER};}
+		@media(max-width:820px){.inner{gap:12px;padding:0 16px;}.links{gap:16px;margin-left:8px;}.lang{display:none;}}
+		@media(max-width:560px){.ghost span{display:none;}.links{display:none;}}
+	`;
+	const FOOT = `
+		:host{display:block;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;}
+		a{text-decoration:none;}
+		.foot{border-top:1px solid #EEEFF1;background:#fff;padding:40px 0;}
+		.inner{max-width:1080px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;font-size:13px;color:rgba(0,0,0,.45);}
+		.inner svg{display:block;}
+		.links{display:flex;gap:20px;margin-left:auto;}
+		.links a{color:rgba(0,0,0,.65);}
+		.links a:hover{color:${BLUE};}
+	`;
+
+	// Flip every bilingual node in the host document (landing-page toggle).
+	function applyLang(lang) {
+		const isZh = lang === 'zh';
+		document.documentElement.lang = isZh ? 'zh-CN' : 'en';
+		document.querySelectorAll('[data-en],[data-zh]').forEach((el) => {
+			const v = el.getAttribute(isZh ? 'data-zh' : 'data-en');
+			if (v != null) el.textContent = v;
+		});
+		document.querySelectorAll('[data-href-en],[data-href-zh]').forEach((el) => {
+			const v = el.getAttribute(isZh ? 'data-href-zh' : 'data-href-en');
+			if (v != null) el.setAttribute('href', v);
+		});
+		document.querySelectorAll('octo-site-nav[lang-toggle],octo-site-footer[lang-toggle]').forEach((el) => {
+			el.setAttribute('locale', lang);
+			el.connectedCallback && el.connectedCallback();
+		});
+	}
+
+	class Nav extends HTMLElement {
+		connectedCallback() {
+			const loc = this.getAttribute('locale') === 'zh' ? 'zh' : 'en';
+			const active = this.getAttribute('active') || '';
+			const variant = this.getAttribute('variant') || 'site';
+			const toggle = this.hasAttribute('lang-toggle');
+			const isZh = loc === 'zh';
+			const t = T[loc];
+			const blogHome = isZh ? '/blog/' : '/blog/en/';
+			const docsHref = isZh ? '/docs/zh/' : '/docs/';
+			const alt = this.getAttribute('alt') || (isZh ? '/blog/en/' : '/blog/');
+			const releases = 'https://github.com/open-octo/octo-agent/releases/latest';
+			const repo = 'https://github.com/open-octo/octo-agent';
+			const sections =
+				variant === 'landing'
+					? t.s.map(([h, l]) => `<a href="${h}">${l}</a>`).join('')
+					: '';
+			const cls = (k) => (active === k ? ' class="active"' : '');
+			const langPill = toggle
+				? `<div class="lang" role="group" aria-label="Language">
+						<button type="button" class="seg${isZh ? ' active' : ''}" data-lang="zh">中文</button>
+						<button type="button" class="seg${isZh ? '' : ' active'}" data-lang="en">EN</button>
+					</div>`
+				: `<div class="lang" role="group" aria-label="Language">
+						<a class="seg${isZh ? ' active' : ''}"${isZh ? '' : ` href="${alt}"`}>中文</a>
+						<a class="seg${isZh ? '' : ' active'}"${isZh ? ` href="${alt}"` : ''}>EN</a>
+					</div>`;
+			const root = this.shadowRoot || this.attachShadow({ mode: 'open' });
+			root.innerHTML = `<style>${BASE}${toggle ? '.lang button{background:none;border:0;cursor:pointer;font:inherit;}' : ''}</style>
+				<div class="nav"><div class="inner">
+					<a class="brand" href="https://octo-agent.dev/">${MARK(28)} Octo</a>
+					<nav class="links">
+						${sections}
+						<a href="${docsHref}"${cls('docs')}>${t.docs}</a>
+						<a href="${blogHome}"${cls('blog')}>${t.blog}</a>
+					</nav>
+					<a class="ghost" href="${repo}">${GH}<span>${t.star}</span></a>
+					${langPill}
+					<a class="cta" href="${releases}">${DL}<span>${t.dl}</span></a>
+				</div></div>`;
+			if (toggle) {
+				root.querySelectorAll('.lang button').forEach((b) =>
+					b.addEventListener('click', () => applyLang(b.dataset.lang)),
+				);
+			}
+		}
+	}
+
+	class Footer extends HTMLElement {
+		connectedCallback() {
+			const loc = this.getAttribute('locale') === 'zh' ? 'zh' : 'en';
+			const isZh = loc === 'zh';
+			const t = T[loc];
+			const docsHref = isZh ? '/docs/zh/' : '/docs/';
+			const blogHome = isZh ? '/blog/' : '/blog/en/';
+			const year = new Date().getFullYear();
+			const root = this.shadowRoot || this.attachShadow({ mode: 'open' });
+			root.innerHTML = `<style>${FOOT}</style>
+				<div class="foot"><div class="inner">
+					${MARK(20)}
+					<span>© ${year} octo-agent · ${t.legal}</span>
+					<div class="links"><a href="${docsHref}">${t.docs}</a><a href="${blogHome}">${t.blog}</a><a href="https://github.com/open-octo/octo-agent">GitHub</a></div>
+				</div></div>`;
+		}
+	}
+
+	if (!customElements.get('octo-site-nav')) customElements.define('octo-site-nav', Nav);
+	if (!customElements.get('octo-site-footer')) customElements.define('octo-site-footer', Footer);
+})();

--- a/blog/src/components/SiteFooter.astro
+++ b/blog/src/components/SiteFooter.astro
@@ -1,0 +1,10 @@
+---
+/** Thin wrapper around the shared /octo-nav.js footer component. */
+interface Props {
+	locale?: 'zh' | 'en';
+}
+const { locale = 'zh' } = Astro.props;
+---
+
+<script is:inline src="/octo-nav.js" defer></script>
+<octo-site-footer locale={locale}></octo-site-footer>

--- a/blog/src/components/SiteFooter.astro
+++ b/blog/src/components/SiteFooter.astro
@@ -4,7 +4,8 @@ interface Props {
 	locale?: 'zh' | 'en';
 }
 const { locale = 'zh' } = Astro.props;
+const navSrc = import.meta.env.BASE_URL.replace(/\/?$/, '/') + 'octo-nav.js';
 ---
 
-<script is:inline src="/octo-nav.js" defer></script>
+<script is:inline src={navSrc} defer></script>
 <octo-site-footer locale={locale}></octo-site-footer>

--- a/blog/src/components/SiteHeader.astro
+++ b/blog/src/components/SiteHeader.astro
@@ -10,7 +10,8 @@ interface Props {
 	alternateUrl?: string;
 }
 const { locale = 'zh', active = 'blog', alternateUrl } = Astro.props;
+const navSrc = import.meta.env.BASE_URL.replace(/\/?$/, '/') + 'octo-nav.js';
 ---
 
-<script is:inline src="/octo-nav.js" defer></script>
+<script is:inline src={navSrc} defer></script>
 <octo-site-nav variant="site" locale={locale} active={active} alt={alternateUrl}></octo-site-nav>

--- a/blog/src/components/SiteHeader.astro
+++ b/blog/src/components/SiteHeader.astro
@@ -1,0 +1,16 @@
+---
+/**
+ * Thin wrapper around the shared web component in /octo-nav.js — the single
+ * source of truth for the nav across the landing page and the blog.
+ * (Copy shared/octo-nav.js to blog/public/octo-nav.js so it serves at /octo-nav.js.)
+ */
+interface Props {
+	locale?: 'zh' | 'en';
+	active?: 'blog' | 'docs' | 'home';
+	alternateUrl?: string;
+}
+const { locale = 'zh', active = 'blog', alternateUrl } = Astro.props;
+---
+
+<script is:inline src="/octo-nav.js" defer></script>
+<octo-site-nav variant="site" locale={locale} active={active} alt={alternateUrl}></octo-site-nav>

--- a/blog/src/layouts/BlogPost.astro
+++ b/blog/src/layouts/BlogPost.astro
@@ -1,11 +1,14 @@
 ---
 import type { CollectionEntry } from 'astro:content';
+import SiteHeader from '../components/SiteHeader.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import '../styles/blog.css';
 
 type Props = CollectionEntry<'posts'>['data'] & { slug?: string; locale?: string; alternateSlug?: string };
 
 const { title, description, pubDate, updatedDate, author, tags, image, slug, locale = 'zh', alternateSlug } = Astro.props;
-const dateFormatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', {
+const isZh = locale === 'zh';
+const dateFormatter = new Intl.DateTimeFormat(isZh ? 'zh-CN' : 'en-US', {
 	year: 'numeric',
 	month: 'long',
 	day: 'numeric',
@@ -13,30 +16,22 @@ const dateFormatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US
 
 const siteUrl = 'https://octo-agent.dev';
 const pageSlug = slug ?? '';
-const canonicalPath = pageSlug.startsWith('en/')
-	? `/blog/posts/${pageSlug}/`
-	: `/blog/posts/${pageSlug}/`;
-const canonicalUrl = `${siteUrl}${canonicalPath}`;
+const canonicalUrl = `${siteUrl}/blog/posts/${pageSlug}/`;
 
-const navLabels = {
-	en: { home: 'octo blog', landing: 'Octo', docs: 'Docs', github: 'GitHub', lang: 'EN' },
-	zh: { home: 'octo 博客', landing: 'Octo', docs: '文档', github: 'GitHub', lang: '中文' },
-};
-const labels = navLabels[locale as keyof typeof navLabels] || navLabels.zh;
+const blogHome = isZh ? '/blog/' : '/blog/en/';
+const backLabel = isZh ? '返回博客' : 'Back to Blog';
 
-const alternateLocale = locale === 'zh' ? 'en' : 'zh';
+const alternateLocale = isZh ? 'en' : 'zh';
 const alternateUrl = alternateSlug
 	? `${siteUrl}/blog/posts/${alternateLocale === 'en' ? 'en/' : ''}${alternateSlug}/`
 	: `${siteUrl}/blog/${alternateLocale === 'zh' ? '' : 'en/'}`;
-const alternateLabel = locale === 'zh' ? 'English' : '中文';
 
 const ogImage = image ? (image.startsWith('http') ? image : `${siteUrl}${image}`) : `${siteUrl}/blog/og-default.svg`;
-const ogType = 'article';
-const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
+const siteName = isZh ? 'octo 博客' : 'octo blog';
 ---
 
 <!DOCTYPE html>
-<html lang={locale === 'zh' ? 'zh-CN' : 'en'}>
+<html lang={isZh ? 'zh-CN' : 'en'}>
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -50,8 +45,8 @@ const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
 		<meta property="og:title" content={title} />
 		<meta property="og:description" content={description} />
 		<meta property="og:url" content={canonicalUrl} />
-		<meta property="og:type" content={ogType} />
-		<meta property="og:locale" content={locale === 'zh' ? 'zh-CN' : 'en'} />
+		<meta property="og:type" content="article" />
+		<meta property="og:locale" content={isZh ? 'zh-CN' : 'en'} />
 		<meta property="og:site_name" content={siteName} />
 		<meta property="og:image" content={ogImage} />
 
@@ -68,37 +63,32 @@ const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
 		{tags.map((tag) => <meta property="article:tag" content={tag} />)}
 	</head>
 	<body>
-		<header class="site-header">
-			<div class="container">
-				<a href={locale === 'zh' ? '/blog/' : '/blog/en/'} class="site-title">{labels.home}</a>
-				<nav class="site-nav">
-					<a href="https://octo-agent.dev/">{labels.landing}</a>
-					<a href="/docs/">{labels.docs}</a>
-					<a href="https://github.com/open-octo/octo-agent">{labels.github}</a>
-					<a class="lang-switch" href={alternateUrl} title={alternateLabel}>{alternateLabel}</a>
-				</nav>
-			</div>
-		</header>
+		<SiteHeader locale={isZh ? 'zh' : 'en'} active="blog" alternateUrl={alternateUrl} />
 
-		<main class="container">
+		<main>
 			<article class="blog-post">
+				<a href={blogHome} class="back-link">
+					<svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 3 5 8l5 5"></path></svg>
+					{backLabel}
+				</a>
+
 				<header class="post-header">
 					<h1>{title}</h1>
 					<p class="post-meta">
 						<time datetime={pubDate.toISOString()}>{dateFormatter.format(pubDate)}</time>
 						{updatedDate && (
 							<>
-								{' · updated '}
-								<time datetime={updatedDate.toISOString()}>{dateFormatter.format(updatedDate)}</time>
+								<span>·</span>
+								<span>{isZh ? '更新于' : 'updated'} {dateFormatter.format(updatedDate)}</span>
 							</>
 						)}
-						{' · '}
+						<span>·</span>
 						<span class="author">{author}</span>
 					</p>
 					{tags.length > 0 && (
 						<div class="tags">
 							{tags.map((tag) => (
-								<span class="tag">{tag}</span>
+								<span class="tag brand">{tag}</span>
 							))}
 						</div>
 					)}
@@ -110,13 +100,7 @@ const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
 			</article>
 		</main>
 
-		<footer class="site-footer">
-			<div class="container">
-				<p>
-					© {new Date().getFullYear()} <a href="https://octo-agent.dev/">octo-agent</a>. Built with <a href="https://astro.build">Astro</a>.
-				</p>
-			</div>
-		</footer>
+		<SiteFooter locale={isZh ? 'zh' : 'en'} />
 
 		<script type="module">
 			import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
@@ -130,9 +114,6 @@ const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
 				container.className = 'mermaid-diagram';
 				container.id = 'mermaid-container-' + suffix;
 				pre.replaceWith(container);
-				// mermaid.render() creates and then removes a temporary DOM node
-				// with this id internally, so it must differ from container.id
-				// or mermaid ends up deleting our own container instead.
 				mermaid.render('mermaid-render-' + suffix, source).then(({ svg }) => {
 					container.innerHTML = svg;
 				}).catch((err) => {

--- a/blog/src/pages/en/index.astro
+++ b/blog/src/pages/en/index.astro
@@ -1,16 +1,21 @@
 ---
 import { getCollection } from 'astro:content';
+import SiteHeader from '../../components/SiteHeader.astro';
+import SiteFooter from '../../components/SiteFooter.astro';
 import '../../styles/blog.css';
 
 const posts = (await getCollection('posts'))
 	.filter((post) => !post.data.draft && post.data.locale === 'en')
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
+const [featured, ...rest] = posts;
+
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	year: 'numeric',
 	month: 'long',
 	day: 'numeric',
 });
+const href = (post) => `/blog/posts/${post.id}/`;
 
 const siteUrl = 'https://octo-agent.dev';
 const canonicalUrl = `${siteUrl}/blog/en/`;
@@ -45,62 +50,72 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 		<meta name="twitter:image" content={ogImage} />
 	</head>
 	<body>
-		<header class="site-header">
+		<SiteHeader locale="en" active="blog" alternateUrl={alternateUrl} />
+
+		<section class="hero">
 			<div class="container">
-				<a href="/blog/en/" class="site-title">octo blog</a>
-				<nav class="site-nav">
-					<a href="https://octo-agent.dev/">Octo</a>
-					<a href="/docs/">Docs</a>
-					<a href="https://github.com/open-octo/octo-agent">GitHub</a>
-					<a class="lang-switch" href={alternateUrl} title="中文">中文</a>
-				</nav>
-			</div>
-		</header>
-
-		<main class="container">
-			<section class="hero">
+				<span class="kicker">Engineering notes from the Octo team</span>
 				<h1>octo blog</h1>
-				<p>
-					Engineering notes, release updates, and deep dives from the octo-agent team.
-				</p>
-			</section>
+				<p>Release notes, deep dives on Loop Engineering, and field reports on building a private, self-hosted AI agent.</p>
+			</div>
+		</section>
 
-			<section class="post-list">
+		<main class="post-list">
+			<div class="post-list-head">
 				<h2>Latest posts</h2>
-				{posts.length === 0 && <p>No posts yet.</p>}
-				<ul>
-					{
-						posts.map((post) => (
-							<li class="post-card">
-								<a href={`/blog/posts/${post.id}/`} class="post-card-title">
-									{post.data.title}
-								</a>
+				<div class="rule"></div>
+			</div>
+
+			{posts.length === 0 && <p>No posts yet.</p>}
+
+			{
+				featured && (
+					<a href={href(featured)} class="post-card featured">
+						<span class="flag">Featured</span>
+						<span class="post-card-title">{featured.data.title}</span>
+						<p class="post-card-description">{featured.data.description}</p>
+						<p class="post-card-meta">
+							<time datetime={featured.data.pubDate.toISOString()}>
+								{dateFormatter.format(featured.data.pubDate)}
+							</time>
+							<span>·</span>
+							<span>{featured.data.author}</span>
+							<span class="tags">
+								{featured.data.tags.slice(0, 2).map((tag) => (
+									<span class="tag brand">{tag}</span>
+								))}
+							</span>
+						</p>
+					</a>
+				)
+			}
+
+			<ul>
+				{
+					rest.map((post) => (
+						<li>
+							<a href={href(post)} class="post-card">
+								<span class="post-card-title">{post.data.title}</span>
 								<p class="post-card-description">{post.data.description}</p>
 								<p class="post-card-meta">
 									<time datetime={post.data.pubDate.toISOString()}>
 										{dateFormatter.format(post.data.pubDate)}
 									</time>
-									{' · '}
-									{post.data.tags.slice(0, 3).map((tag, i) => (
-											<>
-												{i > 0 && ', '}
-												<span class="tag">{tag}</span>
-											</>
-									))}
+									<span>·</span>
+									<span>{post.data.author}</span>
+									<span class="tags">
+										{post.data.tags.slice(0, 2).map((tag) => (
+											<span class="tag">{tag}</span>
+										))}
+									</span>
 								</p>
-							</li>
-						))
-					}
-				</ul>
-			</section>
+							</a>
+						</li>
+					))
+				}
+			</ul>
 		</main>
 
-		<footer class="site-footer">
-			<div class="container">
-				<p>
-					© {new Date().getFullYear()} <a href="https://octo-agent.dev/">octo-agent</a>. Built with <a href="https://astro.build">Astro</a>.
-				</p>
-			</div>
-		</footer>
+		<SiteFooter locale="en" />
 	</body>
 </html>

--- a/blog/src/pages/index.astro
+++ b/blog/src/pages/index.astro
@@ -1,22 +1,28 @@
 ---
 import { getCollection } from 'astro:content';
+import SiteHeader from '../components/SiteHeader.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import '../styles/blog.css';
 
 const posts = (await getCollection('posts'))
 	.filter((post) => !post.data.draft && post.data.locale === 'zh')
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
+const [featured, ...rest] = posts;
+
 const dateFormatter = new Intl.DateTimeFormat('zh-CN', {
 	year: 'numeric',
 	month: 'long',
 	day: 'numeric',
 });
+const href = (post) => `/blog/posts/${post.id.slice(3)}/`;
 
 const siteUrl = 'https://octo-agent.dev';
 const canonicalUrl = `${siteUrl}/blog/`;
 const alternateUrl = `${siteUrl}/blog/en/`;
 const title = 'octo 博客';
-const description = 'octo-agent 团队的工程笔记、版本更新与 AI Agent 技术深度文章，分享 Loop Engineering、工具链与实战经验。';
+const description =
+	'octo-agent 团队的工程笔记、版本更新与 AI Agent 技术深度文章，分享 Loop Engineering、工具链与实战经验。';
 const ogImage = `${siteUrl}/blog/og-default.svg`;
 ---
 
@@ -45,62 +51,72 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 		<meta name="twitter:image" content={ogImage} />
 	</head>
 	<body>
-		<header class="site-header">
+		<SiteHeader locale="zh" active="blog" alternateUrl={alternateUrl} />
+
+		<section class="hero">
 			<div class="container">
-				<a href="/blog/" class="site-title">octo 博客</a>
-				<nav class="site-nav">
-					<a href="https://octo-agent.dev/">Octo</a>
-					<a href="/docs/">文档</a>
-					<a href="https://github.com/open-octo/octo-agent">GitHub</a>
-					<a class="lang-switch" href={alternateUrl} title="English">English</a>
-				</nav>
-			</div>
-		</header>
-
-		<main class="container">
-			<section class="hero">
+				<span class="kicker">Octo 团队的工程笔记</span>
 				<h1>octo 博客</h1>
-				<p>
-					octo-agent 团队的工程笔记、版本更新与技术深度文章。
-				</p>
-			</section>
+				<p>版本说明、Loop Engineering 深度解析，以及构建私密、自托管 AI Agent 的一线实践。</p>
+			</div>
+		</section>
 
-			<section class="post-list">
+		<main class="post-list">
+			<div class="post-list-head">
 				<h2>最新文章</h2>
-				{posts.length === 0 && <p>暂无文章。</p>}
-				<ul>
-					{
-						posts.map((post) => (
-							<li class="post-card">
-								<a href={`/blog/posts/${post.id.slice(3)}/`} class="post-card-title">
-									{post.data.title}
-								</a>
+				<div class="rule"></div>
+			</div>
+
+			{posts.length === 0 && <p>暂无文章。</p>}
+
+			{
+				featured && (
+					<a href={href(featured)} class="post-card featured">
+						<span class="flag">精选</span>
+						<span class="post-card-title">{featured.data.title}</span>
+						<p class="post-card-description">{featured.data.description}</p>
+						<p class="post-card-meta">
+							<time datetime={featured.data.pubDate.toISOString()}>
+								{dateFormatter.format(featured.data.pubDate)}
+							</time>
+							<span>·</span>
+							<span>{featured.data.author}</span>
+							<span class="tags">
+								{featured.data.tags.slice(0, 2).map((tag) => (
+									<span class="tag brand">{tag}</span>
+								))}
+							</span>
+						</p>
+					</a>
+				)
+			}
+
+			<ul>
+				{
+					rest.map((post) => (
+						<li>
+							<a href={href(post)} class="post-card">
+								<span class="post-card-title">{post.data.title}</span>
 								<p class="post-card-description">{post.data.description}</p>
 								<p class="post-card-meta">
 									<time datetime={post.data.pubDate.toISOString()}>
 										{dateFormatter.format(post.data.pubDate)}
 									</time>
-									{' · '}
-									{post.data.tags.slice(0, 3).map((tag, i) => (
-										<>
-											{i > 0 && ', '}
+									<span>·</span>
+									<span>{post.data.author}</span>
+									<span class="tags">
+										{post.data.tags.slice(0, 2).map((tag) => (
 											<span class="tag">{tag}</span>
-										</>
-									))}
+										))}
+									</span>
 								</p>
-							</li>
-						))
-					}
-				</ul>
-			</section>
+							</a>
+						</li>
+					))
+				}
+			</ul>
 		</main>
 
-		<footer class="site-footer">
-			<div class="container">
-				<p>
-					© {new Date().getFullYear()} <a href="https://octo-agent.dev/">octo-agent</a>. Built with <a href="https://astro.build">Astro</a>.
-				</p>
-			</div>
-		</footer>
+		<SiteFooter locale="zh" />
 	</body>
 </html>

--- a/blog/src/styles/blog.css
+++ b/blog/src/styles/blog.css
@@ -1,116 +1,241 @@
-:root {
-	color-scheme: light dark;
-	--color-bg: #ffffff;
-	--color-text: #1f2937;
-	--color-text-muted: #6b7280;
-	/* Brand indigo — matches the landing page and docs (--accent #4f46e5). */
-	--color-accent: #4f46e5;
-	--color-accent-dark: #4338ca;
-	--color-border: #e5e7eb;
-	--color-code-bg: #f3f4f6;
-	--font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-	--font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
-	--max-width: 760px;
-}
+/*
+ * octo blog — unified with the landing page (octo-agent/landing/index.html).
+ * Ant Blue #1677FF, native system stack, flat white, light-only. No dark mode.
+ * Tokens mirror the landing page's :root exactly.
+ */
 
-/* Dark theme, following the viewer's OS preference — the same palette the
-   landing page uses, so the blog matches the rest of the brand in both modes.
-   In dark mode the hover accent goes lighter (a5b4fc), mirroring the landing. */
-@media (prefers-color-scheme: dark) {
-	:root {
-		--color-bg: #0b0f19;
-		--color-text: #f3f4f6;
-		--color-text-muted: #9ca3af;
-		--color-accent: #818cf8;
-		--color-accent-dark: #a5b4fc;
-		--color-border: #1f2937;
-		--color-code-bg: #111827;
-	}
+:root {
+	--blue: #1677ff;
+	--blue-hover: #4096ff;
+	--blue-active: #0958d9;
+	--blue-soft: #e6f4ff;
+	--blue-wash: #f0f7ff;
+	--blue-line: #bae0ff;
+
+	--ink: #1f1f1f;
+	--t88: rgba(0, 0, 0, 0.88);
+	--t78: rgba(0, 0, 0, 0.78);
+	--t65: rgba(0, 0, 0, 0.65);
+	--t45: rgba(0, 0, 0, 0.45);
+
+	--line: #eeeff1;
+	--line2: #f0f0f0;
+	--ctrl: #d9d9d9;
+	--canvas: #fafafa;
+
+	--font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+		"Helvetica Neue", Arial, "PingFang SC", "Microsoft YaHei", sans-serif;
+	--font-mono: "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+	--reading: 720px;
+	--content: 820px;
 }
 
 * {
 	box-sizing: border-box;
 }
 
+html {
+	scroll-behavior: smooth;
+}
+
 body {
 	margin: 0;
-	font-family: var(--font-sans);
-	background-color: var(--color-bg);
-	color: var(--color-text);
+	background: #fff;
+	color: var(--t88);
 	line-height: 1.7;
+	font-family: var(--font-sans);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 a {
-	color: var(--color-accent);
+	color: var(--blue);
 	text-decoration: none;
 }
-
 a:hover {
-	color: var(--color-accent-dark);
-	text-decoration: underline;
+	color: var(--blue-hover);
+}
+
+::selection {
+	background: var(--blue-line);
 }
 
 .container {
-	max-width: var(--max-width);
+	max-width: var(--content);
 	margin: 0 auto;
-	padding: 0 1.5rem;
+	padding: 0 24px;
 }
 
+/* ---------- nav ---------- */
 .site-header {
-	border-bottom: 1px solid var(--color-border);
-	padding: 1rem 0;
+	position: sticky;
+	top: 0;
+	z-index: 100;
+	background: rgba(255, 255, 255, 0.92);
+	backdrop-filter: blur(8px);
+	border-bottom: 1px solid var(--line);
 }
-
-.site-header .container {
+.nav-inner {
+	max-width: 1080px;
+	margin: 0 auto;
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
+	gap: 24px;
+	height: 60px;
+	padding: 0 24px;
+}
+.brand {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	color: var(--t88);
+	font-weight: 600;
+	font-size: 17px;
+}
+.brand:hover {
+	color: var(--t88);
+}
+.brand svg {
+	display: block;
+}
+.navlinks {
+	flex: 1;
+	display: flex;
+	gap: 24px;
+	margin-left: 16px;
+	font-size: 14px;
+}
+.navlinks a {
+	color: var(--t65);
+}
+.navlinks a:hover {
+	color: var(--blue);
+}
+.navlinks a.active {
+	color: var(--blue);
+	font-weight: 600;
+}
+.ghost {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 5px 14px;
+	border: 1px solid var(--ctrl);
+	border-radius: 6px;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--t88);
+}
+.ghost:hover {
+	border-color: var(--blue-hover);
+	color: var(--blue);
+}
+.lang {
+	display: inline-flex;
+	align-items: center;
+	border: 1px solid var(--ctrl);
+	border-radius: 9999px;
+	padding: 2px;
+	font-size: 12px;
+	font-weight: 600;
+}
+.lang .seg {
+	color: var(--t45);
+	padding: 3px 12px;
+	border-radius: 9999px;
+	line-height: 1;
+}
+.lang .seg.active {
+	background: var(--blue);
+	color: #fff;
+}
+.lang a.seg:hover {
+	color: var(--blue);
+}
+.lang a.seg.active:hover {
+	color: #fff;
+}
+.nav-cta {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 16px;
+	background: var(--blue);
+	border-radius: 6px;
+	color: #fff;
+	font-size: 14px;
+	font-weight: 600;
+}
+.nav-cta:hover {
+	background: var(--blue-hover);
+	color: #fff;
 }
 
-.site-title {
-	font-size: 1.25rem;
-	font-weight: 700;
-	color: var(--color-text);
-}
-
-.site-nav a {
-	margin-left: 1.5rem;
-	color: var(--color-text-muted);
-	font-size: 0.95rem;
-}
-
-.site-nav a:hover {
-	color: var(--color-text);
-}
-
+/* ---------- hero ---------- */
 .hero {
-	padding: 4rem 0 2rem;
-	border-bottom: 1px solid var(--color-border);
+	background: linear-gradient(180deg, var(--blue-wash) 0%, #fff 100%);
+	border-bottom: 1px solid var(--line);
+	padding: 64px 0 40px;
 }
-
+.hero .container {
+	max-width: var(--content);
+}
+.hero .kicker {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 14px;
+	border: 1px solid rgba(22, 119, 255, 0.5);
+	background: rgba(22, 119, 255, 0.06);
+	border-radius: 9999px;
+	font-size: 12.5px;
+	font-weight: 600;
+	color: var(--blue);
+	margin-bottom: 20px;
+}
 .hero h1 {
-	font-size: 2.5rem;
-	margin: 0 0 0.75rem;
-	letter-spacing: -0.02em;
+	font-size: 44px;
+	line-height: 1.1;
+	letter-spacing: -0.03em;
+	font-weight: 600;
+	color: var(--ink);
+	margin: 0 0 12px;
 }
-
 .hero p {
-	font-size: 1.15rem;
-	color: var(--color-text-muted);
+	font-size: 18px;
+	line-height: 1.6;
+	color: var(--t65);
 	margin: 0;
+	max-width: 560px;
+	text-wrap: pretty;
 }
 
+/* ---------- post list ---------- */
 .post-list {
-	padding: 3rem 0;
+	max-width: var(--content);
+	margin: 0 auto;
+	padding: 48px 24px 24px;
 }
-
-.post-list h2 {
-	font-size: 1.25rem;
-	margin-bottom: 1.5rem;
-	color: var(--color-text-muted);
-	font-weight: 500;
+.post-list-head {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 24px;
 }
-
+.post-list-head h2 {
+	margin: 0;
+	font-size: 14px;
+	font-weight: 600;
+	letter-spacing: 0.5px;
+	text-transform: uppercase;
+	color: var(--t45);
+}
+.post-list-head .rule {
+	flex: 1;
+	height: 1px;
+	background: var(--line2);
+}
 .post-list ul {
 	list-style: none;
 	padding: 0;
@@ -118,218 +243,381 @@ a:hover {
 }
 
 .post-card {
-	padding: 1.5rem 0;
-	border-bottom: 1px solid var(--color-border);
+	display: block;
+	padding: 24px 4px;
+	border-bottom: 1px solid var(--line2);
+	color: inherit;
 }
-
 .post-card:last-child {
 	border-bottom: none;
 }
-
+.post-card:hover {
+	background: rgba(22, 119, 255, 0.03);
+	color: inherit;
+}
 .post-card-title {
-	font-size: 1.35rem;
-	font-weight: 700;
-	color: var(--color-text);
+	font-size: 19px;
+	font-weight: 600;
+	color: var(--ink);
 	display: block;
-	margin-bottom: 0.5rem;
+	margin-bottom: 6px;
+	line-height: 1.3;
 }
-
+.post-card:hover .post-card-title {
+	color: var(--blue);
+}
 .post-card-description {
-	color: var(--color-text-muted);
-	margin: 0 0 0.75rem;
+	color: var(--t65);
+	margin: 0 0 12px;
+	font-size: 14.5px;
+	line-height: 1.6;
+}
+.post-card-meta {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	font-size: 13px;
+	color: var(--t45);
+	margin: 0;
+}
+.post-card-meta .tags {
+	display: flex;
+	gap: 6px;
+	margin-left: auto;
 }
 
-.post-card-meta {
-	font-size: 0.875rem;
-	color: var(--color-text-muted);
+/* featured card (first / pinned post) */
+.post-card.featured {
+	border: 1px solid rgba(22, 119, 255, 0.25);
+	background: var(--blue-wash);
+	border-radius: 16px;
+	padding: 28px;
+	margin-bottom: 16px;
+}
+.post-card.featured:hover {
+	border-color: rgba(22, 119, 255, 0.5);
+	background: var(--blue-wash);
+}
+.post-card.featured .flag {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 11.5px;
+	font-weight: 600;
+	color: var(--blue);
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	margin-bottom: 12px;
+}
+.post-card.featured .post-card-title {
+	font-size: 24px;
+	letter-spacing: -0.01em;
+	margin-bottom: 10px;
+}
+.post-card.featured .post-card-description {
+	font-size: 15px;
+}
+
+/* tag chips */
+.tag {
+	font-size: 12px;
+	color: var(--t65);
+	background: var(--canvas);
+	border: 1px solid var(--line);
+	padding: 1px 9px;
+	border-radius: 4px;
+}
+.tag.brand {
+	color: var(--blue);
+	background: var(--blue-soft);
+	border-color: var(--blue-line);
+}
+
+/* ---------- article ---------- */
+.blog-post {
+	max-width: var(--reading);
+	margin: 0 auto;
+	padding: 44px 24px 8px;
+}
+.back-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--t65);
+	margin-bottom: 28px;
+}
+.back-link:hover {
+	color: var(--blue);
+}
+.back-link svg {
+	display: block;
+}
+.post-header {
+	padding-bottom: 28px;
+	border-bottom: 1px solid var(--line);
+	margin-bottom: 36px;
+}
+.post-header h1 {
+	font-size: 38px;
+	line-height: 1.15;
+	letter-spacing: -0.02em;
+	font-weight: 600;
+	color: var(--ink);
+	margin: 0 0 16px;
+	text-wrap: pretty;
+}
+.post-meta {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	color: var(--t45);
+	font-size: 14px;
+	margin: 0 0 14px;
+}
+.post-meta .author {
+	color: var(--t65);
+}
+.post-header .tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
 	margin: 0;
 }
 
-.blog-post {
-	padding: 3rem 0;
+/* ---------- prose ---------- */
+.post-content {
+	font-size: 16.5px;
+	line-height: 1.75;
+	color: var(--t78);
 }
-
-.post-header {
-	margin-bottom: 2.5rem;
-	padding-bottom: 2rem;
-	border-bottom: 1px solid var(--color-border);
+.post-content > :first-child {
+	margin-top: 0;
 }
-
-.post-header h1 {
-	font-size: 2.25rem;
-	margin: 0 0 1rem;
-	letter-spacing: -0.02em;
-	line-height: 1.2;
+/* the markdown H1 duplicates the page title — hide it */
+.post-content > h1:first-of-type {
+	display: none;
 }
-
-.post-meta {
-	color: var(--color-text-muted);
-	font-size: 0.95rem;
-	margin: 0 0 1rem;
-}
-
-.post-content h1,
-.post-content h2,
-.post-content h3,
-.post-content h4 {
-	margin-top: 2.5rem;
-	margin-bottom: 1rem;
-	line-height: 1.3;
-}
-
 .post-content h2 {
-	font-size: 1.75rem;
-	border-bottom: 1px solid var(--color-border);
-	padding-bottom: 0.5rem;
+	margin: 40px 0 14px;
+	font-size: 26px;
+	font-weight: 600;
+	letter-spacing: -0.01em;
+	line-height: 1.3;
+	color: var(--ink);
 }
-
 .post-content h3 {
-	font-size: 1.35rem;
+	margin: 32px 0 12px;
+	font-size: 20px;
+	font-weight: 600;
+	line-height: 1.35;
+	color: var(--ink);
 }
-
 .post-content p,
 .post-content ul,
 .post-content ol {
-	margin: 1rem 0;
+	margin: 0 0 20px;
 }
-
 .post-content ul,
 .post-content ol {
-	padding-left: 1.5rem;
+	padding-left: 1.4em;
 }
-
 .post-content li {
 	margin: 0.35rem 0;
 }
-
+.post-content strong {
+	font-weight: 600;
+	color: var(--ink);
+}
+.post-content a {
+	color: var(--blue);
+	text-decoration: none;
+	border-bottom: 1px solid rgba(22, 119, 255, 0.3);
+}
+.post-content a:hover {
+	color: var(--blue-hover);
+	border-bottom-color: var(--blue-hover);
+}
 .post-content img {
 	max-width: 100%;
 	height: auto;
 	display: block;
-	margin: 1.5rem 0;
-	border-radius: 0.5rem;
-	border: 1px solid var(--color-border);
+	margin: 24px 0;
+	border-radius: 12px;
+	border: 1px solid var(--line);
 }
-
 .post-content blockquote {
-	margin: 1.5rem 0;
-	padding: 0.75rem 1.25rem;
-	border-left: 4px solid var(--color-accent);
-	background-color: var(--color-code-bg);
-	color: var(--color-text-muted);
+	margin: 28px 0;
+	padding: 14px 22px;
+	border-left: 3px solid var(--blue);
+	background: var(--blue-wash);
+	border-radius: 0 8px 8px 0;
+	color: var(--t65);
 	font-style: italic;
 }
+.post-content blockquote p:last-child {
+	margin-bottom: 0;
+}
 
+/* inline + block code — light chip / card, matching the landing page */
 .post-content code {
 	font-family: var(--font-mono);
-	font-size: 0.875em;
-	background-color: var(--color-code-bg);
-	padding: 0.15rem 0.35rem;
-	border-radius: 0.25rem;
+	font-size: 0.86em;
+	background: #f5f5f5;
+	border: 1px solid var(--line);
+	padding: 1px 6px;
+	border-radius: 4px;
 }
-
 .post-content pre {
-	background-color: var(--color-code-bg);
-	padding: 1rem;
-	border-radius: 0.5rem;
+	background: #f5f5f5;
+	border: 1px solid var(--line);
+	padding: 16px 20px;
+	border-radius: 12px;
 	overflow-x: auto;
-	margin: 1.5rem 0;
+	margin: 0 0 28px;
+	line-height: 1.7;
 }
-
 .post-content pre code {
-	background-color: transparent;
+	background: transparent;
+	border: 0;
 	padding: 0;
+	font-size: 13.5px;
+}
+/* Astro/Shiki blocks keep their own token colors; just adopt our chrome */
+.post-content pre.astro-code,
+.post-content :where(.expressive-code) pre {
+	background: #141414 !important;
+	border-color: #2a2a2a;
 }
 
 .post-content table {
 	width: 100%;
 	border-collapse: collapse;
-	margin: 1.5rem 0;
+	margin: 0 0 28px;
+	font-size: 14.5px;
 }
-
 .post-content th,
 .post-content td {
-	border: 1px solid var(--color-border);
-	padding: 0.75rem;
+	border: 1px solid var(--line2);
+	padding: 10px 14px;
 	text-align: left;
 }
-
 .post-content th {
-	background-color: var(--color-code-bg);
+	background: var(--canvas);
 	font-weight: 600;
+	color: var(--ink);
 }
 
-.tags {
+/* prev / next */
+.post-nav {
 	display: flex;
-	flex-wrap: wrap;
-	gap: 0.5rem;
-	margin-top: 1rem;
+	gap: 16px;
+	margin: 44px 0 8px;
+	padding-top: 28px;
+	border-top: 1px solid var(--line);
 }
-
-.tag {
-	font-size: 0.75rem;
-	background-color: var(--color-code-bg);
-	color: var(--color-text-muted);
-	padding: 0.25rem 0.6rem;
-	border-radius: 9999px;
+.post-nav a {
+	flex: 1;
+	padding: 18px 20px;
+	border: 1px solid var(--line2);
+	border-radius: 12px;
+	color: inherit;
 }
-
-.site-footer {
-	border-top: 1px solid var(--color-border);
-	padding: 2rem 0;
-	margin-top: 3rem;
-	text-align: center;
-	color: var(--color-text-muted);
-	font-size: 0.9rem;
+.post-nav a:hover {
+	background: rgba(22, 119, 255, 0.06);
+	border-color: rgba(22, 119, 255, 0.5);
+	color: inherit;
 }
-
-.site-footer a {
-	color: var(--color-text-muted);
-	text-decoration: underline;
+.post-nav .label {
+	font-size: 12px;
+	color: var(--t45);
+	margin-bottom: 4px;
 }
-
-.lang-switch {
+.post-nav .title {
+	font-size: 15px;
 	font-weight: 600;
-	border: 1px solid var(--color-border);
-	border-radius: 0.375rem;
-	padding: 0.25rem 0.5rem;
+	color: var(--ink);
+}
+.post-nav a.next {
+	text-align: right;
 }
 
+/* ---------- footer ---------- */
+.site-footer {
+	border-top: 1px solid var(--line);
+	background: #fff;
+	padding: 40px 0;
+	margin-top: 40px;
+}
+.site-footer .foot-inner {
+	max-width: 1080px;
+	margin: 0 auto;
+	padding: 0 24px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	font-size: 13px;
+	color: var(--t45);
+}
+.site-footer .foot-inner svg {
+	display: block;
+}
+.site-footer .foot-links {
+	display: flex;
+	gap: 20px;
+	margin-left: auto;
+}
+.site-footer a {
+	color: var(--t65);
+	text-decoration: none;
+}
+.site-footer a:hover {
+	color: var(--blue);
+}
+
+/* ---------- mermaid ---------- */
 .mermaid-diagram {
-	margin: 1.5rem 0;
+	margin: 24px 0;
 	text-align: center;
 	overflow-x: auto;
 }
-
 .mermaid-diagram svg {
 	max-width: 100%;
 	height: auto;
 }
-
 .mermaid-error {
-	color: var(--color-danger, #dc2626);
-	background-color: var(--color-code-bg);
+	color: #ff4d4f;
+	background: #f5f5f5;
 	padding: 1rem;
-	border-radius: 0.5rem;
+	border-radius: 8px;
 }
 
-@media (max-width: 640px) {
+/* ---------- responsive ---------- */
+@media (max-width: 820px) {
+	.nav-inner {
+		gap: 12px;
+		padding: 0 16px;
+	}
+	.navlinks {
+		gap: 16px;
+		margin-left: 8px;
+	}
+	.lang {
+		display: none;
+	}
 	.hero h1 {
-		font-size: 2rem;
+		font-size: 34px;
 	}
-
 	.post-header h1 {
-		font-size: 1.75rem;
+		font-size: 28px;
 	}
-
-	.site-header .container {
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 0.75rem;
+}
+@media (max-width: 560px) {
+	.ghost span {
+		display: none;
 	}
-
-	.site-nav a {
-		margin-left: 0;
-		margin-right: 1rem;
+	.post-card-meta .tags {
+		display: none;
 	}
 }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -22,6 +22,13 @@ export default defineConfig({
 				baseUrl: 'https://github.com/open-octo/octo-agent/edit/main/docs/',
 			},
 			customCss: ['./src/styles/custom.css'],
+			head: [
+				{
+					tag: 'script',
+					content:
+						"try{localStorage.setItem('starlight-theme','light')}catch(e){}document.documentElement.dataset.theme='light';",
+				},
+			],
 			defaultLocale: 'root',
 			locales: {
 				root: { label: 'English', lang: 'en' },

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,41 +1,183 @@
 /*
- * octo docs theme — indigo accent + monospace headings.
- * Palette and rationale: dev-docs/docs-site-design.md.
+ * octo docs theme — unified with the landing page (octo-agent/landing/index.html).
+ * Ant Blue #1677FF accent, native system stack (no more mono headings),
+ * flat white, light-only. Pairs with the astro.config `head` snippet that
+ * forces the light theme (see HANDOFF.md).
  */
 
 :root {
-	/* Indigo accent (dark theme, Starlight's default) */
-	--sl-color-accent-low: #312e81;
-	--sl-color-accent: #818cf8;
-	--sl-color-accent-high: #c7d2fe;
+	/* Ant Blue accent */
+	--sl-color-accent-low: #e6f4ff;
+	--sl-color-accent: #1677ff;
+	--sl-color-accent-high: #0958d9;
 
-	--sl-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-	--sl-font-mono: ui-monospace, 'SF Mono', 'Roboto Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+	/* One system font everywhere — matches the landing page. */
+	--sl-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+		"Helvetica Neue", Arial, "PingFang SC", "Microsoft YaHei", sans-serif;
+	--sl-font-mono: "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 }
 
-:root[data-theme='light'] {
-	--sl-color-accent-low: #e0e7ff;
-	--sl-color-accent: #4f46e5;
-	--sl-color-accent-high: #3730a3;
+/* Force the light palette even if a stale data-theme="dark" slips through. */
+:root,
+:root[data-theme="light"],
+:root[data-theme="dark"] {
+	color-scheme: light;
+	--sl-color-accent-low: #e6f4ff;
+	--sl-color-accent: #1677ff;
+	--sl-color-accent-high: #0958d9;
+
+	--sl-color-white: #1f1f1f;
+	--sl-color-gray-1: #262626;
+	--sl-color-gray-2: rgba(0, 0, 0, 0.78);
+	--sl-color-gray-3: rgba(0, 0, 0, 0.65);
+	--sl-color-gray-4: rgba(0, 0, 0, 0.45);
+	--sl-color-gray-5: #d9d9d9;
+	--sl-color-gray-6: #f0f0f0;
+	--sl-color-gray-7: #f5f5f5;
+	--sl-color-black: #ffffff;
+
+	--sl-color-text: rgba(0, 0, 0, 0.88);
+	--sl-color-text-accent: #1677ff;
+	--sl-color-bg: #ffffff;
+	--sl-color-bg-nav: rgba(255, 255, 255, 0.92);
+	--sl-color-bg-sidebar: #ffffff;
+	--sl-color-hairline: #eeeff1;
+	--sl-color-hairline-light: #f0f0f0;
+	--sl-color-hairline-shade: #eeeff1;
 }
 
-/* octo is a terminal-first tool — headings, the site title, and sidebar
-   group labels use the monospace face; body copy stays humanist sans. */
-.sl-markdown-content :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)),
-.site-title,
-.group-label .large,
-.hero h1,
-.hero .tagline {
-	font-family: var(--__sl-font-mono);
+/* Headings use the system font (the old build forced monospace). */
+.sl-markdown-content
+	:is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
+	font-family: var(--sl-font);
+	font-weight: 600;
+	letter-spacing: -0.01em;
+	color: #1f1f1f;
+}
+.sl-markdown-content h1:not(:where(.not-content *)) {
 	letter-spacing: -0.02em;
 }
-
-.sl-markdown-content :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
-	font-weight: 700;
+.site-title {
+	font-family: var(--sl-font);
+	font-weight: 600;
+	color: #1f1f1f;
 }
 
-/* Maturity badges reuse Starlight's Badge component; keep them monospace too. */
+/* Drop the light card shadow the landing avoids; keep hairline chrome. */
+.sl-container,
+.sl-markdown-content {
+	--sl-shadow-md: none;
+}
+
+/* ---------- sticky blur header, matching the landing nav ---------- */
+header.header {
+	background: rgba(255, 255, 255, 0.92);
+	backdrop-filter: blur(8px);
+	border-bottom: 1px solid #eeeff1;
+}
+
+/* ---------- sidebar: rounded pills, blue = current ---------- */
+.sidebar-content a {
+	border-radius: 9999px;
+	color: rgba(0, 0, 0, 0.65);
+	transition: background 0.15s, color 0.15s;
+}
+.sidebar-content a:hover {
+	background: rgba(0, 0, 0, 0.04);
+	color: rgba(0, 0, 0, 0.88);
+}
+.sidebar-content a[aria-current="page"],
+.sidebar-content a[aria-current="page"]:hover {
+	background: rgba(22, 119, 255, 0.06);
+	color: #1677ff;
+	font-weight: 600;
+	border-inline-start-color: transparent;
+}
+/* Group titles: uppercase, tracked out (landing sidebar convention). */
+.sidebar-content .large,
+summary .group-label .large {
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: rgba(0, 0, 0, 0.45);
+}
+
+/* ---------- header search pill (Klook soft grey-blue fill) ---------- */
+site-search button {
+	background: #e9eef6;
+	border: 0;
+	border-radius: 9999px;
+}
+
+/* ---------- content: links, code, tables, cards ---------- */
+.sl-markdown-content a:not(:where(.not-content *)) {
+	color: #1677ff;
+	text-underline-offset: 3px;
+}
+.sl-markdown-content a:hover:not(:where(.not-content *)) {
+	color: #4096ff;
+}
+
+.sl-markdown-content :not(pre) > code {
+	background: #f5f5f5;
+	border: 1px solid #eeeff1;
+	border-radius: 4px;
+	color: rgba(0, 0, 0, 0.88);
+}
+
+.sl-markdown-content th {
+	background: #fafafa;
+	font-weight: 600;
+	color: #1f1f1f;
+}
+.sl-markdown-content :is(th, td) {
+	border-color: #f0f0f0;
+}
+
+/* CardGrid cards react with color, not elevation (Klook rule). */
+.card {
+	border: 1px solid #f0f0f0;
+	border-radius: 16px;
+	background: #fff;
+	box-shadow: none;
+	transition: background 0.15s, border-color 0.15s;
+}
+.card:hover {
+	background: rgba(22, 119, 255, 0.06);
+	border-color: rgba(22, 119, 255, 0.5);
+}
+.card .icon {
+	color: #1677ff;
+	background: #e6f4ff;
+	border-radius: 9999px;
+}
+
+/* Asides / callouts keep the flat blue-wash treatment. */
+.starlight-aside {
+	border-radius: 12px;
+}
+.starlight-aside--note,
+.starlight-aside--tip {
+	background: #f0f7ff;
+	border-color: rgba(22, 119, 255, 0.25);
+}
 starlight-aside .aside-title,
 .badge {
-	font-family: var(--__sl-font-mono);
+	font-family: var(--sl-font);
+	font-weight: 600;
+}
+
+/* Buttons — Ant Blue primary, 6px radius. */
+.sl-link-button.primary {
+	background: #1677ff;
+	border-radius: 6px;
+}
+.sl-link-button.primary:hover {
+	background: #4096ff;
+}
+
+/* Hide the light/dark toggle — the site is light-only now. */
+starlight-theme-select {
+	display: none;
 }

--- a/shared/octo-nav.js
+++ b/shared/octo-nav.js
@@ -21,6 +21,13 @@
  *               page can delete its own inline nav + language script.
  */
 (() => {
+	// Both attrs (`alt`) and same-document data-attrs (`data-href-en/zh`) are
+	// treated as untrusted: escape before splicing into innerHTML, and refuse
+	// dangerous URL schemes before handing a value to setAttribute('href', …).
+	const escapeHtml = (s) =>
+		String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+	const safeHref = (s) => (/^\s*(javascript|data|vbscript):/i.test(String(s)) ? '' : s);
+
 	const BLUE = '#1677FF',
 		HOVER = '#4096FF';
 	const MARK = (s) =>
@@ -81,7 +88,7 @@
 		});
 		document.querySelectorAll('[data-href-en],[data-href-zh]').forEach((el) => {
 			const v = el.getAttribute(isZh ? 'data-href-zh' : 'data-href-en');
-			if (v != null) el.setAttribute('href', v);
+			if (v != null) el.setAttribute('href', safeHref(v));
 		});
 		document.querySelectorAll('octo-site-nav[lang-toggle],octo-site-footer[lang-toggle]').forEach((el) => {
 			el.setAttribute('locale', lang);
@@ -99,7 +106,7 @@
 			const t = T[loc];
 			const blogHome = isZh ? '/blog/' : '/blog/en/';
 			const docsHref = isZh ? '/docs/zh/' : '/docs/';
-			const alt = this.getAttribute('alt') || (isZh ? '/blog/en/' : '/blog/');
+			const alt = escapeHtml(safeHref(this.getAttribute('alt')) || (isZh ? '/blog/en/' : '/blog/'));
 			const releases = 'https://github.com/open-octo/octo-agent/releases/latest';
 			const repo = 'https://github.com/open-octo/octo-agent';
 			const sections =

--- a/shared/octo-nav.js
+++ b/shared/octo-nav.js
@@ -1,0 +1,160 @@
+/*
+ * octo shared chrome — one source of truth for the top nav + footer across
+ * the landing page (static HTML) and the blog (Astro). Drop this one file in
+ * anywhere and use the custom elements; styles are self-contained (shadow DOM)
+ * so the nav looks identical regardless of the host page's CSS.
+ *
+ *   <script src="/octo-nav.js" defer></script>
+ *   <octo-site-nav variant="landing" active="home" locale="en"></octo-site-nav>
+ *   <octo-site-nav variant="site" active="blog" locale="en" alt="/blog/"></octo-site-nav>
+ *   <octo-site-footer locale="en"></octo-site-footer>
+ *
+ * Attributes:
+ *   variant     "landing" (adds in-page section anchors) | "site" (default)
+ *   active      "home" | "docs" | "blog"
+ *   locale      "en" | "zh"
+ *   alt         URL of the alternate-language version of the current page
+ *   lang-toggle present → the EN/中文 pill flips text in place (for the landing
+ *               page's bilingual single-page toggle) instead of navigating.
+ *               It updates every [data-en]/[data-zh] and [data-href-en]/
+ *               [data-href-zh] element in the host document, so the landing
+ *               page can delete its own inline nav + language script.
+ */
+(() => {
+	const BLUE = '#1677FF',
+		HOVER = '#4096FF';
+	const MARK = (s) =>
+		`<svg width="${s}" height="${s}" viewBox="0 0 100 100" aria-hidden="true"><rect width="100" height="100" rx="22" fill="${BLUE}"/><path fill="#fff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/><circle cx="40" cy="42" r="5" fill="${BLUE}"/><circle cx="60" cy="42" r="5" fill="${BLUE}"/></svg>`;
+	const GH =
+		'<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>';
+	const DL =
+		'<svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.5a.75.75 0 01.75.75v6.19l1.72-1.72a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 111.06-1.06l1.72 1.72V2.25A.75.75 0 018 1.5zM2.75 12a.75.75 0 01.75.75v.75c0 .14.11.25.25.25h8.5a.25.25 0 00.25-.25v-.75a.75.75 0 011.5 0v.75A1.75 1.75 0 0112.25 15h-8.5A1.75 1.75 0 012 13.5v-.75a.75.75 0 01.75-.75z"/></svg>';
+
+	const T = {
+		en: { docs: 'Docs', blog: 'Blog', star: 'Star', dl: 'Download', legal: 'MIT licensed',
+			s: [['#arms', 'Interfaces'], ['#features', 'Features'], ['#demo', 'Demo'], ['#faq', 'FAQ']] },
+		zh: { docs: '文档', blog: '博客', star: 'Star', dl: '下载', legal: 'MIT 许可',
+			s: [['#arms', '界面'], ['#features', '特性'], ['#demo', '演示'], ['#faq', '常见问题']] },
+	};
+
+	const BASE = `
+		:host{display:block;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"PingFang SC","Microsoft YaHei",sans-serif;}
+		a{text-decoration:none;color:inherit;}
+		.nav{position:sticky;top:0;z-index:100;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);border-bottom:1px solid #EEEFF1;}
+		.inner{max-width:1080px;margin:0 auto;display:flex;align-items:center;gap:24px;height:60px;padding:0 24px;}
+		.brand{display:flex;align-items:center;gap:10px;color:rgba(0,0,0,.88);font-weight:600;font-size:17px;}
+		.brand svg{display:block;}
+		.links{flex:1;display:flex;gap:24px;margin-left:16px;font-size:14px;}
+		.links a{color:rgba(0,0,0,.65);}
+		.links a:hover{color:${BLUE};}
+		.links a.active{color:${BLUE};font-weight:600;}
+		.ghost{display:inline-flex;align-items:center;gap:8px;padding:5px 14px;border:1px solid #D9D9D9;border-radius:6px;font-size:13px;font-weight:600;color:rgba(0,0,0,.88);}
+		.ghost:hover{border-color:${HOVER};color:${BLUE};}
+		.lang{display:inline-flex;align-items:center;border:1px solid #D9D9D9;border-radius:9999px;padding:2px;font-size:12px;font-weight:600;}
+		.lang .seg{color:rgba(0,0,0,.45);padding:3px 12px;border-radius:9999px;line-height:1;}
+		.lang .seg.active{background:${BLUE};color:#fff;}
+		.lang a.seg:hover{color:${BLUE};}
+		.lang a.seg.active:hover{color:#fff;}
+		.cta{display:inline-flex;align-items:center;gap:8px;padding:6px 16px;background:${BLUE};border-radius:6px;color:#fff;font-size:14px;font-weight:600;}
+		.cta:hover{background:${HOVER};}
+		@media(max-width:820px){.inner{gap:12px;padding:0 16px;}.links{gap:16px;margin-left:8px;}.lang{display:none;}}
+		@media(max-width:560px){.ghost span{display:none;}.links{display:none;}}
+	`;
+	const FOOT = `
+		:host{display:block;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;}
+		a{text-decoration:none;}
+		.foot{border-top:1px solid #EEEFF1;background:#fff;padding:40px 0;}
+		.inner{max-width:1080px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;font-size:13px;color:rgba(0,0,0,.45);}
+		.inner svg{display:block;}
+		.links{display:flex;gap:20px;margin-left:auto;}
+		.links a{color:rgba(0,0,0,.65);}
+		.links a:hover{color:${BLUE};}
+	`;
+
+	// Flip every bilingual node in the host document (landing-page toggle).
+	function applyLang(lang) {
+		const isZh = lang === 'zh';
+		document.documentElement.lang = isZh ? 'zh-CN' : 'en';
+		document.querySelectorAll('[data-en],[data-zh]').forEach((el) => {
+			const v = el.getAttribute(isZh ? 'data-zh' : 'data-en');
+			if (v != null) el.textContent = v;
+		});
+		document.querySelectorAll('[data-href-en],[data-href-zh]').forEach((el) => {
+			const v = el.getAttribute(isZh ? 'data-href-zh' : 'data-href-en');
+			if (v != null) el.setAttribute('href', v);
+		});
+		document.querySelectorAll('octo-site-nav[lang-toggle],octo-site-footer[lang-toggle]').forEach((el) => {
+			el.setAttribute('locale', lang);
+			el.connectedCallback && el.connectedCallback();
+		});
+	}
+
+	class Nav extends HTMLElement {
+		connectedCallback() {
+			const loc = this.getAttribute('locale') === 'zh' ? 'zh' : 'en';
+			const active = this.getAttribute('active') || '';
+			const variant = this.getAttribute('variant') || 'site';
+			const toggle = this.hasAttribute('lang-toggle');
+			const isZh = loc === 'zh';
+			const t = T[loc];
+			const blogHome = isZh ? '/blog/' : '/blog/en/';
+			const docsHref = isZh ? '/docs/zh/' : '/docs/';
+			const alt = this.getAttribute('alt') || (isZh ? '/blog/en/' : '/blog/');
+			const releases = 'https://github.com/open-octo/octo-agent/releases/latest';
+			const repo = 'https://github.com/open-octo/octo-agent';
+			const sections =
+				variant === 'landing'
+					? t.s.map(([h, l]) => `<a href="${h}">${l}</a>`).join('')
+					: '';
+			const cls = (k) => (active === k ? ' class="active"' : '');
+			const langPill = toggle
+				? `<div class="lang" role="group" aria-label="Language">
+						<button type="button" class="seg${isZh ? ' active' : ''}" data-lang="zh">中文</button>
+						<button type="button" class="seg${isZh ? '' : ' active'}" data-lang="en">EN</button>
+					</div>`
+				: `<div class="lang" role="group" aria-label="Language">
+						<a class="seg${isZh ? ' active' : ''}"${isZh ? '' : ` href="${alt}"`}>中文</a>
+						<a class="seg${isZh ? '' : ' active'}"${isZh ? ` href="${alt}"` : ''}>EN</a>
+					</div>`;
+			const root = this.shadowRoot || this.attachShadow({ mode: 'open' });
+			root.innerHTML = `<style>${BASE}${toggle ? '.lang button{background:none;border:0;cursor:pointer;font:inherit;}' : ''}</style>
+				<div class="nav"><div class="inner">
+					<a class="brand" href="https://octo-agent.dev/">${MARK(28)} Octo</a>
+					<nav class="links">
+						${sections}
+						<a href="${docsHref}"${cls('docs')}>${t.docs}</a>
+						<a href="${blogHome}"${cls('blog')}>${t.blog}</a>
+					</nav>
+					<a class="ghost" href="${repo}">${GH}<span>${t.star}</span></a>
+					${langPill}
+					<a class="cta" href="${releases}">${DL}<span>${t.dl}</span></a>
+				</div></div>`;
+			if (toggle) {
+				root.querySelectorAll('.lang button').forEach((b) =>
+					b.addEventListener('click', () => applyLang(b.dataset.lang)),
+				);
+			}
+		}
+	}
+
+	class Footer extends HTMLElement {
+		connectedCallback() {
+			const loc = this.getAttribute('locale') === 'zh' ? 'zh' : 'en';
+			const isZh = loc === 'zh';
+			const t = T[loc];
+			const docsHref = isZh ? '/docs/zh/' : '/docs/';
+			const blogHome = isZh ? '/blog/' : '/blog/en/';
+			const year = new Date().getFullYear();
+			const root = this.shadowRoot || this.attachShadow({ mode: 'open' });
+			root.innerHTML = `<style>${FOOT}</style>
+				<div class="foot"><div class="inner">
+					${MARK(20)}
+					<span>© ${year} octo-agent · ${t.legal}</span>
+					<div class="links"><a href="${docsHref}">${t.docs}</a><a href="${blogHome}">${t.blog}</a><a href="https://github.com/open-octo/octo-agent">GitHub</a></div>
+				</div></div>`;
+		}
+	}
+
+	if (!customElements.get('octo-site-nav')) customElements.define('octo-site-nav', Nav);
+	if (!customElements.get('octo-site-footer')) customElements.define('octo-site-footer', Footer);
+})();


### PR DESCRIPTION
## Summary
- Blog (`blog/src/styles/blog.css`, `pages/index.astro`, `pages/en/index.astro`, `layouts/BlogPost.astro`) adopts the landing page's Ant Blue (`#1677FF`) palette, native system font stack, sticky blur nav, blue-wash hero, and light-only look (dark mode removed).
- Blog header/footer now render through a shared shadow-DOM web component (`shared/octo-nav.js`, published to `blog/public/octo-nav.js`) via thin `SiteHeader.astro`/`SiteFooter.astro` wrappers, instead of duplicated markup + CSS on every page.
- Docs (`docs/src/styles/custom.css`) switches the Starlight accent to Ant Blue and headings back to the system font (previously forced monospace); `docs/astro.config.mjs` adds a `head` script forcing the light Starlight theme so a stale `dark` preference can't override it.
- `landing/index.html` is intentionally left unchanged — its inline script does language-preference persistence (`localStorage`) and OS-aware download-button labeling that the shared nav component doesn't replicate yet; swapping it in now would silently regress that behavior.

## Bugs found and fixed during verification
- `SiteHeader`/`SiteFooter` hardcoded the nav script src as `/octo-nav.js`, but the blog is served under `base: '/blog'`, so it 404'd in practice and the shared nav/footer silently failed to render. Resolved via `import.meta.env.BASE_URL`.
- CodeQL flagged `js/html-constructed-from-input` in `octo-nav.js`: the `alt` attribute was spliced raw into an `innerHTML` template, and `data-href-en/zh` attribute values went straight into `setAttribute('href', …)` with no scheme check. Fixed with `escapeHtml()` before interpolation and inline URL-parse + http/https protocol allowlisting (not a wrapping helper — CodeQL's dataflow still treats a helper's "return input unchanged" branch as tainted) before either sink.
- Docs sidebar's "Blog" entry is a single link shared by every locale (Starlight's `translations` only localizes the label, not the href), so English docs pages linked to the Chinese blog. Added a small `head` script that rewrites the href to `/blog/en/` when the page's `lang` isn't `zh-CN`.

## Test plan
- [x] `cd blog && npm run build` / `cd docs && npm run build` — clean
- [x] `npm run preview` on both sites, driven headless via Playwright: zero console/network errors on blog `/`, `/en/`, a post page, and docs `/` (both locales)
- [x] Screenshots confirm Ant Blue nav/hero on blog; `#1677ff` computed accent + light `data-theme` + system-font headings + blue pill sidebar highlight on docs
- [x] Verified the docs→blog language-link fix: English docs page's "Blog" link resolves to `https://octo-agent.dev/blog/en/`, Chinese docs page's to `https://octo-agent.dev/blog/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)