### PR TITLE
fix(config): skip default-model prompt when no default exists yet

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -660,11 +660,13 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 	full.UpsertEndpoint(ep)
 	cid := endpointID + "::" + outEntry.Model
 
-	// On first run the very first model becomes the default without asking —
-	// same as the web first-run setup (saveModel in web/src/lib/api.ts). When
-	// the wizard is re-run later to add another model, ask before touching the
-	// default, so adding a model doesn't silently steal the existing default.
-	if firstRun {
+	// The very first model becomes the default without asking — same as the web
+	// first-run setup (saveModel in web/src/lib/api.ts). This covers both the
+	// startup onboarding (firstRun) and an explicit `octo config` against an
+	// as-yet defaultless config: with nothing to steal from, the prompt is just
+	// noise. Only once a default already exists do we ask before touching it, so
+	// adding another model doesn't silently steal the existing default.
+	if firstRun || full.Default == "" {
 		full.SetDefaultComposite(cid)
 	} else {
 		setDefault, ok := pickYesNo(tty, reader, stdin, stdout,


### PR DESCRIPTION
## Problem

Running `octo config` on a config that has **no default model yet** still prompted "Set _X_ as the default model?". The wizard's `firstRun` flag was hardcoded to `false` for the explicit `octo config` path (`cmd/octo/config.go:116`), so the "ask before stealing the default" branch always fired — even when there was no existing default to protect. With nothing to steal from, the prompt is pure noise.

## Fix

Gate the prompt on whether a default **actually exists** (`full.Default == ""`) rather than on which entry point invoked the wizard:

- **First-time setup** (no default in config) → the model is set as default silently, no prompt.
- **Adding a model when a default already exists** → still asks, so a new model can't silently steal the existing default.

`UpsertEndpoint` never touches `Default`, so the check reflects the pre-run state and is reliable.

## Testing

- `go build ./cmd/octo/`
- `go test ./cmd/octo/`
- `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)