### PR TITLE
chore: bump version to 1.12.27

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.26"
+var Version = "1.12.27"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bumps the internal default version to `1.12.27` ahead of tagging `v1.12.27`.

Includes since v1.12.26:
- #1664 — rebuild the message rail as a scroll timeline
- #1666 — bump blog astro to 7.1.3 (patch reflected XSS GHSA-4g3v-8h47-v7g6)
- #1665 — add CODEOWNERS for sensitive core paths
- #1663 — stop /onboard retriggering after an interrupted attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)