### PR TITLE
feat(mobile): batch 1b — chat detail wired to the live stream

### DIFF
--- a/web/src/mobile/ChatDetail.svelte
+++ b/web/src/mobile/ChatDetail.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+  // Mobile chat detail: renders a session's transcript and sends replies, wired
+  // to the shared stores via chatWiring (which reuses the same store helpers the
+  // desktop uses). A simplified view — tool cards are collapsed to a one-line
+  // hint (the detailed tool/progress view is batch 2), and the composer is a
+  // lightweight mobile input rather than the desktop Composer.
+  import { tick } from 'svelte'
+  import { activeSessionId, chatMessages, chatStreaming, sessions, clearMsgs } from '../lib/stores'
+  import { ws } from '../lib/ws'
+  import { wireMobileSession, loadMobileHistory, sendMobile } from './chatWiring'
+
+  let { onBack }: { onBack: () => void } = $props()
+
+  const sid = $derived($activeSessionId ?? '')
+  const msgs = $derived($chatMessages[sid] ?? [])
+  const streaming = $derived($chatStreaming[sid] ?? false)
+  const session = $derived($sessions.find(s => s.id === sid) ?? null)
+  const title = $derived(session?.title || session?.name || '会话')
+
+  let draft = $state('')
+  let scroller: HTMLElement | undefined
+  let composing = $state(false)
+
+  // Subscribe + wire while this session is open; tear down on switch/unmount.
+  $effect(() => {
+    const s = sid
+    if (!s) return
+    clearMsgs(s)
+    let cancelled = false
+    // Subscribe only after history renders (same ordering the desktop relies on).
+    loadMobileHistory(s).then(() => {
+      if (!cancelled) ws.subscribe(s)
+    })
+    const cleanup = wireMobileSession(s)
+    return () => {
+      cancelled = true
+      ws.unsubscribe(s)
+      cleanup()
+    }
+  })
+
+  // Keep pinned to the latest message as the transcript grows.
+  $effect(() => {
+    void msgs.length
+    tick().then(() => {
+      if (scroller) scroller.scrollTop = scroller.scrollHeight
+    })
+  })
+
+  function send() {
+    const t = draft.trim()
+    if (!t || !sid) return
+    sendMobile(sid, t, [])
+    draft = ''
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey && !composing) {
+      e.preventDefault()
+      send()
+    }
+  }
+
+  function toolLabel(tools: any[]): string {
+    if (!tools?.length) return ''
+    const names = tools.map(t => t.name).filter(Boolean)
+    return names.length ? names.join(' · ') : `${tools.length} 个工具`
+  }
+</script>
+
+<header class="dhead">
+  <button class="back" onclick={onBack} aria-label="返回">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--m-text)" stroke-width="2"><path d="m15 18-6-6 6-6"/></svg>
+  </button>
+  <div class="dtitle">
+    <span class="t">{title}</span>
+    <span class="sub">
+      <span class="d" class:live={streaming}></span>
+      {streaming ? '处理中' : '空闲'}{session?.model ? ` · ${session.model}` : ''}
+    </span>
+  </div>
+</header>
+
+<div class="scroll" bind:this={scroller}>
+  {#each msgs as msg (msg.id)}
+    {#if msg.type === 'user'}
+      <div class="bubble user" class:pending={msg.pending}>{msg.content}</div>
+    {:else if msg.type === 'assistant'}
+      <div class="bubble agent">
+        {#if msg.thinking}<div class="thoughts">{msg.thinking}</div>{/if}
+        <div class="body">{msg.content}{#if msg.streaming}<span class="caret">▋</span>{/if}</div>
+      </div>
+    {:else if msg.type === 'thinking'}
+      <div class="thoughts standalone">{msg.thinking}</div>
+    {:else if msg.type === 'tool_group'}
+      <div class="tools">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--m-text-3)" stroke-width="2"><path d="M14.7 6.3a4 4 0 0 1-5 5L4 17v3h3l5.7-5.7a4 4 0 0 0 5-5z"/></svg>
+        <span>{toolLabel(msg.tools)}</span>
+      </div>
+    {:else if msg.type === 'notice'}
+      <div class="notice" class:err={msg.level === 'error'}>{msg.content}</div>
+    {/if}
+  {/each}
+</div>
+
+<div class="composer">
+  <textarea
+    bind:value={draft}
+    onkeydown={onKey}
+    oncompositionstart={() => (composing = true)}
+    oncompositionend={() => (composing = false)}
+    placeholder="回复 agent…"
+    rows="1"
+  ></textarea>
+  <button class="send" onclick={send} disabled={!draft.trim()} aria-label="发送">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M22 2 11 13M22 2l-7 20-4-9-9-4z"/></svg>
+  </button>
+</div>
+
+<style>
+  .dhead {
+    flex: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 14px 12px;
+  }
+  .back {
+    flex: none;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    border: none;
+    background: var(--m-surface);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: var(--m-shadow-card);
+  }
+  .dtitle { flex: 1; min-width: 0; }
+  .dtitle .t {
+    display: block;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--m-text);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  .dtitle .sub {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-top: 2px;
+    font-size: 11px;
+    color: var(--m-text-3);
+  }
+  .sub .d { width: 7px; height: 7px; border-radius: 50%; background: var(--m-text-4); }
+  .sub .d.live { background: var(--m-success); }
+  .scroll {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 8px 16px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .bubble {
+    max-width: 82%;
+    padding: 11px 14px;
+    font-size: 14px;
+    line-height: 1.55;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .bubble.user {
+    align-self: flex-end;
+    background: var(--m-accent);
+    color: #fff;
+    border-radius: 14px 4px 14px 14px;
+  }
+  .bubble.user.pending { opacity: .6; }
+  .bubble.agent {
+    align-self: flex-start;
+    background: var(--m-surface);
+    color: var(--m-text);
+    border-radius: 4px 14px 14px 14px;
+    box-shadow: var(--m-shadow-card);
+  }
+  .thoughts {
+    font-size: 12.5px;
+    color: var(--m-text-3);
+    border-left: 2px solid var(--m-border);
+    padding-left: 8px;
+    margin-bottom: 6px;
+    white-space: pre-wrap;
+  }
+  .thoughts.standalone {
+    align-self: flex-start;
+    max-width: 82%;
+    margin: 0;
+  }
+  .caret { color: var(--m-accent); animation: bk 1.1s steps(1) infinite; }
+  @keyframes bk { 50% { opacity: .2 } }
+  @media (prefers-reduced-motion: reduce) { .caret { animation: none } }
+  .tools {
+    align-self: flex-start;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--m-text-3);
+    font-family: ui-monospace, Menlo, monospace;
+  }
+  .notice {
+    align-self: center;
+    font-size: 12px;
+    color: var(--m-text-3);
+    text-align: center;
+  }
+  .notice.err { color: var(--m-error); }
+  .composer {
+    flex: none;
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    padding: 10px 12px calc(14px + env(safe-area-inset-bottom));
+    background: var(--m-surface);
+    border-top: 1px solid var(--m-border-2);
+  }
+  .composer textarea {
+    flex: 1;
+    resize: none;
+    border: 1px solid var(--m-border);
+    border-radius: 12px;
+    padding: 9px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    outline: none;
+    max-height: 96px;
+    color: var(--m-text);
+    background: var(--m-bg);
+  }
+  .composer .send {
+    flex: none;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    background: var(--m-accent);
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+  .composer .send:disabled { opacity: .4; cursor: default; }
+</style>

--- a/web/src/mobile/MobileApp.svelte
+++ b/web/src/mobile/MobileApp.svelte
@@ -6,6 +6,7 @@
   // dev-docs/mobile-ui-implementation.md).
   import './theme.css'
   import Feed from './Feed.svelte'
+  import ChatDetail from './ChatDetail.svelte'
   import { setActiveSession } from '../lib/stores'
 
   type Tab = 'chat' | 'tasks' | 'config' | 'settings'
@@ -23,15 +24,7 @@
   <main class="m-view">
     {#if tab === 'chat'}
       {#if openId}
-        <header class="m-dhead">
-          <button class="m-back" onclick={() => (openId = null)} aria-label="返回">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--m-text)" stroke-width="2"><path d="m15 18-6-6 6-6"/></svg>
-          </button>
-          <span class="m-dtitle">对话详情</span>
-        </header>
-        <div class="m-scroll">
-          <div class="m-ph">ChatDetail · 批 1b 接入 Composer + 消息流</div>
-        </div>
+        <ChatDetail onBack={() => (openId = null)} />
       {:else}
         <Feed onOpen={openSession} />
       {/if}
@@ -94,30 +87,6 @@
     font-size: 24px;
     font-weight: 600;
     color: var(--m-text-strong);
-  }
-  .m-dhead {
-    flex: none;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 6px 14px 12px;
-  }
-  .m-back {
-    width: 34px;
-    height: 34px;
-    border-radius: 50%;
-    border: none;
-    background: var(--m-surface);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    box-shadow: var(--m-shadow-card);
-  }
-  .m-dtitle {
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--m-text);
   }
   .m-scroll {
     flex: 1;

--- a/web/src/mobile/chatWiring.ts
+++ b/web/src/mobile/chatWiring.ts
@@ -32,6 +32,7 @@ import {
   finishAllTools,
   finishToolsById,
   clearMsgs,
+  showToast,
   uid,
 } from '../lib/stores'
 
@@ -198,10 +199,47 @@ export function wireMobileSession(sid: string): () => void {
   cleanups.push(ws.on('turn_error', (ev: any) => {
     if (!forSid(ev)) return
     addChatMsg(sid, {
-      id: uid('err'), type: 'notice', content: `**Error:** ${ev.error ?? 'request failed'}`,
+      id: uid('err'), type: 'notice', content: `错误: ${ev.error ?? 'request failed'}`,
       level: 'error', createdAt: Date.now(), streaming: false, tools: [], todos: [],
     })
     chatStreaming.update(s => ({ ...s, [sid]: false }))
+  }))
+
+  cleanups.push(ws.on('toast', (ev: any) => {
+    if (ev.session_id !== sid) return
+    showToast(ev.message ?? '', ev.level ?? 'info')
+  }))
+
+  // Operation errors surfaced over WS (retry-while-running, session-not-found…).
+  cleanups.push(ws.on('error', (ev: any) => {
+    if (!forSid(ev)) return
+    showToast(ev.message ?? 'Error', 'error')
+  }))
+
+  // The server rejected the send (session bound to another client, not found…).
+  // Without this the optimistic bubble and the streaming flag would hang forever
+  // — the server sends no idle snapshot after a rejection. Roll the echo back,
+  // clear streaming, and surface why. (No steer/force bookkeeping — mobile has
+  // no optimistic-steer path; force-takeover UI is a later batch.)
+  const rollbackSend = (ev: any) => {
+    chatMessages.update(m => {
+      const msgs = [...(m[sid] || [])]
+      const lastPending = msgs.findLastIndex((x: any) => x.type === 'user' && x.pending)
+      if (lastPending >= 0) msgs.splice(lastPending, 1)
+      return { ...m, [sid]: msgs }
+    })
+    chatStreaming.update(s => ({ ...s, [sid]: false }))
+    showToast(ev.message ?? '发送失败', 'error')
+  }
+  cleanups.push(ws.on('send_rejected', (ev: any) => {
+    if (!forSid(ev)) return
+    rollbackSend(ev)
+  }))
+  cleanups.push(ws.on('bind_required', (ev: any) => {
+    if (!forSid(ev)) return
+    // Mobile has no force-takeover UI yet, so treat it as a rejection rather
+    // than leaving the turn stuck: roll back and tell the user it's in use.
+    rollbackSend({ message: ev.message ?? '会话正被其他端占用' })
   }))
 
   cleanups.push(ws.on('session_update', (ev: any) => {

--- a/web/src/mobile/chatWiring.ts
+++ b/web/src/mobile/chatWiring.ts
@@ -1,0 +1,224 @@
+// Mobile chat session wiring.
+//
+// The desktop ChatView owns a large, DOM- and UI-coupled $effect that wires the
+// WebSocket stream into the chat stores. Mobile only needs a CORE SUBSET of that
+// stream, and the real message-assembly logic already lives in stores.ts
+// (appendToLastAssistant / addToolCallToGroup / updateToolResult / …), shared by
+// both. So rather than extract ChatView's coupled wiring, this registers a thin
+// mobile-only handler set that calls those same shared store functions.
+//
+// Deliberately omitted (desktop-only or a later batch): optimistic-send
+// bookkeeping / steer queues / rollback, sub-agent & workflow panels, artifact
+// auto-open, turn-error banner, next-message suggestions. Mobile chat is a
+// simplified view; the detailed tool/progress rendering is batch 2.
+import { get } from 'svelte/store'
+import { ws } from '../lib/ws'
+import * as api from '../lib/api'
+import {
+  chatMessages,
+  chatStreaming,
+  chatThinking,
+  chatProgress,
+  chatLastTextAt,
+  chatGoal,
+  addChatMsg,
+  appendToLastAssistant,
+  commitThinking,
+  stopTrailingCaret,
+  addToolCallToGroup,
+  updateToolResult,
+  setToolError,
+  appendToolStdout,
+  finishAllTools,
+  finishToolsById,
+  clearMsgs,
+  uid,
+} from '../lib/stores'
+
+// Apply one persisted history event to the stores. A trimmed copy of the
+// desktop's handleHistoryEvent (no artifact observation); the message-shaping is
+// the shared store helpers, so the two stay behaviourally aligned.
+function applyHistoryEvent(sid: string, ev: Record<string, any>, showReasoning: boolean) {
+  if (ev.type === 'history_user_message') {
+    addChatMsg(sid, {
+      id: uid('u'), type: 'user', content: ev.content ?? '', createdAt: ev.created_at ?? Date.now(),
+      streaming: false, pending: false, tools: [], todos: [], images: ev.images ?? [],
+      messageIndex: ev.message_index,
+    })
+  } else if (ev.type === 'assistant_message') {
+    if (!(ev.content ?? '').trim() && !(ev.thinking ?? '').trim()) return
+    addChatMsg(sid, {
+      id: uid('a'), type: 'assistant', content: ev.content ?? '', thinking: ev.thinking ?? '',
+      createdAt: Date.now(), streaming: false, tools: [], todos: [],
+    })
+  } else if (ev.type === 'thinking') {
+    if (showReasoning) commitThinking(sid, ev.text ?? '')
+  } else if (ev.type === 'tool_call') {
+    addToolCallToGroup(sid, {
+      id: uid('t'), toolId: ev.tool_id ?? '', name: ev.name ?? '', args: ev.args ?? '',
+      summary: ev.summary ?? '', done: false, error: null, result: null, stdout: [], diff: null,
+    })
+  } else if (ev.type === 'tool_result') {
+    updateToolResult(sid, ev.tool_id, ev.result, ev.ui_payload)
+  }
+}
+
+// Fetch and render a session's persisted transcript. Resolves once settled, so
+// the caller can subscribe over WS only after history renders (same ordering the
+// desktop relies on to avoid replayed tool cards landing before their message).
+export function loadMobileHistory(sid: string): Promise<void> {
+  api.getSessionGoal(sid)
+    .then(resp => chatGoal.update(m => ({ ...m, [sid]: resp?.goal ?? null })))
+    .catch(() => {})
+  return api.getSessionMessages(sid).then((resp: any) => {
+    const events: any[] = resp?.events ?? []
+    const showReasoning = resp?.show_reasoning ?? true
+    const historyToolIds = new Set<string>()
+    for (const ev of events) {
+      if (ev.type === 'tool_call' && ev.tool_id) historyToolIds.add(ev.tool_id)
+      applyHistoryEvent(sid, ev, showReasoning)
+    }
+    finishToolsById(sid, historyToolIds)
+  }).catch(() => {})
+}
+
+// Optimistically echo the user's message, mark the turn streaming, and send.
+// history_user_message reconciles the echo (see the handler below).
+export function sendMobile(sid: string, text: string, files?: unknown[]) {
+  const t = text.trim()
+  if (!t) return
+  addChatMsg(sid, {
+    id: uid('u'), type: 'user', content: t, createdAt: Date.now(),
+    streaming: false, pending: true, tools: [], todos: [], images: [],
+  })
+  chatStreaming.update(s => ({ ...s, [sid]: true }))
+  ws.sendMessage(sid, t, files)
+}
+
+// Register the core WS handlers for a session. Returns a cleanup that removes
+// them all. Pair with ws.subscribe/unsubscribe in the caller's effect.
+export function wireMobileSession(sid: string): () => void {
+  const forSid = (ev: any) => !ev.session_id || ev.session_id === sid
+  const cleanups: Array<() => void> = []
+
+  cleanups.push(ws.on('text_delta', (ev: any) => {
+    if (!forSid(ev)) return
+    const txt = ev.text ?? ''
+    const pendingThinking = get(chatThinking)[sid] ?? ''
+    appendToLastAssistant(sid, txt, pendingThinking)
+    if (pendingThinking) chatThinking.update(tt => ({ ...tt, [sid]: '' }))
+    if (txt) chatLastTextAt.update(tt => ({ ...tt, [sid]: Date.now() }))
+  }))
+
+  cleanups.push(ws.on('thinking_delta', (ev: any) => {
+    if (!forSid(ev)) return
+    if (!(get(chatThinking)[sid] ?? '')) stopTrailingCaret(sid)
+    chatThinking.update(tt => ({ ...tt, [sid]: (tt[sid] ?? '') + (ev.text ?? '') }))
+  }))
+
+  cleanups.push(ws.on('assistant_message', (ev: any) => {
+    if (!forSid(ev)) return
+    const think = ev.thinking ?? ''
+    chatThinking.update(tt => ({ ...tt, [sid]: '' }))
+    const cur = get(chatMessages)[sid] ?? []
+    const streaming = get(chatStreaming)[sid] ?? false
+    if (streaming && cur.length > 0 && cur[cur.length - 1]?.type === 'assistant') {
+      chatMessages.update(m => {
+        const arr = [...(m[sid] || [])]
+        const last = arr.length - 1
+        if (last >= 0) arr[last] = { ...arr[last], content: ev.content ?? arr[last].content, thinking: think || arr[last].thinking, streaming: false }
+        return { ...m, [sid]: arr }
+      })
+    } else {
+      addChatMsg(sid, { id: uid('a'), type: 'assistant', content: ev.content ?? '', thinking: think, createdAt: Date.now(), streaming: false, tools: [], todos: [] })
+    }
+  }))
+
+  cleanups.push(ws.on('history_user_message', (ev: any) => {
+    if (!forSid(ev)) return
+    const content = ev.content ?? ''
+    const createdAt = ev.created_at ?? Date.now()
+    const images = ev.images ?? []
+    chatMessages.update(m => {
+      const msgs = [...(m[sid] || [])]
+      // Reconcile the optimistic echo: replace the trailing pending user bubble
+      // of the same text, else append. (Mobile has no steer path.)
+      const lastPending = msgs.findLastIndex((x: any) => x.type === 'user' && x.pending)
+      if (lastPending >= 0 && msgs[lastPending].content === content) {
+        msgs[lastPending] = { ...msgs[lastPending], id: uid('u'), createdAt, pending: false, images, messageIndex: ev.message_index }
+      } else {
+        msgs.push({ id: uid('u'), type: 'user', content, createdAt, streaming: false, pending: false, tools: [], todos: [], images, messageIndex: ev.message_index })
+      }
+      return { ...m, [sid]: msgs }
+    })
+  }))
+
+  cleanups.push(ws.on('tool_call', (ev: any) => {
+    if (!forSid(ev)) return
+    commitThinking(sid, get(chatThinking)[sid] ?? '')
+    chatThinking.update(tt => ({ ...tt, [sid]: '' }))
+    addToolCallToGroup(sid, {
+      id: uid('t'), toolId: ev.tool_id ?? '', name: ev.name ?? '', args: ev.args ?? '',
+      summary: ev.summary ?? '', startedAt: Date.now(), done: false, error: null, result: null, stdout: [], diff: null,
+    })
+  }))
+
+  cleanups.push(ws.on('tool_result', (ev: any) => {
+    if (!forSid(ev)) return
+    updateToolResult(sid, ev.tool_id, ev.result, ev.ui_payload)
+  }))
+
+  cleanups.push(ws.on('tool_error', (ev: any) => {
+    if (!forSid(ev)) return
+    setToolError(sid, ev.tool_id, ev.error ?? 'error')
+  }))
+
+  cleanups.push(ws.on('tool_stdout', (ev: any) => {
+    if (!forSid(ev)) return
+    appendToolStdout(sid, ev.tool_id, ev.lines ?? [])
+  }))
+
+  cleanups.push(ws.on('progress', (ev: any) => {
+    if (!forSid(ev)) return
+    chatProgress.update(p => ({ ...p, [sid]: { message: ev.message || 'Thinking', phase: ev.phase } }))
+    if (ev.phase === 'active') chatStreaming.update(s => ({ ...s, [sid]: true }))
+  }))
+
+  cleanups.push(ws.on('complete', (ev: any) => {
+    if (!forSid(ev)) return
+    chatStreaming.update(s => ({ ...s, [sid]: false }))
+    chatProgress.update(p => ({ ...p, [sid]: null }))
+    chatMessages.update(m => {
+      const msgs = (m[sid] || []).map((x: any) => (x.streaming ? { ...x, streaming: false } : x))
+      return { ...m, [sid]: msgs }
+    })
+    finishAllTools(sid)
+  }))
+
+  cleanups.push(ws.on('turn_error', (ev: any) => {
+    if (!forSid(ev)) return
+    addChatMsg(sid, {
+      id: uid('err'), type: 'notice', content: `**Error:** ${ev.error ?? 'request failed'}`,
+      level: 'error', createdAt: Date.now(), streaming: false, tools: [], todos: [],
+    })
+    chatStreaming.update(s => ({ ...s, [sid]: false }))
+  }))
+
+  cleanups.push(ws.on('session_update', (ev: any) => {
+    if (!forSid(ev)) return
+    // Mobile only needs the idle snapshot to clear a stale streaming indicator.
+    if (ev.status === 'idle') {
+      chatStreaming.update(s => ({ ...s, [sid]: false }))
+      chatProgress.update(p => ({ ...p, [sid]: null }))
+      chatThinking.update(t => ({ ...t, [sid]: '' }))
+    }
+  }))
+
+  cleanups.push(ws.on('history_reload', (ev: any) => {
+    if (!forSid(ev)) return
+    clearMsgs(sid)
+    loadMobileHistory(sid)
+  }))
+
+  return () => cleanups.forEach(fn => fn())
+}


### PR DESCRIPTION
Completes batch 1 of the mobile UI (`dev-docs/mobile-ui-implementation.md`). Batch 1a wired the feed; this makes a tapped session open a **real conversation** — transcript + reply.

## What
- **`chatWiring.ts`** — a mobile-only WS handler set: `subscribe` + `loadMobileHistory` + the core live events (`text_delta` / `thinking_delta` / `assistant_message` / `history_user_message` / `tool_call` / `tool_result` / `tool_error` / `tool_stdout` / `progress` / `complete` / `turn_error` / `session_update` / `history_reload`). Every handler calls the **same `stores.ts` helpers the desktop uses** (`appendToLastAssistant`, `addToolCallToGroup`, `updateToolResult`, …) — the message-assembly business logic is a single source; only the thin event subscription is mobile's own, a deliberate subset.
- **`ChatDetail.svelte`** — transcript bubbles (user / assistant / thinking / a one-line tool hint / notice) + a lightweight mobile composer. Subscribes on open, unsubscribes on close, pins to the latest message.
- **`MobileApp`** — the Sessions tab's detail slot renders `ChatDetail`.

## Design note (per the agreed batch-1b decision)
ChatView (2569 lines) is deeply coupled to its own DOM / local UI state and subtle history↔subscribe ordering, and mobile only needs a core subset — so instead of extracting ChatView's wiring, mobile registers its own thin handlers over the **shared stores**. Desktop-only concerns (optimistic-send / steer / rollback, sub-agent & workflow panels, artifact auto-open, next-message suggestions) are intentionally omitted; detailed tool/progress rendering is batch 2. **No desktop file changed.**

## Verification
- `svelte-check`: 353 files, **0 errors, 0 warnings**.
- `vite build`: green.
- Source only (webdist gitignored).
- ⚠️ **Behaviourally cloned from ChatView's core handlers but not yet exercised on a device/emulator** — needs an on-device walkthrough on a Mac to confirm the live stream renders end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)