### PR TITLE
chore: bump version to 1.12.28

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.27"
+var Version = "1.12.28"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Bump `internal/version.Version` from 1.12.27 to 1.12.28

## Test plan
- [x] No behavior change; version string only

🤖 Generated with [Claude Code](https://claude.com/claude-code)