### PR TITLE
fix(onboard): stop /onboard re-nudge after an interrupted first run (#1660)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -47,28 +47,51 @@ func soulMissing() bool {
 	return os.IsNotExist(statErr)
 }
 
-// onboardAttempted reports whether the soul_setup auto-nudge has already
-// fired once (see config.Config.OnboardAttempted). A Load error is treated as
-// "not attempted yet" — the nudge firing once more on a config hiccup is
-// harmless, while silently skipping it forever would not be.
-func onboardAttempted() bool {
-	cfg, err := config.Load()
-	if err != nil {
+// identityMissing reports whether the user has neither soul.md nor user.md
+// (nor their legacy uppercase spellings) — the signal that they have no
+// identity at all. Onboarding nudges only in that case; if either file exists
+// the user has some identity set up.
+func identityMissing() bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
 		return false
 	}
-	return cfg.OnboardAttempted
+	dir := filepath.Join(home, ".octo")
+	for _, name := range []string{"soul.md", "user.md"} {
+		if _, err := os.Stat(prompt.IdentityPath(dir, name)); err == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// onboardAttempted reports whether the soul_setup auto-nudge has already fired
+// once (see config.OnboardAttempted, backed by ~/.octo/.onboard_attempted). A
+// missing marker is treated as "not attempted yet" — the nudge firing once
+// more is harmless, while silently skipping it forever would not be.
+func onboardAttempted() bool {
+	return config.OnboardAttempted()
 }
 
 // markOnboardAttempted persists that the soul_setup auto-nudge fired, before
 // the TUI takes over — so even if the user interrupts /onboard immediately,
 // the marker is already on disk and it won't retrigger on the next startup.
 func markOnboardAttempted() {
-	cfg, err := config.Load()
-	if err != nil {
-		return
+	_ = config.MarkOnboardAttempted()
+}
+
+// shouldAutoOnboard reports whether a fresh CLI/TUI run should auto-launch the
+// /onboard ceremony — first-ever session, no identity yet, and the nudge hasn't
+// fired. Deciding "yes" writes the one-shot marker as a SIDE EFFECT, on
+// purpose: the two are bound in one place so they can never drift apart. That
+// drift is exactly the #1660 bug — the web's FirstRunSetup launched /onboard
+// but forgot to mark it, so an interrupted first run re-nudged on reopen.
+func shouldAutoOnboard() bool {
+	if isFirstEverSession() && identityMissing() && !onboardAttempted() {
+		markOnboardAttempted()
+		return true
 	}
-	cfg.OnboardAttempted = true
-	_ = cfg.Save()
+	return false
 }
 
 // offerOnboarding asks (on a first run) whether to run the onboarding ceremony.
@@ -1028,13 +1051,11 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// start the onboarding ceremony so a new CLI user isn't left with an
 		// impersonal agent — mirroring the web's soul_setup nudge. The config
 		// wizard above only sets the key/model; onboard is who-it-is/who-you-are.
-		// Gated on !onboardAttempted so an interrupted first run doesn't
-		// retrigger /onboard on every subsequent startup (#1660) — the marker
-		// is written immediately, not on completion, since interrupting is the
-		// exact case it needs to cover.
-		if isFirstEverSession() && soulMissing() && !onboardAttempted() {
+		// shouldAutoOnboard writes the one-shot marker as it decides, so an
+		// interrupted first run can't retrigger /onboard on the next startup
+		// (#1660) — the marker lands before the TUI even takes over.
+		if shouldAutoOnboard() {
 			cfg.autoFirstInput = "/onboard"
-			markOnboardAttempted()
 		}
 		return runTUI(cfg)
 	}

--- a/cmd/octo/onboard_trigger_test.go
+++ b/cmd/octo/onboard_trigger_test.go
@@ -47,6 +47,54 @@ func TestOnboardAttempted(t *testing.T) {
 	}
 }
 
+// TestShouldAutoOnboard_MarksWhenLaunching locks the #1660 invariant: deciding
+// to auto-launch /onboard must, in the same step, record the one-shot marker —
+// otherwise an interrupted first run re-nudges on the next startup (the web's
+// FirstRunSetup drift). It also covers idempotency and the identity gate.
+func TestShouldAutoOnboard_MarksWhenLaunching(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	// Fresh install: no sessions, no soul.md/user.md, marker absent → onboard.
+	if !shouldAutoOnboard() {
+		t.Fatal("shouldAutoOnboard = false on a fresh install, want true")
+	}
+	// The decision MUST have written the marker (the invariant).
+	if !onboardAttempted() {
+		t.Fatal("shouldAutoOnboard launched onboard but did not record the attempt marker (#1660 invariant)")
+	}
+	// Idempotent: the marker now suppresses a repeat launch.
+	if shouldAutoOnboard() {
+		t.Fatal("shouldAutoOnboard = true after the marker was set, want false (no repeat nudge)")
+	}
+}
+
+// TestShouldAutoOnboard_SkipsWhenIdentityExists covers the gate: an existing
+// identity file means the user is set up, so no nudge and no marker written.
+func TestShouldAutoOnboard_SkipsWhenIdentityExists(t *testing.T) {
+	for _, name := range []string{"soul.md", "user.md"} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			octo := filepath.Join(home, ".octo")
+			if err := os.MkdirAll(octo, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(octo, name), []byte("# identity"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if shouldAutoOnboard() {
+				t.Fatalf("shouldAutoOnboard = true with %s present, want false", name)
+			}
+			if onboardAttempted() {
+				t.Fatalf("marker written despite %s present — should not touch it when not launching", name)
+			}
+		})
+	}
+}
+
 func TestOfferOnboarding(t *testing.T) {
 	cases := map[string]bool{
 		"\n":     true,  // default (Enter) → onboard

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,13 +212,12 @@ type Config struct {
 	// (via OSC 2) to the session name on startup. nil means the built-in default
 	// (enabled).
 	TerminalTitle *bool `yaml:"terminal_title,omitempty"`
-	// OnboardAttempted marks that the soul_setup auto-nudge (auto-launching
-	// /onboard on a fresh soul.md-less install) has already fired once. It is
-	// set the moment the nudge fires, regardless of whether the user completes
-	// or interrupts it, so an interrupted first run doesn't retrigger /onboard
-	// on every subsequent startup. Manually re-running onboarding stays
-	// available (the Profile page's soul/user "Update" buttons) whether or not
-	// this is set.
+	// OnboardAttempted is the LEGACY location of the soul_setup nudge marker.
+	// It is only READ now (see the package-level OnboardAttempted /
+	// MarkOnboardAttempted, which use the standalone ~/.octo/.onboard_attempted
+	// file so a config.yml rewrite can't clobber it — #1660). Kept as a field
+	// so installs that recorded it in config.yml before the marker file existed
+	// still count as attempted; nothing writes it anymore.
 	OnboardAttempted bool `yaml:"onboard_attempted,omitempty"`
 }
 
@@ -882,6 +881,50 @@ func legacyPath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, ".octo", "config.yaml"), nil
+}
+
+// onboardMarkerPath returns ~/.octo/.onboard_attempted — a standalone marker
+// that records the soul_setup auto-nudge has fired once. It lives OUTSIDE
+// config.yml on purpose: config.yml is rewritten by many non-atomic
+// Load+modify+Save callers during first-run (the setup panel's key save,
+// language, the /onboard skill), any of which could clobber a bool folded into
+// the same file. A dedicated file can't be lost that way (#1660 follow-up).
+func onboardMarkerPath() (string, error) {
+	p, err := Path()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(p), ".onboard_attempted"), nil
+}
+
+// OnboardAttempted reports whether the soul_setup auto-nudge has already fired
+// once. It honours both the standalone marker file (current) and the legacy
+// config.yml onboard_attempted field (installs that recorded it before the
+// marker file existed) so an upgrade never re-nudges.
+func OnboardAttempted() bool {
+	if p, err := onboardMarkerPath(); err == nil {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	if cfg, err := Load(); err == nil && cfg.OnboardAttempted {
+		return true
+	}
+	return false
+}
+
+// MarkOnboardAttempted records that the soul_setup nudge fired by creating the
+// standalone marker file. Idempotent; safe to call concurrently with any
+// config.yml write (it touches a different file).
+func MarkOnboardAttempted() error {
+	p, err := onboardMarkerPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte("1\n"), 0o600)
 }
 
 // fileConfig is the on-disk superset: the current Endpoints-based schema plus

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -103,6 +103,11 @@ func (s *Server) handleListProviders(w http.ResponseWriter, r *http.Request) {
 // ─── GET /api/onboard/status ────────────────────────────────────────────────
 
 func (s *Server) handleOnboardStatus(w http.ResponseWriter, r *http.Request) {
+	// no-store: this gates the first-run /onboard nudge, and the desktop webview
+	// heuristically caches GET 200s. Without it, the second window open replays
+	// the first load's stale phase from cache and re-launches /onboard even after
+	// the marker is set (#1660). The client also passes cache:'no-store'.
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
 	phase := detectOnboardPhase()
 	writeJSON(w, http.StatusOK, map[string]any{
 		"needs_onboard": phase != "",
@@ -113,11 +118,12 @@ func (s *Server) handleOnboardStatus(w http.ResponseWriter, r *http.Request) {
 // detectOnboardPhase determines whether first-run setup is needed.
 //
 //	"key_setup"  — no API key configured (hard block).
-//	"soul_setup" — key present, soul.md missing, and the nudge hasn't fired yet (soft nudge).
+//	"soul_setup" — key present, the nudge hasn't fired yet, AND the user has no
+//	               identity at all (both soul.md and user.md missing) (soft nudge).
 //	""           — fully configured, or the nudge already fired once (#1660: an
 //	               interrupted first attempt must not retrigger on every restart —
 //	               the Profile page's soul/user "Update" buttons stay available
-//	               as the manual path).
+//	               as the manual path), or any identity file already exists.
 func detectOnboardPhase() string {
 	cfg, _ := config.Load()
 
@@ -141,17 +147,30 @@ func detectOnboardPhase() string {
 		return "key_setup"
 	}
 
-	if cfg.OnboardAttempted {
+	if config.OnboardAttempted() {
 		return ""
 	}
 
-	// Check soul.md (IdentityPath also finds a legacy uppercase SOUL.md).
-	soulPath := prompt.IdentityPath(octoDir(), "soul.md")
-	if _, err := os.Stat(soulPath); os.IsNotExist(err) {
+	// Nudge only on a truly fresh identity: BOTH soul.md (who the agent is) and
+	// user.md (who the user is) absent. If either already exists the user has
+	// some identity set up, so don't nudge. (IdentityPath also finds the legacy
+	// uppercase SOUL.md/USER.md spellings.)
+	if identityMissing(octoDir()) {
 		return "soul_setup"
 	}
 
 	return ""
+}
+
+// identityMissing reports whether dir has neither soul.md nor user.md (nor
+// their legacy uppercase spellings).
+func identityMissing(dir string) bool {
+	for _, name := range []string{"soul.md", "user.md"} {
+		if _, err := os.Stat(prompt.IdentityPath(dir, name)); err == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // ─── POST /api/onboard/complete ─────────────────────────────────────────────
@@ -167,15 +186,11 @@ func (s *Server) handleOnboardComplete(w http.ResponseWriter, r *http.Request) {
 // handleOnboardAttempt records that the soul_setup nudge has fired, before the
 // /onboard chat itself starts — so a user who closes the tab or interrupts the
 // chat before finishing doesn't get re-nudged on every subsequent load (#1660).
+// The marker is a standalone file, not a config.yml field, so a concurrent
+// config.yml write during first-run can't clobber it.
 func (s *Server) handleOnboardAttempt(w http.ResponseWriter, r *http.Request) {
-	cfg, err := config.Load()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
-		return
-	}
-	cfg.OnboardAttempted = true
-	if err := cfg.Save(); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+	if err := config.MarkOnboardAttempted(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("mark onboard attempted: %v", err))
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -148,15 +148,55 @@ func TestOnboardAttempt_StopsSoulSetupNudge(t *testing.T) {
 		t.Fatalf("POST /api/onboard/attempt = %d: %s", w.Code, w.Body.String())
 	}
 
+	if !config.OnboardAttempted() {
+		t.Fatal("config.OnboardAttempted() = false after POST /api/onboard/attempt")
+	}
+	if got := detectOnboardPhase(); got != "" {
+		t.Fatalf("detectOnboardPhase = %q after attempt (identity still missing), want \"\" (no repeat nudge)", got)
+	}
+
+	// The regression this fix targets: a config.yml rewrite AFTER the marker was
+	// set (first-run key save, language, the /onboard skill) must NOT re-open the
+	// nudge. The marker lives in its own file, so a full config Save can't clobber
+	// it — detectOnboardPhase still returns "" (#1660 follow-up).
 	cfg, err := config.Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !cfg.OnboardAttempted {
-		t.Fatal("config.OnboardAttempted = false after POST /api/onboard/attempt")
+	cfg.Language = "zh"
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
 	}
 	if got := detectOnboardPhase(); got != "" {
-		t.Fatalf("detectOnboardPhase = %q after attempt (soul.md still missing), want \"\" (no repeat nudge)", got)
+		t.Fatalf("detectOnboardPhase = %q after a later config.yml Save, want \"\" (marker must survive)", got)
+	}
+}
+
+// TestDetectOnboardPhase_ExistingIdentitySkipsNudge covers the trigger gate:
+// the soul_setup nudge fires only when the user has NO identity at all. If
+// either soul.md or user.md already exists — even without the attempt marker —
+// detectOnboardPhase must return "".
+func TestDetectOnboardPhase_ExistingIdentitySkipsNudge(t *testing.T) {
+	for _, name := range []string{"soul.md", "user.md"} {
+		t.Run(name, func(t *testing.T) {
+			home := setTestHome(t)
+			seedModels(t, config.Config{
+				Endpoints: []config.Endpoint{
+					{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+				},
+				Default: "ep-a::claude-sonnet-4-6",
+			})
+			octo := filepath.Join(home, ".octo")
+			if err := os.MkdirAll(octo, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(octo, name), []byte("# identity"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := detectOnboardPhase(); got != "" {
+				t.Fatalf("detectOnboardPhase = %q with %s present, want \"\" (no nudge when identity exists)", got, name)
+			}
+		})
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -951,6 +951,11 @@ func TestHandleOnboardStatus(t *testing.T) {
 	if body["needs_onboard"] == nil {
 		t.Fatal("expected needs_onboard field")
 	}
+	// The status response must be uncacheable: the desktop webview heuristically
+	// caches GET 200s, and a stale phase re-launches /onboard on reopen (#1660).
+	if cc := w.Header().Get("Cache-Control"); !strings.Contains(cc, "no-store") {
+		t.Errorf("Cache-Control = %q, want it to contain no-store", cc)
+	}
 }
 
 func TestHandleListProviders(t *testing.T) {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -276,15 +276,17 @@
     }
   }
 
-  // soul_setup: key present, soul.md missing → auto-launch one /onboard chat.
+  // soul_setup: key present, no identity yet → auto-launch one /onboard chat.
   // sessionStorage guards against a same-tab refresh spawning a second
-  // session; markOnboardAttempted persists server-side so closing the tab (or
-  // interrupting the chat) doesn't re-nudge on the next load either — the
-  // server also stops reporting phase 'soul_setup' once it's set (#1660).
-  function maybeLaunchOnboard() {
+  // session; markOnboardAttempted persists a server-side marker file so closing
+  // the tab (or interrupting the chat) doesn't re-nudge on the next load either
+  // — the server stops reporting phase 'soul_setup' once it's set (#1660). Await
+  // the marker BEFORE opening the chat so an immediately-closed first run can't
+  // race the write and re-nudge on reopen.
+  async function maybeLaunchOnboard() {
     if (sessionStorage.getItem('octo-onboard-launched')) return
     sessionStorage.setItem('octo-onboard-launched', '1')
-    api.markOnboardAttempted().catch(() => {})
+    await api.markOnboardAttempted().catch(() => {})
     const lang = get(locale).startsWith('zh') ? 'zh' : 'en'
     openAgentSession(`/onboard lang:${lang}`, '✨ Onboard').catch(() => {})
   }

--- a/web/src/components/overlays/FirstRunSetup.svelte
+++ b/web/src/components/overlays/FirstRunSetup.svelte
@@ -45,6 +45,11 @@
     // Persist the language choice so a refresh lands on it.
     await api.updateLanguage(lang).catch(() => {})
     await api.completeOnboard()
+    // This IS the first-run auto-launch of /onboard, so record the one-shot
+    // nudge marker before opening the chat — otherwise interrupting it and
+    // reopening re-fires the soul_setup nudge (this path set phase to '' and
+    // never went through maybeLaunchOnboard, so nothing else marked it) (#1660).
+    await api.markOnboardAttempted().catch(() => {})
     await openAgentSession(`/onboard lang:${lang}`, '✨ Onboard')
     onboardPhase.set('')
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -936,7 +936,11 @@ export interface OnboardStatus {
 }
 
 export async function getOnboardStatus(): Promise<OnboardStatus> {
-  return request<OnboardStatus>('/api/onboard/status')
+  // no-store: the desktop webview (WKWebView) heuristically caches GET 200s, so
+  // without this the second window open would replay the FIRST load's stale
+  // 'soul_setup' from cache — never hitting the server — and re-launch /onboard
+  // even after the marker is set (#1660). Mirrors /api/version, /api/browser/status.
+  return request<OnboardStatus>('/api/onboard/status', { cache: 'no-store' })
 }
 
 export async function completeOnboard(): Promise<void> {


### PR DESCRIPTION
## Problem

The soul_setup auto-nudge fired **twice** on a fresh desktop install: onboard appears → user stops it → close window → reopen → onboard appears again. #1663 (0ef78e96) tried to fix this by persisting an `OnboardAttempted` marker, but the re-trigger persisted.

## Root cause (from live serve.log)

Instrumenting the running desktop revealed the first-run onboard is launched by **`FirstRunSetup.finishOnboard`** (right after the API key is entered), which called `openAgentSession('/onboard')` and set `onboardPhase = ''` — but **never called `markOnboardAttempted`**, and never went through `App.maybeLaunchOnboard` (the only path #1663 instrumented). So the marker was never written on the first run:

```
status phase=key_setup ...                      # first load
session created ✨ Onboard                        # FirstRunSetup launch — NO marker written
status phase=soul_setup marker_exists=false      # reopen: marker still false
onboard/attempt: marked marker_exists=true       # maybeLaunchOnboard finally marks
session created ✨ Onboard                         # ...and re-launches — the bug
```

## Fixes

- **`FirstRunSetup.finishOnboard` now records the attempt before opening the chat** — this first-run launch path was the one missing the marker.
- **Marker moved out of `config.yml`** into a standalone `~/.octo/.onboard_attempted` file, so a concurrent `config.yml` read-modify-write during first-run (key save, language, the `/onboard` skill) can't clobber it. The legacy `config.yml` field is still **read** for back-compat with installs that recorded it there.
- **`GET /api/onboard/status` is now uncacheable** (client `cache:'no-store'` + server `Cache-Control`), so a desktop-webview-cached phase can't replay a stale `soul_setup` on reopen.
- **The nudge fires only when the user has no identity at all** — both `soul.md` and `user.md` missing — instead of keying on `soul.md` alone.

## CLI/TUI

Already marked correctly (and is additionally guarded by `isFirstEverSession()`), so it never had this bug. Its decide-and-mark logic is extracted into `shouldAutoOnboard()` so the two can never drift, with tests locking the invariant.

## Tests

- `internal/config` / `internal/server`: marker survives a later `config.yml` Save; existing identity skips the nudge; status response carries `no-store`.
- `cmd/octo`: `shouldAutoOnboard` writes the marker exactly when it launches, is idempotent, and skips when an identity file exists.
- `go test ./internal/config ./internal/server ./cmd/octo` (race), `go vet`, `gofmt`, and `svelte-check` (0/0) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)