### PR TITLE
fix(web): reconnect/replay UI fixes — tool-group state, sub-agent fan-out, task panel lifecycle

### DIFF
--- a/internal/app/toolenv.go
+++ b/internal/app/toolenv.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/open-octo/octo-agent/internal/agent"
-	"github.com/open-octo/octo-agent/internal/tasks"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
 
@@ -44,7 +43,11 @@ func NewSessionToolEnv(
 ) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, func()) {
 	ctx = tools.WithWorkingDir(ctx, a.CWD)
 	ctx = tools.WithBackgroundManager(ctx, tools.SessionBackgroundManager(sessionID))
-	ctx = tools.WithTaskStore(ctx, tasks.New())
+	// Per-session task store, cached by sessionID like the managers above, so the
+	// task/plan checklist survives across turns and a page refresh (a per-turn
+	// tasks.New() here is why the panel used to vanish). Callers that want a plan
+	// reset between turns do it via CloseSessionTaskStore before this call.
+	ctx = tools.WithTaskStore(ctx, tools.SessionTaskStore(sessionID))
 
 	mkSpawner := func() tools.Spawner {
 		return NewSpawner(a, executor, func(ctx context.Context) []agent.ToolDefinition {

--- a/internal/browser/recording_test.go
+++ b/internal/browser/recording_test.go
@@ -1109,7 +1109,12 @@ func TestReplayNavigateEncodesParams(t *testing.T) {
 	defer cancel()
 	var gotQ, gotURI string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotQ, gotURI = r.URL.Query().Get("q"), r.RequestURI
+		// Capture only the navigation target — Chromium may also fetch
+		// /favicon.ico after load, whose empty query would otherwise clobber
+		// the recorded values and flake the assertions (seen on windows).
+		if strings.HasPrefix(r.URL.Path, "/item/") {
+			gotQ, gotURI = r.URL.Query().Get("q"), r.RequestURI
+		}
 		w.Write([]byte(`<!doctype html><title>echo</title>ok`))
 	}))
 	defer srv.Close()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -688,6 +688,7 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 	tools.CloseSessionSubAgentManager(id)   // and its sub-agents
 	tools.CloseSessionWorkflowManager(id)   // and its background workflows
 	tools.CloseSessionReadTracker(id)       // and its read-before-write tracker
+	tools.CloseSessionTaskStore(id)         // and its task/plan checklist
 	tools.CloseSessionReplaySecrets(id)     // and any cached replay secrets
 	s.wsHub.broadcast("", wsEventSessionDeleted{Type: "session_deleted", SessionID: id})
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": []string{id}})
@@ -723,6 +724,7 @@ func (s *Server) handleDeleteSessions(w http.ResponseWriter, r *http.Request) {
 		tools.CloseSessionSubAgentManager(id)   // and its sub-agents
 		tools.CloseSessionWorkflowManager(id)   // and its background workflows
 		tools.CloseSessionReadTracker(id)       // and its read-before-write tracker
+		tools.CloseSessionTaskStore(id)         // and its task/plan checklist
 		tools.CloseSessionReplaySecrets(id)     // and any cached replay secrets
 		s.wsHub.broadcast("", wsEventSessionDeleted{Type: "session_deleted", SessionID: id})
 		deleted = append(deleted, id)

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -180,6 +180,19 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 				s.deliverModelNote(sid, tools.FormatWorkflowNote(ev))
 			},
 		})
+		// NewSessionToolEnv stamps a per-turn task store; override it with the
+		// per-session one so the task/plan panel persists across turns and
+		// survives a post-turn refresh — replayLiveState rebuilds the panel from
+		// this same store (a per-turn store is gone by the time a tab resubscribes).
+		//
+		// Clear-and-rebuild: a fully-completed plan is closed, so drop it here so
+		// this turn's new tasks start a fresh plan rather than piling onto old,
+		// done ones. An incomplete plan carries over so the agent keeps working on
+		// it (turns are serialized per session, so this read-then-reset is safe).
+		if tools.AllTasksComplete(tools.PeekSessionTaskStore(sid)) {
+			tools.CloseSessionTaskStore(sid)
+		}
+		ctx = tools.WithTaskStore(ctx, tools.SessionTaskStore(sid))
 	} else {
 		// No session identity (one-shot runTurn paths): keep the old
 		// request/response semantics — block on every sub-agent. Deliberately

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -128,6 +128,14 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	var cleanup func()
 
 	if hasSession && sid != "" {
+		// Clear-and-rebuild: a fully-completed plan is closed, so drop it BEFORE
+		// NewSessionToolEnv picks up the per-session task store — this turn's new
+		// tasks then start a fresh plan instead of piling onto old, done ones. An
+		// incomplete plan carries over so the agent keeps working on it. Turns are
+		// serialized per session, so this read-then-reset is safe.
+		if tools.AllTasksComplete(tools.PeekSessionTaskStore(sid)) {
+			tools.CloseSessionTaskStore(sid)
+		}
 		// Session-scoped path: reuse the concurrency-safe core from app.NewSessionToolEnv.
 		// Server-specific callbacks (WebSocket broadcast, model note delivery) are
 		// injected here; the core function stays free of *Server dependencies.
@@ -180,19 +188,6 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 				s.deliverModelNote(sid, tools.FormatWorkflowNote(ev))
 			},
 		})
-		// NewSessionToolEnv stamps a per-turn task store; override it with the
-		// per-session one so the task/plan panel persists across turns and
-		// survives a post-turn refresh — replayLiveState rebuilds the panel from
-		// this same store (a per-turn store is gone by the time a tab resubscribes).
-		//
-		// Clear-and-rebuild: a fully-completed plan is closed, so drop it here so
-		// this turn's new tasks start a fresh plan rather than piling onto old,
-		// done ones. An incomplete plan carries over so the agent keeps working on
-		// it (turns are serialized per session, so this read-then-reset is safe).
-		if tools.AllTasksComplete(tools.PeekSessionTaskStore(sid)) {
-			tools.CloseSessionTaskStore(sid)
-		}
-		ctx = tools.WithTaskStore(ctx, tools.SessionTaskStore(sid))
 	} else {
 		// No session identity (one-shot runTurn paths): keep the old
 		// request/response semantics — block on every sub-agent. Deliberately

--- a/internal/server/live_replay_test.go
+++ b/internal/server/live_replay_test.go
@@ -369,6 +369,54 @@ func TestReplayLiveState_StdoutClearsAfterToolDone(t *testing.T) {
 	}
 }
 
+// TestReplayLiveState_ReplaysTaskPanel is the regression guard for the task
+// panel vanishing on a mid-turn refresh: the web task store is rebuilt per turn
+// and never persisted, and todo_update is fire-and-forget, so a tab that
+// (re)subscribes after the last task tool ran had no way to rebuild the panel.
+func TestReplayLiveState_ReplaysTaskPanel(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+	srv.pendingQuestions = map[string]wsEventRequestUserQuestion{}
+	srv.pendingConfirms = map[string]wsEventRequestConfirmation{}
+
+	const sid = "replay-task-panel-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+
+	seedLiveTurn(srv, sid)
+	sw := srv.newWSStreamWriter(sid)
+
+	todos := []any{
+		map[string]any{"content": "step one", "status": "completed"},
+		map[string]any{"content": "step two", "status": "in_progress"},
+	}
+	sw.handleEvent(agent.AgentEvent{
+		Kind:   agent.EventToolDone,
+		ToolID: "task1",
+		Output: "ok",
+		UI:     map[string]any{"type": "todo", "todos": todos},
+	})
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.replayLiveState(sid, conn)
+
+	var got []map[string]any
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] == "todo_update" && ev["session_id"] == sid {
+			got = append(got, ev)
+		}
+	}
+	if len(got) != 1 {
+		t.Fatalf("replayed todo_update count = %d, want 1", len(got))
+	}
+	list, ok := got[0]["todos"].([]any)
+	if !ok || len(list) != 2 {
+		t.Fatalf("replayed todos = %v, want 2 items", got[0]["todos"])
+	}
+	if first, _ := list[0].(map[string]any); first["content"] != "step one" || first["status"] != "completed" {
+		t.Errorf("replayed todos[0] = %v, want {step one, completed}", list[0])
+	}
+}
+
 // TestReplayLiveState_ReplaysRunningWorkflow is the regression guard for the
 // web workflow panel never appearing (or never clearing) when a tab
 // (re)subscribes after a background workflow already started: the panel is

--- a/internal/server/live_replay_test.go
+++ b/internal/server/live_replay_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/tasks"
 	"github.com/open-octo/octo-agent/internal/tools"
 	"github.com/open-octo/octo-agent/internal/workflow"
 )
@@ -370,9 +371,10 @@ func TestReplayLiveState_StdoutClearsAfterToolDone(t *testing.T) {
 }
 
 // TestReplayLiveState_ReplaysTaskPanel is the regression guard for the task
-// panel vanishing on a mid-turn refresh: the web task store is rebuilt per turn
-// and never persisted, and todo_update is fire-and-forget, so a tab that
-// (re)subscribes after the last task tool ran had no way to rebuild the panel.
+// panel vanishing on refresh. The store is per-session (not per-turn) and
+// outlives the turn, and replayLiveState rebuilds the panel from it
+// unconditionally — so the panel survives a refresh even AFTER the turn ends,
+// with no live turn to snapshot.
 func TestReplayLiveState_ReplaysTaskPanel(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 	srv.initWS()
@@ -381,20 +383,17 @@ func TestReplayLiveState_ReplaysTaskPanel(t *testing.T) {
 
 	const sid = "replay-task-panel-session"
 	defer tools.CloseSessionBackgroundManager(sid)
+	defer tools.CloseSessionTaskStore(sid)
 
-	seedLiveTurn(srv, sid)
-	sw := srv.newWSStreamWriter(sid)
-
-	todos := []any{
-		map[string]any{"content": "step one", "status": "completed"},
-		map[string]any{"content": "step two", "status": "in_progress"},
+	// Seed the per-session store as the task_* tools would, then DON'T seed a
+	// live turn — this is the post-turn refresh case the per-turn store lost.
+	store := tools.SessionTaskStore(sid)
+	if _, err := store.Create("step one", "", ""); err != nil {
+		t.Fatalf("create task: %v", err)
 	}
-	sw.handleEvent(agent.AgentEvent{
-		Kind:   agent.EventToolDone,
-		ToolID: "task1",
-		Output: "ok",
-		UI:     map[string]any{"type": "todo", "todos": todos},
-	})
+	if _, err := store.Create("step two", "", ""); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
 
 	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
 	srv.replayLiveState(sid, conn)
@@ -408,12 +407,62 @@ func TestReplayLiveState_ReplaysTaskPanel(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("replayed todo_update count = %d, want 1", len(got))
 	}
-	list, ok := got[0]["todos"].([]any)
-	if !ok || len(list) != 2 {
+	if list, ok := got[0]["todos"].([]any); !ok || len(list) != 2 {
 		t.Fatalf("replayed todos = %v, want 2 items", got[0]["todos"])
 	}
-	if first, _ := list[0].(map[string]any); first["content"] != "step one" || first["status"] != "completed" {
-		t.Errorf("replayed todos[0] = %v, want {step one, completed}", list[0])
+}
+
+// TestReplayLiveState_SkipsCompletedTaskPanel guards that a fully-completed plan
+// is NOT replayed: it fades out client-side once done, so a refresh afterwards
+// must not bring the panel back (and the store is cleared at the next turn).
+func TestReplayLiveState_SkipsCompletedTaskPanel(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+	srv.pendingQuestions = map[string]wsEventRequestUserQuestion{}
+	srv.pendingConfirms = map[string]wsEventRequestConfirmation{}
+
+	const sid = "replay-completed-task-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+	defer tools.CloseSessionTaskStore(sid)
+
+	store := tools.SessionTaskStore(sid)
+	id, _ := store.Create("only step", "", "")
+	done := tasks.Completed
+	if _, err := store.Update(id, tasks.UpdateField{Status: &done}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.replayLiveState(sid, conn)
+
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] == "todo_update" {
+			t.Errorf("replayed a todo_update for a fully-completed plan: %v", ev)
+		}
+	}
+}
+
+// TestReplayLiveState_NoTaskPanelWhenEmpty guards the leak/no-op side: a session
+// that never ran a task tool must not create a store or replay a todo_update.
+func TestReplayLiveState_NoTaskPanelWhenEmpty(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+	srv.pendingQuestions = map[string]wsEventRequestUserQuestion{}
+	srv.pendingConfirms = map[string]wsEventRequestConfirmation{}
+
+	const sid = "replay-no-task-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.replayLiveState(sid, conn)
+
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] == "todo_update" {
+			t.Errorf("replayed a todo_update for a session with no tasks: %v", ev)
+		}
+	}
+	if tools.PeekSessionTaskStore(sid) != nil {
+		t.Error("replay created a task store for a session that never used one")
 	}
 }
 

--- a/internal/server/live_replay_test.go
+++ b/internal/server/live_replay_test.go
@@ -417,6 +417,48 @@ func TestReplayLiveState_ReplaysTaskPanel(t *testing.T) {
 	}
 }
 
+// TestReplayLiveState_ReplaysAllRunningSyncSubAgents is the regression guard
+// for a parallel sub_agent fan-out losing all but one entry on a mid-turn
+// refresh: every concurrently-running foreground (sync) sub-agent must replay
+// its own started event, not just one.
+func TestReplayLiveState_ReplaysAllRunningSyncSubAgents(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "replay-fanout-session"
+	defer tools.CloseSessionSubAgentManager(sid)
+
+	block := make(chan struct{})
+	defer close(block)
+	mgr := tools.SessionSubAgentManager(sid, func() tools.Spawner { return &blockingSpawner{block: block} })
+
+	const n = 4
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			_, _ = mgr.RunSync(context.Background(), tools.SpawnRequest{
+				Description: fmt.Sprintf("fanout-%d", i),
+			})
+		}()
+	}
+
+	// Wait until all n are registered and running.
+	waitFor(t, func() bool { return len(mgr.ListRunning()) == n })
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.replayLiveState(sid, conn)
+
+	started := map[string]bool{}
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] == "sub_agent_event" && ev["kind"] == "started" {
+			started[fmt.Sprintf("%v", ev["agent_id"])] = true
+		}
+	}
+	if len(started) != n {
+		t.Fatalf("replayed started events for %d sub-agents, want %d", len(started), n)
+	}
+}
+
 // TestReplayLiveState_ReplaysRunningWorkflow is the regression guard for the
 // web workflow panel never appearing (or never clearing) when a tab
 // (re)subscribes after a background workflow already started: the panel is

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -25,13 +25,6 @@ type sessionLiveState struct {
 	// right card (see #1193's pickToolIndex on the frontend).
 	stdoutToolID string
 
-	// todos is the latest task-checklist snapshot broadcast this turn (the
-	// `todos` payload of a todo_update). The web task store is rebuilt per turn
-	// and never persisted, so this live copy is the only way a tab that
-	// (re)subscribes mid-turn — e.g. a page refresh — can rebuild the task
-	// panel; without it the panel vanishes until the next task tool runs.
-	todos any
-
 	// events buffers the turn's already-broadcast transcript events
 	// (tool_call / tool_result / tool_error / steer history_user_message,
 	// plus flushed deltas) so a tab that subscribes mid-turn — e.g. after a
@@ -320,6 +313,28 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 		}
 	}
 
+	// Rebuild the task panel from the per-session task store. Done outside the
+	// live-turn snapshot below (and unconditionally) because the store outlives
+	// the turn: a refresh AFTER the turn ends must still restore the checklist,
+	// which the dropped live state can't provide. PeekSessionTaskStore avoids
+	// creating an empty store for a session that never ran a task tool. A
+	// fully-completed plan is skipped: it fades out client-side once done, so it
+	// must not reappear on refresh (and it's cleared at the next turn's start).
+	if store := tools.PeekSessionTaskStore(sessionID); !tools.AllTasksComplete(store) {
+		if todos := tools.TaskSnapshot(store); len(todos) > 0 {
+			if b, err := json.Marshal(map[string]any{
+				"type":       "todo_update",
+				"session_id": sessionID,
+				"todos":      todos,
+			}); err == nil {
+				select {
+				case conn.send <- b:
+				default:
+				}
+			}
+		}
+	}
+
 	// Snapshot the in-progress turn under the read lock: the event buffer,
 	// any unflushed streaming deltas, the current progress, and buffered
 	// stdout. Marshaling happens inside the lock because the builders and the
@@ -373,18 +388,6 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 				"session_id": sessionID,
 				"tool_id":    state.stdoutToolID,
 				"lines":      state.stdoutLines,
-			}); err == nil {
-				replay = append(replay, b)
-			}
-		}
-		// Rebuild the task panel: without this a mid-turn refresh leaves it
-		// empty until the next task tool fires (the store is per-turn, so the
-		// live snapshot is the only source).
-		if state.todos != nil {
-			if b, err := json.Marshal(map[string]any{
-				"type":       "todo_update",
-				"session_id": sessionID,
-				"todos":      state.todos,
 			}); err == nil {
 				replay = append(replay, b)
 			}
@@ -634,6 +637,15 @@ func (s *Server) wsClearSession(sid string) {
 	s.injectorMu.Lock()
 	delete(s.sessionInjectors, sid)
 	s.injectorMu.Unlock()
+
+	// The per-session task store now outlives turns (unlike the old per-turn
+	// store), so /clear must reset the plan too — otherwise the next turn's
+	// task_list still shows the wiped conversation's checklist and the panel
+	// lingers over an empty transcript. /compact deliberately does NOT do this
+	// (it preserves the conversation). Broadcast an empty todo_update so live
+	// tabs drop the panel immediately (history_reload also clears it).
+	tools.CloseSessionTaskStore(sid)
+	s.wsHub.broadcast(sid, map[string]any{"type": "todo_update", "session_id": sid, "todos": []any{}})
 
 	s.wsHub.broadcast(sid, map[string]any{"type": "session_update", "session_id": sid, "status": "idle", "context_usage": 0, "context_tokens": 0})
 	s.broadcastHistoryReload(sid)
@@ -1887,13 +1899,6 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 					SessionID: w.sessionID,
 					Todos:     m["todos"],
 				})
-				// Retain for replayLiveState so a mid-turn refresh rebuilds the
-				// task panel (the web task store is per-turn, not persisted).
-				w.server.liveStateMu.Lock()
-				if ls, ok := w.server.liveStates[w.sessionID]; ok {
-					ls.todos = m["todos"]
-				}
-				w.server.liveStateMu.Unlock()
 			}
 		}
 		w.hub.broadcast(w.sessionID, toolResult)

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -25,6 +25,13 @@ type sessionLiveState struct {
 	// right card (see #1193's pickToolIndex on the frontend).
 	stdoutToolID string
 
+	// todos is the latest task-checklist snapshot broadcast this turn (the
+	// `todos` payload of a todo_update). The web task store is rebuilt per turn
+	// and never persisted, so this live copy is the only way a tab that
+	// (re)subscribes mid-turn — e.g. a page refresh — can rebuild the task
+	// panel; without it the panel vanishes until the next task tool runs.
+	todos any
+
 	// events buffers the turn's already-broadcast transcript events
 	// (tool_call / tool_result / tool_error / steer history_user_message,
 	// plus flushed deltas) so a tab that subscribes mid-turn — e.g. after a
@@ -366,6 +373,18 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 				"session_id": sessionID,
 				"tool_id":    state.stdoutToolID,
 				"lines":      state.stdoutLines,
+			}); err == nil {
+				replay = append(replay, b)
+			}
+		}
+		// Rebuild the task panel: without this a mid-turn refresh leaves it
+		// empty until the next task tool fires (the store is per-turn, so the
+		// live snapshot is the only source).
+		if state.todos != nil {
+			if b, err := json.Marshal(map[string]any{
+				"type":       "todo_update",
+				"session_id": sessionID,
+				"todos":      state.todos,
 			}); err == nil {
 				replay = append(replay, b)
 			}
@@ -1868,6 +1887,13 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 					SessionID: w.sessionID,
 					Todos:     m["todos"],
 				})
+				// Retain for replayLiveState so a mid-turn refresh rebuilds the
+				// task panel (the web task store is per-turn, not persisted).
+				w.server.liveStateMu.Lock()
+				if ls, ok := w.server.liveStates[w.sessionID]; ok {
+					ls.todos = m["todos"]
+				}
+				w.server.liveStateMu.Unlock()
 			}
 		}
 		w.hub.broadcast(w.sessionID, toolResult)

--- a/internal/tools/session_managers.go
+++ b/internal/tools/session_managers.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"sync"
+
+	"github.com/open-octo/octo-agent/internal/tasks"
 )
 
 // backgroundManagerCtxKey scopes a BackgroundManager to a turn's context, the
@@ -236,6 +238,52 @@ func CloseSessionReadTracker(id string) {
 	sessionReadTrackersMu.Lock()
 	delete(sessionReadTrackers, id)
 	sessionReadTrackersMu.Unlock()
+}
+
+// ─── Task stores ────────────────────────────────────────────────────────
+
+// Per-session task stores, keyed like the other session managers. The task_*
+// tools' store, built fresh per turn (as the server's tool-env setup did),
+// forgot the plan the moment a turn ended — so the web task panel vanished on
+// the next turn and on a post-turn page refresh. Keying by session id keeps the
+// checklist alive across turns (matching the IM path's per-session store and
+// SessionReadTracker's rationale) and lets replayLiveState rebuild the panel
+// from it on (re)subscribe. In-memory only: a daemon restart still starts fresh.
+// Reaped on session delete (CloseSessionTaskStore).
+var (
+	sessionTaskStoresMu sync.Mutex
+	sessionTaskStores   = map[string]TaskStore{}
+)
+
+// SessionTaskStore returns the per-session task store for id, creating it on
+// first use. Used by the per-turn tool-env setup.
+func SessionTaskStore(id string) TaskStore {
+	sessionTaskStoresMu.Lock()
+	defer sessionTaskStoresMu.Unlock()
+	s := sessionTaskStores[id]
+	if s == nil {
+		s = tasks.New()
+		sessionTaskStores[id] = s
+	}
+	return s
+}
+
+// PeekSessionTaskStore returns the per-session task store for id without
+// creating one. nil means the session has never used a task tool — replay
+// paths use this so a mere (re)subscribe doesn't leak an empty store per
+// browsed session.
+func PeekSessionTaskStore(id string) TaskStore {
+	sessionTaskStoresMu.Lock()
+	defer sessionTaskStoresMu.Unlock()
+	return sessionTaskStores[id]
+}
+
+// CloseSessionTaskStore drops the per-session task store for id. No-op for an
+// unknown id.
+func CloseSessionTaskStore(id string) {
+	sessionTaskStoresMu.Lock()
+	delete(sessionTaskStores, id)
+	sessionTaskStoresMu.Unlock()
 }
 
 // allBackgroundManagers returns defaultBg plus every live per-session manager,

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -289,6 +289,39 @@ func taskUI(action string, store TaskStore) map[string]any {
 	}
 }
 
+// AllTasksComplete reports whether the store holds at least one non-deleted
+// task and every one of them is completed — i.e. the current plan is finished.
+// Used to close a plan: a finished one is cleared at the next turn's start
+// (clear-and-rebuild) and skipped by replay so it doesn't reappear after its
+// fade-out. Empty/nil stores return false (nothing to close).
+func AllTasksComplete(store TaskStore) bool {
+	if store == nil {
+		return false
+	}
+	seen := false
+	for _, t := range store.List() {
+		if t.Status == tasks.Deleted {
+			continue
+		}
+		if t.Status != tasks.Completed {
+			return false
+		}
+		seen = true
+	}
+	return seen
+}
+
+// TaskSnapshot returns the current checklist as the same [{content,status}]
+// payload taskUI embeds in a todo_update, for rebuilding the web task panel on
+// (re)subscribe. Returns nil when the store is nil or has no non-deleted tasks.
+func TaskSnapshot(store TaskStore) []map[string]any {
+	if store == nil {
+		return nil
+	}
+	todos, _ := taskUI("Tasks", store)["todos"].([]map[string]any)
+	return todos
+}
+
 // FormatTaskList renders a slice of tasks for display. Used both by the
 // task_list tool's Execute and by the REPL's /tasks slash command.
 //

--- a/internal/tools/tasks_snapshot_test.go
+++ b/internal/tools/tasks_snapshot_test.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/tasks"
+)
+
+func TestAllTasksComplete(t *testing.T) {
+	if AllTasksComplete(nil) {
+		t.Error("nil store should be false")
+	}
+
+	s := tasks.New()
+	if AllTasksComplete(s) {
+		t.Error("empty store should be false (nothing to close)")
+	}
+
+	id1, _ := s.Create("a", "", "")
+	id2, _ := s.Create("b", "", "")
+	if AllTasksComplete(s) {
+		t.Error("pending tasks should be false")
+	}
+
+	done := tasks.Completed
+	if _, err := s.Update(id1, tasks.UpdateField{Status: &done}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if AllTasksComplete(s) {
+		t.Error("one completed, one pending should be false")
+	}
+
+	if _, err := s.Update(id2, tasks.UpdateField{Status: &done}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !AllTasksComplete(s) {
+		t.Error("all completed should be true")
+	}
+
+	// A deleted task is ignored; the rest are still all completed.
+	id3, _ := s.Create("c", "", "")
+	del := tasks.Deleted
+	if _, err := s.Update(id3, tasks.UpdateField{Status: &del}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !AllTasksComplete(s) {
+		t.Error("deleted task ignored, rest completed → true")
+	}
+}
+
+func TestTaskSnapshot(t *testing.T) {
+	if TaskSnapshot(nil) != nil {
+		t.Error("nil store → nil")
+	}
+	s := tasks.New()
+	if TaskSnapshot(s) != nil {
+		t.Error("empty store → nil")
+	}
+	if _, err := s.Create("x", "", ""); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	snap := TaskSnapshot(s)
+	if len(snap) != 1 || snap[0]["content"] != "x" || snap[0]["status"] != "pending" {
+		t.Errorf("snapshot = %v, want one {x, pending}", snap)
+	}
+}

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -926,7 +926,7 @@
         <button class="chip" title={workingDir} onclick={(e) => { e.stopPropagation(); openDirMenu() }}>
           <iconify-icon icon="ant-design:folder-outlined" width="12"></iconify-icon>
           <span>{$t('chat.dir_label')}</span>
-          <span class="mono">{shortDir(workingDir)}</span>
+          <span class="mono dir-path">{shortDir(workingDir)}</span>
           <iconify-icon icon="lucide:chevron-down" width="12"></iconify-icon>
         </button>
         {#if dirMenu}
@@ -1157,6 +1157,7 @@
 .reasoning-chip { padding-right: 8px; }
 .reasoning-eye { color: var(--success); }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.dir-path { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .context-chip { gap: 8px; }
 .ctx-bar { width: 56px; height: 4px; background: var(--border-table); border-radius: 9999px; overflow: hidden; display: inline-block; }
 .ctx-fill { display: block; height: 100%; background: var(--blue-6); border-radius: 9999px; }

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -250,11 +250,17 @@
 {#if tools !== null && tools.length > 0}
   <!-- Real data rendering -->
   {@const lastId = tools[tools.length - 1]?.id}
+  <!-- "running" reflects whether a tool is still in flight, NOT the group's
+       message-level `streaming` flag: that flag stays true until the whole turn
+       completes (finishAllTools), so a group whose tools all finished — or one
+       rebuilt done-but-streaming on reconnect replay — would otherwise show a
+       perpetual "running". -->
+  {@const anyRunning = tools.some((t) => !t.done && !t.error)}
   <div class="tool-group">
     <div class="group-header">
       <iconify-icon icon="ant-design:tool-outlined" width="14" style="color:var(--text-tertiary)"></iconify-icon>
       <span class="hdr-label">{$t(tools.length === 1 ? 'tools.n_used_one' : 'tools.n_used').replace('{n}', String(tools.length))}</span>
-      {#if groupStreaming}
+      {#if anyRunning}
         <span style="margin-left:auto;display:flex;align-items:center;gap:5px;font-size:12px;color:var(--blue-6)">
           <iconify-icon icon="ant-design:loading-outlined" width="13" style="animation:octo-spin 0.8s linear infinite"></iconify-icon>
           {$t('tools.running')}

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -280,7 +280,7 @@
            ellipsizes it. Surfacing it via `title` + selectable text lets the
            user read/copy the whole thing despite the truncation. -->
       {@const argText = tool.summary || (tool.args ? argSummary(tool.name, tool.args) : '')}
-      <details open={toolOpenState(toolOpen, tool, lastId, groupStreaming)} ontoggle={(e) => applyToolToggle(toolOpen, tool, lastId, groupStreaming, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
+      <details open={toolOpenState(toolOpen, tool, lastId, anyRunning)} ontoggle={(e) => applyToolToggle(toolOpen, tool, lastId, anyRunning, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
         <summary class="tool-summary">
           <iconify-icon icon="lucide:chevron-right" width="13" class="chev" style="color:var(--text-tertiary)"></iconify-icon>
           <iconify-icon icon={toolIcon(tool.name)} width="14" style="color:var(--text-tertiary);flex:0 0 auto"></iconify-icon>

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -176,6 +176,21 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     return () => clearTimeout(timer)
   })
 
+  // Fade the task panel once the whole plan is done: 3s after every task reads
+  // completed, drop it. Cancels if a task reverts to incomplete or a new one is
+  // added (the effect re-runs on any todos change). Mirrors the sub-agent
+  // dismiss above; the server skips replaying a fully-completed plan so a
+  // refresh after the fade doesn't bring it back.
+  const TODO_DISMISS_MS = 3000
+  $effect(() => {
+    const sid = $activeSessionId ?? ''
+    if (!sid) return
+    if (todos.length === 0) return
+    if (todos.some(t => t.status !== 'completed')) return
+    const timer = setTimeout(() => chatTodos.update(t => ({ ...t, [sid]: [] })), TODO_DISMISS_MS)
+    return () => clearTimeout(timer)
+  })
+
   // Live "Thinking" readout — mirrors the TUI thinkingLine: elapsed since the
   // turn began plus a rough output-token estimate (streamed chars / 4) so a
   // long silent wait reads as the model working, not a freeze.


### PR DESCRIPTION
A batch of web-UI reconnect/replay fixes (mid-turn and post-turn page refresh → WS resubscribe → replayLiveState).

## 1. Tool-group "running" header + last-tool collapse
Header and last-tool auto-open were bound to the group's message-level `streaming` flag, which only clears at turn end — so a group whose tools all finished (or one rebuilt done-but-streaming on reconnect) showed a perpetual "running" and kept its last card force-expanded. Keyed both on `anyRunning = tools.some(!done && !error)`.

## 2. Reply caret only while typing
The assistant bubble stays `streaming` the whole turn; the caret kept blinking under finished text during silent generation gaps. Gated on recent `text_delta` (`chatLastTextAt`).

## 3. Task / plan panel — persistence + lifecycle
The web task store was `tasks.New()` per turn and never persisted, so the panel vanished on any refresh (the outlier among per-session resources).
- **Per-session store**: new `SessionTaskStore` registry (mirrors `SessionReadTracker`); server re-stamps the ctx store to it; `replayLiveState` rebuilds the panel from it — survives across turns and a post-turn refresh.
- **Clear-and-rebuild**: a fully-completed plan (`AllTasksComplete`) is dropped at the next turn's start; an incomplete plan carries over.
- **Fade-on-complete**: panel clears client-side 3s after all tasks complete (mirrors sub-agent dismiss); replay skips a completed plan so the fade isn't undone by refresh.
- **/clear resets the plan** (`CloseSessionTaskStore` + empty `todo_update`); `/compact` deliberately does not.

## 4. Sub-agent fan-out replay guard
Test proving `replayLiveState` replays every concurrently-running sync sub-agent, not just one. (Note: a *separate*, still-open issue — completed-mid-batch sync agents are deleted from `m.agents` while the fan-out's tool_results are batched, so the panel under-reports on refresh — is deferred to its own PR.)

## Tests
`internal/tools`: AllTasksComplete, TaskSnapshot. `internal/server`: task-panel replay (in-progress / completed-skip / empty-no-op), sync fan-out replay. `web`: toolFold override logic (116/116). svelte-check 0/0, gofmt clean, full server package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)