### PR TITLE
fix(blog,docs): close the CodeQL XSS gap and docs→blog language link

### DIFF
--- a/blog/public/octo-nav.js
+++ b/blog/public/octo-nav.js
@@ -26,7 +26,18 @@
 	// dangerous URL schemes before handing a value to setAttribute('href', …).
 	const escapeHtml = (s) =>
 		String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-	const safeHref = (s) => (/^\s*(javascript|data|vbscript):/i.test(String(s)) ? '' : s);
+	// Parse via the URL API and require the result to carry a same-flow http(s)
+	// protocol check right at the call site — inlined, not behind a helper
+	// function, so the scheme guard visibly dominates every setAttribute('href')
+	// sink below (a wrapped helper's "return the input unchanged" branch still
+	// reads as tainted data reaching the sink to static analysis).
+	function parseUrl(s) {
+		try {
+			return new URL(String(s ?? ''), location.origin);
+		} catch {
+			return null;
+		}
+	}
 
 	const BLUE = '#1677FF',
 		HOVER = '#4096FF';
@@ -87,8 +98,10 @@
 			if (v != null) el.textContent = v;
 		});
 		document.querySelectorAll('[data-href-en],[data-href-zh]').forEach((el) => {
-			const v = el.getAttribute(isZh ? 'data-href-zh' : 'data-href-en');
-			if (v != null) el.setAttribute('href', safeHref(v));
+			const raw = el.getAttribute(isZh ? 'data-href-zh' : 'data-href-en');
+			if (raw == null) return;
+			const u = parseUrl(raw);
+			if (u && (u.protocol === 'http:' || u.protocol === 'https:')) el.setAttribute('href', u.href);
 		});
 		document.querySelectorAll('octo-site-nav[lang-toggle],octo-site-footer[lang-toggle]').forEach((el) => {
 			el.setAttribute('locale', lang);
@@ -106,7 +119,12 @@
 			const t = T[loc];
 			const blogHome = isZh ? '/blog/' : '/blog/en/';
 			const docsHref = isZh ? '/docs/zh/' : '/docs/';
-			const alt = escapeHtml(safeHref(this.getAttribute('alt')) || (isZh ? '/blog/en/' : '/blog/'));
+			const altAttr = this.getAttribute('alt');
+			const altUrl = altAttr == null ? null : parseUrl(altAttr);
+			const altSafe = altUrl && (altUrl.protocol === 'http:' || altUrl.protocol === 'https:')
+				? altUrl.href
+				: isZh ? '/blog/en/' : '/blog/';
+			const alt = escapeHtml(altSafe);
 			const releases = 'https://github.com/open-octo/octo-agent/releases/latest';
 			const repo = 'https://github.com/open-octo/octo-agent';
 			const sections =

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,6 +28,15 @@ export default defineConfig({
 					content:
 						"try{localStorage.setItem('starlight-theme','light')}catch(e){}document.documentElement.dataset.theme='light';",
 				},
+				{
+					// The sidebar's "Blog" entry is a single external link shared by every
+					// locale (Starlight's `translations` only localizes the label, not the
+					// href), so it hardcodes the zh blog. Point it at the English blog on
+					// non-zh-CN pages instead.
+					tag: 'script',
+					content:
+						"document.addEventListener('DOMContentLoaded',function(){if(document.documentElement.lang!=='zh-CN'){document.querySelectorAll('a[href=\"https://octo-agent.dev/blog/\"]').forEach(function(a){a.href='https://octo-agent.dev/blog/en/';});}});",
+				},
 			],
 			defaultLocale: 'root',
 			locales: {

--- a/shared/octo-nav.js
+++ b/shared/octo-nav.js
@@ -26,7 +26,18 @@
 	// dangerous URL schemes before handing a value to setAttribute('href', …).
 	const escapeHtml = (s) =>
 		String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-	const safeHref = (s) => (/^\s*(javascript|data|vbscript):/i.test(String(s)) ? '' : s);
+	// Parse via the URL API and require the result to carry a same-flow http(s)
+	// protocol check right at the call site — inlined, not behind a helper
+	// function, so the scheme guard visibly dominates every setAttribute('href')
+	// sink below (a wrapped helper's "return the input unchanged" branch still
+	// reads as tainted data reaching the sink to static analysis).
+	function parseUrl(s) {
+		try {
+			return new URL(String(s ?? ''), location.origin);
+		} catch {
+			return null;
+		}
+	}
 
 	const BLUE = '#1677FF',
 		HOVER = '#4096FF';
@@ -87,8 +98,10 @@
 			if (v != null) el.textContent = v;
 		});
 		document.querySelectorAll('[data-href-en],[data-href-zh]').forEach((el) => {
-			const v = el.getAttribute(isZh ? 'data-href-zh' : 'data-href-en');
-			if (v != null) el.setAttribute('href', safeHref(v));
+			const raw = el.getAttribute(isZh ? 'data-href-zh' : 'data-href-en');
+			if (raw == null) return;
+			const u = parseUrl(raw);
+			if (u && (u.protocol === 'http:' || u.protocol === 'https:')) el.setAttribute('href', u.href);
 		});
 		document.querySelectorAll('octo-site-nav[lang-toggle],octo-site-footer[lang-toggle]').forEach((el) => {
 			el.setAttribute('locale', lang);
@@ -106,7 +119,12 @@
 			const t = T[loc];
 			const blogHome = isZh ? '/blog/' : '/blog/en/';
 			const docsHref = isZh ? '/docs/zh/' : '/docs/';
-			const alt = escapeHtml(safeHref(this.getAttribute('alt')) || (isZh ? '/blog/en/' : '/blog/'));
+			const altAttr = this.getAttribute('alt');
+			const altUrl = altAttr == null ? null : parseUrl(altAttr);
+			const altSafe = altUrl && (altUrl.protocol === 'http:' || altUrl.protocol === 'https:')
+				? altUrl.href
+				: isZh ? '/blog/en/' : '/blog/';
+			const alt = escapeHtml(altSafe);
 			const releases = 'https://github.com/open-octo/octo-agent/releases/latest';
 			const repo = 'https://github.com/open-octo/octo-agent';
 			const sections =


### PR DESCRIPTION
## Context
PR #1650 (blog+docs Ant Blue theme unification) squash-merged an intermediate commit before its final two fix commits landed — a GitHub PR-head sync delay meant the last two pushes never triggered CI or got included in the merge. Confirmed by diffing `origin/main`'s `shared/octo-nav.js` against what was actually pushed. This PR carries forward exactly those two missed commits, unchanged, on top of current `main`.

## What this fixes

**1. CodeQL `js/html-constructed-from-input` — still open on `main`.** The version that merged used a `safeHref()` wrapper with a regex scheme blocklist:
```js
const safeHref = (s) => (/^\s*(javascript|data|vbscript):/i.test(String(s)) ? '' : s);
```
CodeQL's dataflow analysis correctly treats this as taint-preserving — the function has a code path that returns the input completely unchanged, so a tainted `data-href-en/zh` attribute value can still reach `setAttribute('href', …)`. Replaced with real URL parsing plus an inline protocol-allowlist guard at each call site (not behind a helper), passing the `URL` object's own `.href` — a value derived from parsed components, not the original string — into the sink:
```js
const u = parseUrl(raw);
if (u && (u.protocol === 'http:' || u.protocol === 'https:')) el.setAttribute('href', u.href);
```
Applies to both the `data-href-en/zh` language-flip path and the `alt` attribute path in `shared/octo-nav.js` (and its published copy `blog/public/octo-nav.js`).

**2. Docs sidebar "Blog" link pointed at the wrong locale.** Starlight's sidebar `translations` only localizes the item label, not the `link` — so the single shared "Blog" entry hardcoded the Chinese blog URL regardless of which docs locale you were on. Reading the English docs and clicking "Blog" landed on the Chinese blog. Added a small `head` script in `docs/astro.config.mjs` that rewrites the href to `/blog/en/` when the page's `lang` isn't `zh-CN`.

## Test plan
- [x] `cd blog && npm run build` / `cd docs && npm run build` — clean
- [x] `npm run preview` on both, driven headless via Playwright: zero console/network errors on blog `/`, `/en/`, and docs `/`, `/zh/`
- [x] Confirmed the language-link fix: English docs → `https://octo-agent.dev/blog/en/`, Chinese docs → `https://octo-agent.dev/blog/`
- [x] Diffed `shared/octo-nav.js` against `blog/public/octo-nav.js` — identical after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)