### PR TITLE
fix(tunnel): skip the 0600 perm assertion on Windows

### DIFF
--- a/internal/tunnel/identity_test.go
+++ b/internal/tunnel/identity_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -22,12 +23,16 @@ func TestLoadOrCreateIdentity_RoundTrip(t *testing.T) {
 	}
 
 	// The identity file must not be world-readable — it holds a private key.
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Errorf("identity file perm = %o, want 600", perm)
+	// Windows does not honor Unix mode bits (os.WriteFile's 0o600 surfaces as
+	// 0666 there), so this invariant is only meaningful on Unix.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("identity file perm = %o, want 600", perm)
+		}
 	}
 
 	// Reloading returns the same identity, not a new one.


### PR DESCRIPTION
`TestLoadOrCreateIdentity_RoundTrip` fails on **windows-latest**:

```
identity_test.go:29: identity file perm = 666, want 600
```

Windows doesn't honor Unix mode bits, so `os.WriteFile(path, data, 0o600)` surfaces as `0666` there. This guards the private-key perm assertion with `runtime.GOOS != "windows"` — the invariant still holds and is checked on Unix, where file permissions are the real defense.

The test landed with the tunnel identity work (#1674) and only Windows CI catches it. It surfaced on the still-open mobile PRs (#1679/#1680) and is on `main` too (their Windows job runs this `internal/tunnel` test). Letting the Windows CI on this PR confirm the fix before merge.

Test-only; `go test` + `vet` + `gofmt` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)