### PR TITLE
docs(readme): add contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,14 @@ octo stands on the shoulders of two projects and doesn't pretend otherwise:
 
 Any bugs or bad decisions are octo's own.
 
+## Contributors
+
+Thanks to everyone who has contributed to octo:
+
+<a href="https://github.com/open-octo/octo-agent/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=open-octo/octo-agent" alt="Contributors" />
+</a>
+
 ## License
 
 MIT. See [`LICENSE.txt`](LICENSE.txt).

--- a/README_CN.md
+++ b/README_CN.md
@@ -399,6 +399,14 @@ octo 站在两个项目的肩膀上，这点不遮掩：
 
 有 bug 或者设计得不好的地方，都算 octo 自己的。
 
+## 贡献者
+
+感谢每一位为 octo 做出贡献的人：
+
+<a href="https://github.com/open-octo/octo-agent/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=open-octo/octo-agent" alt="Contributors" />
+</a>
+
 ## 许可
 
 MIT。见 [`LICENSE.txt`](LICENSE.txt)。


### PR DESCRIPTION
## What

Add a **Contributors / 贡献者** section to both `README.md` and `README_CN.md`, placed between the acknowledgements and license sections.

## Why

Give credit to project contributors directly in the README.

## How

Uses the auto-updating [contrib.rocks](https://contrib.rocks) image pointed at `open-octo/octo-agent`'s contributors graph — new contributors show up automatically without manual README edits, and bots like dependabot are filtered out by the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)