### PR TITLE
fix(browser): surface real JS exception in eval errors

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -435,6 +436,52 @@ func (p *Page) Navigate(ctx context.Context, url string) error {
 // Chrome to finish its first navigation even to a local fixture page.
 var navigateLoadTimeout = 30 * time.Second
 
+// evalException mirrors the fields of a CDP Runtime.ExceptionDetails we surface
+// when an evaluated expression throws.
+type evalException struct {
+	Text         string `json:"text"`
+	LineNumber   int    `json:"lineNumber"`
+	ColumnNumber int    `json:"columnNumber"`
+	Exception    *struct {
+		ClassName   string          `json:"className"`
+		Description string          `json:"description"`
+		Value       json.RawMessage `json:"value"`
+	} `json:"exception"`
+}
+
+// message builds a human-readable one-liner from a thrown exception. CDP's
+// top-level Text is almost always just "Uncaught", so the useful detail lives
+// in the exception RemoteObject: Description carries an Error's message plus its
+// stack, Value carries a thrown non-Error primitive (e.g. `throw "boom"`).
+func (e *evalException) message() string {
+	detail := ""
+	if e.Exception != nil {
+		switch {
+		case e.Exception.Description != "":
+			// Description already includes the message; keep only its first
+			// line so the stack trace doesn't bury the actual error.
+			detail = strings.SplitN(e.Exception.Description, "\n", 2)[0]
+		case len(e.Exception.Value) > 0:
+			detail = strings.Trim(string(e.Exception.Value), `"`)
+		case e.Exception.ClassName != "":
+			detail = e.Exception.ClassName
+		}
+	}
+	text := strings.TrimSpace(e.Text)
+	switch {
+	case detail == "":
+		if text == "" {
+			return "unknown error"
+		}
+		return text
+	case text == "" || text == "Uncaught":
+		// Bare "Uncaught" adds nothing; the detail is the message.
+		return detail
+	default:
+		return text + ": " + detail
+	}
+}
+
 // Eval runs a JS expression in the page and unmarshals its return value into
 // out (pass nil to ignore the value). The expression may be a Promise.
 func (p *Page) Eval(ctx context.Context, expr string, out any) error {
@@ -450,15 +497,13 @@ func (p *Page) Eval(ctx context.Context, expr string, out any) error {
 		Result struct {
 			Value json.RawMessage `json:"value"`
 		} `json:"result"`
-		ExceptionDetails *struct {
-			Text string `json:"text"`
-		} `json:"exceptionDetails"`
+		ExceptionDetails *evalException `json:"exceptionDetails"`
 	}
 	if err := json.Unmarshal(res, &r); err != nil {
 		return err
 	}
 	if r.ExceptionDetails != nil {
-		return fmt.Errorf("eval threw: %s", r.ExceptionDetails.Text)
+		return fmt.Errorf("eval threw: %s", r.ExceptionDetails.message())
 	}
 	if out != nil && len(r.Result.Value) > 0 {
 		return json.Unmarshal(r.Result.Value, out)

--- a/internal/browser/eval_message_test.go
+++ b/internal/browser/eval_message_test.go
@@ -1,0 +1,59 @@
+package browser
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestEvalExceptionMessage checks that a thrown exception is rendered with its
+// real detail rather than a bare "Uncaught". Inputs are the raw CDP
+// exceptionDetails shapes Chrome sends for each throw form.
+func TestEvalExceptionMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want string
+	}{
+		{
+			name: "error object uses description first line, not stack",
+			json: `{"text":"Uncaught","exception":{"className":"ReferenceError","description":"ReferenceError: LEGS is not defined\n    at <anonymous>:1:1"}}`,
+			want: "ReferenceError: LEGS is not defined",
+		},
+		{
+			name: "thrown string primitive uses value",
+			json: `{"text":"Uncaught","exception":{"value":"boom"}}`,
+			want: "boom",
+		},
+		{
+			name: "class name only",
+			json: `{"text":"Uncaught","exception":{"className":"TypeError"}}`,
+			want: "TypeError",
+		},
+		{
+			name: "non-Uncaught text keeps prefix",
+			json: `{"text":"Syntax error","exception":{"description":"SyntaxError: Unexpected token"}}`,
+			want: "Syntax error: SyntaxError: Unexpected token",
+		},
+		{
+			name: "no exception object falls back to text",
+			json: `{"text":"Uncaught SyntaxError: missing ) after argument list"}`,
+			want: "Uncaught SyntaxError: missing ) after argument list",
+		},
+		{
+			name: "empty exceptionDetails",
+			json: `{}`,
+			want: "unknown error",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var e evalException
+			if err := json.Unmarshal([]byte(tc.json), &e); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := e.message(); got != tc.want {
+				t.Errorf("message() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When an evaluated JS expression throws, the browser tool reported only:

```
eval threw: Uncaught
```

CDP's top-level `exceptionDetails.text` is almost always the bare prefix `"Uncaught"` — the actual error message and stack live in the `exceptionDetails.exception` RemoteObject, which the old code never read. That left both the model and the user with nothing actionable to diagnose.

## Fix

`Page.Eval` now parses the exception object and builds a readable one-liner via `evalException.message()`, in priority order:

- **Error object** → first line of `exception.description` (the message; the stack trace is dropped so it doesn't bury the error)
- **Thrown primitive** (`throw "boom"`) → `exception.value`
- **Class name only** → `exception.className`
- Falls back to `text`, then `"unknown error"`

A lone `"Uncaught"` prefix is discarded (no signal); a non-`Uncaught` `text` is kept as a prefix.

So the screenshot's `LEGS.length` case now reads:

```
eval threw: ReferenceError: LEGS is not defined
```

## Tests

- New `eval_message_test.go` — pure unit test (no Chrome), 6 exception shapes, all green.
- Full `internal/browser` package passes `go test -race` (145s, real Chrome), including the existing `TestClick_InvalidSelectorMessage` which asserts an actionable message.
- `make fmt-check` / `make vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)