### PR TITLE
ci(mobile): restrict GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -22,6 +22,10 @@ on:
       - 'mobile/**'
       - '.github/workflows/mobile.yml'
 
+# Only reads the checkout; no token write scope needed.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Type-check + test


### PR DESCRIPTION
Adds an explicit `permissions: contents: read` block to `.github/workflows/mobile.yml`, matching every other workflow in the repo (`go.yml`, `desktop.yml`, etc.).

Fixes CodeQL **actions/missing-workflow-permissions** ([alert #159](https://github.com/open-octo/octo-agent/security/code-scanning/159)) — introduced when the workflow landed in #1695. The job only checks out the repo and runs npm, so read scope is sufficient; defaulting the token to least privilege closes the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)