### PR TITLE
chore(agent): raise interactive default max-turns 200 -> 1000

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -410,7 +410,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	verboseFlag := fs.Bool("verbose", false, "Print extra context (provider/model/endpoint, always-on cache line). Also OCTO_VERBOSITY=verbose.")
 	permMode := fs.String("permission-mode", "", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask). Empty = use `octo config` value, else interactive.")
 	noCoauthor := fs.Bool("no-coauthor", false, "Disable appending Co-authored-by to git commit messages. Also OCTO_COAUTHOR=0.")
-	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 200 interactive, unlimited unattended/--prompt-file)")
+	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 1000 interactive, unlimited unattended/--prompt-file)")
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (percentage of the model's context window, settable via --compact-auto-pct or config), <0 = disabled")
 	compactAutoPct := fs.Int("compact-auto-pct", 0, "Auto-compaction threshold as a percentage of the model's context window (0 = use `octo config` or built-in default 75). Only used when --compact-threshold=0.")
 	reasoningEffort := fs.String("reasoning-effort", "", "Reasoning intensity: off | low | medium | high | xhigh | max (empty = use `octo config`/default; 'off' forces it off for this run). OpenAI → reasoning_effort; Anthropic → adaptive thinking + effort.")

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -707,7 +707,7 @@ func (a *Agent) turnStream(
 // defaultMaxTurns is the fallback per-Run loop cap when Agent.MaxTurns is
 // unset (0). A "turn" here is one provider round-trip inside the agentic
 // loop; the cap stops a misbehaving model from looping on tools forever.
-const defaultMaxTurns = 200
+const defaultMaxTurns = 1000
 
 // unlimitedTurns signals no cap (used for unattended runs).
 const unlimitedTurns = -1

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -54,7 +54,7 @@ func NewSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func(c
 }
 
 // childMaxTurns caps the sub-agent's tool loop per round. Deliberately lower
-// than the parent's defaultMaxTurns (200): a sub-task should make focused
+// than the parent's defaultMaxTurns (1000): a sub-task should make focused
 // progress and check back rather than run unbounded. Each Continue re-arms
 // this budget for the next round.
 const childMaxTurns = 100


### PR DESCRIPTION
## What

Raise the interactive default agentic-loop cap (`defaultMaxTurns`) from **200** to **1000**.

## Why

The 200-turn cap was never a hard wall:

- **Unattended runs** (piped stdin / `--prompt-file`) already run **unlimited** (`unlimitedTurns`).
- **Explicit `--max-turns N`** always wins.
- Hitting the cap is a **graceful checkpoint** (`StopReason: "max_turns"`), not an error — history is preserved and the user just sends another message to continue.

So 200 only affected interactive REPL sessions, where it increasingly interrupted normal long tasks. 1000 keeps a runaway-tool-loop backstop while removing the friction. Sub-agent `childMaxTurns` (100) is deliberately left unchanged — a sub-task should stay focused and check back.

## Changes

- `internal/agent/agent.go` — `defaultMaxTurns` 200 → 1000
- `cmd/octo/chat.go` — `--max-turns` help text
- `internal/app/spawner.go` — stale comment reference to the parent default

## Test

`go build ./...` + `go test ./internal/agent/ ./cmd/octo/ ./internal/app/` green; `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)