### PR TITLE
fix(suggestion): clear stale follow-up + extend 5→10s timeout

### DIFF
--- a/dev-docs/next-suggestion.md
+++ b/dev-docs/next-suggestion.md
@@ -16,17 +16,7 @@ Its usage is intentionally **not** accrued into the session — it's an auxiliar
 UI call, not part of a turn. Returns `""` (no error) when there's nothing to
 suggest.
 
-**Cache alignment is the whole reason it's cheap.** Anthropic's cache prefix is
-ordered `tools → system → messages`. The agentic loop sends a tools block, so if
-Suggest sent *no* tools (a plain `SendMessages`) its prefix would diverge at
-block 0 and the entire history would be re-billed at full input price every
-turn. So Suggest takes the **same `tools`** the loop uses and routes through the
-`ToolSender` path: the `tools → system → history` prefix matches, the whole
-history is reused at the cheap cache-read rate, and only the instruction plus the
-one-line reply are fresh tokens. The instruction tells the model not to call
-tools; if it returns a `tool_use` anyway, `Content` is empty and that turn simply
-yields no suggestion. The TUI passes `cfg.tools`; with no ToolSender/tools,
-Suggest falls back to `SendMessages` (uncached but still correct).
+**Effort strategy mirrors GenerateTitle.** Both are throwaway, one-line calls: a follow-up suggestion needs no reasoning just like a 6-word title, and even the `"low"` budget adds latency/tokens that can push the call past its timeout on a slow provider. So Suggest prefers a sender's `NoReasoning()` (thinking disabled entirely) when available, falling back to `LowEffort()` (cap to `"low"`) otherwise.
 
 ## TUI wiring (cmd/octo)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -63,25 +63,28 @@ type ToolSender interface {
 
 // LowEffortSender is implemented by a Sender that can produce a cheaper
 // variant of itself with reasoning effort capped to a small, fast budget.
-// Suggest uses this: it deliberately reuses the turn's own Sender (so the
-// request shares the main conversation's prompt-cache prefix — see its doc
-// comment), but that Sender carries whatever reasoning_effort the session
-// happens to be configured with. A session running "high"/"max" would otherwise
-// pay the model's full reasoning budget just to produce a one-line suggestion,
-// for no benefit — and on a slower provider this reliably exceeds the throwaway
-// call's timeout. LowEffort caps effort to "low" rather than disabling it
-// outright, so the request shape stays consistent with earlier turns that may
-// already carry thinking blocks in history.
+// Suggest and GenerateTitle use this as a fallback when NoReasoningSender
+// isn't available: the throwaway call deliberately reuses the turn's own
+// Sender (so the request shares the main conversation's prompt-cache prefix —
+// see Suggest's doc comment), but that Sender carries whatever
+// reasoning_effort the session happens to be configured with. A session
+// running "high"/"max" would otherwise pay the model's full reasoning budget
+// just to produce a one-line suggestion, for no benefit — and on a slower
+// provider this reliably exceeds the throwaway call's timeout. LowEffort caps
+// effort to "low" rather than disabling it outright, so the request shape
+// stays consistent with earlier turns that may already carry thinking blocks
+// in history.
 type LowEffortSender interface {
 	Sender
 	LowEffort() Sender
 }
 
 // NoReasoningSender is implemented by a Sender that can produce a variant of
-// itself with reasoning disabled entirely. GenerateTitle uses this because a
-// 6-word title needs no reasoning at all, and even "low" reasoning can consume
-// the tight title token budget or time out. If a sender does not implement this
-// interface, GenerateTitle falls back to LowEffortSender instead.
+// itself with reasoning disabled entirely. GenerateTitle and Suggest prefer
+// this over LowEffortSender: a 6-word title / one-line follow-up suggestion
+// needs no reasoning at all, and even "low" reasoning can consume the tight
+// token budget or time out. If a sender does not implement this interface,
+// both calls fall back to LowEffortSender instead.
 type NoReasoningSender interface {
 	Sender
 	NoReasoning() Sender

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1350,7 +1350,13 @@ func (a *Agent) Suggest(ctx context.Context, tools []ToolDefinition) (string, er
 	msgs = append(msgs, snap...)
 	msgs = append(msgs, NewUserMessage(suggestInstruction))
 
-	if le, ok := sender.(LowEffortSender); ok {
+	// Prefer NoReasoning, fall back to LowEffort: a one-line follow-up
+	// suggestion needs no reasoning, and even "low" effort wastes time and
+	// tokens that can push this throwaway call past its timeout on a slow
+	// provider (same logic as GenerateTitle).
+	if nr, ok := sender.(NoReasoningSender); ok {
+		sender = nr.NoReasoning()
+	} else if le, ok := sender.(LowEffortSender); ok {
 		sender = le.LowEffort()
 	}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1860,6 +1860,42 @@ func TestAgent_Suggest_UsesLowEffortSenderWhenAvailable(t *testing.T) {
 	}
 }
 
+// TestAgent_Suggest_PrefersNoReasoningOverLowEffort guards the same hierarchy
+// GenerateTitle uses: a sender that implements both NoReasoningSender and
+// LowEffortSender must have NoReasoning() preferred, since the follow-up
+// suggestion (like a title) needs no reasoning at all.
+func TestAgent_Suggest_PrefersNoReasoningOverLowEffort(t *testing.T) {
+	low := &fakeSender{reply: Reply{Content: "low effort — should not be used"}}
+	noReasoning := &fakeSender{reply: Reply{Content: "no-reasoning suggestion"}}
+	main := &fakeNoReasoningSender{
+		fakeLowEffortSender: fakeLowEffortSender{
+			fakeSender: fakeSender{reply: Reply{Content: "main — should not be used"}},
+			low:        low,
+		},
+		noReasoning: noReasoning,
+	}
+	a := New(main, "m")
+	a.History.Append(NewUserMessage("do X"))
+	a.History.Append(NewAssistantMessage("did X"))
+
+	s, err := a.Suggest(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Suggest: %v", err)
+	}
+	if s != "no-reasoning suggestion" {
+		t.Errorf("suggestion = %q, want the no-reasoning sender's reply", s)
+	}
+	if len(main.gotMessages) != 0 {
+		t.Errorf("main sender should not have been called; got %d messages", len(main.gotMessages))
+	}
+	if len(low.gotMessages) != 0 {
+		t.Errorf("low-effort sender should not have been called when no-reasoning is available; got %d messages", len(low.gotMessages))
+	}
+	if len(noReasoning.gotMessages) == 0 {
+		t.Error("no-reasoning sender was never called")
+	}
+}
+
 func TestAgent_GenerateTitle(t *testing.T) {
 	send := &fakeSender{reply: Reply{Content: "\"Fix the login redirect bug\"."}}
 	a := New(send, "m")

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1579,14 +1579,23 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	})
 
 	// After-turn follow-up suggestion (matches TUI suggestCmd behaviour).
-	// Fire-and-forget: the frontend shows it as ghost text; failures are silent.
+	// Fire-and-forget: the frontend shows it as ghost text; failures/timeouts
+	// still broadcast an empty text so a stale suggestion from the previous
+	// turn gets cleared (the browser's chatSuggestion store only mutates on
+	// next_message_suggestion — without this, a timed-out generation would
+	// leave the prior turn's chip stuck on screen).
 	if err == nil {
 		go func() {
 			defer s.recoverBg("suggestion generation")
 			ctx, cancel := context.WithTimeout(context.Background(), throwawayGenerationTimeout)
 			defer cancel()
 			text, serr := a.Suggest(ctx, toolDefs)
-			if serr != nil || strings.TrimSpace(text) == "" {
+			if serr != nil {
+				s.wsHub.broadcast(sess.ID, map[string]any{
+					"type":       "next_message_suggestion",
+					"session_id": sess.ID,
+					"text":       "",
+				})
 				return
 			}
 			s.wsHub.broadcast(sess.ID, map[string]any{
@@ -1605,11 +1614,12 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 // ("max"), paying the model's full reasoning budget even for a 6-word title.
 // The real fix is agent.LowEffortSender (both calls now cap effort to "low"
 // instead of inheriting the session's), which removes most of that latency at
-// the source — this timeout is only the remaining safety margin for normal
-// network/provider variance, not a substitute for the effort cap, so it stays
-// modest rather than papering over a slow call with a long wait. (Session
-// titles use agent.TitleGenerationTimeout, the shared title mechanism.)
-const throwawayGenerationTimeout = 5 * time.Second
+// the source. Raised from 5s to 10s because even with LowEffort a slow
+// provider/network can still exceed 5s for a short suggestion, and the call
+// is now bounded more tightly (so a longer wait is safe); the timeout
+// remains the backstop, not a substitute for the effort cap. (Session titles
+// use agent.TitleGenerationTimeout, the shared title mechanism.)
+const throwawayGenerationTimeout = 10 * time.Second
 
 // claimTitleGeneration marks a title generation in flight for the session;
 // it returns false when one is already running so concurrent turn ends don't

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1265,11 +1265,14 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     const steering = wasStreaming
     if (!steering) {
       // A fresh turn starts: clear the previous turn's finished sub-agents and
-      // thinking buffer, clear the error banner, and flip the session into
-      // streaming.
+      // thinking buffer, clear the error banner, clear any stale follow-up
+      // suggestion from the last turn (it belongs to a conversation that has now
+      // moved on and must not re-render when this turn ends), and flip the
+      // session into streaming.
       turnError = null
       clearDoneSubAgents(sid)
       chatThinking.update(tt => ({ ...tt, [sid]: '' }))
+      chatSuggestion.update(s => ({ ...s, [sid]: '' }))
       chatStreaming.update(s => ({ ...s, [sid]: true }))
     }
     const pendingId = 'pending-' + Date.now()

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1003,6 +1003,13 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       // Panel-launched agentic sessions (Replay/Record/Edit/…) are single-purpose;
       // a follow-up suggestion is just noise there.
       if (agenticSessions.has(sid)) return
+      // A turn is in flight: drop the event. The previous turn's Suggest call
+      // can still resolve after a new one starts (fire-and-forget goroutine on
+      // the server); applying its stale suggestion would resurrect text that
+      // send() just cleared. Mirrors the TUI's "only apply suggestion while
+      // idle" rule. The new turn's own Suggest (or its empty-timeout event)
+      // will carry the authoritative follow-up.
+      if (get(chatStreaming)[sid]) return
       chatSuggestion.update(s => ({ ...s, [sid]: (ev as any).text ?? '' }))
     }))
 


### PR DESCRIPTION
## Summary
- Web UI kept showing the previous turn's next-message suggestion when the server's 5s generation timed out. Root cause:
  - `internal/server/ws_handlers.go` silently dropped timed-out generations (no event emitted).
  - The browser's `chatSuggestion` store only mutates on `next_message_suggestion`, so a missing event left the stale chip on screen indefinitely.
- **Web (`web/src/views/ChatView.svelte`):** clear `chatSuggestion[sid]` when a fresh turn starts (`send()` → streaming=true branch). Mirrors TUI's `startTurnEcho` → `clearSuggestion()` so the stale chip is gone before the new turn even ends.
- **Server (`internal/server/ws_handlers.go`):** on suggestion `Suggest` error/timeout, broadcast an empty-text `next_message_suggestion` event as a defensive clear; raise `throwawayGenerationTimeout` from 5s to 10s (`LowEffortSender` already caps reasoning effort, so the extra headroom is safe for slow providers/network).

## Verification
- `npx svelte-check` — 0 errors, 0 warnings
- `go build ./internal/server/...` — ok
- `go test -run Suggest ./internal/agent/...` — ok