### PR TITLE
feat(tunnel): host demux for /api + /ws over the managed tunnel

### DIFF
--- a/internal/tunnel/bridge.go
+++ b/internal/tunnel/bridge.go
@@ -1,0 +1,194 @@
+package tunnel
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+// bridge demultiplexes one device's shim frames onto the local server. It
+// replays http-req frames as loopback HTTP calls and opens a loopback /ws per
+// ws-open stream; responses and server-pushed messages are framed again,
+// encrypted with the device's Noise session, and sent back through the relay.
+//
+// This is the host counterpart of the phone's local shim (mobile/src/shim.ts):
+// the phone multiplexes the webview's /api + /ws into shim frames, and the
+// bridge fans them back out onto the real loopback server.
+type bridge struct {
+	t        *Tunnel
+	ctx      context.Context
+	deviceID string
+	sess     *session
+
+	// sendMu serializes Noise encryption with the relay write. A device's
+	// CipherState nonce increments per message, so the order frames are
+	// encrypted must equal the order they hit the wire — many goroutines
+	// (one per in-flight HTTP call, one per ws stream) send concurrently.
+	sendMu sync.Mutex
+
+	mu      sync.Mutex
+	streams map[string]*wsStream
+	closed  bool
+}
+
+type wsStream struct {
+	conn    *websocket.Conn
+	writeMu sync.Mutex
+}
+
+func newBridge(ctx context.Context, t *Tunnel, deviceID string, sess *session) *bridge {
+	return &bridge{t: t, ctx: ctx, deviceID: deviceID, sess: sess, streams: map[string]*wsStream{}}
+}
+
+// handle dispatches one inbound shim frame. HTTP calls run on their own
+// goroutine so a slow request doesn't stall the device's frame stream.
+func (b *bridge) handle(f shimFrame) {
+	switch f.Kind {
+	case shimHTTPReq:
+		go b.doHTTP(f)
+	case shimWSOpen:
+		b.openWS(f)
+	case shimWSMessage:
+		b.wsWrite(f.ID, f.Data)
+	case shimWSClose:
+		b.closeStream(f.ID)
+	default:
+		// http-resp / ws-msg only travel host→phone; nothing to do inbound.
+	}
+}
+
+// send frames, encrypts, and writes to the relay under sendMu.
+func (b *bridge) send(f shimFrame) {
+	data, err := f.encode()
+	if err != nil {
+		b.t.logf("[tunnel] device=%s encode: %v", b.deviceID, err)
+		return
+	}
+	b.sendMu.Lock()
+	defer b.sendMu.Unlock()
+	ct, err := b.sess.encrypt(data)
+	if err != nil {
+		b.t.logf("[tunnel] device=%s encrypt: %v", b.deviceID, err)
+		return
+	}
+	if err := b.t.writeRelay(frame{Type: frameData, Device: b.deviceID, Payload: ct}); err != nil {
+		b.t.logf("[tunnel] device=%s relay write: %v", b.deviceID, err)
+	}
+}
+
+func (b *bridge) doHTTP(f shimFrame) {
+	var body io.Reader
+	if f.Body != nil {
+		body = strings.NewReader(*f.Body)
+	}
+	req, err := http.NewRequestWithContext(b.ctx, f.Method, b.t.httpBase+f.Path, body)
+	if err != nil {
+		b.send(httpError(f.ID, err))
+		return
+	}
+	for k, v := range f.Headers {
+		if skipRequestHeader(k) {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+	resp, err := b.t.httpClient.Do(req)
+	if err != nil {
+		b.send(httpError(f.ID, err))
+		return
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	headers := make(map[string]string, len(resp.Header))
+	for k := range resp.Header {
+		headers[k] = resp.Header.Get(k)
+	}
+	b.send(shimFrame{Kind: shimHTTPResp, ID: f.ID, Status: resp.StatusCode, Headers: headers, Body: strPtr(string(respBody))})
+}
+
+func httpError(id string, err error) shimFrame {
+	return shimFrame{Kind: shimHTTPResp, ID: id, Status: http.StatusBadGateway, Headers: map[string]string{}, Body: strPtr(err.Error())}
+}
+
+// skipRequestHeader drops headers the loopback HTTP client must set itself; the
+// phone's copy of them would be wrong or rejected.
+func skipRequestHeader(k string) bool {
+	switch strings.ToLower(k) {
+	case "host", "connection", "content-length", "accept-encoding", "transfer-encoding":
+		return true
+	}
+	return false
+}
+
+func (b *bridge) openWS(f shimFrame) {
+	conn, _, err := websocket.DefaultDialer.DialContext(b.ctx, b.t.wsBase+f.Path, nil)
+	if err != nil {
+		b.send(shimFrame{Kind: shimWSError, ID: f.ID, Message: err.Error()})
+		return
+	}
+	st := &wsStream{conn: conn}
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		conn.Close()
+		return
+	}
+	b.streams[f.ID] = st
+	b.mu.Unlock()
+	go b.wsPump(f.ID, st)
+}
+
+// wsPump forwards server-pushed messages on one loopback /ws to the phone, and
+// reports the close when the loopback side ends.
+func (b *bridge) wsPump(id string, st *wsStream) {
+	for {
+		_, msg, err := st.conn.ReadMessage()
+		if err != nil {
+			b.send(shimFrame{Kind: shimWSClose, ID: id})
+			b.closeStream(id)
+			return
+		}
+		b.send(shimFrame{Kind: shimWSMessage, ID: id, Data: string(msg)})
+	}
+}
+
+func (b *bridge) wsWrite(id, data string) {
+	b.mu.Lock()
+	st := b.streams[id]
+	b.mu.Unlock()
+	if st == nil {
+		return
+	}
+	st.writeMu.Lock()
+	defer st.writeMu.Unlock()
+	_ = st.conn.WriteMessage(websocket.TextMessage, []byte(data))
+}
+
+// closeStream closes and forgets a ws stream. Idempotent: a stream can be closed
+// by the phone (ws-close) and by its own pump (loopback ended) in either order.
+func (b *bridge) closeStream(id string) {
+	b.mu.Lock()
+	st := b.streams[id]
+	delete(b.streams, id)
+	b.mu.Unlock()
+	if st != nil {
+		st.conn.Close()
+	}
+}
+
+// close tears down every ws stream; called when the device or relay connection
+// goes away.
+func (b *bridge) close() {
+	b.mu.Lock()
+	b.closed = true
+	streams := b.streams
+	b.streams = map[string]*wsStream{}
+	b.mu.Unlock()
+	for _, st := range streams {
+		st.conn.Close()
+	}
+}

--- a/internal/tunnel/frames.go
+++ b/internal/tunnel/frames.go
@@ -1,0 +1,49 @@
+package tunnel
+
+import "encoding/json"
+
+// shimFrame is the plaintext unit multiplexed inside the Noise data channel
+// between the phone's local shim and this host. One channel carries many
+// concurrent /api requests and /ws sockets, each tagged with a stream id.
+//
+// It mirrors mobile/src/frames.ts field-for-field (a service-boundary duplicate,
+// like the relay/host wire.Frame split): the two ends agree on this JSON, not on
+// shared code. Keep the json tags in lockstep with frames.ts.
+type shimFrame struct {
+	Kind string `json:"kind"`
+	ID   string `json:"id"`
+
+	// http-req / http-resp
+	Method  string            `json:"method,omitempty"`
+	Path    string            `json:"path,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Body    *string           `json:"body,omitempty"` // string|null in frames.ts
+	Status  int               `json:"status,omitempty"`
+
+	// ws-open / ws-msg / ws-close / ws-error
+	Data    string `json:"data,omitempty"`
+	Code    int    `json:"code,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+const (
+	shimHTTPReq   = "http-req"
+	shimHTTPResp  = "http-resp"
+	shimWSOpen    = "ws-open"
+	shimWSMessage = "ws-msg"
+	shimWSClose   = "ws-close"
+	shimWSError   = "ws-error"
+)
+
+func decodeShimFrame(b []byte) (shimFrame, error) {
+	var f shimFrame
+	err := json.Unmarshal(b, &f)
+	return f, err
+}
+
+func (f shimFrame) encode() ([]byte, error) {
+	return json.Marshal(f)
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 	"sync"
 	"time"
@@ -27,11 +28,13 @@ type Config struct {
 	// PairTokens are the one-time pairing tokens the host offers (one per phone
 	// it expects to pair). Production mints these per QR.
 	PairTokens []string
-	// LoopbackURL is the local server's /ws, e.g. ws://127.0.0.1:8088/ws.
+	// LoopbackURL points at the local server's /ws, e.g. ws://127.0.0.1:8088/ws.
+	// Its host:port is the base the bridge dials for both loopback HTTP (/api)
+	// and loopback WebSocket (/ws) calls.
 	LoopbackURL string
-	// AccessKey is presented to the local /ws as ?access_key=. Loopback is
-	// exempt from the key check, so this is belt-and-suspenders, but it keeps
-	// the tunnel an ordinary key-authenticated client.
+	// AccessKey would authenticate a non-loopback client. The bridge dials
+	// 127.0.0.1, which the server exempts from the key check, so it is unused for
+	// now; kept for a future non-loopback bind.
 	AccessKey string
 	// Identity supplies the host's Noise static keypair (and, if TunnelID is
 	// unset, the tunnel id). Load it with LoadOrCreateIdentity to persist it in
@@ -42,10 +45,14 @@ type Config struct {
 }
 
 // Tunnel is the host side of the managed tunnel: one relay connection bridging N
-// paired devices to the local /ws, each over its own Noise session.
+// paired devices to the local server, each over its own Noise session.
 type Tunnel struct {
 	cfg  Config
 	logf func(string, ...any)
+
+	httpBase   string // http(s)://host:port — loopback base for /api replays
+	wsBase     string // ws(s)://host:port     — loopback base for /ws streams
+	httpClient *http.Client
 
 	relayMu sync.Mutex // guards the relay pointer and serializes writes to it
 	relay   *websocket.Conn
@@ -54,12 +61,13 @@ type Tunnel struct {
 	devices map[string]*device
 }
 
-// device is one paired phone: its Noise session and its dedicated loopback /ws
-// connection to the local server.
+// device is one paired phone: its Noise session and, once the handshake
+// completes, the bridge that demultiplexes its shim frames onto the loopback
+// server.
 type device struct {
-	id       string
-	sess     *session
-	loopback *websocket.Conn
+	id   string
+	sess *session
+	br   *bridge
 }
 
 // New builds a tunnel. If cfg.Identity is nil, a throwaway one is generated
@@ -78,11 +86,37 @@ func New(cfg Config) (*Tunnel, error) {
 	if cfg.RelayURL == "" || cfg.TunnelID == "" || cfg.LoopbackURL == "" {
 		return nil, fmt.Errorf("tunnel: RelayURL, TunnelID and LoopbackURL are required")
 	}
+	httpBase, wsBase, err := loopbackBases(cfg.LoopbackURL)
+	if err != nil {
+		return nil, err
+	}
 	logf := cfg.Logf
 	if logf == nil {
 		logf = log.Printf
 	}
-	return &Tunnel{cfg: cfg, logf: logf, devices: map[string]*device{}}, nil
+	return &Tunnel{
+		cfg:        cfg,
+		logf:       logf,
+		httpBase:   httpBase,
+		wsBase:     wsBase,
+		httpClient: &http.Client{},
+		devices:    map[string]*device{},
+	}, nil
+}
+
+// loopbackBases derives the HTTP and WebSocket loopback bases from the /ws URL.
+func loopbackBases(loopbackURL string) (httpBase, wsBase string, err error) {
+	u, err := url.Parse(loopbackURL)
+	if err != nil {
+		return "", "", fmt.Errorf("tunnel: parse LoopbackURL: %w", err)
+	}
+	if u.Host == "" {
+		return "", "", fmt.Errorf("tunnel: LoopbackURL has no host")
+	}
+	if u.Scheme == "wss" || u.Scheme == "https" {
+		return "https://" + u.Host, "wss://" + u.Host, nil
+	}
+	return "http://" + u.Host, "ws://" + u.Host, nil
 }
 
 // Serve maintains the relay connection with reconnect/backoff until ctx is
@@ -109,7 +143,7 @@ func (t *Tunnel) Serve(ctx context.Context) error {
 }
 
 // runOnce dials the relay and bridges until the connection drops or ctx is
-// cancelled. All per-device loopback connections are torn down on return.
+// cancelled. Every device's bridge is torn down on return.
 func (t *Tunnel) runOnce(ctx context.Context) error {
 	q := url.Values{"tunnel": {t.cfg.TunnelID}}
 	for _, tok := range t.cfg.PairTokens {
@@ -130,8 +164,8 @@ func (t *Tunnel) runOnce(ctx context.Context) error {
 	t.mu.Unlock()
 	t.logf("[tunnel] connected to relay tunnel=%s", t.cfg.TunnelID)
 
-	// When the read loop exits, stop the relay socket and every loopback socket
-	// so their pump goroutines unblock and return.
+	// When the read loop exits, stop the relay socket and tear down every
+	// device's bridge (which closes its loopback streams).
 	defer func() {
 		ws.Close()
 		t.relayMu.Lock()
@@ -139,8 +173,8 @@ func (t *Tunnel) runOnce(ctx context.Context) error {
 		t.relayMu.Unlock()
 		t.mu.Lock()
 		for _, d := range t.devices {
-			if d.loopback != nil {
-				d.loopback.Close()
+			if d.br != nil {
+				d.br.close()
 			}
 		}
 		t.devices = map[string]*device{}
@@ -189,74 +223,29 @@ func (t *Tunnel) handleRelayFrame(ctx context.Context, f frame) error {
 			}
 			return t.writeRelay(frame{Type: frameHandshake, Device: f.Device, Payload: msg})
 		}
-		// Handshake complete: open this device's loopback /ws and start pumping
-		// its replies back to the phone. If the loopback dial fails the device
-		// has no destination, so drop it rather than leave a done session with a
-		// nil loopback that a later data frame would deref.
-		if err := t.openLoopback(ctx, d); err != nil {
-			t.removeDevice(f.Device)
-			return err
-		}
+		// Handshake complete: stand up the device's bridge. Loopback connections
+		// open lazily, per shim frame, so there is nothing to dial here.
+		d.br = newBridge(ctx, t, f.Device, d.sess)
 		return nil
 
 	case frameData:
 		d := t.device(f.Device)
-		if d == nil || !d.sess.done || d.loopback == nil {
+		if d == nil || !d.sess.done || d.br == nil {
 			return fmt.Errorf("data with no ready session")
 		}
 		plaintext, err := d.sess.decrypt(f.Payload)
 		if err != nil {
 			return err
 		}
-		// The decrypted payload is a /ws message; hand it to the local server
-		// verbatim, exactly as a browser tab would send it.
-		return d.loopback.WriteMessage(websocket.TextMessage, plaintext)
+		sf, err := decodeShimFrame(plaintext)
+		if err != nil {
+			return fmt.Errorf("decode shim frame: %w", err)
+		}
+		d.br.handle(sf)
+		return nil
 
 	default:
 		return nil
-	}
-}
-
-// openLoopback dials the local /ws for one device and starts its reply pump.
-func (t *Tunnel) openLoopback(ctx context.Context, d *device) error {
-	loopURL := t.cfg.LoopbackURL
-	if t.cfg.AccessKey != "" {
-		if u, err := url.Parse(loopURL); err == nil {
-			q := u.Query()
-			q.Set("access_key", t.cfg.AccessKey)
-			u.RawQuery = q.Encode()
-			loopURL = u.String()
-		}
-	}
-	ws, _, err := websocket.DefaultDialer.DialContext(ctx, loopURL, nil)
-	if err != nil {
-		return fmt.Errorf("dial loopback /ws: %w", err)
-	}
-	t.mu.Lock()
-	d.loopback = ws
-	t.mu.Unlock()
-	t.logf("[tunnel] device=%s bridged to loopback /ws", d.id)
-	go t.loopbackPump(d)
-	return nil
-}
-
-// loopbackPump reads server events from a device's loopback /ws, encrypts them,
-// and forwards them to that phone through the relay. It ends when either socket
-// closes.
-func (t *Tunnel) loopbackPump(d *device) {
-	for {
-		_, msg, err := d.loopback.ReadMessage()
-		if err != nil {
-			return
-		}
-		ciphertext, err := d.sess.encrypt(msg)
-		if err != nil {
-			t.logf("[tunnel] device=%s encrypt: %v", d.id, err)
-			return
-		}
-		if err := t.writeRelay(frame{Type: frameData, Device: d.id, Payload: ciphertext}); err != nil {
-			return
-		}
 	}
 }
 
@@ -279,10 +268,4 @@ func (t *Tunnel) setDevice(d *device) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.devices[d.id] = d
-}
-
-func (t *Tunnel) removeDevice(id string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	delete(t.devices, id)
 }

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -2,6 +2,8 @@ package tunnel
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,28 +15,31 @@ import (
 )
 
 // This test exercises the host tunnel in isolation. The production code under
-// test is Tunnel (relay ↔ loopback /ws bridge). The relay, the phone, and the
-// local /ws are stubs speaking the same wire protocol — the tunnel cannot tell
-// them from the real thing. Because the test is in-package, the phone stub
-// reuses the real Noise session and frame codec instead of duplicating them.
+// test is Tunnel: it demultiplexes a device's shim frames onto the loopback
+// server — replaying http-req as HTTP calls and ws-open/msg as loopback /ws
+// streams. The relay, the phone, and the local server are stubs speaking the
+// same wire protocol. Because the test is in-package, the phone stub reuses the
+// real Noise session and both frame codecs.
 
 var upgrader = websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 
 func wsScheme(s *httptest.Server) string { return "ws" + strings.TrimPrefix(s.URL, "http") }
 
-// --- stub local /ws (the loopback target the tunnel bridges into) ---
+// --- stub loopback server: /api/echo (HTTP) + /ws (WebSocket echo) ---
 
-type stubWS struct {
-	srv      *httptest.Server
-	received chan string // plaintext the tunnel forwarded in from a phone
-	keys     chan string // access_key the tunnel presented on connect
-}
-
-func startStubWS(t *testing.T) *stubWS {
+func startStubLoopback(t *testing.T) *httptest.Server {
 	t.Helper()
-	s := &stubWS{received: make(chan string, 8), keys: make(chan string, 8)}
-	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s.keys <- r.URL.Query().Get("access_key")
+	mux := http.NewServeMux()
+	// Echoes the method and request body back as JSON, so the test can prove a
+	// real HTTP round-trip happened through the tunnel.
+	mux.HandleFunc("/api/echo", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{"method":%q,"body":%q}`, r.Method, string(body))
+	})
+	// Echoes each WebSocket message with a "reply-to:" prefix.
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 		ws, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return
@@ -45,18 +50,17 @@ func startStubWS(t *testing.T) *stubWS {
 			if err != nil {
 				return
 			}
-			s.received <- string(msg)
-			// Exercise the loopback→phone direction: reply to what we got.
 			if err := ws.WriteMessage(websocket.TextMessage, []byte("reply-to:"+string(msg))); err != nil {
 				return
 			}
 		}
-	}))
-	t.Cleanup(s.srv.Close)
-	return s
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
 }
 
-// --- stub relay (broker + bridge), minimal, speaking the wire protocol ---
+// --- stub relay (broker + bridge), minimal, speaking the relay wire protocol ---
 
 type stubRelay struct {
 	srv *httptest.Server
@@ -91,8 +95,6 @@ func startStubRelay(t *testing.T, tokens ...string) *stubRelay {
 	return r
 }
 
-// waitHost blocks until the host tunnel has connected — mirrors reality, where a
-// long-lived host is present before any phone pairs.
 func (r *stubRelay) waitHost(t *testing.T) {
 	t.Helper()
 	select {
@@ -129,7 +131,6 @@ func (r *stubRelay) handleHost(w http.ResponseWriter, req *http.Request) {
 	r.host = ws
 	r.mu.Unlock()
 	r.hostOnce.Do(func() { close(r.hostReady) })
-	// Host → device: route by the device the host named.
 	for {
 		f, err := readFrame(ws)
 		if err != nil {
@@ -160,14 +161,11 @@ func (r *stubRelay) handleDevice(w http.ResponseWriter, req *http.Request) {
 	r.deviceW[id] = &sync.Mutex{}
 	r.mu.Unlock()
 
-	// Announce to both ends, host first so it is ready before the phone's first
-	// handshake frame arrives.
 	_ = r.writeHost(frame{Type: frameDeviceJoined, Device: id})
 	r.deviceW[id].Lock()
 	_ = writeFrame(ws, frame{Type: framePaired, Device: id})
 	r.deviceW[id].Unlock()
 
-	// Device → host: stamp the device id so the host knows the source.
 	for {
 		f, err := readFrame(ws)
 		if err != nil {
@@ -178,14 +176,14 @@ func (r *stubRelay) handleDevice(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// --- mock phone (initiator), reusing the real session + wire ---
+// --- mock phone (initiator), reusing the real session + both frame codecs ---
 
 type mockPhone struct {
 	ws       *websocket.Conn
 	sess     *session
 	deviceID string
 	ready    chan struct{}
-	recvCh   chan string
+	recvCh   chan shimFrame
 }
 
 func (r *stubRelay) dialPhone(t *testing.T, token string) *mockPhone {
@@ -194,12 +192,12 @@ func (r *stubRelay) dialPhone(t *testing.T, token string) *mockPhone {
 	if err != nil {
 		t.Fatalf("dial phone: %v", err)
 	}
-	p := &mockPhone{ws: ws, ready: make(chan struct{}), recvCh: make(chan string, 8)}
-	go p.loop(t)
+	p := &mockPhone{ws: ws, ready: make(chan struct{}), recvCh: make(chan shimFrame, 16)}
+	go p.loop()
 	return p
 }
 
-func (p *mockPhone) loop(t *testing.T) {
+func (p *mockPhone) loop() {
 	for {
 		f, err := readFrame(p.ws)
 		if err != nil {
@@ -241,7 +239,11 @@ func (p *mockPhone) loop(t *testing.T) {
 			if err != nil {
 				return
 			}
-			p.recvCh <- string(pt)
+			sf, err := decodeShimFrame(pt)
+			if err != nil {
+				return
+			}
+			p.recvCh <- sf
 		}
 	}
 }
@@ -255,9 +257,13 @@ func (p *mockPhone) waitReady(t *testing.T) {
 	}
 }
 
-func (p *mockPhone) send(t *testing.T, plaintext string) {
+func (p *mockPhone) sendShim(t *testing.T, f shimFrame) {
 	t.Helper()
-	ct, err := p.sess.encrypt([]byte(plaintext))
+	data, err := f.encode()
+	if err != nil {
+		t.Fatalf("phone encode: %v", err)
+	}
+	ct, err := p.sess.encrypt(data)
 	if err != nil {
 		t.Fatalf("phone encrypt: %v", err)
 	}
@@ -266,71 +272,96 @@ func (p *mockPhone) send(t *testing.T, plaintext string) {
 	}
 }
 
-func (p *mockPhone) recv(t *testing.T) string {
+func (p *mockPhone) recvShim(t *testing.T) shimFrame {
 	t.Helper()
 	select {
-	case m := <-p.recvCh:
-		return m
+	case sf := <-p.recvCh:
+		return sf
 	case <-time.After(3 * time.Second):
-		t.Fatal("phone received nothing")
+		t.Fatal("phone received no frame")
 	}
-	return ""
+	return shimFrame{}
 }
 
-func recvWithin(t *testing.T, ch <-chan string) string {
+func newPairedPhone(t *testing.T) *mockPhone {
 	t.Helper()
-	select {
-	case v := <-ch:
-		return v
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting on channel")
-	}
-	return ""
-}
-
-// TestHostTunnel_BridgesBothDirections is the isolated proof: a phone pairs and
-// runs Noise with the host tunnel through a stub relay; a message the phone
-// encrypts arrives as plaintext at the local /ws, and the /ws's reply arrives
-// back at the phone decrypted. The tunnel decrypts and re-encrypts host-side —
-// the local server sees an ordinary /ws client.
-func TestHostTunnel_BridgesBothDirections(t *testing.T) {
-	stub := startStubWS(t)
+	stub := startStubLoopback(t)
 	relay := startStubRelay(t, "tok-1")
-
 	tun, err := New(Config{
 		RelayURL:    wsScheme(relay.srv),
 		TunnelID:    "tunnel-A",
 		PairTokens:  []string{"tok-1"},
-		LoopbackURL: wsScheme(stub.srv),
-		AccessKey:   "secret-key",
-		Logf:        func(string, ...any) {}, // quiet
+		LoopbackURL: wsScheme(stub) + "/ws",
+		Logf:        func(string, ...any) {},
 	})
 	if err != nil {
 		t.Fatalf("new tunnel: %v", err)
 	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 	go func() { _ = tun.Serve(ctx) }()
 
-	relay.waitHost(t) // a phone only pairs once the long-lived host is present
+	relay.waitHost(t)
 	phone := relay.dialPhone(t, "tok-1")
 	phone.waitReady(t)
+	return phone
+}
 
-	// Phone → local /ws: the plaintext must surface at the loopback verbatim.
-	phone.send(t, "REQ-hello-🔒")
-	if got := recvWithin(t, stub.received); got != "REQ-hello-🔒" {
-		t.Errorf("loopback received %q, want %q", got, "REQ-hello-🔒")
+// TestHostTunnel_HTTPRoundTrip proves an /api call tunnels: the phone's http-req
+// frame is replayed as a real loopback HTTP request and its response comes back
+// as an http-resp frame.
+func TestHostTunnel_HTTPRoundTrip(t *testing.T) {
+	phone := newPairedPhone(t)
+
+	phone.sendShim(t, shimFrame{
+		Kind:    shimHTTPReq,
+		ID:      "r1",
+		Method:  "POST",
+		Path:    "/api/echo",
+		Headers: map[string]string{"content-type": "application/json"},
+		Body:    strPtr(`{"hi":1}`),
+	})
+
+	resp := phone.recvShim(t)
+	if resp.Kind != shimHTTPResp || resp.ID != "r1" {
+		t.Fatalf("got %+v, want an http-resp for r1", resp)
 	}
-
-	// The tunnel presented the access key to the local /ws.
-	if got := recvWithin(t, stub.keys); got != "secret-key" {
-		t.Errorf("tunnel presented access_key %q, want %q", got, "secret-key")
+	if resp.Status != http.StatusCreated {
+		t.Errorf("status = %d, want %d", resp.Status, http.StatusCreated)
 	}
+	if resp.Body == nil || !strings.Contains(*resp.Body, `"method":"POST"`) || !strings.Contains(*resp.Body, `{\"hi\":1}`) {
+		t.Errorf("body = %v, want it to echo the POST + request body", resp.Body)
+	}
+}
 
-	// Local /ws → phone: the stub's reply must arrive decrypted at the phone.
-	if got := phone.recv(t); got != "reply-to:REQ-hello-🔒" {
-		t.Errorf("phone received %q, want %q", got, "reply-to:REQ-hello-🔒")
+// TestHostTunnel_WSRoundTrip proves a /ws stream tunnels: ws-open dials the
+// loopback /ws, ws-msg is delivered, and the server's reply comes back as a
+// ws-msg frame tagged with the same stream id.
+func TestHostTunnel_WSRoundTrip(t *testing.T) {
+	phone := newPairedPhone(t)
+
+	phone.sendShim(t, shimFrame{Kind: shimWSOpen, ID: "w1", Path: "/ws"})
+	phone.sendShim(t, shimFrame{Kind: shimWSMessage, ID: "w1", Data: "hello"})
+
+	msg := phone.recvShim(t)
+	if msg.Kind != shimWSMessage || msg.ID != "w1" {
+		t.Fatalf("got %+v, want a ws-msg for w1", msg)
+	}
+	if msg.Data != "reply-to:hello" {
+		t.Errorf("data = %q, want %q", msg.Data, "reply-to:hello")
+	}
+}
+
+// TestHostTunnel_WSErrorOnBadPath proves a ws-open to a path the loopback server
+// won't upgrade comes back as a ws-error, not a hang.
+func TestHostTunnel_WSErrorOnBadPath(t *testing.T) {
+	phone := newPairedPhone(t)
+
+	phone.sendShim(t, shimFrame{Kind: shimWSOpen, ID: "w9", Path: "/api/echo"})
+
+	f := phone.recvShim(t)
+	if f.Kind != shimWSError || f.ID != "w9" {
+		t.Fatalf("got %+v, want a ws-error for w9", f)
 	}
 }
 


### PR DESCRIPTION
Closes the gap flagged in #1680: the host tunnel now speaks the **multiplexed frame protocol** the phone shim produces (`mobile/src/frames.ts`), so **both `/api` (HTTP) and `/ws` (WebSocket)** tunnel — not just a single raw `/ws` as the original `internal/tunnel` did.

## How

A decrypted relay `data` payload is now a `shimFrame` (`frames.go`, a service-boundary mirror of `frames.ts` — the two ends share JSON, not code). Per device, a **bridge** (`bridge.go`) fans them onto the loopback server:

| Inbound frame | Action |
|---|---|
| `http-req` | a loopback HTTP call (127.0.0.1 is auth-exempt) → `http-resp` |
| `ws-open` | dial a loopback `/ws` for that stream id; pump its messages back as `ws-msg`; `ws-close` when it ends (`ws-error` on dial failure) |
| `ws-msg` | write to that stream's loopback `/ws` |
| `ws-close` | close that stream |

Outbound frames are encrypted and written **under one mutex per device**, so the Noise `CipherState` nonce order matches the wire order even though many goroutines (one per in-flight HTTP call, one per ws stream) send concurrently. Loopback HTTP/WS bases are derived from `Config.LoopbackURL`.

Replaces the old one-loopback-`/ws`-per-device model (`openLoopback` / `loopbackPump`) and its raw-passthrough data path.

## Tests

- **HTTP round-trip** — an `http-req` becomes a real loopback request; the response returns as `http-resp` (status + echoed method/body).
- **/ws round-trip** — `ws-open` + `ws-msg`, server echo returns as `ws-msg` tagged with the stream id.
- **ws-error** — `ws-open` to an un-upgradable path returns `ws-error`, not a hang.

`go test -race` + `go vet` + `gofmt` clean; parent `go build ./...` OK; **no new deps** (`net/http` is stdlib).

## Arc

relay PoC (#1672 ✅) → host bridge (#1673 ✅) → serve wiring (#1674 ✅) → pairing QR (#1678) → mobile groundwork (#1679) → shim + frames (#1680) → **host /api+/ws demux (this)**. The phone shim (#1680) and this host demux now speak the same protocol end to end. Native app (Mac) + push + multi-node remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)