### PR TITLE
feat(serve): wire the managed tunnel into `octo serve --tunnel`

### DIFF
--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -44,6 +44,8 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	maxTokens := fs.Int("max-tokens", 0, "max_tokens for responses")
 	tools := fs.Bool("tools", true, "Enable agentic tool loop")
 	cors := fs.String("cors", "", "Additional CORS allowed origins (comma-separated, * for any). app://obsidian.md and vscode-webview:// origins are always allowed by default.")
+	tunnelOn := fs.Bool("tunnel", false, "Connect to octo's managed relay so a paired phone can reach this server through NAT (end-to-end encrypted; opt-in)")
+	relayURL := fs.String("relay", defaultRelayURL, "Managed-tunnel relay endpoint (override to self-host the relay or use staging)")
 	noChannel := fs.Bool("no-channel", false, "Disable IM channel (DingTalk, Feishu)")
 	noMemory := fs.Bool("no-memory", false, "Disable cross-session memory injection")
 	noSupervisor := fs.Bool("no-supervisor", false, "Run the server directly, without the self-restart supervisor (exit code 42 still signals a restart request to an external supervisor)")
@@ -133,6 +135,16 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	if *tunnelOn {
+		// The tunnel is a goroutine in this process; it stops when ctx is
+		// cancelled on shutdown. It dials the relay and bridges to the local
+		// /ws as a normal client, so the server needs no tunnel awareness.
+		if err := startTunnel(ctx, srv, *addr, *relayURL, stdout); err != nil {
+			fmt.Fprintf(stderr, "octo serve: tunnel: %v\n", err)
+			return 1
+		}
+	}
 
 	go func() {
 		sigCh := make(chan os.Signal, 1)

--- a/cmd/octo/serve_tunnel.go
+++ b/cmd/octo/serve_tunnel.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/open-octo/octo-agent/internal/server"
+	"github.com/open-octo/octo-agent/internal/tunnel"
+)
+
+// defaultRelayURL is octo's hosted relay. A user can point --relay elsewhere to
+// self-host the relay or reach a staging one.
+const defaultRelayURL = "wss://relay.octo.dev"
+
+// startTunnel brings up the managed-tunnel host bridge for `octo serve --tunnel`.
+// It runs in the serve worker: the tunnel is a goroutine in this process and an
+// ordinary key-authenticated /ws client of the local server, so internal/server
+// is untouched. The goroutine stops when ctx is cancelled (serve shutdown).
+func startTunnel(ctx context.Context, srv *server.Server, addr, relayURL string, stdout io.Writer) error {
+	idPath, err := tunnelIdentityPath()
+	if err != nil {
+		return err
+	}
+	identity, err := tunnel.LoadOrCreateIdentity(idPath)
+	if err != nil {
+		return err
+	}
+	token, err := newPairToken()
+	if err != nil {
+		return err
+	}
+
+	tun, err := tunnel.New(tunnel.Config{
+		RelayURL:    relayURL,
+		TunnelID:    identity.TunnelID(),
+		PairTokens:  []string{token},
+		LoopbackURL: loopbackWSURL(addr),
+		AccessKey:   srv.AccessKey(),
+		Identity:    identity,
+	})
+	if err != nil {
+		return err
+	}
+
+	printPairingMaterial(stdout, relayURL, identity, token)
+	go func() { _ = tun.Serve(ctx) }()
+	return nil
+}
+
+// tunnelIdentityPath is ~/.octo/tunnel.json, alongside the other serve state.
+func tunnelIdentityPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".octo", "tunnel.json"), nil
+}
+
+// newPairToken returns a one-time, single-use pairing token (128 bits of hex).
+func newPairToken() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// loopbackWSURL derives the local /ws URL the tunnel bridges into. A wildcard or
+// empty bind host means the server listens on loopback too, so dial 127.0.0.1; a
+// specific bind host is dialed as-is (that is the only interface it accepts).
+func loopbackWSURL(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		host, port = "127.0.0.1", "8088"
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return "ws://" + net.JoinHostPort(host, port) + "/ws"
+}
+
+// printPairingMaterial shows the raw data a pairing QR encodes. Rendering it as
+// a scannable QR (CLI ASCII, web/desktop panel) is a later step; the text is
+// enough to pair a device by hand and to test against a relay.
+func printPairingMaterial(w io.Writer, relayURL string, id *tunnel.Identity, token string) {
+	fmt.Fprintln(w, "octo serve: managed tunnel enabled — pair a device with:")
+	fmt.Fprintf(w, "  relay:      %s\n", relayURL)
+	fmt.Fprintf(w, "  tunnel id:  %s\n", id.TunnelID())
+	fmt.Fprintf(w, "  host key:   %s\n", id.PublicKeyBase64())
+	fmt.Fprintf(w, "  pair token: %s  (one-time)\n", token)
+}

--- a/cmd/octo/serve_tunnel_test.go
+++ b/cmd/octo/serve_tunnel_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestLoopbackWSURL(t *testing.T) {
+	cases := map[string]string{
+		"127.0.0.1:8088":   "ws://127.0.0.1:8088/ws",
+		":8088":            "ws://127.0.0.1:8088/ws",   // empty host = wildcard, dial loopback
+		"0.0.0.0:9000":     "ws://127.0.0.1:9000/ws",   // IPv4 wildcard
+		"[::]:8088":        "ws://127.0.0.1:8088/ws",   // IPv6 wildcard
+		"192.168.1.5:8088": "ws://192.168.1.5:8088/ws", // specific bind dialed as-is
+		"localhost:8088":   "ws://localhost:8088/ws",
+	}
+	for addr, want := range cases {
+		if got := loopbackWSURL(addr); got != want {
+			t.Errorf("loopbackWSURL(%q) = %q, want %q", addr, got, want)
+		}
+	}
+}
+
+func TestNewPairToken(t *testing.T) {
+	a, err := newPairToken()
+	if err != nil {
+		t.Fatalf("newPairToken: %v", err)
+	}
+	if len(a) != 32 { // 16 bytes hex
+		t.Errorf("token %q has length %d, want 32", a, len(a))
+	}
+	if _, err := hex.DecodeString(a); err != nil {
+		t.Errorf("token %q is not hex: %v", a, err)
+	}
+	b, _ := newPairToken()
+	if a == b {
+		t.Error("two tokens should differ")
+	}
+}

--- a/internal/tunnel/identity.go
+++ b/internal/tunnel/identity.go
@@ -1,0 +1,107 @@
+package tunnel
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/flynn/noise"
+)
+
+// Identity is a host's stable tunnel identity: its Noise static keypair and the
+// tunnel id it presents on the relay. It is generated once and persisted so a
+// host keeps the same identity — and its set of paired devices — across
+// restarts. The private key never leaves this process; the relay only ever sees
+// the tunnel id.
+type Identity struct {
+	tunnelID string
+	static   noise.DHKey
+}
+
+// TunnelID is the host's tunnel identity on the relay (its SNI subdomain in
+// production).
+func (i *Identity) TunnelID() string { return i.tunnelID }
+
+// PublicKeyBase64 is the host's static public key — the value a pairing QR
+// carries so a phone can authenticate the host end to end.
+func (i *Identity) PublicKeyBase64() string {
+	return base64.StdEncoding.EncodeToString(i.static.Public)
+}
+
+// identityFile is the on-disk form of an Identity (~/.octo/tunnel.json).
+type identityFile struct {
+	TunnelID   string `json:"tunnel_id"`
+	PrivateKey string `json:"private_key"` // base64
+	PublicKey  string `json:"public_key"`  // base64
+}
+
+// LoadOrCreateIdentity reads the identity at path, or generates and persists a
+// fresh one (0600) when the file does not exist.
+func LoadOrCreateIdentity(path string) (*Identity, error) {
+	b, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		return decodeIdentity(b)
+	case errors.Is(err, os.ErrNotExist):
+		return createIdentity(path)
+	default:
+		return nil, err
+	}
+}
+
+func decodeIdentity(b []byte) (*Identity, error) {
+	var f identityFile
+	if err := json.Unmarshal(b, &f); err != nil {
+		return nil, fmt.Errorf("tunnel: parse identity: %w", err)
+	}
+	priv, err := base64.StdEncoding.DecodeString(f.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("tunnel: decode private key: %w", err)
+	}
+	pub, err := base64.StdEncoding.DecodeString(f.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("tunnel: decode public key: %w", err)
+	}
+	if f.TunnelID == "" || len(priv) == 0 || len(pub) == 0 {
+		return nil, fmt.Errorf("tunnel: incomplete identity file")
+	}
+	return &Identity{tunnelID: f.TunnelID, static: noise.DHKey{Private: priv, Public: pub}}, nil
+}
+
+func createIdentity(path string) (*Identity, error) {
+	kp, err := generateKeypair()
+	if err != nil {
+		return nil, err
+	}
+	tid, err := randomTunnelID()
+	if err != nil {
+		return nil, err
+	}
+	f := identityFile{
+		TunnelID:   tid,
+		PrivateKey: base64.StdEncoding.EncodeToString(kp.Private),
+		PublicKey:  base64.StdEncoding.EncodeToString(kp.Public),
+	}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return nil, fmt.Errorf("tunnel: write identity: %w", err)
+	}
+	return &Identity{tunnelID: tid, static: kp}, nil
+}
+
+// randomTunnelID returns 128 bits of hex — enough to be unguessable as an SNI
+// label and collision-free across hosts.
+func randomTunnelID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/internal/tunnel/identity.go
+++ b/internal/tunnel/identity.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/flynn/noise"
 )
@@ -89,6 +90,11 @@ func createIdentity(path string) (*Identity, error) {
 	data, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
 		return nil, err
+	}
+	// Don't rely on ~/.octo already existing: on a fresh machine the access key
+	// can come from OCTO_ACCESS_KEY, so server startup may not have created it.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("tunnel: create state dir: %w", err)
 	}
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return nil, fmt.Errorf("tunnel: write identity: %w", err)

--- a/internal/tunnel/identity_test.go
+++ b/internal/tunnel/identity_test.go
@@ -1,0 +1,59 @@
+package tunnel
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadOrCreateIdentity_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tunnel.json")
+
+	created, err := LoadOrCreateIdentity(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if len(created.TunnelID()) != 32 { // 16 bytes hex
+		t.Errorf("tunnel id = %q, want 32 hex chars", created.TunnelID())
+	}
+	if created.PublicKeyBase64() == "" {
+		t.Error("public key is empty")
+	}
+
+	// The identity file must not be world-readable — it holds a private key.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("identity file perm = %o, want 600", perm)
+	}
+
+	// Reloading returns the same identity, not a new one.
+	reloaded, err := LoadOrCreateIdentity(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.TunnelID() != created.TunnelID() {
+		t.Errorf("tunnel id changed on reload: %q -> %q", created.TunnelID(), reloaded.TunnelID())
+	}
+	if reloaded.PublicKeyBase64() != created.PublicKeyBase64() {
+		t.Error("public key changed on reload")
+	}
+	if !bytes.Equal(reloaded.static.Private, created.static.Private) {
+		t.Error("private key changed on reload")
+	}
+}
+
+func TestDecodeIdentity_Rejects(t *testing.T) {
+	if _, err := decodeIdentity([]byte("{not json")); err == nil {
+		t.Error("malformed JSON should error")
+	}
+	if _, err := decodeIdentity([]byte(`{"tunnel_id":"","private_key":"","public_key":""}`)); err == nil {
+		t.Error("empty identity should error")
+	}
+	if _, err := decodeIdentity([]byte(`{"tunnel_id":"abc","private_key":"!!notbase64","public_key":"AA=="}`)); err == nil {
+		t.Error("invalid base64 private key should error")
+	}
+}

--- a/internal/tunnel/identity_test.go
+++ b/internal/tunnel/identity_test.go
@@ -46,6 +46,24 @@ func TestLoadOrCreateIdentity_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestLoadOrCreateIdentity_CreatesParentDir covers a fresh machine where
+// ~/.octo does not exist yet (e.g. access key came from the environment, so
+// server startup never created it). Creating the identity must make the dir.
+func TestLoadOrCreateIdentity_CreatesParentDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist-yet", "tunnel.json")
+
+	id, err := LoadOrCreateIdentity(path)
+	if err != nil {
+		t.Fatalf("create in missing dir: %v", err)
+	}
+	if id.TunnelID() == "" {
+		t.Error("tunnel id is empty")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("identity file was not written: %v", err)
+	}
+}
+
 func TestDecodeIdentity_Rejects(t *testing.T) {
 	if _, err := decodeIdentity([]byte("{not json")); err == nil {
 		t.Error("malformed JSON should error")

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/flynn/noise"
 	"github.com/gorilla/websocket"
 )
 
@@ -34,9 +33,10 @@ type Config struct {
 	// exempt from the key check, so this is belt-and-suspenders, but it keeps
 	// the tunnel an ordinary key-authenticated client.
 	AccessKey string
-	// StaticKey is the host's Noise static keypair. Persisted in ~/.octo in
-	// production; the PoC generates a throwaway one (see New).
-	StaticKey noise.DHKey
+	// Identity supplies the host's Noise static keypair (and, if TunnelID is
+	// unset, the tunnel id). Load it with LoadOrCreateIdentity to persist it in
+	// ~/.octo. When nil, New generates a throwaway identity — the PoC/test path.
+	Identity *Identity
 	// Logf overrides the logger. nil uses log.Printf.
 	Logf func(string, ...any)
 }
@@ -62,18 +62,21 @@ type device struct {
 	loopback *websocket.Conn
 }
 
-// New builds a tunnel. If cfg.StaticKey is the zero value, a throwaway keypair
-// is generated (PoC behavior); production passes a persisted key.
+// New builds a tunnel. If cfg.Identity is nil, a throwaway one is generated
+// (PoC/test path); production passes a persisted identity.
 func New(cfg Config) (*Tunnel, error) {
-	if cfg.RelayURL == "" || cfg.TunnelID == "" || cfg.LoopbackURL == "" {
-		return nil, fmt.Errorf("tunnel: RelayURL, TunnelID and LoopbackURL are required")
-	}
-	if cfg.StaticKey.Private == nil {
+	if cfg.Identity == nil {
 		kp, err := generateKeypair()
 		if err != nil {
 			return nil, err
 		}
-		cfg.StaticKey = kp
+		cfg.Identity = &Identity{tunnelID: cfg.TunnelID, static: kp}
+	}
+	if cfg.TunnelID == "" {
+		cfg.TunnelID = cfg.Identity.tunnelID
+	}
+	if cfg.RelayURL == "" || cfg.TunnelID == "" || cfg.LoopbackURL == "" {
+		return nil, fmt.Errorf("tunnel: RelayURL, TunnelID and LoopbackURL are required")
 	}
 	logf := cfg.Logf
 	if logf == nil {
@@ -164,7 +167,7 @@ func (t *Tunnel) runOnce(ctx context.Context) error {
 func (t *Tunnel) handleRelayFrame(ctx context.Context, f frame) error {
 	switch f.Type {
 	case frameDeviceJoined:
-		s, err := newSession(false /* responder */, t.cfg.StaticKey)
+		s, err := newSession(false /* responder */, t.cfg.Identity.static)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
> **Stacked on #1673** (base is that branch, so this diff shows only the serve-wiring delta). Merge #1673 first, then this rebases onto main.

## What

The opt-in flag that starts the [host tunnel bridge](https://github.com/open-octo/octo-agent/pull/1673) inside the serve process, plus the persistence and pairing material it needs. The tunnel is a goroutine and an ordinary key-authenticated `/ws` client — **`internal/server` stays untouched**.

- `--tunnel` opts in; `--relay` overrides the endpoint (default `wss://relay.octo.dev`) for self-hosting or staging.
- `internal/tunnel` gains a persisted **`Identity`**: `LoadOrCreateIdentity` reads `~/.octo/tunnel.json` (0600) or generates a host Noise static keypair + tunnel id and saves it, so a host keeps its identity — and its paired devices — across restarts. `Config` now takes an `*Identity` instead of a raw `noise.DHKey`, so **cmd/octo never imports `flynn/noise`**.
- On `--tunnel` the serve **worker** loads the identity, mints a one-time pairing token, prints the pairing material (relay, tunnel id, host public key, token), and starts `tun.Serve(ctx)`. The goroutine stops when serve shuts down (ctx cancel).
- `loopbackWSURL` derives the local `/ws` target: wildcard/empty binds dial `127.0.0.1`, a specific bind is dialed as-is.

## Deferred

Rendering the pairing material as a **scannable QR** (CLI ASCII + web/desktop panel — needs a QR dep), a `config.yml` relay field, and re-pairing/revocation UX. Push (APNs/FCM) and multi-node routing remain separate steps.

## Tests

- `identity_test.go` — load/create round-trip, file perms (0600), malformed-file rejection.
- `serve_tunnel_test.go` — `loopbackWSURL` cases (wildcard v4/v6, specific bind, localhost), pair-token format.
- End-to-end bridge correctness is covered by `internal/tunnel`'s own test (#1673).

`go test -race` + `go vet` + `gofmt` clean; CLI builds; root `go mod tidy -diff` empty; `cmd/octo-desktop` nested-module tidy unaffected.

## Arc

relay PoC (#1672) → host bridge (#1673) → **serve wiring (this)** → `octo-mobile` Capacitor app. QR rendering + push + multi-node are the remaining relay/UX steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)