### PR TITLE
feat(mobile): Android + iOS native tunnel plugins + app bootstrap (verified E2E)

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -41,6 +41,7 @@ webview fetch('/api/…') / new WebSocket('/ws')
 | App boot: install shim, pair, connect | `src/boot.ts` | on-device |
 | QR scan (getUserMedia + jsQR) | `src/qr.ts` | on-device |
 | Android native plugin (Noise XX) | `native/OctoTunnelPlugin.kt` | emulator E2E |
+| iOS native plugin (Noise XX) | `native/OctoTunnelPlugin.swift` | simulator E2E |
 | Capacitor config + web bundling | `capacitor.config.ts`, `scripts/bundle-web.mjs` | tsc |
 
 ```bash
@@ -50,15 +51,13 @@ npm test          # vitest: pairing + frames + shim + buffering-transport
 npm run typecheck # tsc
 ```
 
-The **Android** app is verified end to end: paired to a local
+Both the **Android** and **iOS** apps are verified end to end: paired to a local
 `octo serve --tunnel` + `octo-relay` over a real Noise XX session, and the
-bundled frontend drove `/api` + `/ws` through the tunnel. See
-`native/README.md` for the Android wiring.
+bundled frontend drove `/api` + `/ws` through the tunnel. See `native/README.md`
+for the per-platform wiring.
 
 ## Not done yet
 
-- **iOS native plugin** — `native/` has only the Android `OctoTunnelPlugin.kt`.
-  The Swift/Keychain equivalent hasn't been written (no iOS toolchain yet).
 - The other native plugins (biometric, push, notifications, share) and the
   `mobileShell` branch re-pointing in the frontend.
 - **Self-tunnel transport** — `SelfTunnelTransport` dials a `/tunnel` endpoint

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -35,29 +35,34 @@ webview fetch('/api/…') / new WebSocket('/ws')
 | Tunnel frame protocol | `src/frames.ts` | vitest |
 | Local shim (fetch + WebSocket) | `src/shim.ts` | vitest |
 | Transport interface + two impls | `src/transport.ts` | tsc |
+| Buffering transport (holds traffic until paired) | `src/buffering-transport.ts` | vitest |
 | Native plugin JS contract | `src/native-bridge.ts` | tsc |
 | Plugin registration | `src/plugin.ts` | tsc |
+| App boot: install shim, pair, connect | `src/boot.ts` | on-device |
+| QR scan (getUserMedia + jsQR) | `src/qr.ts` | on-device |
+| Android native plugin (Noise XX) | `native/OctoTunnelPlugin.kt` | emulator E2E |
 | Capacitor config + web bundling | `capacitor.config.ts`, `scripts/bundle-web.mjs` | tsc |
 
 ```bash
 cd mobile
 npm install
-npm test          # vitest: pairing + frames + shim
+npm test          # vitest: pairing + frames + shim + buffering-transport
 npm run typecheck # tsc
 ```
 
+The **Android** app is verified end to end: paired to a local
+`octo serve --tunnel` + `octo-relay` over a real Noise XX session, and the
+bundled frontend drove `/api` + `/ws` through the tunnel. See
+`native/README.md` for the Android wiring.
+
 ## Not done yet
 
-- **Native plugin (`native/`)** — `OctoTunnelPlugin.swift` / `.kt` are
-  **unverified skeletons** (no iOS/Android toolchain here). They run the Noise
-  handshake + hold keys in Keychain/Keystore. See `native/README.md`.
-- **Host-side `/api` tunneling** — the shim frames both HTTP (`/api`) and
-  WebSocket (`/ws`), but the host tunnel (`internal/tunnel`) currently bridges a
-  raw `/ws` only. A follow-up must teach it the frame protocol: replay
-  `http-req` frames as loopback HTTP calls and open a loopback `/ws` per `ws-*`
-  stream.
-- The other native plugins (biometric, push, QR scan, notifications, share) and
-  the `mobileShell` branch re-pointing in the frontend.
+- **iOS native plugin** — `native/` has only the Android `OctoTunnelPlugin.kt`.
+  The Swift/Keychain equivalent hasn't been written (no iOS toolchain yet).
+- The other native plugins (biometric, push, notifications, share) and the
+  `mobileShell` branch re-pointing in the frontend.
+- **Self-tunnel transport** — `SelfTunnelTransport` dials a `/tunnel` endpoint
+  the server doesn't expose yet; only the managed-relay path is wired end to end.
 
 ## Build the app (on a Mac)
 

--- a/mobile/native/OctoTunnelPlugin.kt
+++ b/mobile/native/OctoTunnelPlugin.kt
@@ -1,0 +1,312 @@
+package dev.octo.mobile
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import com.getcapacitor.JSObject
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.PluginMethod
+import com.getcapacitor.annotation.CapacitorPlugin
+import com.southernstorm.noise.protocol.CipherState
+import com.southernstorm.noise.protocol.DHState
+import com.southernstorm.noise.protocol.HandshakeState
+import com.southernstorm.noise.protocol.Noise
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.json.JSONObject
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+// OctoTunnel is the phone half of octo's managed tunnel — the native piece that
+// cannot live in JavaScript. It holds the device's Noise static keypair in the
+// Android Keystore, runs the Noise XX handshake with the host (brokered by the
+// relay, which sees only ciphertext), and moves encrypted frames over a relay
+// WebSocket. JavaScript hands it plaintext frames and receives plaintext frames
+// back; no key material ever crosses the bridge.
+//
+// It mirrors the phone (initiator) side of the Go reference client in
+// cmd/octo-relay/internal/client and interoperates with the host in
+// internal/tunnel: Noise_XX_25519_ChaChaPoly_SHA256, empty prologue, JSON relay
+// frames {t, tn, d, p} with p a base64 payload the relay never inspects.
+@CapacitorPlugin(name = "OctoTunnel")
+class OctoTunnelPlugin : Plugin() {
+
+    // Noise suite / pattern shared with the host. Must match flynn/noise's
+    // NewCipherSuite(DH25519, CipherChaChaPoly, HashSHA256) + HandshakeXX.
+    private val protocolName = "Noise_XX_25519_ChaChaPoly_SHA256"
+
+    private val http = OkHttpClient.Builder().build()
+
+    // Session state. The WebSocket listener (one OkHttp thread) drives the
+    // handshake and inbound decryption; send() runs on the Capacitor thread.
+    // cryptoLock serializes cipher use — a Noise CipherState nonce is stateful.
+    private val cryptoLock = Any()
+    private var ws: WebSocket? = null
+    private var hs: HandshakeState? = null
+    private var tx: CipherState? = null
+    private var rx: CipherState? = null
+    private var deviceId: String? = null
+    private var expectedHostKey: ByteArray? = null
+    private var pairCall: PluginCall? = null
+
+    // ── JS contract (native-bridge.ts) ──────────────────────────────────────
+
+    @PluginMethod
+    fun loadDeviceIdentity(call: PluginCall) {
+        try {
+            val (_, pub) = deviceKeypair()
+            call.resolve(JSObject().put("publicKey", Base64.encodeToString(pub, Base64.NO_WRAP)))
+        } catch (e: Exception) {
+            call.reject("load identity failed: ${e.message}", e)
+        }
+    }
+
+    @PluginMethod
+    fun pair(call: PluginCall) {
+        val relay = call.getString("relay")
+        val token = call.getString("token")
+        val hostKey = call.getString("hostKey")
+        if (relay.isNullOrEmpty() || token.isNullOrEmpty() || hostKey.isNullOrEmpty()) {
+            call.reject("pair: relay, token and hostKey are required")
+            return
+        }
+        try {
+            expectedHostKey = Base64.decode(hostKey, Base64.DEFAULT)
+
+            // Build the initiator handshake with our persistent static keypair.
+            val handshake = HandshakeState(protocolName, HandshakeState.INITIATOR)
+            val (priv, _) = deviceKeypair()
+            handshake.localKeyPair.setPrivateKey(priv, 0)
+            handshake.start()
+            hs = handshake
+            tx = null
+            rx = null
+            deviceId = null
+            pairCall = call
+
+            // Dial the relay's device endpoint. OkHttp performs the WebSocket
+            // upgrade over http(s); map ws(s):// accordingly.
+            val base = relay
+                .replaceFirst("wss://", "https://")
+                .replaceFirst("ws://", "http://")
+                .trimEnd('/')
+            val url = "$base/device?token=$token"
+            ws = http.newWebSocket(Request.Builder().url(url).build(), Listener())
+        } catch (e: Exception) {
+            pairCall = null
+            call.reject("pair failed: ${e.message}", e)
+        }
+    }
+
+    @PluginMethod
+    fun send(call: PluginCall) {
+        val frame = call.getString("frame")
+        if (frame == null) {
+            call.reject("send: frame is required")
+            return
+        }
+        try {
+            synchronized(cryptoLock) {
+                val sender = tx ?: throw IllegalStateException("no active session")
+                val pt = frame.toByteArray(Charsets.UTF_8)
+                val out = ByteArray(pt.size + sender.macLength)
+                val n = sender.encryptWithAd(null, pt, 0, out, 0, pt.size)
+                sendFrame("data", out.copyOf(n))
+            }
+            call.resolve()
+        } catch (e: Exception) {
+            call.reject("send failed: ${e.message}", e)
+        }
+    }
+
+    @PluginMethod
+    fun disconnect(call: PluginCall) {
+        teardown(null)
+        call.resolve()
+    }
+
+    // ── relay WebSocket ─────────────────────────────────────────────────────
+
+    private inner class Listener : WebSocketListener() {
+        override fun onMessage(webSocket: WebSocket, text: String) {
+            try {
+                val f = JSONObject(text)
+                when (f.optString("t")) {
+                    "paired" -> {
+                        deviceId = f.optString("d")
+                        pump() // send handshake message 1
+                    }
+                    "handshake" -> {
+                        val h = hs ?: return
+                        val msg = Base64.decode(f.optString("p"), Base64.DEFAULT)
+                        val payload = ByteArray(Noise.MAX_PACKET_LEN)
+                        h.readMessage(msg, 0, msg.size, payload, 0)
+                        pump()
+                    }
+                    "data" -> deliverData(f.optString("p"))
+                }
+            } catch (e: Exception) {
+                teardown(e)
+            }
+        }
+
+        override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+            teardown(t)
+        }
+
+        override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+            teardown(if (tx == null) IllegalStateException("relay closed before handshake") else null)
+        }
+    }
+
+    // pump drives the initiator handshake: it writes every outgoing handshake
+    // message the state machine is ready to send, then completes the session
+    // (verify host key + split into transport ciphers) once the pattern is done.
+    private fun pump() {
+        val h = hs ?: return
+        while (h.action == HandshakeState.WRITE_MESSAGE) {
+            val buf = ByteArray(Noise.MAX_PACKET_LEN)
+            val len = h.writeMessage(buf, 0, ByteArray(0), 0, 0)
+            sendFrame("handshake", buf.copyOf(len))
+        }
+        if (h.action == HandshakeState.SPLIT) {
+            completeHandshake(h)
+        }
+    }
+
+    private fun completeHandshake(h: HandshakeState) {
+        // Authenticate the host: its static key, learned during XX, must equal
+        // the one the pairing QR carried. This is what the relay can't forge.
+        val remote: DHState = h.remotePublicKey
+        val hostPub = ByteArray(remote.publicKeyLength)
+        remote.getPublicKey(hostPub, 0)
+        val expected = expectedHostKey
+        if (expected != null && !hostPub.contentEquals(expected)) {
+            teardown(SecurityException("host key mismatch — refusing to trust relay peer"))
+            return
+        }
+        val pair = h.split()
+        synchronized(cryptoLock) {
+            tx = pair.sender
+            rx = pair.receiver
+        }
+        h.destroy()
+        hs = null
+        pairCall?.resolve()
+        pairCall = null
+    }
+
+    private fun deliverData(payloadB64: String) {
+        val text: String
+        synchronized(cryptoLock) {
+            val receiver = rx ?: return
+            val ct = Base64.decode(payloadB64, Base64.DEFAULT)
+            val out = ByteArray(ct.size)
+            val n = receiver.decryptWithAd(null, ct, 0, out, 0, ct.size)
+            text = String(out, 0, n, Charsets.UTF_8)
+        }
+        notifyListeners("frame", JSObject().put("frame", text))
+    }
+
+    private fun sendFrame(type: String, payload: ByteArray) {
+        val o = JSONObject()
+        o.put("t", type)
+        deviceId?.let { o.put("d", it) }
+        o.put("p", Base64.encodeToString(payload, Base64.NO_WRAP))
+        ws?.send(o.toString())
+    }
+
+    private fun teardown(err: Throwable?) {
+        pairCall?.let { call ->
+            if (err != null) call.reject("tunnel error: ${err.message}", err as? Exception)
+            pairCall = null
+        }
+        try {
+            ws?.close(1000, null)
+        } catch (_: Exception) {
+        }
+        ws = null
+        synchronized(cryptoLock) {
+            tx = null
+            rx = null
+        }
+        hs?.destroy()
+        hs = null
+    }
+
+    // ── device static keypair (Keystore-wrapped X25519) ─────────────────────
+    //
+    // AndroidKeyStore can't hold a raw X25519 scalar we can feed to Noise, so we
+    // keep a Keystore-resident AES-GCM master key and store the 32-byte private
+    // key wrapped by it. The private key is never persisted in the clear and the
+    // master key never leaves the Keystore (hardware-backed where available).
+
+    private val prefsName = "octo.tunnel"
+    private val keyPriv = "device_priv" // base64(iv || ciphertext)
+    private val keyPub = "device_pub" // base64
+    private val masterAlias = "octo_tunnel_master"
+    private val gcmTagBits = 128
+    private val ivLen = 12
+
+    @Synchronized
+    private fun deviceKeypair(): Pair<ByteArray, ByteArray> {
+        val prefs = context.getSharedPreferences(prefsName, 0)
+        val storedPriv = prefs.getString(keyPriv, null)
+        val storedPub = prefs.getString(keyPub, null)
+        if (storedPriv != null && storedPub != null) {
+            return unwrap(Base64.decode(storedPriv, Base64.DEFAULT)) to Base64.decode(storedPub, Base64.DEFAULT)
+        }
+
+        val dh = Noise.createDH("25519")
+        dh.generateKeyPair()
+        val priv = ByteArray(dh.privateKeyLength)
+        dh.getPrivateKey(priv, 0)
+        val pub = ByteArray(dh.publicKeyLength)
+        dh.getPublicKey(pub, 0)
+        dh.destroy()
+
+        prefs.edit()
+            .putString(keyPriv, Base64.encodeToString(wrap(priv), Base64.NO_WRAP))
+            .putString(keyPub, Base64.encodeToString(pub, Base64.NO_WRAP))
+            .apply()
+        return priv to pub
+    }
+
+    private fun masterKey(): SecretKey {
+        val ks = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        (ks.getKey(masterAlias, null) as? SecretKey)?.let { return it }
+        val kg = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+        kg.init(
+            KeyGenParameterSpec.Builder(
+                masterAlias,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .build(),
+        )
+        return kg.generateKey()
+    }
+
+    private fun wrap(plain: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, masterKey())
+        val ct = cipher.doFinal(plain)
+        return cipher.iv + ct
+    }
+
+    private fun unwrap(blob: ByteArray): ByteArray {
+        val iv = blob.copyOfRange(0, ivLen)
+        val ct = blob.copyOfRange(ivLen, blob.size)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, masterKey(), GCMParameterSpec(gcmTagBits, iv))
+        return cipher.doFinal(ct)
+    }
+}

--- a/mobile/native/OctoTunnelPlugin.swift
+++ b/mobile/native/OctoTunnelPlugin.swift
@@ -1,0 +1,423 @@
+import Capacitor
+import CryptoKit
+import Foundation
+import Security
+
+// OctoTunnel is the phone half of octo's managed tunnel — the native piece that
+// cannot live in JavaScript. It holds the device's Noise static keypair in the
+// iOS Keychain, runs the Noise XX handshake with the host (brokered by the
+// relay, which sees only ciphertext), and moves encrypted frames over a relay
+// WebSocket. JavaScript hands it plaintext frames and receives plaintext frames
+// back; no key material ever crosses the bridge.
+//
+// It mirrors the phone (initiator) side of the Go reference client in
+// cmd/octo-relay/internal/client and the Kotlin plugin, and interoperates with
+// the host in internal/tunnel: Noise_XX_25519_ChaChaPoly_SHA256, empty prologue,
+// JSON relay frames {t, tn, d, p} with p a base64 payload the relay never reads.
+@objc(OctoTunnelPlugin)
+public class OctoTunnelPlugin: CAPPlugin, CAPBridgedPlugin {
+    // Capacitor plugin identity + method table, declared in Swift (the modern
+    // pure-Swift plugin form) so no companion Objective-C CAP_PLUGIN macro file
+    // is needed. jsName is the name the JS side calls: registerPlugin('OctoTunnel').
+    public let identifier = "OctoTunnelPlugin"
+    public let jsName = "OctoTunnel"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "loadDeviceIdentity", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "pair", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "send", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "disconnect", returnType: CAPPluginReturnPromise),
+    ]
+
+    private let queue = DispatchQueue(label: "dev.octo.tunnel")
+    private var handshake: NoiseHandshakeXX?
+    private var tx: NoiseCipherState?
+    private var rx: NoiseCipherState?
+    private var ws: URLSessionWebSocketTask?
+    private var urlSession: URLSession?
+    private var deviceId: String?
+    private var expectedHostKey: Data?
+    private var pairCall: CAPPluginCall?
+
+    // MARK: - JS contract (native-bridge.ts)
+
+    @objc func loadDeviceIdentity(_ call: CAPPluginCall) {
+        do {
+            let identity = try deviceIdentity()
+            call.resolve(["publicKey": identity.publicKey.base64EncodedString()])
+        } catch {
+            call.reject("load identity failed: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func pair(_ call: CAPPluginCall) {
+        guard let relay = call.getString("relay"), !relay.isEmpty,
+              let token = call.getString("token"), !token.isEmpty,
+              let hostKey = call.getString("hostKey"), !hostKey.isEmpty else {
+            call.reject("pair: relay, token and hostKey are required")
+            return
+        }
+        guard let expected = Data(base64Encoded: hostKey) else {
+            call.reject("pair: hostKey is not valid base64")
+            return
+        }
+        queue.async {
+            do {
+                let identity = try self.deviceIdentity()
+                self.handshake = try NoiseHandshakeXX(staticPrivate: identity.privateKey)
+                self.tx = nil
+                self.rx = nil
+                self.deviceId = nil
+                self.expectedHostKey = expected
+                self.pairCall = call
+
+                // URLSessionWebSocketTask dials ws(s):// directly (unlike OkHttp,
+                // which upgrades over http). The PoC relay routes by token;
+                // production dials <tunnelId>.<relay-host> for SNI routing.
+                let base = relay.hasSuffix("/") ? String(relay.dropLast()) : relay
+                guard let url = URL(string: "\(base)/device?token=\(token)") else {
+                    throw TunnelError.message("bad relay URL")
+                }
+                let session = URLSession(configuration: .default)
+                let task = session.webSocketTask(with: url)
+                self.urlSession = session
+                self.ws = task
+                task.resume()
+                self.receiveLoop()
+            } catch {
+                self.pairCall = nil
+                call.reject("pair failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func send(_ call: CAPPluginCall) {
+        guard let frame = call.getString("frame") else {
+            call.reject("send: frame is required")
+            return
+        }
+        queue.async {
+            guard let tx = self.tx else {
+                call.reject("send: no active session")
+                return
+            }
+            do {
+                let ct = try tx.encrypt(Data(frame.utf8))
+                self.sendFrame(type: "data", payload: ct)
+                call.resolve()
+            } catch {
+                call.reject("send failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func disconnect(_ call: CAPPluginCall) {
+        queue.async {
+            self.teardown(nil)
+            call.resolve()
+        }
+    }
+
+    // MARK: - relay WebSocket
+
+    private func receiveLoop() {
+        ws?.receive { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure(let error):
+                self.queue.async { self.teardown(error) }
+            case .success(let message):
+                let text: String
+                switch message {
+                case .string(let s): text = s
+                case .data(let d): text = String(decoding: d, as: UTF8.self)
+                @unknown default: text = ""
+                }
+                self.queue.async { self.onMessage(text) }
+                self.receiveLoop()
+            }
+        }
+    }
+
+    private func onMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = obj["t"] as? String else { return }
+        do {
+            switch type {
+            case "paired":
+                deviceId = obj["d"] as? String
+                // Initiator opens the XX handshake: send message 1 (e).
+                if let hs = handshake {
+                    let msg1 = try hs.writeMessage1()
+                    sendFrame(type: "handshake", payload: msg1)
+                }
+            case "handshake":
+                guard let hs = handshake, let p = obj["p"] as? String,
+                      let msg = Data(base64Encoded: p) else { return }
+                // The one inbound handshake message in XX is msg2 (e, ee, s, es).
+                let msg3 = try hs.readMessage2WriteMessage3(msg)
+                // Authenticate the host: its static key, learned in msg2, must
+                // equal the one the pairing QR carried — the relay can't forge it.
+                if let expected = expectedHostKey, hs.remoteStatic != expected {
+                    teardown(TunnelError.message("host key mismatch — refusing to trust relay peer"))
+                    return
+                }
+                sendFrame(type: "handshake", payload: msg3)
+                let keys = hs.split()
+                tx = NoiseCipherState(key: keys.send)
+                rx = NoiseCipherState(key: keys.receive)
+                handshake = nil
+                pairCall?.resolve()
+                pairCall = nil
+            case "data":
+                guard let rx = rx, let p = obj["p"] as? String,
+                      let ct = Data(base64Encoded: p) else { return }
+                let pt = try rx.decrypt(ct)
+                let frame = String(decoding: pt, as: UTF8.self)
+                notifyListeners("frame", data: ["frame": frame])
+            default:
+                break
+            }
+        } catch {
+            teardown(error)
+        }
+    }
+
+    private func sendFrame(type: String, payload: Data) {
+        var obj: [String: Any] = ["t": type, "p": payload.base64EncodedString()]
+        if let d = deviceId { obj["d"] = d }
+        guard let data = try? JSONSerialization.data(withJSONObject: obj) else { return }
+        ws?.send(.string(String(decoding: data, as: UTF8.self))) { _ in }
+    }
+
+    private func teardown(_ error: Error?) {
+        if let call = pairCall {
+            call.reject("tunnel error: \(error?.localizedDescription ?? "closed")")
+            pairCall = nil
+        }
+        ws?.cancel(with: .normalClosure, reason: nil)
+        ws = nil
+        urlSession = nil
+        tx = nil
+        rx = nil
+        handshake = nil
+    }
+
+    // MARK: - device static keypair (Keychain-held X25519)
+
+    private struct Identity {
+        let privateKey: Curve25519.KeyAgreement.PrivateKey
+        let publicKey: Data
+    }
+
+    private let keychainService = "dev.octo.mobile.tunnel"
+    private let keychainAccount = "device_static_key"
+
+    private func deviceIdentity() throws -> Identity {
+        if let raw = keychainLoad() {
+            let key = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: raw)
+            return Identity(privateKey: key, publicKey: key.publicKey.rawRepresentation)
+        }
+        let key = Curve25519.KeyAgreement.PrivateKey()
+        try keychainStore(key.rawRepresentation)
+        return Identity(privateKey: key, publicKey: key.publicKey.rawRepresentation)
+    }
+
+    private func keychainLoad() -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess else { return nil }
+        return item as? Data
+    }
+
+    private func keychainStore(_ data: Data) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        SecItemDelete(query as CFDictionary)
+        let status = SecItemAdd(query as CFDictionary, nil)
+        if status != errSecSuccess {
+            throw TunnelError.message("keychain store failed (\(status))")
+        }
+    }
+}
+
+private enum TunnelError: Error, LocalizedError {
+    case message(String)
+    var errorDescription: String? {
+        if case .message(let m) = self { return m }
+        return nil
+    }
+}
+
+// MARK: - Noise XX (initiator), Noise_XX_25519_ChaChaPoly_SHA256, empty prologue
+//
+// A focused implementation of just the initiator's three steps — write e; read
+// (e, ee, s, es); write (s, se) — rather than a general token interpreter, built
+// on CryptoKit primitives. It is byte-compatible with the Go host's flynn/noise
+// and the Android noise-java plugin.
+
+private func hmacSHA256(key: Data, data: Data) -> Data {
+    Data(HMAC<SHA256>.authenticationCode(for: data, using: SymmetricKey(data: key)))
+}
+
+// Noise HKDF: extract with the chaining key as salt, then expand into `outputs`
+// chained blocks. Matches the spec's HKDF used by MixKey and Split.
+private func noiseHKDF(chainingKey: Data, ikm: Data, outputs: Int) -> [Data] {
+    let tempKey = hmacSHA256(key: chainingKey, data: ikm)
+    let o1 = hmacSHA256(key: tempKey, data: Data([0x01]))
+    let o2 = hmacSHA256(key: tempKey, data: o1 + Data([0x02]))
+    if outputs == 2 { return [o1, o2] }
+    let o3 = hmacSHA256(key: tempKey, data: o2 + Data([0x03]))
+    return [o1, o2, o3]
+}
+
+// NoiseCipherState is one direction's transport cipher: a key plus a 64-bit
+// nonce counter. The 96-bit ChaChaPoly nonce is 4 zero bytes then the counter
+// little-endian — the Noise convention both other ends use.
+private final class NoiseCipherState {
+    private let key: SymmetricKey
+    private var n: UInt64 = 0
+
+    init(key: Data) { self.key = SymmetricKey(data: key) }
+
+    private func nonce() -> ChaChaPoly.Nonce {
+        var bytes = Data(count: 4)
+        withUnsafeBytes(of: n.littleEndian) { bytes.append(contentsOf: $0) }
+        return try! ChaChaPoly.Nonce(data: bytes)
+    }
+
+    func encrypt(_ plaintext: Data, ad: Data = Data()) throws -> Data {
+        let box = try ChaChaPoly.seal(plaintext, using: key, nonce: nonce(), authenticating: ad)
+        n &+= 1
+        return box.ciphertext + box.tag
+    }
+
+    func decrypt(_ ciphertext: Data, ad: Data = Data()) throws -> Data {
+        let tag = ciphertext.suffix(16)
+        let ct = ciphertext.prefix(ciphertext.count - 16)
+        let box = try ChaChaPoly.SealedBox(nonce: nonce(), ciphertext: ct, tag: tag)
+        let pt = try ChaChaPoly.open(box, using: key, authenticating: ad)
+        n &+= 1
+        return pt
+    }
+}
+
+private final class NoiseHandshakeXX {
+    private var ck: Data
+    private var h: Data
+    private var k: SymmetricKey?
+    private var n: UInt64 = 0
+
+    private let staticPrivate: Curve25519.KeyAgreement.PrivateKey
+    private let ephemeral: Curve25519.KeyAgreement.PrivateKey
+    private var remoteEphemeral: Data?
+    private(set) var remoteStatic: Data?
+
+    init(staticPrivate: Curve25519.KeyAgreement.PrivateKey) throws {
+        self.staticPrivate = staticPrivate
+        self.ephemeral = Curve25519.KeyAgreement.PrivateKey()
+        let name = Data("Noise_XX_25519_ChaChaPoly_SHA256".utf8) // exactly 32 bytes
+        self.h = name.count <= 32 ? name + Data(count: 32 - name.count) : Data(SHA256.hash(data: name))
+        self.ck = self.h
+        // Noise Initialize() always MixHash(prologue). Ours is empty, but even
+        // MixHash([]) advances h (= SHA256(h)); skipping it diverges the running
+        // hash from the host and fails the first AEAD tag in msg2.
+        mixHash(Data())
+    }
+
+    private func mixHash(_ data: Data) { h = Data(SHA256.hash(data: h + data)) }
+
+    private func mixKey(_ ikm: Data) {
+        let out = noiseHKDF(chainingKey: ck, ikm: ikm, outputs: 2)
+        ck = out[0]
+        k = SymmetricKey(data: out[1])
+        n = 0
+    }
+
+    private func chaNonce() -> ChaChaPoly.Nonce {
+        var bytes = Data(count: 4)
+        withUnsafeBytes(of: n.littleEndian) { bytes.append(contentsOf: $0) }
+        return try! ChaChaPoly.Nonce(data: bytes)
+    }
+
+    private func encryptAndHash(_ plaintext: Data) throws -> Data {
+        guard let k = k else { mixHash(plaintext); return plaintext }
+        let box = try ChaChaPoly.seal(plaintext, using: k, nonce: chaNonce(), authenticating: h)
+        n &+= 1
+        let ct = box.ciphertext + box.tag
+        mixHash(ct)
+        return ct
+    }
+
+    private func decryptAndHash(_ ciphertext: Data) throws -> Data {
+        guard let k = k else { mixHash(ciphertext); return ciphertext }
+        let tag = ciphertext.suffix(16)
+        let ct = ciphertext.prefix(ciphertext.count - 16)
+        let box = try ChaChaPoly.SealedBox(nonce: chaNonce(), ciphertext: ct, tag: tag)
+        let pt = try ChaChaPoly.open(box, using: k, authenticating: h)
+        n &+= 1
+        mixHash(Data(ciphertext))
+        return pt
+    }
+
+    private func dh(_ priv: Curve25519.KeyAgreement.PrivateKey, _ pubRaw: Data) throws -> Data {
+        let pub = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: pubRaw)
+        let secret = try priv.sharedSecretFromKeyAgreement(with: pub)
+        return secret.withUnsafeBytes { Data($0) }
+    }
+
+    // msg1 (initiator → responder): e
+    func writeMessage1() throws -> Data {
+        let ePub = ephemeral.publicKey.rawRepresentation
+        mixHash(ePub)
+        let payload = try encryptAndHash(Data()) // no key yet → empty plaintext
+        return ePub + payload
+    }
+
+    // msg2 read (e, ee, s, es) then msg3 write (s, se). Returns msg3 bytes.
+    func readMessage2WriteMessage3(_ msg: Data) throws -> Data {
+        var offset = msg.startIndex
+
+        // e
+        let re = msg.subdata(in: offset..<msg.index(offset, offsetBy: 32))
+        offset = msg.index(offset, offsetBy: 32)
+        remoteEphemeral = re
+        mixHash(re)
+        // ee
+        mixKey(try dh(ephemeral, re))
+        // s (encrypted static: 32 + 16 tag)
+        let encStatic = msg.subdata(in: offset..<msg.index(offset, offsetBy: 48))
+        offset = msg.index(offset, offsetBy: 48)
+        let rs = try decryptAndHash(encStatic)
+        remoteStatic = rs
+        // es
+        mixKey(try dh(ephemeral, rs))
+        // payload (empty; 16-byte tag)
+        let encPayload = msg.subdata(in: offset..<msg.endIndex)
+        _ = try decryptAndHash(encPayload)
+
+        // msg3: s, se
+        let encMyStatic = try encryptAndHash(staticPrivate.publicKey.rawRepresentation)
+        mixKey(try dh(staticPrivate, remoteEphemeral!))
+        let encMsg3Payload = try encryptAndHash(Data())
+        return encMyStatic + encMsg3Payload
+    }
+
+    // split derives the two transport keys. flynn/noise returns the
+    // initiator→responder cipher first, so for the initiator send=out[0].
+    func split() -> (send: Data, receive: Data) {
+        let out = noiseHKDF(chainingKey: ck, ikm: Data(), outputs: 2)
+        return (out[0], out[1])
+    }
+}

--- a/mobile/native/README.md
+++ b/mobile/native/README.md
@@ -11,24 +11,66 @@ after `npx cap add ios` / `add android`, place them into the platform projects:
 
 - **iOS** — `ios/App/App/OctoTunnelPlugin.swift`, plus a companion
   `OctoTunnelPlugin.m` with the `CAP_PLUGIN` macro (or export via Package.swift)
-  so Capacitor discovers it.
-- **Android** — `android/app/src/main/java/dev/octo/mobile/OctoTunnelPlugin.kt`,
-  and register it in `MainActivity` (`registerPlugin(OctoTunnelPlugin::class.java)`).
+  so Capacitor discovers it. **Not written yet** — the iOS toolchain hasn't been
+  available; mirror the Android plugin against the same JS contract.
+- **Android** — `OctoTunnelPlugin.kt` → place at
+  `android/app/src/main/java/dev/octo/mobile/OctoTunnelPlugin.kt`. See the wiring
+  below.
 
-## ⚠️ Unverified
+## Status
 
-Both files were written without the iOS/Android toolchains and have **not been
-compiled**. They match the JS contract and sketch the structure; every method
-body is a TODO. Expect to iterate on them once they build.
+- **Android (`OctoTunnelPlugin.kt`)** — implemented and **verified end to end**
+  on an emulator: paired to a local `octo serve --tunnel` + `octo-relay` over a
+  real Noise XX session, and the bundled web frontend drove `/api` + `/ws`
+  through the tunnel. It interoperates with the Go host (`internal/tunnel`) and
+  relay (`cmd/octo-relay`).
+- **iOS** — not started.
 
-## What each must implement
+## What it implements
 
-- A device static keypair (X25519) in the **Keychain** (iOS) / **Keystore**
-  (Android), created on first run.
-- The **Noise XX** handshake (DH25519 / ChaChaPoly / SHA256) with the host,
-  brokered by the relay, authenticating the host against the scanned `hostKey`.
-  Pick a maintained native Noise library, or bind libsodium/noise-c.
-- A **relay WebSocket** (`URLSessionWebSocketTask` / OkHttp), dialing
-  `<tunnelId>.<relay-host>` so the relay routes by SNI.
-- Encrypt outbound plaintext frames, decrypt inbound ones and emit them as the
-  `"frame"` listener event.
+- A device static keypair (X25519) created on first run and kept in secure
+  storage. On Android the 32-byte private key is wrapped by an AES-GCM key held
+  in the **AndroidKeyStore** and stored in `SharedPreferences`; iOS should hold
+  its key in the **Keychain**.
+- The **Noise XX** handshake (`Noise_XX_25519_ChaChaPoly_SHA256`, empty
+  prologue) with the host, brokered by the relay, authenticating the host by
+  comparing its transmitted static key against the scanned `hostKey`.
+- A **relay WebSocket** dialing `<relay>/device?token=<token>` (OkHttp on
+  Android; `URLSessionWebSocketTask` on iOS). Production dials
+  `<tunnelId>.<relay-host>` so the relay routes by SNI; the single-node PoC relay
+  routes by token.
+- Encrypt outbound plaintext frames, decrypt inbound ones, and emit them as the
+  `"frame"` listener event. Cipher use is serialized — a Noise CipherState nonce
+  is stateful.
+
+## Android wiring (after `npx cap add android`)
+
+The generated `android/` is gitignored, so redo these each time it is
+regenerated:
+
+1. **Kotlin plugin** — the project template is Java-only. In the root
+   `android/build.gradle` buildscript dependencies add
+   `classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22'`; in
+   `android/app/build.gradle` add `apply plugin: 'kotlin-android'`, a
+   `kotlinOptions { jvmTarget = "17" }` block, and
+   `implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.22"`.
+2. **Dependencies** (`android/app/build.gradle`, resolved from Maven Central):
+   - `implementation "com.github.auties00:noise-java:1.2"` — Noise XX; its
+     `com.southernstorm.noise` classes are pure Java (no NDK).
+   - `implementation "com.squareup.okhttp3:okhttp:4.12.0"` — relay WebSocket.
+3. **Register** the plugin in `MainActivity` **before** `super.onCreate`:
+   `registerPlugin(OctoTunnelPlugin.class);`. The pairing screen scans a QR with
+   `getUserMedia`, so also request `CAMERA` at runtime there.
+4. **AndroidManifest.xml** — add `android.permission.CAMERA` (plus a non-required
+   `android.hardware.camera` feature) and, on `MainActivity`, an
+   `android.intent.action.VIEW` intent-filter for the `octo-pair` scheme so a
+   scanned QR opens the app as a deep link.
+5. **Local testing only** — to reach a plaintext `ws://` relay from the emulator
+   (`10.0.2.2`), set `android:usesCleartextTraffic="true"` on `<application>`.
+   Production uses `wss://`; do not ship cleartext.
+
+The JS side (`../src/plugin.ts`) resolves every plugin — `OctoTunnel` and
+first-party ones like `App` — through `@capacitor/core`'s `registerPlugin`, not
+each plugin's own JS wrapper. The boot bundle loads at document start; a second
+`@capacitor/core` copy or a wrapper's event layer races Capacitor's native
+bridge injection.

--- a/mobile/native/README.md
+++ b/mobile/native/README.md
@@ -9,22 +9,20 @@ These files are the **reference source**, committed here because the generated
 `ios/` and `android/` folders (from `npx cap add`) are gitignored. On a Mac,
 after `npx cap add ios` / `add android`, place them into the platform projects:
 
-- **iOS** — `ios/App/App/OctoTunnelPlugin.swift`, plus a companion
-  `OctoTunnelPlugin.m` with the `CAP_PLUGIN` macro (or export via Package.swift)
-  so Capacitor discovers it. **Not written yet** — the iOS toolchain hasn't been
-  available; mirror the Android plugin against the same JS contract.
+- **iOS** — `OctoTunnelPlugin.swift` → place at `ios/App/App/OctoTunnelPlugin.swift`.
+  It is a pure-Swift Capacitor plugin (conforms to `CAPBridgedPlugin`), so no
+  companion Objective-C `CAP_PLUGIN` macro file is needed. See the wiring below.
 - **Android** — `OctoTunnelPlugin.kt` → place at
   `android/app/src/main/java/dev/octo/mobile/OctoTunnelPlugin.kt`. See the wiring
   below.
 
 ## Status
 
-- **Android (`OctoTunnelPlugin.kt`)** — implemented and **verified end to end**
-  on an emulator: paired to a local `octo serve --tunnel` + `octo-relay` over a
-  real Noise XX session, and the bundled web frontend drove `/api` + `/ws`
-  through the tunnel. It interoperates with the Go host (`internal/tunnel`) and
-  relay (`cmd/octo-relay`).
-- **iOS** — not started.
+Both plugins are implemented and **verified end to end** on a simulator/emulator:
+paired to a local `octo serve --tunnel` + `octo-relay` over a real Noise XX
+session, and the bundled web frontend drove `/api` + `/ws` through the tunnel.
+They interoperate with the Go host (`internal/tunnel`) and relay
+(`cmd/octo-relay`). Android uses noise-java; iOS implements Noise XX on CryptoKit.
 
 ## What it implements
 
@@ -68,6 +66,35 @@ regenerated:
 5. **Local testing only** — to reach a plaintext `ws://` relay from the emulator
    (`10.0.2.2`), set `android:usesCleartextTraffic="true"` on `<application>`.
    Production uses `wss://`; do not ship cleartext.
+
+## iOS wiring (after `npx cap add ios` + `pod install`)
+
+The generated `ios/` is gitignored, so redo these each time it is regenerated:
+
+1. **Plugin source** — add `OctoTunnelPlugin.swift` to the `App` target
+   (`ios/App/App/`). It is pure Swift and conforms to `CAPBridgedPlugin`; no
+   `.m` file is needed. It uses CryptoKit (Curve25519 / ChaChaPoly / SHA256 /
+   HMAC-HKDF) — no third-party dependency.
+2. **Register the plugin.** Capacitor's ObjC-runtime auto-scan does not reliably
+   surface an app-target Swift plugin, and `registerPluginType` is a no-op while
+   `autoRegisterPlugins` is on. Register an instance explicitly: subclass
+   `CAPBridgeViewController` and override `capacitorDidLoad()` with
+   `bridge?.registerPluginInstance(OctoTunnelPlugin())`, then use that subclass
+   as the bridge view controller (Main.storyboard's custom class, or the
+   programmatic root VC).
+3. **Info.plist** — add `NSCameraUsageDescription` (getUserMedia QR scan) and a
+   `CFBundleURLTypes` entry for the `octo-pair` scheme (the deep link Capacitor's
+   `App` plugin delivers as `appUrlOpen`).
+4. **Local testing only** — add `NSAppTransportSecurity → NSAllowsLocalNetworking
+   = true` so the app can reach a plaintext `ws://127.0.0.1` relay on the
+   simulator (the simulator shares the Mac's network; no `10.0.2.2` needed).
+   Production uses `wss://`.
+
+> Note: on a machine whose installed simulator runtime matches the Xcode SDK,
+> keep the generated storyboards. This environment only had an older iOS runtime,
+> so the local `ios/` project was patched to drop the storyboards and build the
+> bridge view controller programmatically — a workaround for the toolchain
+> mismatch, not part of the plugin.
 
 The JS side (`../src/plugin.ts`) resolves every plugin — `OctoTunnel` and
 first-party ones like `App` — through `@capacitor/core`'s `registerPlugin`, not

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,12 +8,15 @@
       "name": "octo-mobile",
       "version": "0.0.0",
       "dependencies": {
-        "@capacitor/core": "^6.0.0"
+        "@capacitor/app": "^6.0.0",
+        "@capacitor/core": "^6.0.0",
+        "jsqr": "^1.4.0"
       },
       "devDependencies": {
         "@capacitor/android": "^6.0.0",
         "@capacitor/cli": "^6.0.0",
         "@capacitor/ios": "^6.0.0",
+        "esbuild": "^0.23.0",
         "typescript": "^5.5.3",
         "vitest": "^4.1.10"
       }
@@ -26,6 +29,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^6.2.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-6.0.3.tgz",
+      "integrity": "sha512-4gFUCbcVz0N/YYN32OBFerocWXslIv3Nc90gDiRsBkJc0plwK6kIUT6PKa5WtW2kfhteUeCVXQbvArH2fH+0Ug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@capacitor/cli": {
@@ -112,6 +124,414 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ionic/cli-framework-output": {
@@ -1089,6 +1509,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1303,6 +1763,12 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/kleur": {
       "version": "4.1.5",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,12 +10,15 @@
     "bundle-web": "node scripts/bundle-web.mjs"
   },
   "dependencies": {
-    "@capacitor/core": "^6.0.0"
+    "@capacitor/app": "^6.0.0",
+    "@capacitor/core": "^6.0.0",
+    "jsqr": "^1.4.0"
   },
   "devDependencies": {
     "@capacitor/android": "^6.0.0",
     "@capacitor/cli": "^6.0.0",
     "@capacitor/ios": "^6.0.0",
+    "esbuild": "^0.23.0",
     "typescript": "^5.5.3",
     "vitest": "^4.1.10"
   }

--- a/mobile/scripts/bundle-web.mjs
+++ b/mobile/scripts/bundle-web.mjs
@@ -1,11 +1,19 @@
-// Copies the built web frontend (internal/server/webdist) into www/, the
-// Capacitor webDir. Run `make web-build` at the repo root first to produce
-// webdist. www/ is a build artifact and is gitignored.
-import { cp, rm, stat } from 'node:fs/promises'
+// Produces www/, the Capacitor webDir, from two inputs:
+//   1. the built octo web frontend (internal/server/webdist) — copied in as-is,
+//   2. the mobile boot layer (src/boot.ts) — bundled to www/octo-boot.js and
+//      injected as the first <head> script of the frontend's index.html, so it
+//      installs the local shim before any frontend module runs.
+// Run `make web-build` at the repo root first to produce webdist. www/ is a
+// build artifact and is gitignored.
+import { cp, rm, stat, readFile, writeFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
+import { build } from 'esbuild'
 
 const src = fileURLToPath(new URL('../../internal/server/webdist', import.meta.url))
 const dst = fileURLToPath(new URL('../www', import.meta.url))
+const boot = fileURLToPath(new URL('../src/boot.ts', import.meta.url))
+const bootOut = fileURLToPath(new URL('../www/octo-boot.js', import.meta.url))
+const indexHtml = fileURLToPath(new URL('../www/index.html', import.meta.url))
 
 try {
   const s = await stat(src)
@@ -18,6 +26,33 @@ try {
   process.exit(1)
 }
 
+// 1. Copy the frontend in.
 await rm(dst, { recursive: true, force: true })
 await cp(src, dst, { recursive: true })
-console.log(`bundle-web: copied webdist -> ${dst}`)
+
+// 2. Bundle the boot layer as a classic (IIFE) script so it runs synchronously
+//    ahead of the frontend's deferred module scripts.
+await build({
+  entryPoints: [boot],
+  bundle: true,
+  format: 'iife',
+  platform: 'browser',
+  target: 'es2020',
+  outfile: bootOut,
+  legalComments: 'none',
+})
+
+// 3. Inject the boot script as the first child of <head>.
+const TAG = '<script src="./octo-boot.js"></script>'
+let html = await readFile(indexHtml, 'utf8')
+if (!html.includes('octo-boot.js')) {
+  if (/<head[^>]*>/i.test(html)) {
+    html = html.replace(/(<head[^>]*>)/i, `$1${TAG}`)
+  } else {
+    // No <head>: prepend the tag so it still runs before the app.
+    html = TAG + html
+  }
+  await writeFile(indexHtml, html)
+}
+
+console.log(`bundle-web: webdist + octo-boot.js -> ${dst}`)

--- a/mobile/src/boot.ts
+++ b/mobile/src/boot.ts
@@ -1,0 +1,172 @@
+import { installShim } from './shim'
+import { BufferingTransport } from './buffering-transport'
+import { ManagedRelayTransport } from './transport'
+import { OctoTunnel, registerPlugin } from './plugin'
+import { parsePairingURL, type PairingInfo } from './pairing'
+import { scanPairingURL } from './qr'
+
+// The first-party App plugin, resolved through the same native bridge as
+// OctoTunnel (see plugin.ts) rather than @capacitor/app's JS, so a scanned QR
+// arriving as an octo-pair:// deep link reaches us via appUrlOpen.
+interface AppPlugin {
+  getLaunchUrl(): Promise<{ url: string } | null>
+  addListener(event: 'appUrlOpen', cb: (data: { url: string }) => void): void
+}
+const App = registerPlugin<AppPlugin>('App')
+
+// boot is octo-mobile's entry point. It is bundled to a classic script and
+// injected as the first element of the bundled frontend's <head>, so it runs
+// before any frontend module. It installs the local shim (shim.ts) against a
+// BufferingTransport immediately — so the frontend's /api + /ws traffic is
+// captured and held from its very first request — then pairs (scanning the
+// host's QR on first launch, or reusing the stored pairing), stands up the
+// native managed-relay transport, and hands it to the buffer to flush. The
+// frontend never learns it started life offline.
+
+const STORAGE_KEY = 'octo:pairing'
+
+const buffering = new BufferingTransport()
+installShim(buffering)
+
+// Guards against pairing more than once. On a cold start into a deep link,
+// Capacitor delivers the same octo-pair:// URL through BOTH getLaunchUrl() and
+// appUrlOpen; without this, two pair() calls race on the one-time token — the
+// first pairs, the second is rejected 403 and tears the shared session down.
+let pairing = false
+
+function loadStored(): PairingInfo | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as PairingInfo) : null
+  } catch {
+    return null
+  }
+}
+
+function saveStored(info: PairingInfo): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(info))
+  } catch {
+    // Best effort: a paired session still works this launch without persistence.
+  }
+}
+
+async function connect(info: PairingInfo): Promise<void> {
+  const transport = new ManagedRelayTransport(OctoTunnel, info)
+  await transport.connect()
+  await buffering.attach(transport)
+}
+
+// ── pairing overlay ─────────────────────────────────────────────────────────
+// A minimal full-screen gate shown until a session is live. The frontend is
+// rendering underneath (its requests buffered), so this must fully cover it.
+
+let overlay: HTMLElement | null = null
+let statusEl: HTMLElement | null = null
+
+function ensureBody(): Promise<void> {
+  if (document.body) return Promise.resolve()
+  return new Promise((r) => document.addEventListener('DOMContentLoaded', () => r(), { once: true }))
+}
+
+async function showOverlay(): Promise<void> {
+  await ensureBody()
+  if (overlay) return
+  overlay = document.createElement('div')
+  overlay.style.cssText =
+    'position:fixed;inset:0;z-index:2147483646;background:#0f1115;color:#fff;' +
+    'display:flex;flex-direction:column;align-items:center;justify-content:center;' +
+    'gap:20px;font-family:system-ui,-apple-system,sans-serif;padding:32px;text-align:center;'
+
+  const title = document.createElement('div')
+  title.textContent = 'octo'
+  title.style.cssText = 'font-size:32px;font-weight:700;letter-spacing:-0.5px;'
+
+  const sub = document.createElement('div')
+  sub.textContent = '连接到你的 octo serve'
+  sub.style.cssText = 'font-size:15px;opacity:0.7;'
+
+  const button = document.createElement('button')
+  button.textContent = '扫码配对'
+  button.style.cssText =
+    'padding:14px 40px;border:0;border-radius:26px;background:#3b82f6;color:#fff;' +
+    'font-size:16px;font-weight:600;'
+  button.onclick = () => void startScan()
+
+  statusEl = document.createElement('div')
+  statusEl.style.cssText = 'font-size:13px;opacity:0.6;min-height:18px;'
+
+  overlay.append(title, sub, button, statusEl)
+  document.body.appendChild(overlay)
+}
+
+function setStatus(text: string): void {
+  if (statusEl) statusEl.textContent = text
+}
+
+function hideOverlay(): void {
+  overlay?.remove()
+  overlay = null
+  statusEl = null
+}
+
+async function pairWith(url: string): Promise<void> {
+  if (pairing || buffering.attached) return
+  pairing = true
+  try {
+    const info = parsePairingURL(url)
+    setStatus('正在建立加密隧道…')
+    await connect(info)
+    saveStored(info)
+    hideOverlay()
+  } catch (err) {
+    pairing = false // allow a retry (scan again / re-open the link)
+    throw err
+  }
+}
+
+async function startScan(): Promise<void> {
+  try {
+    const url = await scanPairingURL()
+    await pairWith(url)
+  } catch (err) {
+    if (err instanceof Error && err.message === 'scan cancelled') return
+    setStatus(`配对失败：${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+// ── entry ─────────────────────────────────────────────────────────────────
+async function boot(): Promise<void> {
+  const stored = loadStored()
+  if (stored) {
+    try {
+      await connect(stored)
+      return
+    } catch {
+      // The stored pairing is stale (host rekeyed, token spent, relay moved).
+      // Drop it and fall through to a fresh pairing.
+      try {
+        localStorage.removeItem(STORAGE_KEY)
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  await showOverlay()
+
+  // A QR scanned by the system camera app (or an `adb … VIEW` in dev) arrives as
+  // an octo-pair:// deep link, delivered through the App plugin.
+  if (App) {
+    App.getLaunchUrl()
+      .then((launch) => {
+        if (launch?.url?.startsWith('octo-pair://')) void pairWith(launch.url).catch(() => {})
+      })
+      .catch(() => {})
+    App.addListener('appUrlOpen', (event) => {
+      if (event.url?.startsWith('octo-pair://')) void pairWith(event.url).catch((err) => setStatus(String(err)))
+    })
+  }
+}
+
+void boot()

--- a/mobile/src/buffering-transport.test.ts
+++ b/mobile/src/buffering-transport.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { BufferingTransport } from './buffering-transport'
+import type { Transport } from './transport'
+
+// A recording inner transport standing in for a connected ManagedRelayTransport.
+class FakeInner implements Transport {
+  sent: string[] = []
+  handler: ((f: string) => void) | null = null
+  async connect(): Promise<void> {}
+  async send(frame: string): Promise<void> {
+    this.sent.push(frame)
+  }
+  onMessage(handler: (f: string) => void): void {
+    this.handler = handler
+  }
+  async disconnect(): Promise<void> {}
+}
+
+describe('BufferingTransport', () => {
+  it('buffers sends before attach and flushes them in order on attach', async () => {
+    const buf = new BufferingTransport()
+    await buf.send('a')
+    await buf.send('b')
+    const inner = new FakeInner()
+    expect(inner.sent).toEqual([])
+    await buf.attach(inner)
+    expect(inner.sent).toEqual(['a', 'b'])
+  })
+
+  it('forwards sends straight through once attached', async () => {
+    const buf = new BufferingTransport()
+    const inner = new FakeInner()
+    await buf.attach(inner)
+    await buf.send('c')
+    expect(inner.sent).toEqual(['c'])
+  })
+
+  it('routes the shim handler to the inner transport, whenever it was set', async () => {
+    const buf = new BufferingTransport()
+    const received: string[] = []
+    buf.onMessage((f) => received.push(f)) // shim registers before a transport exists
+    const inner = new FakeInner()
+    await buf.attach(inner)
+    inner.handler?.('down')
+    expect(received).toEqual(['down'])
+  })
+
+  it('re-buffers after detach so a reconnect can flush again', async () => {
+    const buf = new BufferingTransport()
+    const first = new FakeInner()
+    await buf.attach(first)
+    buf.detach()
+    expect(buf.attached).toBe(false)
+    await buf.send('queued')
+    const second = new FakeInner()
+    await buf.attach(second)
+    expect(second.sent).toEqual(['queued'])
+    expect(first.sent).toEqual([])
+  })
+})

--- a/mobile/src/buffering-transport.ts
+++ b/mobile/src/buffering-transport.ts
@@ -1,0 +1,57 @@
+import type { Transport } from './transport'
+
+// BufferingTransport is the transport the local shim (shim.ts) is installed
+// against at boot, before a real transport exists. The bundled frontend starts
+// firing /api + /ws traffic the instant its scripts run, but the managed-relay
+// session isn't ready until the Noise handshake finishes (and, on first launch,
+// until the user has paired at all). This transport absorbs that gap: it holds
+// the shim's message handler and buffers every outbound frame, then replays the
+// buffer once a connected inner transport is attached. From the shim's side it
+// is an ordinary Transport; from boot's side, attach() hands over control.
+export class BufferingTransport implements Transport {
+  private inner: Transport | null = null
+  private handler: ((frame: string) => void) | null = null
+  private buffer: string[] = []
+
+  // connect is a no-op: the real transport is connected by boot and handed in
+  // via attach(). The shim never calls this.
+  async connect(): Promise<void> {}
+
+  onMessage(handler: (frame: string) => void): void {
+    this.handler = handler
+    if (this.inner) this.inner.onMessage(handler)
+  }
+
+  async send(frame: string): Promise<void> {
+    if (this.inner) {
+      await this.inner.send(frame)
+      return
+    }
+    this.buffer.push(frame)
+  }
+
+  async disconnect(): Promise<void> {
+    await this.inner?.disconnect()
+  }
+
+  // attach wires an already-connected transport in, flushing any frames the
+  // frontend sent while we were still pairing/handshaking. The handler is routed
+  // first so a response can't arrive before its listener is in place.
+  async attach(inner: Transport): Promise<void> {
+    if (this.handler) inner.onMessage(this.handler)
+    this.inner = inner
+    const pending = this.buffer
+    this.buffer = []
+    for (const frame of pending) await inner.send(frame)
+  }
+
+  // detach drops the inner transport (e.g. the session died) and re-enters
+  // buffering mode, so a reconnect can flush again.
+  detach(): void {
+    this.inner = null
+  }
+
+  get attached(): boolean {
+    return this.inner !== null
+  }
+}

--- a/mobile/src/pairing.ts
+++ b/mobile/src/pairing.ts
@@ -12,34 +12,49 @@ export interface PairingInfo {
   token: string
 }
 
-const SCHEME = 'octo-pair:'
+const SCHEME = 'octo-pair'
 const VERSION = 'v1'
 
 /**
  * parsePairingURL parses an `octo-pair://v1?relay=&tid=&hk=&tok=` URL into typed
  * PairingInfo. It throws on a wrong scheme, an unsupported version, or a missing
  * field. The values were percent-encoded by the host (Go's url.Values.Encode),
- * and URL's searchParams decodes them back.
+ * and URLSearchParams decodes them back.
+ *
+ * It parses the string directly rather than via the WHATWG `URL` constructor:
+ * `octo-pair` is a non-special scheme, and engines disagree on whether the
+ * authority (which carries our version, e.g. //v1) is populated — Node fills
+ * `url.host`, but the Android System WebView leaves it empty, which silently
+ * broke version detection on-device. Manual parsing behaves identically
+ * everywhere, and it also tolerates the `//` being dropped when a custom-scheme
+ * deep link is delivered as an opaque URI.
  */
 export function parsePairingURL(raw: string): PairingInfo {
-  let url: URL
-  try {
-    url = new URL(raw)
-  } catch {
-    throw new Error('pairing: not a valid URL')
+  const trimmed = raw.trim()
+
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed)
+  if (!schemeMatch || schemeMatch[1].toLowerCase() !== SCHEME) {
+    const got = schemeMatch ? `${schemeMatch[1]}:` : '(none)'
+    throw new Error(`pairing: expected ${SCHEME}: scheme, got ${got}`)
   }
-  if (url.protocol !== SCHEME) {
-    throw new Error(`pairing: expected ${SCHEME} scheme, got ${url.protocol}`)
+
+  // Everything after `octo-pair:`, with an optional `//` authority marker
+  // stripped. The version rides in the authority slot: octo-pair://v1?...
+  const afterScheme = trimmed.slice(schemeMatch[0].length).replace(/^\/\//, '')
+  const queryStart = afterScheme.search(/[?#]/)
+  const versionPart = (queryStart === -1 ? afterScheme : afterScheme.slice(0, queryStart)).replace(/\/+$/, '')
+  const queryStr = queryStart === -1 ? '' : afterScheme.slice(queryStart + 1).replace(/#.*$/, '')
+
+  if (versionPart !== VERSION) {
+    throw new Error(`pairing: unsupported version ${versionPart || '(none)'}`)
   }
-  // The version rides in the URL authority slot: octo-pair://v1?...
-  if (url.host !== VERSION) {
-    throw new Error(`pairing: unsupported version ${url.host || '(none)'}`)
-  }
+
+  const params = new URLSearchParams(queryStr)
   const info: PairingInfo = {
-    relay: url.searchParams.get('relay') ?? '',
-    tunnelId: url.searchParams.get('tid') ?? '',
-    hostKey: url.searchParams.get('hk') ?? '',
-    token: url.searchParams.get('tok') ?? '',
+    relay: params.get('relay') ?? '',
+    tunnelId: params.get('tid') ?? '',
+    hostKey: params.get('hk') ?? '',
+    token: params.get('tok') ?? '',
   }
   const required: Array<[string, string]> = [
     ['relay', info.relay],

--- a/mobile/src/plugin.ts
+++ b/mobile/src/plugin.ts
@@ -1,11 +1,19 @@
 import { registerPlugin } from '@capacitor/core'
 import type { OctoTunnelPlugin } from './native-bridge'
 
-// OctoTunnel is the app's custom native plugin. Its Swift (ios/) and Kotlin
-// (android/) implementations run the Noise handshake, hold the device keypair in
-// the Keychain / Keystore, and move ciphertext over the relay — none of which
-// can live in JavaScript. registerPlugin wires the JS-side proxy; Capacitor
-// resolves the native implementation at runtime on-device. In a plain browser
-// (no native host) the calls reject, which is why the managed-relay transport is
-// only selected inside the app (mobileShell).
+// OctoTunnel is the app's custom native plugin. Its Kotlin (android/) and Swift
+// (ios/) implementations run the Noise handshake, hold the device keypair in the
+// Keystore / Keychain, and move ciphertext over the relay — none of which can
+// live in JavaScript. registerPlugin (from @capacitor/core, which augments the
+// native-injected bridge) wires the JS-side proxy; Capacitor resolves the native
+// implementation at runtime on-device. In a plain browser the calls reject,
+// which is why the managed-relay transport is only used inside the app.
+//
+// We deliberately use @capacitor/core's registerPlugin for every plugin — our
+// own OctoTunnel and first-party ones like App — rather than each plugin's own
+// JS wrapper (e.g. @capacitor/app). The wrappers layer a second event path that
+// misbehaves when this boot bundle loads at document start; the low-level proxy
+// from registerPlugin talks straight to the one native bridge.
+export { registerPlugin }
+
 export const OctoTunnel = registerPlugin<OctoTunnelPlugin>('OctoTunnel')

--- a/mobile/src/qr.ts
+++ b/mobile/src/qr.ts
@@ -1,0 +1,85 @@
+import jsQR from 'jsqr'
+
+// scanPairingURL opens the device camera in a fullscreen overlay and scans for
+// an octo-pair:// QR — the pairing code the host renders in Settings › Mobile.
+// It resolves with the decoded URL string (validated only as far as the scheme;
+// parsePairingURL does the real parsing) and stops the camera. It rejects if the
+// user cancels or the camera can't be opened. QR decoding runs entirely in JS
+// (jsQR over getUserMedia frames), so it needs no native scanner plugin — just
+// the CAMERA permission the Capacitor WebView requests on first getUserMedia.
+export function scanPairingURL(): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let stream: MediaStream | null = null
+    let raf = 0
+    const root = document.createElement('div')
+    root.style.cssText =
+      'position:fixed;inset:0;z-index:2147483647;background:#000;display:flex;' +
+      'flex-direction:column;align-items:center;justify-content:center;'
+
+    const video = document.createElement('video')
+    video.setAttribute('playsinline', 'true')
+    video.muted = true
+    video.style.cssText = 'width:100%;height:100%;object-fit:cover;'
+    root.appendChild(video)
+
+    const hint = document.createElement('div')
+    hint.textContent = '将 Settings › Mobile 的二维码对准取景框'
+    hint.style.cssText =
+      'position:absolute;top:12%;left:0;right:0;text-align:center;color:#fff;' +
+      'font:15px system-ui,sans-serif;text-shadow:0 1px 3px rgba(0,0,0,.6);padding:0 24px;'
+    root.appendChild(hint)
+
+    const cancel = document.createElement('button')
+    cancel.textContent = '取消'
+    cancel.style.cssText =
+      'position:absolute;bottom:8%;padding:12px 32px;border:0;border-radius:24px;' +
+      'background:#fff;color:#111;font:600 15px system-ui,sans-serif;'
+    root.appendChild(cancel)
+
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d', { willReadFrequently: true })
+
+    const cleanup = () => {
+      cancelAnimationFrame(raf)
+      stream?.getTracks().forEach((t) => t.stop())
+      root.remove()
+    }
+    cancel.onclick = () => {
+      cleanup()
+      reject(new Error('scan cancelled'))
+    }
+
+    const tick = () => {
+      if (video.readyState === video.HAVE_ENOUGH_DATA && ctx) {
+        canvas.width = video.videoWidth
+        canvas.height = video.videoHeight
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
+        const img = ctx.getImageData(0, 0, canvas.width, canvas.height)
+        const code = jsQR(img.data, img.width, img.height, { inversionAttempts: 'dontInvert' })
+        if (code && code.data.startsWith('octo-pair://')) {
+          const url = code.data
+          cleanup()
+          resolve(url)
+          return
+        }
+      }
+      raf = requestAnimationFrame(tick)
+    }
+
+    document.body.appendChild(root)
+    navigator.mediaDevices
+      .getUserMedia({ video: { facingMode: 'environment' } })
+      .then((s) => {
+        stream = s
+        video.srcObject = s
+        return video.play()
+      })
+      .then(() => {
+        raf = requestAnimationFrame(tick)
+      })
+      .catch((err) => {
+        cleanup()
+        reject(err instanceof Error ? err : new Error(String(err)))
+      })
+  })
+}


### PR DESCRIPTION
First working end-to-end managed-tunnel clients for **both Android and iOS**: the native `OctoTunnel` plugins plus the shared app boot layer. Each was paired to a local `octo serve --tunnel` + `octo-relay` over a real Noise session, and the bundled web frontend drove `/api` + `/ws` through the tunnel (the UI showed the host's real model config and working directory).

This fills the piece `mobile/native/README.md` flagged as the only unverified part — the native Noise/keys layer.

## Native plugins (interoperate byte-for-byte with the Go host `internal/tunnel` + relay `cmd/octo-relay`)

- **`native/OctoTunnelPlugin.kt`** (Android) — Noise XX over [noise-java](https://github.com/rweather/noise-java) (`com.github.auties00:noise-java`, pure Java, no NDK). X25519 static key wrapped by an AndroidKeyStore AES-GCM key; relay WebSocket over OkHttp.
- **`native/OctoTunnelPlugin.swift`** (iOS) — pure-Swift Capacitor plugin (`CAPBridgedPlugin`, no `.m`). Noise XX implemented directly on **CryptoKit** (Curve25519 / ChaChaPoly / SHA256 / HMAC-HKDF), no third-party dependency. X25519 static key in the **Keychain**; relay WebSocket over `URLSessionWebSocketTask`.

Both: `Noise_XX_25519_ChaChaPoly_SHA256`, empty prologue, authenticate the host against the scanned `hostKey`, mirror the phone (initiator) side of `cmd/octo-relay/internal/client`.

## App layer (shared)

- **`src/boot.ts`** — entry point. Installs the local shim on a **BufferingTransport** that holds the frontend's `/api` + `/ws` traffic from its first request until the Noise session is ready, then pairs (QR scan or `octo-pair://` deep link) and flushes.
- **`src/qr.ts`** — QR pairing via `getUserMedia` + jsQR. **`src/buffering-transport.ts`** (+ test).
- **`plugin.ts`** / **`pairing.ts`** / **`bundle-web.mjs`** — fixes found during bring-up (see below).

## Fixes found during bring-up

- **`plugin.ts`** — resolve plugins through `@capacitor/core`'s `registerPlugin`, not each plugin's own JS wrapper (a second core copy races the native bridge → `triggerEvent of undefined`).
- **`pairing.ts`** — parse the `octo-pair://` URL directly instead of via `new URL()`; the Android System WebView leaves the authority (our version slot) empty for non-special schemes. Parser contract unchanged (vitest 19/19).
- **`bundle-web.mjs`** — bundle `boot.ts` to an IIFE (esbuild) injected as the first `<head>` script of the frontend's `index.html`.

## Verification

- `npm test` (vitest) 19/19, `npm run typecheck` clean.
- **Android**: APK on an emulator; paired over a real Noise handshake; `/api` + `/ws` bridged end to end (stable session, decrypted frames both directions).
- **iOS**: app on the Simulator; same — the `handshake complete` trace, `data` frames flowing, and the full octo UI rendering over the tunnel.

## Notes

- The generated `android/` and `ios/` projects stay gitignored; the per-platform wiring (Gradle/Kotlin + noise-java/OkHttp; pure-Swift plugin + `registerPluginInstance` + Info.plist) is documented in `mobile/native/README.md`.
- The `self-tunnel` transport still dials a `/tunnel` endpoint the server doesn't expose; only the managed-relay path is wired end to end.
- The iOS `ios/` build here was locally patched to drop storyboards (this machine only had an older simulator runtime than Xcode's SDK) — a toolchain workaround, not part of the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)