### PR TITLE
fix(onboard): stop retriggering /onboard on every startup after an interrupted attempt

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -47,6 +47,30 @@ func soulMissing() bool {
 	return os.IsNotExist(statErr)
 }
 
+// onboardAttempted reports whether the soul_setup auto-nudge has already
+// fired once (see config.Config.OnboardAttempted). A Load error is treated as
+// "not attempted yet" — the nudge firing once more on a config hiccup is
+// harmless, while silently skipping it forever would not be.
+func onboardAttempted() bool {
+	cfg, err := config.Load()
+	if err != nil {
+		return false
+	}
+	return cfg.OnboardAttempted
+}
+
+// markOnboardAttempted persists that the soul_setup auto-nudge fired, before
+// the TUI takes over — so even if the user interrupts /onboard immediately,
+// the marker is already on disk and it won't retrigger on the next startup.
+func markOnboardAttempted() {
+	cfg, err := config.Load()
+	if err != nil {
+		return
+	}
+	cfg.OnboardAttempted = true
+	_ = cfg.Save()
+}
+
 // offerOnboarding asks (on a first run) whether to run the onboarding ceremony.
 // Default is yes; "n"/"no"/"s"/"skip" declines. Returns true to run /onboard.
 // Kept for tests; the CLI/TUI now auto-starts onboarding instead of prompting.
@@ -1004,8 +1028,13 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// start the onboarding ceremony so a new CLI user isn't left with an
 		// impersonal agent — mirroring the web's soul_setup nudge. The config
 		// wizard above only sets the key/model; onboard is who-it-is/who-you-are.
-		if isFirstEverSession() && soulMissing() {
+		// Gated on !onboardAttempted so an interrupted first run doesn't
+		// retrigger /onboard on every subsequent startup (#1660) — the marker
+		// is written immediately, not on completion, since interrupting is the
+		// exact case it needs to cover.
+		if isFirstEverSession() && soulMissing() && !onboardAttempted() {
 			cfg.autoFirstInput = "/onboard"
+			markOnboardAttempted()
 		}
 		return runTUI(cfg)
 	}

--- a/cmd/octo/onboard_trigger_test.go
+++ b/cmd/octo/onboard_trigger_test.go
@@ -29,6 +29,24 @@ func TestSoulMissing(t *testing.T) {
 	}
 }
 
+func TestOnboardAttempted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// os.UserHomeDir() reads %USERPROFILE% on Windows, not $HOME.
+	t.Setenv("USERPROFILE", home)
+
+	if onboardAttempted() {
+		t.Fatal("expected onboardAttempted=false before markOnboardAttempted")
+	}
+	markOnboardAttempted()
+	if !onboardAttempted() {
+		t.Fatal("expected onboardAttempted=true after markOnboardAttempted, even with soul.md still missing (#1660)")
+	}
+	if !soulMissing() {
+		t.Fatal("markOnboardAttempted must not itself create soul.md")
+	}
+}
+
 func TestOfferOnboarding(t *testing.T) {
 	cases := map[string]bool{
 		"\n":     true,  // default (Enter) → onboard

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,6 +212,14 @@ type Config struct {
 	// (via OSC 2) to the session name on startup. nil means the built-in default
 	// (enabled).
 	TerminalTitle *bool `yaml:"terminal_title,omitempty"`
+	// OnboardAttempted marks that the soul_setup auto-nudge (auto-launching
+	// /onboard on a fresh soul.md-less install) has already fired once. It is
+	// set the moment the nudge fires, regardless of whether the user completes
+	// or interrupts it, so an interrupted first run doesn't retrigger /onboard
+	// on every subsequent startup. Manually re-running onboarding stays
+	// available (the Profile page's soul/user "Update" buttons) whether or not
+	// this is set.
+	OnboardAttempted bool `yaml:"onboard_attempted,omitempty"`
 }
 
 // TrashConfig configures the file recycle bin.

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -113,8 +113,11 @@ func (s *Server) handleOnboardStatus(w http.ResponseWriter, r *http.Request) {
 // detectOnboardPhase determines whether first-run setup is needed.
 //
 //	"key_setup"  — no API key configured (hard block).
-//	"soul_setup" — key present but soul.md missing (soft nudge).
-//	""           — fully configured.
+//	"soul_setup" — key present, soul.md missing, and the nudge hasn't fired yet (soft nudge).
+//	""           — fully configured, or the nudge already fired once (#1660: an
+//	               interrupted first attempt must not retrigger on every restart —
+//	               the Profile page's soul/user "Update" buttons stay available
+//	               as the manual path).
 func detectOnboardPhase() string {
 	cfg, _ := config.Load()
 
@@ -138,6 +141,10 @@ func detectOnboardPhase() string {
 		return "key_setup"
 	}
 
+	if cfg.OnboardAttempted {
+		return ""
+	}
+
 	// Check soul.md (IdentityPath also finds a legacy uppercase SOUL.md).
 	soulPath := prompt.IdentityPath(octoDir(), "soul.md")
 	if _, err := os.Stat(soulPath); os.IsNotExist(err) {
@@ -152,6 +159,25 @@ func detectOnboardPhase() string {
 func (s *Server) handleOnboardComplete(w http.ResponseWriter, r *http.Request) {
 	// Ensure the ~/.octo directory exists.
 	_ = os.MkdirAll(octoDir(), 0o700)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// ─── POST /api/onboard/attempt ──────────────────────────────────────────────
+
+// handleOnboardAttempt records that the soul_setup nudge has fired, before the
+// /onboard chat itself starts — so a user who closes the tab or interrupts the
+// chat before finishing doesn't get re-nudged on every subsequent load (#1660).
+func (s *Server) handleOnboardAttempt(w http.ResponseWriter, r *http.Request) {
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+		return
+	}
+	cfg.OnboardAttempted = true
+	if err := cfg.Save(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -125,6 +125,41 @@ func TestConfig_ShowReasoningReloadsDefaultSender(t *testing.T) {
 	}
 }
 
+// TestOnboardAttempt_StopsSoulSetupNudge covers #1660: once /api/onboard/attempt
+// has fired, detectOnboardPhase must not keep reporting soul_setup even
+// though soul.md is still missing (the user interrupted the first attempt) —
+// the Profile page's manual "Update" buttons remain the way back in.
+func TestOnboardAttempt_StopsSoulSetupNudge(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	if got := detectOnboardPhase(); got != "soul_setup" {
+		t.Fatalf("detectOnboardPhase = %q before any attempt, want soul_setup", got)
+	}
+
+	w := doJSON(t, srv, http.MethodPost, "/api/onboard/attempt", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/onboard/attempt = %d: %s", w.Code, w.Body.String())
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.OnboardAttempted {
+		t.Fatal("config.OnboardAttempted = false after POST /api/onboard/attempt")
+	}
+	if got := detectOnboardPhase(); got != "" {
+		t.Fatalf("detectOnboardPhase = %q after attempt (soul.md still missing), want \"\" (no repeat nudge)", got)
+	}
+}
+
 func TestListProviders_MarksCustomCatchAll(t *testing.T) {
 	presets := buildProviderPresets()
 	byID := map[string]providerPreset{}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -820,6 +820,7 @@ func (s *Server) registerRoutes() {
 	// Onboard & config
 	s.api("GET /api/onboard/status", s.handleOnboardStatus)
 	s.api("POST /api/onboard/complete", s.handleOnboardComplete)
+	s.api("POST /api/onboard/attempt", s.handleOnboardAttempt)
 	s.api("GET /api/providers", s.handleListProviders)
 	s.api("GET /api/config", s.handleGetConfig)
 	s.api("GET /api/config/endpoints", s.handleGetEndpoints)

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -277,10 +277,14 @@
   }
 
   // soul_setup: key present, soul.md missing → auto-launch one /onboard chat.
-  // Guarded by sessionStorage so a refresh doesn't spawn a second session.
+  // sessionStorage guards against a same-tab refresh spawning a second
+  // session; markOnboardAttempted persists server-side so closing the tab (or
+  // interrupting the chat) doesn't re-nudge on the next load either — the
+  // server also stops reporting phase 'soul_setup' once it's set (#1660).
   function maybeLaunchOnboard() {
     if (sessionStorage.getItem('octo-onboard-launched')) return
     sessionStorage.setItem('octo-onboard-launched', '1')
+    api.markOnboardAttempted().catch(() => {})
     const lang = get(locale).startsWith('zh') ? 'zh' : 'en'
     openAgentSession(`/onboard lang:${lang}`, '✨ Onboard').catch(() => {})
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -943,6 +943,13 @@ export async function completeOnboard(): Promise<void> {
   await request<unknown>('/api/onboard/complete', { method: 'POST' })
 }
 
+// Persists that the soul_setup auto-nudge fired, before the /onboard chat
+// starts — so an interrupted first attempt doesn't retrigger it on the next
+// load (#1660).
+export async function markOnboardAttempted(): Promise<void> {
+  await request<unknown>('/api/onboard/attempt', { method: 'POST' })
+}
+
 // Provider presets (GET /api/providers) — mirrors server providerPreset.
 export interface EndpointVariant {
   label: string


### PR DESCRIPTION
## Summary
- CLI/TUI and Web both auto-nudged `/onboard` based purely on `soul.md`'s absence, with no distinction between "never started" and "started but interrupted" — a user who cancels the first attempt gets re-nudged on every subsequent startup.
- Persist a one-shot `OnboardAttempted` flag in config.yml the moment the auto-nudge fires (CLI: `cmd/octo/chat.go`, Web: new `POST /api/onboard/attempt` called from `App.svelte`), independent of whether the onboarding chat completes.
- `detectOnboardPhase()` now stops reporting `soul_setup` once the flag is set, even if `soul.md` is still missing. The Profile page's existing soul/user "Update" buttons remain the manual path to finish personalization later.

Fixes #1660

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`
- [x] `go test -race ./...` (only pre-existing unrelated flaky race in `internal/browser`)
- [x] New tests: `TestOnboardAttempted` (cmd/octo), `TestOnboardAttempt_StopsSoulSetupNudge` (internal/server)
- [x] `make web-build` + `svelte-check` (0 errors/warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)