### PR TITLE
fix(web): two streaming-UI fixes — collapsible last tool + caret only while typing

### DIFF
--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -3,6 +3,7 @@
   import { activeSessionId, showToast } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
+  import { toolOpenState, applyToolToggle } from '../../lib/toolFold'
 
   // Tracks which overwrite-undo buttons have already fired, keyed by tool id.
   let undone = $state<Record<string, boolean>>({})
@@ -203,16 +204,10 @@
     return tool.name === 'terminal' || tool.name === 'bash'
   }
 
-  // While a turn is still running, keep the LATEST tool open (whether or not it
-  // has finished) so its output stays readable until the next step replaces it
-  // — a finished tool only collapses once the next tool appears, and the whole
-  // group collapses once the turn completes (the assistant reply takes over).
-  // Errors always open — they need attention.
-  function defaultOpen(tool: any, lastId: string | undefined, streaming: boolean): boolean {
-    if (tool.error) return true
-    if (!streaming) return false
-    return tool.id === lastId
-  }
+  // Per-tool open/closed override, seeded by the default (see lib/toolFold).
+  // Binding <details open> straight to the default would let every streaming
+  // re-render revert a manual collapse of the auto-opened last tool.
+  let toolOpen = $state<Record<string, boolean>>({})
 
   // todo_write renders its checklist from the tool args.
   function todoItems(tool: any): Array<{ status: string; content: string }> | null {
@@ -279,7 +274,7 @@
            ellipsizes it. Surfacing it via `title` + selectable text lets the
            user read/copy the whole thing despite the truncation. -->
       {@const argText = tool.summary || (tool.args ? argSummary(tool.name, tool.args) : '')}
-      <details open={defaultOpen(tool, lastId, groupStreaming)} class="tool-item">
+      <details open={toolOpenState(toolOpen, tool, lastId, groupStreaming)} ontoggle={(e) => applyToolToggle(toolOpen, tool, lastId, groupStreaming, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
         <summary class="tool-summary">
           <iconify-icon icon="lucide:chevron-right" width="13" class="chev" style="color:var(--text-tertiary)"></iconify-icon>
           <iconify-icon icon={toolIcon(tool.name)} width="14" style="color:var(--text-tertiary);flex:0 0 auto"></iconify-icon>

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -94,6 +94,14 @@ export const editDraft = writable('')
 // Per-session chat state (keyed by sessionId)
 export const chatMessages = writable<Record<string, any[]>>({})
 export const chatStreaming = writable<Record<string, boolean>>({})
+// Wall-clock time (ms) of the last text_delta per session. The reply caret is
+// gated on this being recent: the assistant message stays `streaming` for the
+// whole turn (cleared only at segment boundaries — tool_call, new reasoning,
+// complete), so between a finished text run and the next tool the caret would
+// otherwise keep blinking under text that stopped growing while the model is
+// silently generating. Showing it only while text is actively arriving makes it
+// a true typewriter cursor.
+export const chatLastTextAt = writable<Record<string, number>>({})
 // Wall-clock start (ms) of the active streaming turn, per session, so the live
 // "Thinking" elapsed readout survives view remounts (page switches) instead of
 // resetting — a component-local start would restart from ~0 (and briefly read

--- a/web/src/lib/toolFold.test.ts
+++ b/web/src/lib/toolFold.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { defaultToolOpen, toolOpenState, applyToolToggle, type ToolLike } from './toolFold'
+
+const tool = (id: string, error?: unknown): ToolLike => ({ id, error })
+
+describe('defaultToolOpen', () => {
+  it('opens the last tool while streaming, closes the rest', () => {
+    expect(defaultToolOpen(tool('b'), 'b', true)).toBe(true)
+    expect(defaultToolOpen(tool('a'), 'b', true)).toBe(false)
+  })
+
+  it('closes everything once streaming stops', () => {
+    expect(defaultToolOpen(tool('b'), 'b', false)).toBe(false)
+  })
+
+  it('always opens error cards', () => {
+    expect(defaultToolOpen(tool('a', 'boom'), 'b', false)).toBe(true)
+  })
+})
+
+describe('toolOpenState + applyToolToggle', () => {
+  it('falls back to the default when there is no override', () => {
+    const ov: Record<string, boolean> = {}
+    expect(toolOpenState(ov, tool('b'), 'b', true)).toBe(true)
+    expect(toolOpenState(ov, tool('a'), 'b', true)).toBe(false)
+  })
+
+  // The core regression: the last tool is auto-open, the user collapses it, and
+  // a later streaming re-render must NOT re-open it.
+  it('keeps a user collapse of the streaming last tool sticky across re-renders', () => {
+    const ov: Record<string, boolean> = {}
+    const last = tool('b')
+    // auto-open
+    expect(toolOpenState(ov, last, 'b', true)).toBe(true)
+    // user collapses -> diverges from default(true) -> override recorded
+    applyToolToggle(ov, last, 'b', true, false)
+    expect(ov).toEqual({ b: false })
+    // re-render(s) while still streaming: stays collapsed
+    expect(toolOpenState(ov, last, 'b', true)).toBe(false)
+    expect(toolOpenState(ov, last, 'b', true)).toBe(false)
+  })
+
+  it('lets the user re-open a collapsed tool and that sticks too', () => {
+    const ov: Record<string, boolean> = { b: false }
+    applyToolToggle(ov, tool('b'), 'b', true, true) // back to default(true) -> override cleared
+    expect(ov).toEqual({})
+    expect(toolOpenState(ov, tool('b'), 'b', true)).toBe(true)
+  })
+
+  it('does not record an override when a programmatic open matches the default (no loop)', () => {
+    const ov: Record<string, boolean> = {}
+    applyToolToggle(ov, tool('b'), 'b', true, true) // auto-open toggle fires, open===default
+    expect(ov).toEqual({})
+  })
+
+  it('lets the user open an earlier finished tool while streaming', () => {
+    const ov: Record<string, boolean> = {}
+    const earlier = tool('a') // not last -> default closed
+    applyToolToggle(ov, earlier, 'b', true, true)
+    expect(ov).toEqual({ a: true })
+    expect(toolOpenState(ov, earlier, 'b', true)).toBe(true)
+  })
+
+  it('lets the user collapse an error card and keeps it collapsed', () => {
+    const ov: Record<string, boolean> = {}
+    const errored = tool('a', 'boom') // default open
+    applyToolToggle(ov, errored, 'b', true, false)
+    expect(ov).toEqual({ a: false })
+    expect(toolOpenState(ov, errored, 'b', true)).toBe(false)
+  })
+})

--- a/web/src/lib/toolFold.ts
+++ b/web/src/lib/toolFold.ts
@@ -1,0 +1,51 @@
+// Open/closed decision for a tool card in ToolGroup.
+//
+// The card is a native <details>. Its `open` can't bind straight to the default
+// below: the default is a derived value the {#each} re-asserts on every streaming
+// re-render, so a manual collapse of the auto-opened last tool (or an error card)
+// would be reverted on the next tick and the fold would appear not to work. So we
+// keep a per-tool override, seeded by the default, that wins once the user
+// diverges from it.
+
+export interface ToolLike {
+  id: string
+  error?: unknown
+}
+
+// Default open state: errors always open (they need attention); while the turn
+// is streaming the latest tool stays open so its output is readable until the
+// next tool replaces it; everything else is closed.
+export function defaultToolOpen(tool: ToolLike, lastId: string | undefined, streaming: boolean): boolean {
+  if (tool.error) return true
+  if (!streaming) return false
+  return tool.id === lastId
+}
+
+// Effective open state given the user's per-tool overrides: use the override when
+// present, otherwise fall back to the default.
+export function toolOpenState(
+  overrides: Record<string, boolean>,
+  tool: ToolLike,
+  lastId: string | undefined,
+  streaming: boolean,
+): boolean {
+  const ov = overrides[tool.id]
+  return ov === undefined ? defaultToolOpen(tool, lastId, streaming) : ov
+}
+
+// Fold a <details> toggle into the overrides map (mutates in place). Record the
+// choice only while it diverges from the current default; when it realigns, drop
+// the override so auto behaviour (last opens, previous collapses when the next
+// tool arrives) resumes. This also keeps auto-open idempotent — the toggle event
+// a programmatic open fires matches the default and clears nothing new, so there
+// is no feedback loop with the reactive `open` binding.
+export function applyToolToggle(
+  overrides: Record<string, boolean>,
+  tool: ToolLike,
+  lastId: string | undefined,
+  streaming: boolean,
+  open: boolean,
+): void {
+  if (open === defaultToolOpen(tool, lastId, streaming)) delete overrides[tool.id]
+  else overrides[tool.id] = open
+}

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -7,6 +7,7 @@
     sessions,
     chatMessages,
     chatStreaming,
+    chatLastTextAt,
     chatTurnStart,
     chatProgress,
     chatBgTasks,
@@ -147,6 +148,9 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     pendingSteerList = pendingSteers[$activeSessionId ?? ''] ?? []
   })
 
+  // How long after the last text_delta the reply caret keeps blinking.
+  const CARET_IDLE_MS = 1200
+
   // Sub-agents card elapsed time + reconnect countdown both tick off `now`.
   let now = $state(Date.now())
   $effect(() => {
@@ -192,6 +196,13 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   })
   let turnStartAt = $derived($chatTurnStart[$activeSessionId ?? ''] ?? 0)
   let thinkElapsed = $derived(turnStartAt ? Math.max(0, Math.floor((now - turnStartAt) / 1000)) : 0)
+  // The reply caret is a typewriter cursor: show it only while text is actively
+  // arriving. Once deltas stop (the model went silent to generate tool calls /
+  // reasoning), it fades within CARET_IDLE_MS even though the bubble stays
+  // `streaming` until the next segment boundary. `now` ticks every 1s, so the
+  // real hide latency is CARET_IDLE_MS..CARET_IDLE_MS+1s.
+  let lastTextAt = $derived($chatLastTextAt[$activeSessionId ?? ''] ?? 0)
+  let typingActive = $derived(streaming && lastTextAt > 0 && (now - lastTextAt) < CARET_IDLE_MS)
   // Output-token estimate (~chars/4), derived from persisted stores — the live
   // assistant text plus the reasoning buffer — so it survives view remounts
   // alongside the elapsed clock instead of resetting to 0.
@@ -565,6 +576,9 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       const pendingThinking = get(chatThinking)[sid] ?? ''
       appendToLastAssistant(sid, txt, pendingThinking)
       if (pendingThinking) chatThinking.update(tt => ({ ...tt, [sid]: '' }))
+      // Stamp the arrival so the reply caret only blinks while text is flowing
+      // (see chatLastTextAt). Empty deltas carry no visible text, so ignore them.
+      if (txt) chatLastTextAt.update(tt => ({ ...tt, [sid]: Date.now() }))
     }))
 
     cleanups.push(ws.on('thinking_delta', (ev) => {
@@ -1783,8 +1797,10 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
                     </div>
                   {/if}
 
-                  <!-- Streaming caret -->
-                  {#if msg.streaming}
+                  <!-- Streaming caret — only while text is actively arriving
+                       (see typingActive), so it doesn't blink under a finished
+                       reply while the model silently generates the next step. -->
+                  {#if msg.streaming && typingActive}
                     <span class="caret"></span>
                   {/if}
 


### PR DESCRIPTION
Two small, independent Svelte fixes in the streaming chat UI.

---

## 1. Last tool card wasn't collapsible during streaming

**Problem** — collapsing the *last* tool card (or an error card) while a turn streams springs it back open.

**Cause** — `ToolGroup.svelte` bound `<details open={defaultOpen(...)}>` straight to a derived value. `defaultOpen` is `true` for the latest tool while streaming (and always for errors), and the `{#each}` re-asserts it on every re-render, so a manual collapse had nowhere to be remembered.

**Fix** — extract the decision to `web/src/lib/toolFold.ts` and add a per-tool override, seeded by the default, that wins once the user diverges and is dropped when it realigns (auto-open stays idempotent, no feedback loop). Unit-tested (`toolFold.test.ts`, 9 cases).

## 2. Reply caret kept blinking during silent generation gaps

**Problem** — the model emits a short reply, then goes silent to generate its tool calls; the typewriter caret keeps blinking under the finished text (with the "thinking" spinner beside it — the "Working" label is just the cycling thinking text at that elapsed mark, not a real phase).

**Cause** — the assistant bubble stays `streaming` for the whole turn; the flag is cleared only at segment boundaries (tool_call, new reasoning, complete). Between a finished text run and the next tool there's no boundary event.

**Fix** — stamp `chatLastTextAt` on every non-empty `text_delta` and show the caret only while `now - lastTextAt < CARET_IDLE_MS` (1.2s). It fades shortly after deltas stop and returns when text resumes — a true typewriter cursor. Turn-end paths already clear `streaming` via `complete` (verified: error/interrupt/panic all fall through to `complete`).

---

## Tests
- Full web suite: **116/116** pass. `svelte-check`: **0 errors / 0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)