### PR TITLE
fix(agent): emit tool results incrementally in a parallel batch (sub-agent fan-out)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1567,19 +1567,9 @@ func emitToolResultEvents(handler EventHandler, useBlocks, resultBlocks []Conten
 		if r.Type != "tool_result" {
 			continue
 		}
-		ev := AgentEvent{
-			ToolID:   r.ToolUseID,
-			ToolName: nameByID[r.ToolUseID],
-			Output:   truncateOutput(StripRemindersForDisplay(r.Result)),
-			UI:       r.UI,
-		}
-		if r.IsError {
-			ev.Kind = EventToolError
-			ev.Err = r.Result // full untruncated error message in Err
-		} else {
-			ev.Kind = EventToolDone
-		}
-		handler(ev)
+		// Delegate the event shaping so the display formatting lives in one
+		// place (emitToolResultBlocks) — this path only supplies the name.
+		emitToolResultBlocks(handler, nameByID[r.ToolUseID], []ContentBlock{r})
 	}
 }
 
@@ -1684,9 +1674,9 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 		// refresh can't see the ones that already completed. emitMu serializes
 		// handler calls so a handler needn't be concurrency-safe.
 		var emitMu sync.Mutex
-		emit := func(name string, blocks []ContentBlock) {
+		emit := func(name string, rblocks []ContentBlock) {
 			emitMu.Lock()
-			emitToolResultBlocks(handler, name, blocks)
+			emitToolResultBlocks(handler, name, rblocks)
 			emitMu.Unlock()
 		}
 		resultSlices = make([][]ContentBlock, len(calls))

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1126,17 +1126,13 @@ func (a *Agent) runLoop(
 				}
 			}
 
-			// Decorate results before events and history so the model and
-			// the persisted session see the same text. UI events strip the
-			// <system-reminder> spans (emitToolResultEvents) — hook output
-			// is model-facing, not part of the tool's visible result.
+			// dispatchTools already emitted EventToolDone / EventToolError for
+			// each tool as it finished (so a parallel batch reports results
+			// incrementally instead of all at once). applyPostToolUse then
+			// appends any PostToolUse hook output to the results for the model
+			// and the persisted session only — it is deliberately kept out of
+			// the UI events, which show the tool's own visible result.
 			a.applyPostToolUse(ctx, reply.Blocks, resultBlocks)
-
-			// Emit EventToolDone / EventToolError per result, pairing
-			// each result with the originating tool_use block so ToolName
-			// can be carried through (tool_result blocks don't carry it
-			// themselves).
-			emitToolResultEvents(handler, reply.Blocks, resultBlocks)
 
 			a.History.Append(NewToolResultMessage(resultBlocks))
 
@@ -1587,6 +1583,36 @@ func emitToolResultEvents(handler EventHandler, useBlocks, resultBlocks []Conten
 	}
 }
 
+// emitToolResultBlocks fires EventToolDone / EventToolError for a single tool's
+// result blocks. toolName is the originating tool's name (a tool_result block
+// doesn't carry it). Used by dispatchTools to report each tool as it finishes —
+// so a parallel batch doesn't hold every card "running" until the slowest tool
+// completes. No-op on a nil handler; emits the pre-decoration result (hook
+// output is model-facing and deliberately kept out of the UI).
+func emitToolResultBlocks(handler EventHandler, toolName string, blocks []ContentBlock) {
+	if handler == nil {
+		return
+	}
+	for _, r := range blocks {
+		if r.Type != "tool_result" {
+			continue
+		}
+		ev := AgentEvent{
+			ToolID:   r.ToolUseID,
+			ToolName: toolName,
+			Output:   truncateOutput(StripRemindersForDisplay(r.Result)),
+			UI:       r.UI,
+		}
+		if r.IsError {
+			ev.Kind = EventToolError
+			ev.Err = r.Result // full untruncated error message in Err
+		} else {
+			ev.Kind = EventToolDone
+		}
+		handler(ev)
+	}
+}
+
 // readOnlyTools are the built-in tools safe for concurrent dispatch. A batch
 // composed entirely of these can be executed concurrently (see dispatchTools).
 // Conservative by design: anything that writes, edits, or shells out is absent,
@@ -1652,10 +1678,22 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 
 	if canParallelize(calls) {
 		var wg sync.WaitGroup
+		// Result events are emitted as each tool finishes rather than batched
+		// after wg.Wait — otherwise a parallel sub_agent fan-out holds every
+		// card "running" until the slowest child returns, and a mid-batch page
+		// refresh can't see the ones that already completed. emitMu serializes
+		// handler calls so a handler needn't be concurrency-safe.
+		var emitMu sync.Mutex
+		emit := func(name string, blocks []ContentBlock) {
+			emitMu.Lock()
+			emitToolResultBlocks(handler, name, blocks)
+			emitMu.Unlock()
+		}
 		resultSlices = make([][]ContentBlock, len(calls))
 		for i := range calls {
 			if calls[i].denyReason != "" {
 				resultSlices[i] = []ContentBlock{NewToolResultBlock(calls[i].block.ID, calls[i].denyReason, true)}
+				emit(calls[i].block.Name, resultSlices[i])
 				continue
 			}
 			wg.Add(1)
@@ -1663,6 +1701,7 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 				defer wg.Done()
 				res, err := executor.Execute(ctx, calls[i].block.Name, calls[i].block.Input)
 				resultSlices[i] = toolResultBlocks(calls[i].block.ID, res, err)
+				emit(calls[i].block.Name, resultSlices[i])
 			}(i)
 		}
 		wg.Wait()
@@ -1675,6 +1714,7 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 		b := calls[i].block
 		if calls[i].denyReason != "" {
 			resultSlices[i] = []ContentBlock{NewToolResultBlock(b.ID, calls[i].denyReason, true)}
+			emitToolResultBlocks(handler, b.Name, resultSlices[i])
 			continue
 		}
 		var (
@@ -1694,6 +1734,7 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 			res, execErr = executor.Execute(ctx, b.Name, b.Input)
 		}
 		resultSlices[i] = toolResultBlocks(b.ID, res, execErr)
+		emitToolResultBlocks(handler, b.Name, resultSlices[i])
 	}
 	return flattenResults(resultSlices), nil
 }

--- a/internal/agent/dispatch_test.go
+++ b/internal/agent/dispatch_test.go
@@ -241,6 +241,20 @@ func (h *recordingHandler) resultKinds() map[string]EventKind {
 	return out
 }
 
+// resultCount is the raw number of result events, NOT deduped by tool id, so a
+// double-emit for one tool is detectable (resultKinds' map would hide it).
+func (h *recordingHandler) resultCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, ev := range h.events {
+		if ev.Kind == EventToolDone || ev.Kind == EventToolError {
+			n++
+		}
+	}
+	return n
+}
+
 // dispatchTools must emit a result event for EVERY tool as it finishes — not
 // batched by the caller after the whole set completes. This is the regression
 // guard for a parallel sub_agent fan-out whose cards stayed "running" (and were
@@ -257,6 +271,11 @@ func TestDispatchTools_EmitsResultEventPerTool(t *testing.T) {
 	}
 	if _, err := dispatchTools(context.Background(), exec, blocks, h.handle, gate); err != nil {
 		t.Fatal(err)
+	}
+	// Exactly one result event per tool — no double-emit (the caller must not
+	// also emit now that dispatchTools does).
+	if n := h.resultCount(); n != 3 {
+		t.Fatalf("emitted %d result events, want exactly 3 (one per tool, no double-emit)", n)
 	}
 	kinds := h.resultKinds()
 	if len(kinds) != 3 {

--- a/internal/agent/dispatch_test.go
+++ b/internal/agent/dispatch_test.go
@@ -215,3 +215,70 @@ func TestDispatchTools_DeniedCallInParallelBatch(t *testing.T) {
 		t.Errorf("executor calls = %d, want 2 (grep was gated out)", len(exec.called))
 	}
 }
+
+// recordingHandler collects AgentEvents; concurrency-safe because dispatchTools'
+// parallel path may emit result events from several goroutines.
+type recordingHandler struct {
+	mu     sync.Mutex
+	events []AgentEvent
+}
+
+func (h *recordingHandler) handle(ev AgentEvent) {
+	h.mu.Lock()
+	h.events = append(h.events, ev)
+	h.mu.Unlock()
+}
+
+func (h *recordingHandler) resultKinds() map[string]EventKind {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := map[string]EventKind{}
+	for _, ev := range h.events {
+		if ev.Kind == EventToolDone || ev.Kind == EventToolError {
+			out[ev.ToolID] = ev.Kind
+		}
+	}
+	return out
+}
+
+// dispatchTools must emit a result event for EVERY tool as it finishes — not
+// batched by the caller after the whole set completes. This is the regression
+// guard for a parallel sub_agent fan-out whose cards stayed "running" (and were
+// lost on a mid-batch refresh) until the slowest child returned. Covers the
+// parallel path (done) and a gate-denied call (error) in the same batch.
+func TestDispatchTools_EmitsResultEventPerTool(t *testing.T) {
+	h := &recordingHandler{}
+	exec := &countingExec{}
+	gate := denyOneGate{deny: "grep"}
+	blocks := []ContentBlock{
+		NewToolUseBlock("c1", "read_file", map[string]any{"path": "a"}),
+		NewToolUseBlock("c2", "grep", map[string]any{"pattern": "x"}),
+		NewToolUseBlock("c3", "glob", map[string]any{"pattern": "*"}),
+	}
+	if _, err := dispatchTools(context.Background(), exec, blocks, h.handle, gate); err != nil {
+		t.Fatal(err)
+	}
+	kinds := h.resultKinds()
+	if len(kinds) != 3 {
+		t.Fatalf("result events for %d tools, want 3: %v", len(kinds), kinds)
+	}
+	if kinds["c1"] != EventToolDone || kinds["c3"] != EventToolDone {
+		t.Errorf("allowed tools should emit EventToolDone: %v", kinds)
+	}
+	if kinds["c2"] != EventToolError {
+		t.Errorf("gate-denied tool should emit EventToolError: %v", kinds)
+	}
+}
+
+// The serial path emits per-tool too (single-tool batch → not parallelized).
+func TestDispatchTools_EmitsResultEventSerial(t *testing.T) {
+	h := &recordingHandler{}
+	exec := &countingExec{}
+	blocks := []ContentBlock{NewToolUseBlock("only", "read_file", map[string]any{"path": "a"})}
+	if _, err := dispatchTools(context.Background(), exec, blocks, h.handle, nil); err != nil {
+		t.Fatal(err)
+	}
+	if k := h.resultKinds(); len(k) != 1 || k["only"] != EventToolDone {
+		t.Fatalf("serial result events = %v, want {only: done}", k)
+	}
+}


### PR DESCRIPTION
## Problem (bug D)
During a parallel `sub_agent` fan-out, the tool cards all stayed "running" until the slowest child returned, and a mid-batch **page refresh** rebuilt the sub-agent panel with only the still-running agents — while the cards still showed everything "running". The two views disagreed (screenshot: 4 running cards, panel shows 1).

## Root cause
`dispatchTools`'s parallel path collected all results and only emitted `EventToolDone`/`EventToolError` after `wg.Wait` (via the caller's batch `emitToolResultEvents`). Meanwhile a sync sub-agent is dropped from the manager's registry the instant it finishes (`RunSync`), so `replayLiveState` — reading that registry — can only see the ones still running. Cards (no results yet) and panel (registry) therefore disagreed on refresh.

## Fix
Emit result events **inside `dispatchTools`, per tool as it finishes**, for both the parallel and serial paths:
- Parallel path serializes the emits with a mutex, so an `EventHandler` needn't be concurrency-safe (it wasn't invoked concurrently before).
- Caller drops its batch `emitToolResultEvents`; `applyPostToolUse` still runs there for the model + persisted session. Its PostToolUse-hook output is kept out of the UI events — matching the pre-existing comment's stated intent ("hook output is model-facing, not part of the tool's visible result").
- `dispatchTools` signature unchanged (its 4 test call sites pass a nil handler → no emit); `emitToolResultEvents` retained for its own test callers.

Result: cards go green as each tool completes, and a mid-batch refresh shows the true per-tool state.

## Tests
`TestDispatchTools_EmitsResultEventPerTool` (parallel batch: done + gate-denied error, one event per tool) and `TestDispatchTools_EmitsResultEventSerial`. Full `internal/agent` package green under `-race`; gofmt clean.

Touches `internal/agent` (CODEOWNERS). Separate from #1697 (no file overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)