### PR TITLE
fix(web): animate tool card auto-collapse instead of snapping shut

### DIFF
--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -3,7 +3,7 @@
   import { activeSessionId, showToast } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
-  import { toolOpenState, applyToolToggle } from '../../lib/toolFold'
+  import { toolOpenState, applyToolToggle, defaultToolOpen } from '../../lib/toolFold'
 
   // Tracks which overwrite-undo buttons have already fired, keyed by tool id.
   let undone = $state<Record<string, boolean>>({})
@@ -209,6 +209,42 @@
   // re-render revert a manual collapse of the auto-opened last tool.
   let toolOpen = $state<Record<string, boolean>>({})
 
+  // A card whose default flips open->closed on its own (the last tool loses
+  // that status, or the whole group stops running) collapses instantly if we
+  // just let <details open> follow the default — the content is hidden by the
+  // browser in one frame, which reads as a flash/bug. `closingIds` keeps such
+  // a card's <details> forced open for a couple seconds while a CSS max-height
+  // transition (see .tool-body.auto-closing) shrinks it first, so the native
+  // collapse that finally lands is invisible. A user-driven click still closes
+  // instantly (native <details> behaviour, untouched here) — only the
+  // no-override, default-driven collapse gets animated.
+  let closingIds = $state<Record<string, boolean>>({})
+  let prevAutoOpen: Record<string, boolean> = {}
+  const AUTO_CLOSE_MS = 2000
+  $effect(() => {
+    const ts = tools ?? []
+    if (ts.length === 0) return
+    const last = ts[ts.length - 1]?.id
+    const running = ts.some((t) => !t.done && !t.error)
+    for (const tool of ts) {
+      if (toolOpen[tool.id] !== undefined) {
+        delete prevAutoOpen[tool.id]
+        continue
+      }
+      const target = defaultToolOpen(tool, last, running)
+      if (prevAutoOpen[tool.id] === true && target === false) {
+        closingIds = { ...closingIds, [tool.id]: true }
+        const id = tool.id
+        setTimeout(() => {
+          const next = { ...closingIds }
+          delete next[id]
+          closingIds = next
+        }, AUTO_CLOSE_MS)
+      }
+      prevAutoOpen[tool.id] = target
+    }
+  })
+
   // todo_write renders its checklist from the tool args.
   function todoItems(tool: any): Array<{ status: string; content: string }> | null {
     if (tool.name !== 'todo_write' && tool.name !== 'todowrite') return null
@@ -280,7 +316,8 @@
            ellipsizes it. Surfacing it via `title` + selectable text lets the
            user read/copy the whole thing despite the truncation. -->
       {@const argText = tool.summary || (tool.args ? argSummary(tool.name, tool.args) : '')}
-      <details open={toolOpenState(toolOpen, tool, lastId, anyRunning)} ontoggle={(e) => applyToolToggle(toolOpen, tool, lastId, anyRunning, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
+      {@const isClosing = !!closingIds[tool.id]}
+      <details open={toolOpenState(toolOpen, tool, lastId, anyRunning) || isClosing} ontoggle={(e) => applyToolToggle(toolOpen, tool, lastId, anyRunning, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
         <summary class="tool-summary">
           <iconify-icon icon="lucide:chevron-right" width="13" class="chev" style="color:var(--text-tertiary)"></iconify-icon>
           <iconify-icon icon={toolIcon(tool.name)} width="14" style="color:var(--text-tertiary);flex:0 0 auto"></iconify-icon>
@@ -325,6 +362,7 @@
           </span>
         </summary>
 
+        <div class="tool-body" class:auto-closing={isClosing}><div class="tool-body-inner">
         {#if tool.error}
           <div class="error-output mono">{tool.error}</div>
         {:else if fErr}
@@ -448,6 +486,7 @@
             {/if}
           </div>
         {/if}
+        </div></div>
       </details>
     {/each}
   </div>
@@ -483,6 +522,14 @@
 /* Chevron rotates from ▸ (collapsed) to ▾ (open). */
 .chev { transition: transform 0.15s ease; flex: 0 0 auto; }
 details[open] > summary .chev { transform: rotate(90deg); }
+/* Auto-collapse animation: a default-driven close (last tool losing that
+   status, or the group finishing) shrinks this wrapper to nothing over 2s
+   before the <details> is actually allowed to close, so the native collapse
+   that follows is invisible instead of an instant flash. A user click still
+   closes natively/instantly — untouched here. */
+.tool-body { display: grid; grid-template-rows: 1fr; }
+.tool-body.auto-closing { grid-template-rows: 0fr; transition: grid-template-rows 2s ease; }
+.tool-body-inner { overflow: hidden; min-height: 0; }
 /* todo_write checklist */
 .todo-list { border-top: 1px solid var(--border-table); padding: 10px 14px; display: flex; flex-direction: column; gap: 8px; }
 .todo-step { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text); }

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -3,7 +3,7 @@
   import { activeSessionId, showToast } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
-  import { toolOpenState, applyToolToggle, defaultToolOpen } from '../../lib/toolFold'
+  import { toolOpenState, applyToolToggle } from '../../lib/toolFold'
 
   // Tracks which overwrite-undo buttons have already fired, keyed by tool id.
   let undone = $state<Record<string, boolean>>({})
@@ -209,40 +209,42 @@
   // re-render revert a manual collapse of the auto-opened last tool.
   let toolOpen = $state<Record<string, boolean>>({})
 
-  // A card whose default flips open->closed on its own (the last tool loses
-  // that status, or the whole group stops running) collapses instantly if we
-  // just let <details open> follow the default — the content is hidden by the
-  // browser in one frame, which reads as a flash/bug. `closingIds` keeps such
-  // a card's <details> forced open for a couple seconds while a CSS max-height
-  // transition (see .tool-body.auto-closing) shrinks it first, so the native
-  // collapse that finally lands is invisible. A user-driven click still closes
-  // instantly (native <details> behaviour, untouched here) — only the
-  // no-override, default-driven collapse gets animated.
+  // The last tool card auto-collapses the instant its turn stops running,
+  // which — bound straight to <details open> — hides the content in one
+  // frame and reads as a flash/bug. `closingIds` keeps that one card's
+  // <details> forced open for a couple seconds while a CSS transition (see
+  // .tool-body.auto-closing) shrinks it first, so the native collapse that
+  // finally lands is invisible.
+  //
+  // This only fires on the group-level running->not-running edge (the turn
+  // actually finishing), not on every default flip: the last tool also loses
+  // its auto-open default the instant a *later* tool call starts and takes
+  // over as the new last one — collapsing the outgoing card there stays
+  // instant, matching how it always worked, because animating it made the
+  // outgoing card's shrink and the incoming card's arrival read as if both
+  // were "expanding" together.
+  //
+  // A user-driven click still closes instantly (native <details> behaviour,
+  // untouched here) — checking toolOpen[id] here skips a card the user
+  // already has an explicit override on.
   let closingIds = $state<Record<string, boolean>>({})
-  let prevAutoOpen: Record<string, boolean> = {}
+  let prevRunning: boolean | undefined
   const AUTO_CLOSE_MS = 2000
   $effect(() => {
     const ts = tools ?? []
     if (ts.length === 0) return
-    const last = ts[ts.length - 1]?.id
     const running = ts.some((t) => !t.done && !t.error)
-    for (const tool of ts) {
-      if (toolOpen[tool.id] !== undefined) {
-        delete prevAutoOpen[tool.id]
-        continue
-      }
-      const target = defaultToolOpen(tool, last, running)
-      if (prevAutoOpen[tool.id] === true && target === false) {
-        closingIds = { ...closingIds, [tool.id]: true }
-        const id = tool.id
-        setTimeout(() => {
-          const next = { ...closingIds }
-          delete next[id]
-          closingIds = next
-        }, AUTO_CLOSE_MS)
-      }
-      prevAutoOpen[tool.id] = target
+    const last = ts[ts.length - 1]
+    if (prevRunning === true && running === false && last && !last.error && toolOpen[last.id] === undefined) {
+      const id = last.id
+      closingIds = { ...closingIds, [id]: true }
+      setTimeout(() => {
+        const next = { ...closingIds }
+        delete next[id]
+        closingIds = next
+      }, AUTO_CLOSE_MS)
     }
+    prevRunning = running
   })
 
   // todo_write renders its checklist from the tool args.
@@ -526,8 +528,12 @@ details[open] > summary .chev { transform: rotate(90deg); }
    status, or the group finishing) shrinks this wrapper to nothing over 2s
    before the <details> is actually allowed to close, so the native collapse
    that follows is invisible instead of an instant flash. A user click still
-   closes natively/instantly — untouched here. */
-.tool-body { display: grid; grid-template-rows: 1fr; }
+   closes natively/instantly — untouched here. The base rule pins
+   transition-duration to 0s explicitly (not just omits it) — some engines
+   resolve a class-removal transition from the style being left rather than
+   the one being entered, which would otherwise replay the 2s shrink in
+   reverse as a spurious "expand" animation once auto-closing is cleared. */
+.tool-body { display: grid; grid-template-rows: 1fr; transition: grid-template-rows 0s; }
 .tool-body.auto-closing { grid-template-rows: 0fr; transition: grid-template-rows 2s ease; }
 .tool-body-inner { overflow: hidden; min-height: 0; }
 /* todo_write checklist */


### PR DESCRIPTION
## Summary
- The last tool card in a `ToolGroup` auto-opens while its turn streams and auto-collapses once nothing is running; binding `<details open>` straight to that default made the collapse instant, which read as a UI flash/bug.
- The `<details>` now stays forced open for ~2s while a CSS `grid-template-rows` transition shrinks its content first, so the native collapse that lands afterward is invisible.
- A user-driven click on the summary still collapses natively/instantly — only the automatic, no-override default-driven collapse is animated.

## Test plan
- [x] `svelte-check` — 0 errors
- [x] `vitest run src/lib/toolFold.test.ts` — 9 passed (unchanged, confirms default-open logic untouched)
- [x] `make web-build`
- [ ] Manual: run a turn with several tool calls, confirm the previously-last card now shrinks smoothly over ~2s instead of vanishing instantly once the turn finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)