### PR TITLE
feat(mobile): batch 0 — mobile shell scaffold + neutral tokens

### DIFF
--- a/dev-docs/mobile-ui-implementation.md
+++ b/dev-docs/mobile-ui-implementation.md
@@ -48,12 +48,15 @@ explicitly avoided.
   `{#if}` split inside one Vite build: `web/src/lib` imports resolve normally
   and the shim/boot path is unchanged; the mobile shell is simply a component
   tree that never coexists with the desktop one.
-- **`stores.ts` split.** `stores.ts` mixes *data* stores (`sessions`,
+- **No `stores.ts` split.** `stores.ts` mixes *data* stores (`sessions`,
   `chatMessages`, `chatStreaming`, `questionModals`, …, reused on mobile) with
   *desktop-UI* stores (`sidebar`, `cmdkOpen`, `artifactsOpen`, …, unused on
-  mobile). Move the desktop-only ones to a `stores.ui.ts`; keep the data stores
-  in `stores.ts`. This is the one change to an existing web file — a no-risk
-  relocation — and it lets each view tree import only what it needs.
+  mobile). An earlier draft split the desktop-only ones into a `stores.ui.ts`;
+  that was dropped. Store definitions are side-effect-free, so the mobile tree
+  simply imports the data-store subset it needs and never references the
+  desktop-UI stores — splitting the file would rewrite every desktop
+  `from './stores'` import for no real benefit. No change to an existing web
+  file is required here.
 
 ## Component map
 
@@ -121,8 +124,8 @@ in a mobile-local `theme.css`.
 
 ## Delivery batches
 
-- **Batch 0 — groundwork.** `stores.ts` data/UI split; mobile `theme.css`;
-  `MobileApp` + `mobileShell` split skeleton.
+- **Batch 0 — groundwork.** Mobile `theme.css` (neutral tokens); `MobileApp`
+  shell + a `mobileShell` branch in `App.svelte`. (Done.)
 - **Batch 1 — session flow (usable first).** `TabBar` + `Fab` + `Feed`
   (three sections + `feedGroups.ts`) + `SessionCard` + `ChatDetail` (reusing
   Composer) + `DeviceBanner`. Result: view sessions, open a conversation, send
@@ -140,9 +143,6 @@ in a mobile-local `theme.css`.
 
 - **Build shape** — one Vite build with a top-level split (recommended) vs. a
   separate mobile entry.
-- **`stores.ts` split boundary** — which stores count as desktop-only; the
-  relocation is safe but must be drawn cleanly so the two view trees don't
-  cross-reference.
 - **Touch adaptation** — hit areas and long-press behavior on reused components
   (`Composer`, `ToolGroup`), walked through per component.
 - **Dark tokens** — the prototype is light-only; dark values are filled in

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, sessions, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell } from './lib/stores'
+  import { view, sessions, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell } from './lib/stores'
+  import MobileApp from './mobile/MobileApp.svelte'
   import { ws, wsState } from './lib/ws'
   import { notificationsEnabled } from './lib/notifications'
   import { locale, t, tr, setLocale } from './lib/i18n'
@@ -298,6 +299,8 @@
   <div class="splash"><div class="spinner"></div></div>
 {:else if $onboardPhase === 'key_setup'}
   <FirstRunSetup />
+{:else if mobileShell}
+<MobileApp />
 {:else}
 <div class="app">
   <Header />

--- a/web/src/mobile/MobileApp.svelte
+++ b/web/src/mobile/MobileApp.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  // octo-mobile root view tree. Rendered instead of the desktop App layout when
+  // `mobileShell` is true (see App.svelte). Batch 0 is the shell only: bottom
+  // tab bar + neutral tokens. The data-bound feed, typed detail views, and the
+  // other tabs are filled in by later batches (see
+  // dev-docs/mobile-ui-implementation.md).
+  import './theme.css'
+
+  type Tab = 'chat' | 'tasks' | 'config' | 'settings'
+  let tab = $state<Tab>('chat')
+</script>
+
+<div class="m-root">
+  <main class="m-view">
+    {#if tab === 'chat'}
+      <header class="m-head"><h1>会话</h1></header>
+      <div class="m-scroll">
+        <!-- Batch 1 replaces these placeholders with feedGroups + SessionCard -->
+        <p class="m-section">待办</p>
+        <div class="m-ph">待你回复 / 待审批 · 批 1 接入</div>
+        <p class="m-section">进行中</p>
+        <div class="m-ph">运行中的会话 · 批 1 接入</div>
+        <p class="m-section">最近完成</p>
+        <div class="m-ph">已完成会话 · 批 1 接入</div>
+      </div>
+    {:else if tab === 'tasks'}
+      <header class="m-head"><h1>任务</h1></header>
+      <div class="m-scroll"><div class="m-ph">定时与自动化 · 批 3 接入</div></div>
+    {:else if tab === 'config'}
+      <header class="m-head"><h1>配置</h1></header>
+      <div class="m-scroll"><div class="m-ph">技能 / MCP / 工作流 / 数据 · 批 3 接入</div></div>
+    {:else}
+      <header class="m-head"><h1>设置</h1></header>
+      <div class="m-scroll"><div class="m-ph">设备 / 通知 / 外观 · 批 3 接入</div></div>
+    {/if}
+  </main>
+
+  <nav class="m-tabbar">
+    <button class="m-tab" class:on={tab === 'chat'} onclick={() => (tab = 'chat')}>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"/></svg>
+      <span>会话</span>
+    </button>
+    <button class="m-tab" class:on={tab === 'tasks'} onclick={() => (tab = 'tasks')}>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 6h11M9 12h11M9 18h11M4 6h.01M4 12h.01M4 18h.01"/></svg>
+      <span>任务</span>
+    </button>
+    <button class="m-tab" class:on={tab === 'config'} onclick={() => (tab = 'config')}>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h10M18 6h2M4 12h2M10 12h10M4 18h6M14 18h6"/><circle cx="16" cy="6" r="2"/><circle cx="8" cy="12" r="2"/><circle cx="12" cy="18" r="2"/></svg>
+      <span>配置</span>
+    </button>
+    <button class="m-tab" class:on={tab === 'settings'} onclick={() => (tab = 'settings')}>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0v-.1A1.6 1.6 0 0 0 7 19.4a1.6 1.6 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0-1.1-2.7H3a2 2 0 1 1 0-4h.1A1.6 1.6 0 0 0 4.6 7"/></svg>
+      <span>设置</span>
+    </button>
+  </nav>
+</div>
+
+<style>
+  .m-root {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--m-bg);
+    color: var(--m-text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Microsoft YaHei", sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .m-view {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    padding-top: env(safe-area-inset-top);
+  }
+  .m-head {
+    flex: none;
+    padding: 8px 18px 12px;
+  }
+  .m-head h1 {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 600;
+    color: var(--m-text-strong);
+  }
+  .m-scroll {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 0 16px 20px;
+  }
+  .m-section {
+    margin: 14px 2px 8px;
+    font: 600 12px/1 system-ui;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+    color: var(--m-text-3);
+  }
+  .m-ph {
+    background: var(--m-surface);
+    border: 1px dashed var(--m-border);
+    border-radius: 14px;
+    padding: 18px 16px;
+    font-size: 13px;
+    color: var(--m-text-3);
+    box-shadow: var(--m-shadow-card);
+  }
+  .m-tabbar {
+    flex: none;
+    display: flex;
+    padding: 8px 4px calc(8px + env(safe-area-inset-bottom));
+    background: var(--m-surface);
+    border-top: 1px solid var(--m-border-2);
+  }
+  .m-tab {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 0;
+    font-size: 10px;
+    color: var(--m-text-3);
+    background: none;
+    border: none;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .m-tab.on {
+    color: var(--m-accent);
+  }
+</style>

--- a/web/src/mobile/theme.css
+++ b/web/src/mobile/theme.css
@@ -1,0 +1,79 @@
+/* octo-mobile neutral design tokens.
+ *
+ * Independent of the web theme's tokens so the mobile and desktop view trees can
+ * evolve separately. The accent stays Ant Blue (#1677FF) for cross-surface
+ * consistency. Dark values follow the app-wide `data-theme` attribute that
+ * lib/theme.ts writes on <html>. All tokens are `--m-*` so they never collide
+ * with the web palette. */
+
+:root {
+  /* surfaces */
+  --m-bg: #f2f3f5;            /* page background */
+  --m-surface: #ffffff;       /* cards, sheets */
+  --m-surface-2: #f7f8fa;     /* inset / search pill */
+  --m-terminal-bg: #1e1e1e;   /* command / log blocks */
+  --m-terminal-fg: #e6e6e6;
+
+  /* text tiers */
+  --m-text-strong: #0f1114;
+  --m-text: #1f2329;
+  --m-text-2: #4e5969;
+  --m-text-3: #86909c;
+  --m-text-4: #a9aeb8;
+
+  /* lines */
+  --m-border: #dfe2e8;
+  --m-border-2: #e8ebf0;
+  --m-divider: #f0f1f4;
+
+  /* accent + status */
+  --m-accent: #1677ff;
+  --m-accent-soft: #e8f1ff;
+  --m-success: #00b42a;
+  --m-error: #f53f3f;
+  --m-warning: #ff7d00;
+  --m-purple: #6056d6;
+
+  /* tags: warning / success / info / neutral (bg · text · border) */
+  --m-tag-warn-bg: #fff7e6;   --m-tag-warn-text: #d46b08;  --m-tag-warn-border: #ffe0a3;
+  --m-tag-ok-bg: #e8f8ec;     --m-tag-ok-text: #009a29;    --m-tag-ok-border: #b7e8c3;
+  --m-tag-info-bg: #e8f1ff;   --m-tag-info-text: #1677ff;  --m-tag-info-border: #b3d4ff;
+  --m-tag-neutral-bg: #f2f3f5; --m-tag-neutral-text: #4e5969; --m-tag-neutral-border: #dfe2e8;
+
+  /* elevation */
+  --m-shadow-card: 0 1px 2px rgba(15, 23, 42, .04);
+  --m-shadow-fab: 0 10px 24px rgba(22, 119, 255, .4);
+}
+
+:root[data-theme="dark"] {
+  --m-bg: #17171a;
+  --m-surface: #232327;
+  --m-surface-2: #2a2a2f;
+  --m-terminal-bg: #0e0e10;
+  --m-terminal-fg: #e6e6e6;
+
+  --m-text-strong: #f5f5f6;
+  --m-text: #e6e6e8;
+  --m-text-2: #b4b6bd;
+  --m-text-3: #898b93;
+  --m-text-4: #64666e;
+
+  --m-border: #35353b;
+  --m-border-2: #2d2d33;
+  --m-divider: #2a2a2f;
+
+  --m-accent: #3c89ff;
+  --m-accent-soft: #17263f;
+  --m-success: #23c343;
+  --m-error: #f76965;
+  --m-warning: #ff9a2e;
+  --m-purple: #7d75e6;
+
+  --m-tag-warn-bg: #33280f;   --m-tag-warn-text: #f5b95f;  --m-tag-warn-border: #4a3a1a;
+  --m-tag-ok-bg: #102a17;     --m-tag-ok-text: #58d67d;    --m-tag-ok-border: #1e4429;
+  --m-tag-info-bg: #14243d;   --m-tag-info-text: #6aa8ff;  --m-tag-info-border: #244065;
+  --m-tag-neutral-bg: #2a2a2f; --m-tag-neutral-text: #b4b6bd; --m-tag-neutral-border: #35353b;
+
+  --m-shadow-card: 0 1px 2px rgba(0, 0, 0, .3);
+  --m-shadow-fab: 0 10px 24px rgba(22, 119, 255, .5);
+}


### PR DESCRIPTION
First implementation slice of the mobile UI plan (`dev-docs/mobile-ui-implementation.md`, #1702). The phone currently ships the desktop web UI verbatim; this starts replacing it with an **independent mobile view tree** mounted on the same data layer.

## What
- **`web/src/mobile/theme.css`** — octo-mobile's own **neutral token set** (`--m-*`), light + dark driven by the existing `<html data-theme>` attribute (`lib/theme.ts`). Accent stays Ant Blue `#1677FF`. Deliberately independent of the web palette (and carries no third-party design-system tokens) so the two view trees evolve separately.
- **`web/src/mobile/MobileApp.svelte`** — the shell: a bottom tab bar (Sessions / Tasks / Config / Settings), with the Sessions tab's three-section IA (To-do / Active / Recent) stubbed. Content is placeholder — the data-bound feed, typed detail views, and other tabs come in later batches.
- **`App.svelte`** — a single `{:else if mobileShell}` branch routes to `MobileApp` (mobileShell already exists in `stores.ts`). Desktop rendering is untouched.

## Note on scope
The plan listed a `stores.ts` data/UI split as a batch-0 item. On inspection that's **not worth doing**: store definitions are side-effect-free, so mobile just imports the data-store subset it needs — splitting the file would rewrite every desktop `from './stores'` import for no benefit. Dropped.

## Verification
- `svelte-check`: 347 files, **0 errors, 0 warnings**.
- `vite build`: green.
- Source only (webdist is gitignored / CI-rebuilt). No Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)