### PR TITLE
feat(mobile): batch 1a — sessions feed wired to live data

### DIFF
--- a/web/src/mobile/DeviceBanner.svelte
+++ b/web/src/mobile/DeviceBanner.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  // Connection state, bound to the shared ws stores. The full "connected to
+  // <host>, N sessions" form and the push-woken offline flow arrive with the
+  // managed tunnel (M1); for now this reflects the live socket state so the feed
+  // never silently shows stale data as if live.
+  import { wsState, wsReconnect } from '../lib/ws'
+
+  const label = $derived(
+    $wsState === 'connected'
+      ? '已连接远程主机'
+      : $wsState === 'connecting' || $wsReconnect
+        ? '连接中…'
+        : '已断开 · 等待重连',
+  )
+</script>
+
+<div class="banner" class:off={$wsState !== 'connected'}>
+  <span class="d" class:live={$wsState === 'connected'}></span>
+  <span class="txt">{label}</span>
+</div>
+
+<style>
+  .banner {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    background: var(--m-accent-soft);
+    border-radius: 12px;
+    padding: 11px 14px;
+    margin-bottom: 14px;
+    font-size: 12.5px;
+    color: var(--m-text);
+  }
+  .banner.off { background: var(--m-surface-2); color: var(--m-text-2); }
+  .d {
+    flex: none;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--m-text-4);
+  }
+  .d.live { background: var(--m-success); }
+  .txt { flex: 1; }
+</style>

--- a/web/src/mobile/Feed.svelte
+++ b/web/src/mobile/Feed.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { get } from 'svelte/store'
+  import { feedGroups } from './feedGroups'
+  import { createNewSession, activeSessionId } from '../lib/stores'
+  import SessionCard from './SessionCard.svelte'
+  import DeviceBanner from './DeviceBanner.svelte'
+
+  let { onOpen }: { onOpen: (id: string) => void } = $props()
+
+  const groups = feedGroups
+  const empty = $derived($groups.todo.length + $groups.active.length + $groups.recent.length === 0)
+
+  async function newSession() {
+    await createNewSession()
+    const id = get(activeSessionId)
+    if (id) onOpen(id)
+  }
+</script>
+
+<header class="head">
+  <h1>会话</h1>
+  <button class="search" aria-label="搜索">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--m-text-2)" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+  </button>
+</header>
+
+<div class="scroll">
+  <DeviceBanner />
+
+  {#if empty}
+    <div class="empty">还没有会话 · 点右下角 + 新建</div>
+  {/if}
+
+  {#if $groups.todo.length}
+    <p class="lbl">待办</p>
+    {#each $groups.todo as item (item.session.id)}
+      <SessionCard {item} {onOpen} />
+    {/each}
+  {/if}
+
+  {#if $groups.active.length}
+    <p class="lbl">进行中</p>
+    {#each $groups.active as item (item.session.id)}
+      <SessionCard {item} {onOpen} />
+    {/each}
+  {/if}
+
+  {#if $groups.recent.length}
+    <p class="lbl">最近完成</p>
+    {#each $groups.recent as item (item.session.id)}
+      <SessionCard {item} {onOpen} />
+    {/each}
+  {/if}
+</div>
+
+<button class="fab" onclick={newSession} aria-label="新建会话">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><path d="M12 5v14M5 12h14"/></svg>
+</button>
+
+<style>
+  .head {
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 18px 12px;
+  }
+  .head h1 { margin: 0; font-size: 24px; font-weight: 600; color: var(--m-text-strong); }
+  .search {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    border: none;
+    background: var(--m-surface-2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+  .scroll {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 0 16px 20px;
+  }
+  .lbl {
+    margin: 14px 2px 8px;
+    font: 600 12px/1 system-ui;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+    color: var(--m-text-3);
+  }
+  .empty {
+    padding: 40px 16px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--m-text-3);
+  }
+  .fab {
+    position: absolute;
+    right: 18px;
+    bottom: calc(88px + env(safe-area-inset-bottom));
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--m-accent);
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--m-shadow-fab);
+    cursor: pointer;
+    z-index: 30;
+  }
+</style>

--- a/web/src/mobile/MobileApp.svelte
+++ b/web/src/mobile/MobileApp.svelte
@@ -5,24 +5,36 @@
   // other tabs are filled in by later batches (see
   // dev-docs/mobile-ui-implementation.md).
   import './theme.css'
+  import Feed from './Feed.svelte'
+  import { setActiveSession } from '../lib/stores'
 
   type Tab = 'chat' | 'tasks' | 'config' | 'settings'
   let tab = $state<Tab>('chat')
+  // The session opened into a detail view (null = show the feed).
+  let openId = $state<string | null>(null)
+
+  function openSession(id: string) {
+    setActiveSession(id)
+    openId = id
+  }
 </script>
 
 <div class="m-root">
   <main class="m-view">
     {#if tab === 'chat'}
-      <header class="m-head"><h1>会话</h1></header>
-      <div class="m-scroll">
-        <!-- Batch 1 replaces these placeholders with feedGroups + SessionCard -->
-        <p class="m-section">待办</p>
-        <div class="m-ph">待你回复 / 待审批 · 批 1 接入</div>
-        <p class="m-section">进行中</p>
-        <div class="m-ph">运行中的会话 · 批 1 接入</div>
-        <p class="m-section">最近完成</p>
-        <div class="m-ph">已完成会话 · 批 1 接入</div>
-      </div>
+      {#if openId}
+        <header class="m-dhead">
+          <button class="m-back" onclick={() => (openId = null)} aria-label="返回">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--m-text)" stroke-width="2"><path d="m15 18-6-6 6-6"/></svg>
+          </button>
+          <span class="m-dtitle">对话详情</span>
+        </header>
+        <div class="m-scroll">
+          <div class="m-ph">ChatDetail · 批 1b 接入 Composer + 消息流</div>
+        </div>
+      {:else}
+        <Feed onOpen={openSession} />
+      {/if}
     {:else if tab === 'tasks'}
       <header class="m-head"><h1>任务</h1></header>
       <div class="m-scroll"><div class="m-ph">定时与自动化 · 批 3 接入</div></div>
@@ -36,7 +48,7 @@
   </main>
 
   <nav class="m-tabbar">
-    <button class="m-tab" class:on={tab === 'chat'} onclick={() => (tab = 'chat')}>
+    <button class="m-tab" class:on={tab === 'chat'} onclick={() => { tab = 'chat'; openId = null }}>
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"/></svg>
       <span>会话</span>
     </button>
@@ -83,19 +95,36 @@
     font-weight: 600;
     color: var(--m-text-strong);
   }
+  .m-dhead {
+    flex: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 14px 12px;
+  }
+  .m-back {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    border: none;
+    background: var(--m-surface);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: var(--m-shadow-card);
+  }
+  .m-dtitle {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--m-text);
+  }
   .m-scroll {
     flex: 1;
     min-height: 0;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     padding: 0 16px 20px;
-  }
-  .m-section {
-    margin: 14px 2px 8px;
-    font: 600 12px/1 system-ui;
-    letter-spacing: .5px;
-    text-transform: uppercase;
-    color: var(--m-text-3);
   }
   .m-ph {
     background: var(--m-surface);

--- a/web/src/mobile/SessionCard.svelte
+++ b/web/src/mobile/SessionCard.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import type { FeedItem } from './feedGroups'
+
+  let { item, onOpen }: { item: FeedItem; onOpen: (id: string) => void } = $props()
+
+  const s = $derived(item.session)
+  const title = $derived(s.title || s.name || '未命名会话')
+
+  function ago(iso: string): string {
+    if (!iso) return ''
+    const ms = Date.now() - new Date(iso).getTime()
+    if (Number.isNaN(ms)) return ''
+    const m = Math.floor(ms / 60000)
+    if (m < 1) return '刚刚'
+    if (m < 60) return `${m} 分钟前`
+    const h = Math.floor(m / 60)
+    if (h < 24) return `${h} 小时前`
+    return `${Math.floor(h / 24)} 天前`
+  }
+</script>
+
+<button
+  class="card"
+  class:approval={item.kind === 'approval'}
+  class:reply={item.kind === 'reply'}
+  onclick={() => onOpen(s.id)}
+>
+  <div class="top">
+    <span class="title">{title}</span>
+    {#if item.kind === 'reply'}
+      <span class="tag tag-accent">待你回复</span>
+    {:else if item.kind === 'approval'}
+      <span class="tag tag-warn">待审批</span>
+    {:else if item.kind === 'running'}
+      <span class="pulse"></span>
+    {:else}
+      <svg class="done" width="18" height="18" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="var(--m-success)"/><path d="m8 12 2.5 2.5L16 9" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    {/if}
+  </div>
+  <div class="meta">
+    {#if item.kind === 'running'}
+      <span class="running">agent 正在处理<span class="blink">•••</span></span>
+    {:else}
+      <span class="mono">{s.model || s.model_id || ''}</span>
+    {/if}
+    <span class="dot">·</span>
+    <span>{ago(s.updated_at)}</span>
+  </div>
+</button>
+
+<style>
+  .card {
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: var(--m-surface);
+    border: 1px solid transparent;
+    border-radius: 14px;
+    padding: 14px 16px;
+    margin-bottom: 12px;
+    cursor: pointer;
+    font-family: inherit;
+    box-shadow: var(--m-shadow-card);
+  }
+  .card.approval { border-color: var(--m-tag-warn-border); }
+  .card.reply { border-color: var(--m-accent); }
+  .top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--m-text);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  .tag {
+    flex: none;
+    font-size: 11px;
+    font-weight: 600;
+    border-radius: 4px;
+    padding: 2px 7px;
+  }
+  .tag-accent { color: #fff; background: var(--m-accent); }
+  .tag-warn {
+    color: var(--m-tag-warn-text);
+    background: var(--m-tag-warn-bg);
+    border: 1px solid var(--m-tag-warn-border);
+  }
+  .done { flex: none; }
+  .pulse {
+    flex: none;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--m-accent);
+    position: relative;
+  }
+  .pulse::after {
+    content: "";
+    position: absolute;
+    inset: -4px;
+    border-radius: 50%;
+    border: 2px solid var(--m-accent);
+    animation: pr 1.6s ease-out infinite;
+  }
+  @keyframes pr { 0% { transform: scale(.6); opacity: .8 } 100% { transform: scale(1.8); opacity: 0 } }
+  .meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 8px;
+    font-size: 12px;
+    color: var(--m-text-3);
+  }
+  .running { color: var(--m-accent); }
+  .blink { animation: bk 1.1s steps(1) infinite; letter-spacing: 2px; margin-left: 3px; }
+  @keyframes bk { 50% { opacity: .2 } }
+  .mono { font-family: ui-monospace, Menlo, monospace; }
+  .dot { color: var(--m-text-4); }
+  @media (prefers-reduced-motion: reduce) {
+    .pulse::after, .blink { animation: none; }
+  }
+</style>

--- a/web/src/mobile/feedGroups.ts
+++ b/web/src/mobile/feedGroups.ts
@@ -31,10 +31,11 @@ function byPinThenRecent(a: FeedItem, b: FeedItem): number {
 export const feedGroups = derived(
   [sessions, confirmModal],
   ([$sessions, $confirm]): FeedGroups => {
-    // confirmModal holds the open confirmation (or null); it carries the
-    // session it belongs to. Guard the shape since the store is typed `any`.
+    // confirmModal holds the open confirmation (or null); it carries the session
+    // under `sessionId` (camelCase — see where ChatView.svelte sets it), not
+    // `session_id`. Guard the shape since the store is typed `any`.
     const approvalSid =
-      $confirm && typeof $confirm === 'object' ? ($confirm.session_id as string | undefined) : undefined
+      $confirm && typeof $confirm === 'object' ? ($confirm.sessionId as string | undefined) : undefined
 
     const todo: FeedItem[] = []
     const active: FeedItem[] = []

--- a/web/src/mobile/feedGroups.ts
+++ b/web/src/mobile/feedGroups.ts
@@ -1,0 +1,56 @@
+// Derives the mobile Sessions feed's three sections from the shared session
+// state. Pure derivation over existing stores — no new data source:
+//   To-do   — needs-approval (a confirmation is open for the session) or
+//             needs-reply (an outstanding ask_user_question, Session.pending_question)
+//   Active  — the agent is working
+//   Recent  — everything else, newest first, capped
+// Within each section, pinned sessions float to the top.
+import { derived } from 'svelte/store'
+import { sessions, confirmModal } from '../lib/stores'
+import type { Session } from '../lib/types'
+
+export type FeedKind = 'approval' | 'reply' | 'running' | 'done'
+export interface FeedItem {
+  session: Session
+  kind: FeedKind
+}
+export interface FeedGroups {
+  todo: FeedItem[]
+  active: FeedItem[]
+  recent: FeedItem[]
+}
+
+// Cap the Recent section; the full history lives behind a second-level page.
+const RECENT_CAP = 8
+
+function byPinThenRecent(a: FeedItem, b: FeedItem): number {
+  if (!!a.session.pinned !== !!b.session.pinned) return a.session.pinned ? -1 : 1
+  return (b.session.updated_at || '').localeCompare(a.session.updated_at || '')
+}
+
+export const feedGroups = derived(
+  [sessions, confirmModal],
+  ([$sessions, $confirm]): FeedGroups => {
+    // confirmModal holds the open confirmation (or null); it carries the
+    // session it belongs to. Guard the shape since the store is typed `any`.
+    const approvalSid =
+      $confirm && typeof $confirm === 'object' ? ($confirm.session_id as string | undefined) : undefined
+
+    const todo: FeedItem[] = []
+    const active: FeedItem[] = []
+    const recent: FeedItem[] = []
+
+    for (const s of $sessions) {
+      if (approvalSid && s.id === approvalSid) todo.push({ session: s, kind: 'approval' })
+      else if (s.pending_question) todo.push({ session: s, kind: 'reply' })
+      else if (s.status === 'working') active.push({ session: s, kind: 'running' })
+      else recent.push({ session: s, kind: 'done' })
+    }
+
+    todo.sort(byPinThenRecent)
+    active.sort(byPinThenRecent)
+    recent.sort(byPinThenRecent)
+
+    return { todo, active, recent: recent.slice(0, RECENT_CAP) }
+  },
+)


### PR DESCRIPTION
Second implementation slice of the mobile UI (`dev-docs/mobile-ui-implementation.md`). Batch 0 gave the shell; this wires the **Sessions tab to real data**.

## What
- **`feedGroups.ts`** — derived store over `sessions` + `confirmModal`, splitting sessions into **To-do** (needs-approval / needs-reply via `pending_question`), **Active** (`status === 'working'`), and **Recent** (capped, newest first). Pinned sessions float to the top of each section. Pure derivation — no new data source.
- **`SessionCard.svelte`** — typed card (reply / approval / running / done) with status tag / running pulse, model, relative time.
- **`DeviceBanner.svelte`** — connection state bound to `ws`'s `wsState` / `wsReconnect` (the gap-2 model; the "connected to <host>" form + push-woken offline flow arrive with M1).
- **`Feed.svelte`** — the three sections + banner + a new-session FAB.
- **`MobileApp`** — Sessions tab renders `Feed` with feed↔detail navigation; the chat detail itself is a placeholder pending **batch 1b**.

Reuses the shared data layer only — `App.svelte`'s `onMount` already boots `ws.connect()` + `listSessions()` regardless of which shell renders, so mobile just consumes the stores. **No desktop file changed.**

## Next (batch 1b)
`ChatDetail` (reuse `Composer` + render the message stream) needs the ws message handlers currently living inside `ChatView.svelte` (the `ws.on(...)` → `chatMessages` wiring, ~300 lines) extracted into a shared, UI-less module so both the desktop and mobile chat consume one wiring — the "no duplicated business logic" principle. That touches a desktop-critical component, so it's its own slice.

## Verification
- `svelte-check`: 351 files, **0 errors, 0 warnings**.
- `vite build`: green.
- Source only (webdist gitignored). No Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)