### PR TITLE
chore: bump version to 1.12.26

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.25"
+var Version = "1.12.26"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the v1.12.26 release. Ships since v1.12.25:

- fix(browser): recording upgrades — auto waits, download capture, fingerprint anchors, fumble compression, freeze-on-create new-tab race fix (#1654)
- fix(tools): ctx-scope modelVision/browserHealer/browserRecordingGen (#1651)
- fix(suggestion): clear stale follow-up + NoReasoning + drop late events
- fix(blog,docs): CodeQL XSS gap + theme unification (#1650, #1652)
- fix(tools): read_file refuses images for non-vision models (#1649)
- feat(pkg/octoagent): NoReasoningSender alias for SDK consumers (#1648)
- fix(web): restore typed text to composer on turn error (#1647)
- fix(cli): wizard model default fixes (#1640, #1644)
- fix(config): validate global scalar fields (#1643)
- feat(memory): hindsight cloud mode (#1646)
- test(tools): deflake TestBackgroundServerLifecycle (#1655)

🤖 Generated with [Claude Code](https://claude.com/claude-code)