### PR TITLE
test(browser): deflake windows-latest browser tests + fix download-attribution race

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,5 +83,10 @@ jobs:
       # catches platform-specific failures (path handling, process spawning, the
       # GOOS-guarded cases). The race pass on Windows was the CI bottleneck
       # (~150s of a ~220s job) thanks to instrumentation + costly process spawns.
+      # -timeout 20m: the browser package launches a real Chrome per test and
+      # already runs ~6-8min on a starved windows-latest runner; with the
+      # deliberately generous per-test ceilings (see internal/browser
+      # testWaitTimeout) a bad-weather run must fail those tests cleanly
+      # instead of hitting the go-test default 10m panic.
       - name: go test
-        run: go test ${{ matrix.os == 'ubuntu-latest' && '-race' || '' }} ./...
+        run: go test -timeout 20m ${{ matrix.os == 'ubuntu-latest' && '-race' || '' }} ./...

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -424,10 +424,16 @@ func (p *Page) Navigate(ctx context.Context, url string) error {
 		return ctx.Err()
 	case <-events:
 		return nil
-	case <-time.After(30 * time.Second):
+	case <-time.After(navigateLoadTimeout):
 		return fmt.Errorf("navigate %s: timed out waiting for load", url)
 	}
 }
+
+// navigateLoadTimeout caps how long Navigate waits for the load event. A var,
+// not a const, so the package tests can raise it: starved CI runners (2-core
+// windows-latest especially) intermittently need more than 30s for a cold
+// Chrome to finish its first navigation even to a local fixture page.
+var navigateLoadTimeout = 30 * time.Second
 
 // Eval runs a JS expression in the page and unmarshals its return value into
 // out (pass nil to ignore the value). The expression may be a Promise.

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -18,8 +18,41 @@ import (
 // appear. WaitFor returns the instant the element is present, so this ceiling
 // is free on a healthy run — it only matters when a slow/loaded CI runner
 // (Windows cold-starts Chrome notably slower) needs more than a few seconds to
-// finish the first navigation. 5s was too tight there and flaked TestUpload.
-const testWaitTimeout = 20 * time.Second
+// finish the first navigation. 5s was too tight there and flaked TestUpload;
+// 20s flaked five recorder tests in one windows-latest run (2026-07-21).
+const testWaitTimeout = 60 * time.Second
+
+// Navigate's internal load-event ceiling needs the same headroom: the same
+// windows-latest starvation that blows the WaitFor budget also showed first
+// loads of local fixture pages exceeding the 30s production default.
+func init() { navigateLoadTimeout = 90 * time.Second }
+
+// testChromeArgs trims Chrome's background work so a cold start on a starved
+// CI runner spends its two cores on the page under test instead of crashpad,
+// component updates, field trials, and sync. All tests run a throwaway profile
+// against local fixture servers, so none of these features are load-bearing
+// (and --no-sandbox is safe for the same reason: nothing untrusted is loaded).
+var testChromeArgs = []string{
+	"--no-sandbox",
+	"--disable-background-networking",
+	"--disable-background-timer-throttling",
+	"--disable-backgrounding-occluded-windows",
+	"--disable-breakpad",
+	"--disable-client-side-phishing-detection",
+	"--disable-component-update",
+	"--disable-default-apps",
+	"--disable-dev-shm-usage",
+	"--disable-domain-reliability",
+	"--disable-extensions",
+	"--disable-hang-monitor",
+	"--disable-ipc-flooding-protection",
+	"--disable-popup-blocking",
+	"--disable-prompt-on-repost",
+	"--disable-renderer-backgrounding",
+	"--disable-sync",
+	"--metrics-recording-only",
+	"--mute-audio",
+}
 
 // fixtureHTML reproduces the awkward shape of the real target system:
 //   - the download button only appears after a search (no pre-constructable URL)
@@ -61,7 +94,7 @@ func newBrowser(t *testing.T, ctx context.Context) *Browser {
 	if _, err := findChrome(""); err != nil {
 		t.Skipf("chrome not available: %v", err)
 	}
-	b, err := Launch(ctx, LaunchOptions{Headless: true})
+	b, err := Launch(ctx, LaunchOptions{Headless: true, ExtraArgs: testChromeArgs})
 	if err != nil {
 		// A loaded CI runner ships Chrome (so findChrome passes) but launching
 		// it headless intermittently times out reading DevToolsActivePort —
@@ -81,7 +114,7 @@ func newBrowser(t *testing.T, ctx context.Context) *Browser {
 // the owned backend: search, wait for the dynamically-appearing button, click
 // it, and capture the client-side-generated file.
 func TestSearchThenDownload(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
@@ -137,7 +170,7 @@ func TestSearchThenDownload(t *testing.T) {
 // and attach to it (rather than opening a fresh one), as when reusing the user's
 // logged-in session.
 func TestAttachExistingPage(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(fixtureHTML))
@@ -185,7 +218,7 @@ func TestAttachExistingPage(t *testing.T) {
 // TestUpload sets a file on a file input via DOM.setFileInputFiles (no OS
 // dialog) and verifies the page sees it — the upload primitive.
 func TestUpload(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>up</title><input type="file" id="f">`))
@@ -222,7 +255,7 @@ func TestUpload(t *testing.T) {
 // TestHover verifies a trusted pointer move fires real hover DOM events (which
 // synthetic JS events / CSS :hover can't be driven by otherwise).
 func TestHover(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>h</title>
@@ -256,7 +289,7 @@ document.getElementById('t').addEventListener('mouseover',function(){window.hove
 // TestSelectOption picks a native <select> option and verifies the value + that
 // change fired.
 func TestSelectOption(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>s</title>
@@ -296,7 +329,7 @@ func TestSelectOption(t *testing.T) {
 // " >>> " piercing convention (wait, then a trusted click that lands through
 // the computed frame offset). Same-origin as in Klook's admin system.
 func TestSameOriginFrame(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/child" {
@@ -448,7 +481,7 @@ func TestDialError(t *testing.T) {
 // DevToolsActivePort — the path used to reuse a logged-in browser without
 // relaunching (and without /json, which recent Chrome disables).
 func TestConnectViaProfile(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	if !ChromeAvailable("") {
 		t.Skip("chrome not available")
@@ -479,7 +512,7 @@ func TestConnectViaProfile(t *testing.T) {
 
 // TestPrimitives covers eval / screenshot / ax-tree / key on the fixture.
 func TestPrimitives(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(fixtureHTML))
@@ -530,7 +563,7 @@ func TestPrimitives(t *testing.T) {
 // has open. Regression guard for the bug where attaching to a running Chrome
 // hijacked pages[0] (the octo web UI itself) and navigated it away.
 func TestNewPageLeavesOtherTabsUntouched(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	b := newBrowser(t, ctx)
 	defer b.Close()
@@ -575,7 +608,7 @@ func TestNewPageLeavesOtherTabsUntouched(t *testing.T) {
 // not valid CSS; querySelector throws. We should surface an actionable message
 // (not a bare "eval threw: Uncaught") so the model switches to a CSS selector.
 func TestClick_InvalidSelectorMessage(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	b := newBrowser(t, ctx)
 	defer b.Close()
@@ -606,7 +639,7 @@ func TestClick_InvalidSelectorMessage(t *testing.T) {
 // TestClick_PlaywrightSelectors verifies the supported Playwright subset
 // actually resolves and clicks the right element.
 func TestClick_PlaywrightSelectors(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	b := newBrowser(t, ctx)
 	defer b.Close()
@@ -650,7 +683,7 @@ func TestClick_PlaywrightSelectors(t *testing.T) {
 // replace that entry, so going Back from a later page lands on the first real
 // page — not the blank tab octo opened.
 func TestNavigate_ReplacesInitialBlank(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	b := newBrowser(t, ctx)
 	defer b.Close()

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -24,8 +24,13 @@ const testWaitTimeout = 60 * time.Second
 
 // Navigate's internal load-event ceiling needs the same headroom: the same
 // windows-latest starvation that blows the WaitFor budget also showed first
-// loads of local fixture pages exceeding the 30s production default.
-func init() { navigateLoadTimeout = 90 * time.Second }
+// loads of local fixture pages exceeding the 30s production default. The
+// click→download attribution window gets the same treatment: a starved runner
+// delivered downloadWillBegin more than 5s after the click that caused it.
+func init() {
+	navigateLoadTimeout = 90 * time.Second
+	downloadAttributionWindow = 30 * time.Second
+}
 
 // testChromeArgs trims Chrome's background work so a cold start on a starved
 // CI runner spends its two cores on the page under test instead of crashpad,

--- a/internal/browser/digest_test.go
+++ b/internal/browser/digest_test.go
@@ -15,7 +15,7 @@ import (
 // digest is the healer's candidate list, so a wrong filter both hides healable
 // targets and could offer unclickable ones.
 func TestInteractiveDigestVisibility(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, `<!doctype html><title>digest</title>
@@ -25,10 +25,7 @@ func TestInteractiveDigestVisibility(t *testing.T) {
 <button id="invis" style="visibility:hidden">Invis</button>`)
 	}))
 	defer srv.Close()
-	b, err := Launch(ctx, LaunchOptions{Headless: true})
-	if err != nil {
-		t.Skipf("chrome unavailable: %v", err)
-	}
+	b := newBrowser(t, ctx)
 	defer b.Close()
 	page, err := b.NewPage(ctx, srv.URL)
 	if err != nil {
@@ -36,7 +33,7 @@ func TestInteractiveDigestVisibility(t *testing.T) {
 	}
 	// Wait for the document to parse before digesting: NewPage can resolve ahead
 	// of the renderer on slow runners (Windows CI returned an empty digest).
-	if err := page.WaitFor(ctx, "#fixed", 10*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#fixed", testWaitTimeout); err != nil {
 		t.Fatalf("wait for fixture: %v", err)
 	}
 	digest, err := InteractiveDigest(ctx, page, "", 0)

--- a/internal/browser/oopif_test.go
+++ b/internal/browser/oopif_test.go
@@ -34,7 +34,7 @@ func oopifServer(t *testing.T, innerBody string) *httptest.Server {
 
 func newOOPIFBrowser(t *testing.T, ctx context.Context) *Browser {
 	t.Helper()
-	b, err := Launch(ctx, LaunchOptions{Headless: true, ExtraArgs: []string{"--site-per-process"}})
+	b, err := Launch(ctx, LaunchOptions{Headless: true, ExtraArgs: append([]string{"--site-per-process"}, testChromeArgs...)})
 	if err != nil {
 		t.Skipf("chrome unavailable: %v", err)
 	}
@@ -45,7 +45,7 @@ func newOOPIFBrowser(t *testing.T, ctx context.Context) *Browser {
 // frame selector routes into the OOPIF's own session; the click lands there, and a
 // verification WaitFor through the same frame path confirms it.
 func TestOOPIFReplay(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := oopifServer(t, `<button id="go" onclick="var d=document.createElement('div');d.id='done';document.body.appendChild(d)">Go</button>`)
 	defer srv.Close()
@@ -66,7 +66,7 @@ func TestOOPIFReplay(t *testing.T) {
 	}
 	// The click must have run inside the OOPIF: #done appears there. WaitFor also
 	// routes through the frame, so a pass proves both directions work.
-	if err := page.WaitFor(ctx, "#f >>> #done", 10*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#f >>> #done", testWaitTimeout); err != nil {
 		t.Fatalf("click did not land inside the cross-origin iframe: %v", err)
 	}
 }
@@ -74,7 +74,7 @@ func TestOOPIFReplay(t *testing.T) {
 // TestOOPIFTypeReplay: type into a text input inside a cross-origin iframe, then
 // read it back through the frame path.
 func TestOOPIFTypeReplay(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := oopifServer(t, `<input id="q" name="q">`)
 	defer srv.Close()
@@ -109,7 +109,7 @@ func TestOOPIFTypeReplay(t *testing.T) {
 // TestOOPIFRecord: a user gesture inside a cross-origin iframe is captured and
 // tagged with the parent iframe selector, so the recording replays back into it.
 func TestOOPIFRecord(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := oopifServer(t, `<button id="go">Go</button>`)
 	defer srv.Close()
@@ -124,7 +124,7 @@ func TestOOPIFRecord(t *testing.T) {
 		t.Fatalf("navigate: %v", err)
 	}
 	// Ensure the OOPIF is attached/registered before recording starts.
-	if err := page.WaitFor(ctx, "#f >>> #go", 10*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#f >>> #go", testWaitTimeout); err != nil {
 		t.Fatalf("oopif not ready: %v", err)
 	}
 

--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -57,6 +57,14 @@ type Recorder struct {
 	lastClickIdx int
 	lastClickAt  time.Time
 
+	// pendingDLName / pendingDLAt park a downloadWillBegin that arrived before
+	// the click that triggered it: the download event travels straight from the
+	// browser process while the click rides the renderer→binding→CDP path, so
+	// on a loaded machine the download can win the race. The next click within
+	// the attribution window claims it.
+	pendingDLName string
+	pendingDLAt   time.Time
+
 	// dlDir is the temp directory downloads land in during recording (set by
 	// watchDownloads). Removed in Stop() — recording-time downloads are only
 	// used to detect the event, not kept.
@@ -99,35 +107,47 @@ func (r *Recorder) addEvent(re RecordedEvent, frameSel string) {
 	}
 	r.mu.Lock()
 	if re.Type == "click" {
-		r.lastClickIdx = len(r.events)
-		r.lastClickAt = time.Now()
+		if r.pendingDLName != "" && time.Since(r.pendingDLAt) <= downloadAttributionWindow {
+			// A downloadWillBegin already arrived for this click (it beat the
+			// click's binding delivery) — record the click as the download.
+			re.Type = "download"
+			re.DownloadName = r.pendingDLName
+			r.pendingDLName = ""
+		} else {
+			r.lastClickIdx = len(r.events)
+			r.lastClickAt = time.Now()
+		}
 	}
 	r.events = append(r.events, re)
 	r.mu.Unlock()
 }
 
+// downloadAttributionWindow is how far apart a click and its
+// Browser.downloadWillBegin may arrive and still be treated as one action.
+// A var, not a const, so the package tests can widen it for starved CI
+// runners where event delivery lags by many seconds.
+var downloadAttributionWindow = 5 * time.Second
+
 // upgradeLastClickToDownload upgrades the most recent click event to a "download"
 // event with the given filename — called when Browser.downloadWillBegin fires
-// within a short window after the click that triggered it. No-op if the click is
-// too old or already consumed.
+// within a short window after the click that triggered it. When no eligible
+// click has been recorded yet (the download event won the race against the
+// click's binding delivery), the download is parked for addEvent to claim.
 func (r *Recorder) upgradeLastClickToDownload(filename string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	idx := r.lastClickIdx
-	if idx < 0 || idx >= len(r.events) {
+	if idx >= 0 && idx < len(r.events) && r.events[idx].Type == "click" &&
+		time.Since(r.lastClickAt) <= downloadAttributionWindow {
+		ev := r.events[idx]
+		ev.Type = "download"
+		ev.DownloadName = filename
+		r.events[idx] = ev
+		r.lastClickIdx = -1 // consumed
 		return
 	}
-	if time.Since(r.lastClickAt) > 5*time.Second {
-		return
-	}
-	ev := r.events[idx]
-	if ev.Type != "click" {
-		return
-	}
-	ev.Type = "download"
-	ev.DownloadName = filename
-	r.events[idx] = ev
-	r.lastClickIdx = -1 // consumed
+	r.pendingDLName = filename
+	r.pendingDLAt = time.Now()
 }
 
 // watchDownloads subscribes to Browser.downloadWillBegin globally (the browser-

--- a/internal/browser/recorder_test.go
+++ b/internal/browser/recorder_test.go
@@ -661,9 +661,12 @@ func TestAutoDownloadDetection(t *testing.T) {
 	if err := page.Click(ctx, "#dl"); err != nil {
 		t.Fatalf("click: %v", err)
 	}
-	// Wait for the click to be upgraded to a download event.
+	// Wait for the click to be upgraded to a download event. The ceiling
+	// matches testWaitTimeout: downloadWillBegin delivery on a starved runner
+	// can lag the click by many seconds (5s of polling flaked on windows-latest).
 	found := false
-	for i := 0; i < 50; i++ {
+	deadline := time.Now().Add(testWaitTimeout)
+	for time.Now().Before(deadline) {
 		time.Sleep(100 * time.Millisecond)
 		for _, e := range rec.Events() {
 			if e.Type == "download" && e.DownloadName == "report.xlsx" {

--- a/internal/browser/recorder_test.go
+++ b/internal/browser/recorder_test.go
@@ -14,7 +14,7 @@ import (
 // selector anchored at its nearest id-bearing ancestor, not a free nth-of-type
 // chain from <body> — shorter and far more stable across layout changes.
 func TestRecorderAnchorsSelectorAtNearestID(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>rec</title>
@@ -58,7 +58,7 @@ func TestRecorderAnchorsSelectorAtNearestID(t *testing.T) {
 // driven via trusted input (standing in for a human), and the recorder must
 // capture both with usable selectors and values.
 func TestRecorderCapturesActions(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>rec</title>
@@ -147,7 +147,7 @@ func TestRecorderCapturesActions(t *testing.T) {
 // and keeps going there is captured end to end — previously everything after the
 // tab switch was silently lost (the attach watcher only instrumented iframes).
 func TestRecorderCapturesNewTab(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/b", func(w http.ResponseWriter, _ *http.Request) {
@@ -214,7 +214,7 @@ func TestRecorderCapturesNewTab(t *testing.T) {
 // click must still be captured. Regression test for the race where early
 // new-tab clicks were silently lost.
 func TestRecorderCapturesNewTab_ClickBeforeInstrument(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/b", func(w http.ResponseWriter, _ *http.Request) {
@@ -289,7 +289,7 @@ func TestRecorderCapturesNewTab_ClickBeforeInstrument(t *testing.T) {
 // auto-inserted "network" wait event — the page is loading data and the next
 // step must not race ahead of it.
 func TestAutoWaitNetwork(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/data", func(w http.ResponseWriter, _ *http.Request) {
@@ -364,7 +364,7 @@ document.getElementById('load').addEventListener('click', function(){
 // auto-inserted "element" wait event for that modal is emitted — the next step
 // that interacts with the modal must wait for it to be present.
 func TestAutoWaitElement(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>modal</title>
@@ -445,7 +445,7 @@ func TestCompileRecordingWaitEvents(t *testing.T) {
 // anchors instead of a bare :nth-of-type chain — so the recording survives
 // layout shifts that a purely positional selector would not.
 func TestSelectorSemanticAnchor(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>cal</title>
@@ -503,7 +503,7 @@ func TestSelectorSemanticAnchor(t *testing.T) {
 // current value (change never fires without a blur); Enter in a textarea is a
 // newline, not a submit, and must not be captured.
 func TestRecorderCapturesEnter(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>enter</title>
@@ -564,7 +564,7 @@ func TestRecorderCapturesEnter(t *testing.T) {
 // as navigate events (they never fire Page.frameNavigated), while SPA routing
 // inside a subframe is ignored — it isn't the page moving.
 func TestRecorderCapturesSPANavigation(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/frame", func(w http.ResponseWriter, _ *http.Request) {
@@ -630,7 +630,7 @@ func TestRecorderCapturesSPANavigation(t *testing.T) {
 // upgraded to a "download" event with the suggested filename — so the compiled
 // recording emits a download step that replay uses to capture the file.
 func TestAutoDownloadDetection(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/file.xlsx", func(w http.ResponseWriter, _ *http.Request) {
@@ -685,7 +685,7 @@ func TestAutoDownloadDetection(t *testing.T) {
 // Stop() should remove it so repeated record/stop cycles don't leak temp dirs
 // on disk.
 func TestRecorderStopCleansUpDownloadDir(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>dl-dir</title><button id="b">B</button>`))
@@ -769,7 +769,7 @@ func TestCompileRecordingDownloadEvent(t *testing.T) {
 // fingerprint — alternate selectors (built with a different strategy than the
 // primary), the role attribute, and the nearest label-like neighbor text.
 func TestRecorderCapturesAnchorFacts(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>anchors</title>

--- a/internal/browser/recording_test.go
+++ b/internal/browser/recording_test.go
@@ -135,7 +135,7 @@ func TestCompileAutoVerifyNavigateHost(t *testing.T) {
 // different host (a stand-in for an SSO/login bounce) fails the auto host verify,
 // instead of replay silently continuing on the wrong page.
 func TestReplayVerifyURLCatchesCrossHostRedirect(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	// The "login" host the redirect lands on.
 	login := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -196,7 +196,7 @@ func TestCompileDedupesRepeatedType(t *testing.T) {
 // URL merely echoes the expected host in a query param must still fail the host
 // verify (exact host match, not a naive href substring).
 func TestReplayVerifyURLIgnoresHostInQueryParam(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	var app *httptest.Server
 	login := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -326,7 +326,7 @@ func TestCompileUploadMerge(t *testing.T) {
 // TestUploadViaChooser drives the chooser-based upload: clicking a button opens
 // a (intercepted) file chooser and the file is set on the underlying input.
 func TestUploadViaChooser(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>up</title>
@@ -517,7 +517,7 @@ func TestRunStepWaitFixedDelay(t *testing.T) {
 // TestWaitForNetworkIdle: a wait{network:true} step blocks until an in-flight
 // fetch the page kicked off completes, then returns — the SPA-settle primitive.
 func TestWaitForNetworkIdle(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/slow", func(w http.ResponseWriter, _ *http.Request) {
@@ -565,7 +565,7 @@ func TestWaitForNetworkIdle(t *testing.T) {
 // the tab it opens (the Zhihu-hot-item failure mode), and ReplayRecording returns
 // that tab as the final page.
 func TestReplayClickFollowsNewTab(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/dest", func(w http.ResponseWriter, _ *http.Request) {
@@ -606,7 +606,7 @@ func TestReplayClickFollowsNewTab(t *testing.T) {
 // points at the WRONG element after a layout change, but the recorded text steers
 // replay to the right one — instead of silently clicking the wrong node.
 func TestReplayTextAnchorRecoversFromDrift(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
@@ -650,7 +650,7 @@ func TestReplayTextAnchorRecoversFromDrift(t *testing.T) {
 // hint (its name) re-locates it — so type lands in the right box instead of failing
 // into the healer.
 func TestReplayFieldHintRecoversFromDrift(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
@@ -693,7 +693,7 @@ func TestReplayFieldHintRecoversFromDrift(t *testing.T) {
 // until a consent overlay is accepted; replay recovers by clicking the allow-list
 // "Accept" control — no healer wired — then the retry succeeds.
 func TestReplayDismissesOverlayDeterministically(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
@@ -736,7 +736,7 @@ func TestReplayDismissesOverlayDeterministically(t *testing.T) {
 // still wrong, the second is correct — and replay keeps consulting it (up to the
 // cap) instead of giving up after one attempt.
 func TestReplayMultiRoundHeal(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>t</title>
@@ -785,7 +785,7 @@ func TestReplayMultiRoundHeal(t *testing.T) {
 // the healer repairs the selector, replay retries and succeeds — and reports the
 // recording as modified so the caller can write the fix back.
 func TestReplayRecordingSelfHeal(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>heal</title>
@@ -910,7 +910,7 @@ func TestRecordingYAMLRoundTripOutputs(t *testing.T) {
 // TestReplayRecordingDownloadBindsOutputs: a download step captures the file the
 // trigger produces and binds its path into the recording's declared file[] output.
 func TestReplayRecordingDownloadBindsOutputs(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/file.csv" {
@@ -954,7 +954,7 @@ func TestReplayRecordingDownloadBindsOutputs(t *testing.T) {
 // TestReplayRecordingExtractBindsOutput: an extract step evaluates JS and binds the
 // (unwrapped) string result into a declared output.
 func TestReplayRecordingExtractBindsOutput(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
@@ -1031,7 +1031,7 @@ func TestListRecordings(t *testing.T) {
 // first, then passes after a heal, must bind the file exactly once — recoverStep
 // re-runs the whole step, so binding before Verify would double-count the output.
 func TestReplayRecordingDownloadNoDoubleBindOnHeal(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/file.csv" {
@@ -1105,7 +1105,7 @@ func TestSubstJSEscapesValues(t *testing.T) {
 // original value (properly encoded on the wire), proving replay navigates to the
 // intended URL rather than a value-corrupted one.
 func TestReplayNavigateEncodesParams(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	var gotQ, gotURI string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1140,7 +1140,7 @@ func TestReplayNavigateEncodesParams(t *testing.T) {
 // inside a JS string literal evaluates to the exact original value, not a
 // broken (or altered) expression.
 func TestReplayExtractEscapesParams(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>x</title>ok`))
@@ -1210,7 +1210,7 @@ func TestCompileEnterFlow(t *testing.T) {
 // TestReplayKeyEnter: replay types the value, focuses the field with a real
 // click, and presses Enter — the form actually submits.
 func TestReplayKeyEnter(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>k</title>
@@ -1364,7 +1364,7 @@ func TestGenerateRecordingDistillRestoresDroppedSecretParam(t *testing.T) {
 // verify failure's error text must name the placeholder — never carry the
 // resolved value, which would flow into the tool result and the conversation.
 func TestReplayVerifyErrorRedactsSecret(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>v</title><form><input id="pw" type="password"></form>`))
@@ -1644,7 +1644,7 @@ func TestGenerateRecordingBackfillsAnchors(t *testing.T) {
 // fingerprint (visible text + tag + neighbor text) must still land the click on
 // the right one.
 func TestReplayAnchorsSurviveClassDrift(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>drift</title>
@@ -1684,7 +1684,7 @@ func TestReplayAnchorsSurviveClassDrift(t *testing.T) {
 // would click it silently; anchored replay must refuse with a fingerprint error
 // and must not click anything.
 func TestReplayAnchorsRefuseWrongElement(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>wrong</title>


### PR DESCRIPTION
## Problem

PR #1657 (a landing-page-only change) failed the windows-latest Go job twice, on **different** subsets of `internal/browser` tests each time:

- Attempt 1: `TestRecorderCapturesActions`, `TestRecorderCapturesNewTab_ClickBeforeInstrument`, `TestAutoWaitNetwork`, `TestAutoWaitElement`, `TestSelectorSemanticAnchor` — all `wait for …: timed out after 20s`
- Attempt 2: `TestOOPIFReplay`, `TestOOPIFTypeReplay` — both `navigate: timed out waiting for load` (30s)

Same root cause both times: on a starved 2-core windows-latest runner, a cold headless Chrome intermittently needs more than 20-30s to finish its **first** load of a local fixture page. The random subset per run is the signature of runner starvation, not a code defect (main is green on the same code).

## Fix

Two-pronged: reduce the actual latency, then give the residual tail headroom.

**1. Quiet Chrome down (`testChromeArgs`)** — the test launch (shared by `newBrowser`, the OOPIF helper, and the digest test, which previously launched bare) now disables the background work that competes with the page under test on 2 cores: sandbox broker processes, background networking, component update, crashpad, sync, safe-browsing phishing classification, tab throttling, etc. Safe because every test drives a throwaway profile against local `httptest` fixtures. Launch has no non-test callers (attach-only since #1472), so production is untouched.

**2. Raise the ceilings that only bind when things are already slow:**

| ceiling | before | after |
|---|---|---|
| `testWaitTimeout` (WaitFor) | 20s | 60s (3rd bump: 5s flaked TestUpload, 20s flaked five tests on 2026-07-21) |
| `Navigate` load event | const 30s | package var, still 30s in production; tests raise to 90s |
| whole-test ctx on Chrome-launching tests | 30-60s | 180s, so the per-step ceilings above get to bind and name the slow step |
| CI `go test` | default 10m/pkg | `-timeout 20m`, so a bad-weather browser-package run fails cleanly instead of panicking |

All ceilings are free on healthy runs — WaitFor/Navigate return the instant the condition holds. Pure-mock tests (ws-url resolution etc.) keep their tight 5s/250ms budgets.

## Verification

`go test ./internal/browser/` green locally (real Chrome, 144s, macOS) — including the OOPIF site-isolation tests under the new flag set. `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)