### PR TITLE
fix(web): tool card auto-collapse animation + cron session group live refresh

### DIFF
--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -109,6 +109,14 @@ func (s *Server) CreateSession(task scheduler.Task) (string, error) {
 			slog.Warn("cron: add session to group", "task", task.Name, "err", gerr)
 		}
 	}
+
+	// Announce the new session globally. A scheduled fire has no subscribed
+	// tab yet, and every per-session broadcast in RunTask is dropped for a
+	// session nobody subscribed to — without this, an open sidebar can't learn
+	// the session (or its group filing) exists until a manual reload. Emitted
+	// after the group write above so a tab that refetches on receipt sees the
+	// membership already on disk.
+	s.wsHub.broadcast("", wsEventSessionCreated{Type: "session_created", SessionID: sessionID})
 	return sessionID, nil
 }
 

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -164,6 +164,22 @@
       }
     })
 
+    // Pull the authoritative session list from the server into the stores.
+    // Shared by the reconciliation paths below; never touches activeSessionId.
+    const refreshSessionsFromServer = () => {
+      api.listSessions().then((data: any) => {
+        const list = data.sessions ?? []
+        sessions.set(list)
+        chatShowReasoning.update(m => {
+          const next = { ...m }
+          for (const s of list) {
+            if (typeof s.show_reasoning === 'boolean') next[s.id] = s.show_reasoning
+          }
+          return next
+        })
+      }).catch(() => { /* non-critical: WS fast paths already ran */ })
+    }
+
     // Auto-title: a global broadcast carrying the freshly generated name, so
     // the sidebar reflects the rename live instead of showing the stale title
     // until a reload.
@@ -177,22 +193,19 @@
       )
       // Double-check against the server: the store mutation above is the fast
       // path, but if a slow-consumer drop or a UI reactivity gap hides the
-      // rename, the next REST list will reconcile the sidebar. This is also
-      // the first live signal of a brand-new cron session for a tab that was
-      // already open (its auto-title fires this event on message receipt) —
-      // refresh the groups snapshot alongside it, or the session shows up
-      // ungrouped until a manual reload re-mounts the sidebar (#1699).
-      api.listSessions().then((data: any) => {
-        const list = data.sessions ?? []
-        sessions.set(list)
-        chatShowReasoning.update(m => {
-          const next = { ...m }
-          for (const s of list) {
-            if (typeof s.show_reasoning === 'boolean') next[s.id] = s.show_reasoning
-          }
-          return next
-        })
-      }).catch(() => { /* non-critical: fast-path store update already ran */ })
+      // rename, the next REST list will reconcile the sidebar.
+      refreshSessionsFromServer()
+    })
+
+    // A session created outside this tab's own actions — a scheduled cron
+    // fire filing a fresh session into its task's group, or a branch/fork
+    // made in another tab. Every other broadcast about that session is
+    // per-session and dropped for tabs that never subscribed to it, so this
+    // is the one signal an open sidebar gets: refetch both the session list
+    // AND the groups snapshot (which is otherwise only ever fetched once, at
+    // sidebar mount) so the session appears already inside its group (#1699).
+    ws.on('session_created', () => {
+      refreshSessionsFromServer()
       api.listSessionGroups().then(org => sessionGroups.set(org.groups)).catch(() => { /* non-critical */ })
     })
 

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, sessions, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell } from './lib/stores'
+  import { view, sessions, sessionGroups, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell } from './lib/stores'
   import MobileApp from './mobile/MobileApp.svelte'
   import { ws, wsState } from './lib/ws'
   import { notificationsEnabled } from './lib/notifications'
@@ -177,7 +177,11 @@
       )
       // Double-check against the server: the store mutation above is the fast
       // path, but if a slow-consumer drop or a UI reactivity gap hides the
-      // rename, the next REST list will reconcile the sidebar.
+      // rename, the next REST list will reconcile the sidebar. This is also
+      // the first live signal of a brand-new cron session for a tab that was
+      // already open (its auto-title fires this event on message receipt) —
+      // refresh the groups snapshot alongside it, or the session shows up
+      // ungrouped until a manual reload re-mounts the sidebar (#1699).
       api.listSessions().then((data: any) => {
         const list = data.sessions ?? []
         sessions.set(list)
@@ -189,6 +193,7 @@
           return next
         })
       }).catch(() => { /* non-critical: fast-path store update already ran */ })
+      api.listSessionGroups().then(org => sessionGroups.set(org.groups)).catch(() => { /* non-critical */ })
     })
 
     // session_activity is a lightweight global signal (unlike

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -3,7 +3,7 @@
   import { activeSessionId, showToast } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
-  import { toolOpenState, applyToolToggle } from '../../lib/toolFold'
+  import { toolOpenState, applyToolToggle, autoCloseAction } from '../../lib/toolFold'
 
   // Tracks which overwrite-undo buttons have already fired, keyed by tool id.
   let undone = $state<Record<string, boolean>>({})
@@ -209,24 +209,24 @@
   // re-render revert a manual collapse of the auto-opened last tool.
   let toolOpen = $state<Record<string, boolean>>({})
 
-  // The last tool card auto-collapses the instant its turn stops running,
+  // The last tool card auto-collapses the instant the group stops running,
   // which — bound straight to <details open> — hides the content in one
   // frame and reads as a flash/bug. `closingIds` keeps that one card's
   // <details> forced open for a beat while a CSS transition (see
   // .tool-body.auto-closing) shrinks it first, so the native collapse that
   // finally lands is invisible.
   //
-  // This only fires on the group-level running->not-running edge (the turn
-  // actually finishing), not on every default flip: the last tool also loses
-  // its auto-open default the instant a *later* tool call starts and takes
-  // over as the new last one — collapsing the outgoing card there stays
-  // instant, matching how it always worked, because animating it made the
-  // outgoing card's shrink and the incoming card's arrival read as if both
-  // were "expanding" together.
+  // "Stops running" means no in-flight tool in the group right now — usually
+  // the turn finishing, but the same dip also happens between sequential tool
+  // rounds inside one turn (result received, next call still an LLM round-trip
+  // away). If the next call arrives while the previous card is still
+  // shrinking, the 'cancel' branch in autoCloseAction lands it instantly —
+  // otherwise the outgoing shrink overlaps the incoming card and the pair
+  // reads as everything animating open at once.
   //
   // A user-driven click still closes instantly (native <details> behaviour,
-  // untouched here) — checking toolOpen[id] here skips a card the user
-  // already has an explicit override on.
+  // untouched here); autoCloseAction skips a card the user holds an explicit
+  // override on.
   //
   // This must be $effect.pre, not $effect: a post-DOM effect would let the
   // running->false render close the <details> first and force it back open a
@@ -236,8 +236,8 @@
   // override snaps the card back open (animated shrink, then pop back). Running
   // before the DOM update keeps `open` true continuously, so no toggle fires
   // at all.
-  // Slightly longer than the CSS transition so the shrink always finishes
-  // before the <details> is allowed to natively close.
+  // AUTO_CLOSE_MS is slightly longer than the CSS transition so the shrink
+  // always finishes before the <details> is allowed to natively close.
   let closingIds = $state<Record<string, boolean>>({})
   let prevRunning: boolean | undefined
   const AUTO_CLOSE_MS = 750
@@ -245,17 +245,19 @@
     const ts = tools ?? []
     if (ts.length === 0) return
     const running = ts.some((t) => !t.done && !t.error)
-    const last = ts[ts.length - 1]
-    if (prevRunning === true && running === false && last && !last.error && toolOpen[last.id] === undefined) {
-      const id = last.id
+    const action = autoCloseAction(prevRunning, running, ts, toolOpen, Object.keys(closingIds).length)
+    prevRunning = running
+    if (action?.kind === 'start') {
+      const id = action.id
       closingIds = { ...closingIds, [id]: true }
       setTimeout(() => {
         const next = { ...closingIds }
         delete next[id]
         closingIds = next
       }, AUTO_CLOSE_MS)
+    } else if (action?.kind === 'cancel') {
+      closingIds = {}
     }
-    prevRunning = running
   })
 
   // Toggle handler that is animation-aware: while a card is mid-animated-close,

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -3,7 +3,7 @@
   import { activeSessionId, showToast } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
-  import { toolOpenState, applyToolToggle } from '../../lib/toolFold'
+  import { toolOpenState, applyToolToggle, defaultToolOpen } from '../../lib/toolFold'
 
   // Tracks which overwrite-undo buttons have already fired, keyed by tool id.
   let undone = $state<Record<string, boolean>>({})
@@ -209,6 +209,42 @@
   // re-render revert a manual collapse of the auto-opened last tool.
   let toolOpen = $state<Record<string, boolean>>({})
 
+  // A card whose default flips open->closed on its own (the last tool loses
+  // that status, or the whole group stops running) collapses instantly if we
+  // just let <details open> follow the default — the content is hidden by the
+  // browser in one frame, which reads as a flash/bug. `closingIds` keeps such
+  // a card's <details> forced open for a couple seconds while a CSS max-height
+  // transition (see .tool-body.auto-closing) shrinks it first, so the native
+  // collapse that finally lands is invisible. A user-driven click still closes
+  // instantly (native <details> behaviour, untouched here) — only the
+  // no-override, default-driven collapse gets animated.
+  let closingIds = $state<Record<string, boolean>>({})
+  let prevAutoOpen: Record<string, boolean> = {}
+  const AUTO_CLOSE_MS = 2000
+  $effect(() => {
+    const ts = tools ?? []
+    if (ts.length === 0) return
+    const last = ts[ts.length - 1]?.id
+    const running = ts.some((t) => !t.done && !t.error)
+    for (const tool of ts) {
+      if (toolOpen[tool.id] !== undefined) {
+        delete prevAutoOpen[tool.id]
+        continue
+      }
+      const target = defaultToolOpen(tool, last, running)
+      if (prevAutoOpen[tool.id] === true && target === false) {
+        closingIds = { ...closingIds, [tool.id]: true }
+        const id = tool.id
+        setTimeout(() => {
+          const next = { ...closingIds }
+          delete next[id]
+          closingIds = next
+        }, AUTO_CLOSE_MS)
+      }
+      prevAutoOpen[tool.id] = target
+    }
+  })
+
   // todo_write renders its checklist from the tool args.
   function todoItems(tool: any): Array<{ status: string; content: string }> | null {
     if (tool.name !== 'todo_write' && tool.name !== 'todowrite') return null
@@ -280,7 +316,8 @@
            ellipsizes it. Surfacing it via `title` + selectable text lets the
            user read/copy the whole thing despite the truncation. -->
       {@const argText = tool.summary || (tool.args ? argSummary(tool.name, tool.args) : '')}
-      <details open={toolOpenState(toolOpen, tool, lastId, anyRunning)} ontoggle={(e) => applyToolToggle(toolOpen, tool, lastId, anyRunning, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
+      {@const isClosing = !!closingIds[tool.id]}
+      <details open={toolOpenState(toolOpen, tool, lastId, anyRunning) || isClosing} ontoggle={(e) => applyToolToggle(toolOpen, tool, lastId, anyRunning, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
         <summary class="tool-summary">
           <iconify-icon icon="lucide:chevron-right" width="13" class="chev" style="color:var(--text-tertiary)"></iconify-icon>
           <iconify-icon icon={toolIcon(tool.name)} width="14" style="color:var(--text-tertiary);flex:0 0 auto"></iconify-icon>
@@ -325,6 +362,7 @@
           </span>
         </summary>
 
+        <div class="tool-body" class:auto-closing={isClosing}><div class="tool-body-inner">
         {#if tool.error}
           <div class="error-output mono">{tool.error}</div>
         {:else if fErr}
@@ -448,6 +486,7 @@
             {/if}
           </div>
         {/if}
+        </div></div>
       </details>
     {/each}
   </div>
@@ -483,6 +522,14 @@
 /* Chevron rotates from ▸ (collapsed) to ▾ (open). */
 .chev { transition: transform 0.15s ease; flex: 0 0 auto; }
 details[open] > summary .chev { transform: rotate(90deg); }
+/* Auto-collapse animation: a default-driven close (last tool losing that
+   status, or the group finishing) shrinks this wrapper to nothing over 2s
+   before the <details> is actually allowed to close, so the native collapse
+   that follows is invisible instead of an instant flash. A user click still
+   closes natively/instantly — untouched here. */
+.tool-body { display: grid; grid-template-rows: 1fr; }
+.tool-body.auto-closing { grid-template-rows: 0fr; transition: grid-template-rows 2s ease; }
+.tool-body-inner { overflow: hidden; min-height: 0; }
 /* todo_write checklist */
 .todo-list { border-top: 1px solid var(--border-table); padding: 10px 14px; display: flex; flex-direction: column; gap: 8px; }
 .todo-step { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text); }

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -227,10 +227,19 @@
   // A user-driven click still closes instantly (native <details> behaviour,
   // untouched here) — checking toolOpen[id] here skips a card the user
   // already has an explicit override on.
+  //
+  // This must be $effect.pre, not $effect: a post-DOM effect would let the
+  // running->false render close the <details> first and force it back open a
+  // flush later. That reopen fires a toggle whose open=true diverges from the
+  // now-false default, so applyToolToggle records it as a user "keep open"
+  // override — and when the animation ends and closingIds clears, that stale
+  // override snaps the card back open (shrink 2s, then pop back). Running
+  // before the DOM update keeps `open` true continuously, so no toggle fires
+  // at all.
   let closingIds = $state<Record<string, boolean>>({})
   let prevRunning: boolean | undefined
   const AUTO_CLOSE_MS = 2000
-  $effect(() => {
+  $effect.pre(() => {
     const ts = tools ?? []
     if (ts.length === 0) return
     const running = ts.some((t) => !t.done && !t.error)
@@ -246,6 +255,22 @@
     }
     prevRunning = running
   })
+
+  // Toggle handler that is animation-aware: while a card is mid-animated-close,
+  // the only genuine toggle is the user clicking to collapse it early — end the
+  // animation so the native close sticks, and record no override either way
+  // (the forced-open state must never be mistaken for a user choice).
+  function onToggle(tool: any, lastId: string | undefined, running: boolean, open: boolean) {
+    if (closingIds[tool.id]) {
+      if (!open) {
+        const next = { ...closingIds }
+        delete next[tool.id]
+        closingIds = next
+      }
+      return
+    }
+    applyToolToggle(toolOpen, tool, lastId, running, open)
+  }
 
   // todo_write renders its checklist from the tool args.
   function todoItems(tool: any): Array<{ status: string; content: string }> | null {
@@ -319,7 +344,7 @@
            user read/copy the whole thing despite the truncation. -->
       {@const argText = tool.summary || (tool.args ? argSummary(tool.name, tool.args) : '')}
       {@const isClosing = !!closingIds[tool.id]}
-      <details open={toolOpenState(toolOpen, tool, lastId, anyRunning) || isClosing} ontoggle={(e) => applyToolToggle(toolOpen, tool, lastId, anyRunning, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
+      <details open={toolOpenState(toolOpen, tool, lastId, anyRunning) || isClosing} ontoggle={(e) => onToggle(tool, lastId, anyRunning, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
         <summary class="tool-summary">
           <iconify-icon icon="lucide:chevron-right" width="13" class="chev" style="color:var(--text-tertiary)"></iconify-icon>
           <iconify-icon icon={toolIcon(tool.name)} width="14" style="color:var(--text-tertiary);flex:0 0 auto"></iconify-icon>

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -212,7 +212,7 @@
   // The last tool card auto-collapses the instant its turn stops running,
   // which — bound straight to <details open> — hides the content in one
   // frame and reads as a flash/bug. `closingIds` keeps that one card's
-  // <details> forced open for a couple seconds while a CSS transition (see
+  // <details> forced open for a beat while a CSS transition (see
   // .tool-body.auto-closing) shrinks it first, so the native collapse that
   // finally lands is invisible.
   //
@@ -233,12 +233,14 @@
   // flush later. That reopen fires a toggle whose open=true diverges from the
   // now-false default, so applyToolToggle records it as a user "keep open"
   // override — and when the animation ends and closingIds clears, that stale
-  // override snaps the card back open (shrink 2s, then pop back). Running
+  // override snaps the card back open (animated shrink, then pop back). Running
   // before the DOM update keeps `open` true continuously, so no toggle fires
   // at all.
+  // Slightly longer than the CSS transition so the shrink always finishes
+  // before the <details> is allowed to natively close.
   let closingIds = $state<Record<string, boolean>>({})
   let prevRunning: boolean | undefined
-  const AUTO_CLOSE_MS = 2000
+  const AUTO_CLOSE_MS = 750
   $effect.pre(() => {
     const ts = tools ?? []
     if (ts.length === 0) return
@@ -549,17 +551,17 @@
 /* Chevron rotates from ▸ (collapsed) to ▾ (open). */
 .chev { transition: transform 0.15s ease; flex: 0 0 auto; }
 details[open] > summary .chev { transform: rotate(90deg); }
-/* Auto-collapse animation: a default-driven close (last tool losing that
-   status, or the group finishing) shrinks this wrapper to nothing over 2s
-   before the <details> is actually allowed to close, so the native collapse
-   that follows is invisible instead of an instant flash. A user click still
-   closes natively/instantly — untouched here. The base rule pins
+/* Auto-collapse animation: when the turn finishes, this wrapper shrinks to
+   nothing before the <details> is actually allowed to close (AUTO_CLOSE_MS
+   in the script keeps it forced open just past this duration), so the native
+   collapse that follows is invisible instead of an instant flash. A user
+   click still closes natively/instantly — untouched here. The base rule pins
    transition-duration to 0s explicitly (not just omits it) — some engines
    resolve a class-removal transition from the style being left rather than
-   the one being entered, which would otherwise replay the 2s shrink in
-   reverse as a spurious "expand" animation once auto-closing is cleared. */
+   the one being entered, which would otherwise replay the shrink in reverse
+   as a spurious "expand" animation once auto-closing is cleared. */
 .tool-body { display: grid; grid-template-rows: 1fr; transition: grid-template-rows 0s; }
-.tool-body.auto-closing { grid-template-rows: 0fr; transition: grid-template-rows 2s ease; }
+.tool-body.auto-closing { grid-template-rows: 0fr; transition: grid-template-rows 0.6s ease; }
 .tool-body-inner { overflow: hidden; min-height: 0; }
 /* todo_write checklist */
 .todo-list { border-top: 1px solid var(--border-table); padding: 10px 14px; display: flex; flex-direction: column; gap: 8px; }

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -3,7 +3,7 @@
   import { activeSessionId, showToast } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
-  import { toolOpenState, applyToolToggle, defaultToolOpen } from '../../lib/toolFold'
+  import { toolOpenState, applyToolToggle } from '../../lib/toolFold'
 
   // Tracks which overwrite-undo buttons have already fired, keyed by tool id.
   let undone = $state<Record<string, boolean>>({})
@@ -209,40 +209,42 @@
   // re-render revert a manual collapse of the auto-opened last tool.
   let toolOpen = $state<Record<string, boolean>>({})
 
-  // A card whose default flips open->closed on its own (the last tool loses
-  // that status, or the whole group stops running) collapses instantly if we
-  // just let <details open> follow the default — the content is hidden by the
-  // browser in one frame, which reads as a flash/bug. `closingIds` keeps such
-  // a card's <details> forced open for a couple seconds while a CSS max-height
-  // transition (see .tool-body.auto-closing) shrinks it first, so the native
-  // collapse that finally lands is invisible. A user-driven click still closes
-  // instantly (native <details> behaviour, untouched here) — only the
-  // no-override, default-driven collapse gets animated.
+  // The last tool card auto-collapses the instant its turn stops running,
+  // which — bound straight to <details open> — hides the content in one
+  // frame and reads as a flash/bug. `closingIds` keeps that one card's
+  // <details> forced open for a couple seconds while a CSS transition (see
+  // .tool-body.auto-closing) shrinks it first, so the native collapse that
+  // finally lands is invisible.
+  //
+  // This only fires on the group-level running->not-running edge (the turn
+  // actually finishing), not on every default flip: the last tool also loses
+  // its auto-open default the instant a *later* tool call starts and takes
+  // over as the new last one — collapsing the outgoing card there stays
+  // instant, matching how it always worked, because animating it made the
+  // outgoing card's shrink and the incoming card's arrival read as if both
+  // were "expanding" together.
+  //
+  // A user-driven click still closes instantly (native <details> behaviour,
+  // untouched here) — checking toolOpen[id] here skips a card the user
+  // already has an explicit override on.
   let closingIds = $state<Record<string, boolean>>({})
-  let prevAutoOpen: Record<string, boolean> = {}
+  let prevRunning: boolean | undefined
   const AUTO_CLOSE_MS = 2000
   $effect(() => {
     const ts = tools ?? []
     if (ts.length === 0) return
-    const last = ts[ts.length - 1]?.id
     const running = ts.some((t) => !t.done && !t.error)
-    for (const tool of ts) {
-      if (toolOpen[tool.id] !== undefined) {
-        delete prevAutoOpen[tool.id]
-        continue
-      }
-      const target = defaultToolOpen(tool, last, running)
-      if (prevAutoOpen[tool.id] === true && target === false) {
-        closingIds = { ...closingIds, [tool.id]: true }
-        const id = tool.id
-        setTimeout(() => {
-          const next = { ...closingIds }
-          delete next[id]
-          closingIds = next
-        }, AUTO_CLOSE_MS)
-      }
-      prevAutoOpen[tool.id] = target
+    const last = ts[ts.length - 1]
+    if (prevRunning === true && running === false && last && !last.error && toolOpen[last.id] === undefined) {
+      const id = last.id
+      closingIds = { ...closingIds, [id]: true }
+      setTimeout(() => {
+        const next = { ...closingIds }
+        delete next[id]
+        closingIds = next
+      }, AUTO_CLOSE_MS)
     }
+    prevRunning = running
   })
 
   // todo_write renders its checklist from the tool args.
@@ -526,8 +528,12 @@ details[open] > summary .chev { transform: rotate(90deg); }
    status, or the group finishing) shrinks this wrapper to nothing over 2s
    before the <details> is actually allowed to close, so the native collapse
    that follows is invisible instead of an instant flash. A user click still
-   closes natively/instantly — untouched here. */
-.tool-body { display: grid; grid-template-rows: 1fr; }
+   closes natively/instantly — untouched here. The base rule pins
+   transition-duration to 0s explicitly (not just omits it) — some engines
+   resolve a class-removal transition from the style being left rather than
+   the one being entered, which would otherwise replay the 2s shrink in
+   reverse as a spurious "expand" animation once auto-closing is cleared. */
+.tool-body { display: grid; grid-template-rows: 1fr; transition: grid-template-rows 0s; }
 .tool-body.auto-closing { grid-template-rows: 0fr; transition: grid-template-rows 2s ease; }
 .tool-body-inner { overflow: hidden; min-height: 0; }
 /* todo_write checklist */

--- a/web/src/lib/toolFold.test.ts
+++ b/web/src/lib/toolFold.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { defaultToolOpen, toolOpenState, applyToolToggle, type ToolLike } from './toolFold'
+import { defaultToolOpen, toolOpenState, applyToolToggle, autoCloseAction, type ToolLike } from './toolFold'
 
 const tool = (id: string, error?: unknown): ToolLike => ({ id, error })
 
@@ -67,5 +67,46 @@ describe('toolOpenState + applyToolToggle', () => {
     applyToolToggle(ov, errored, 'b', true, false)
     expect(ov).toEqual({ a: false })
     expect(toolOpenState(ov, errored, 'b', true)).toBe(false)
+  })
+})
+
+describe('autoCloseAction', () => {
+  const tools = [tool('a'), tool('b')]
+
+  it('starts the animated close of the last card on the running->false edge', () => {
+    expect(autoCloseAction(true, false, tools, {}, 0)).toEqual({ kind: 'start', id: 'b' })
+  })
+
+  it('does not start on first render (history replay lands already-done tools)', () => {
+    expect(autoCloseAction(undefined, false, tools, {}, 0)).toBeNull()
+  })
+
+  it('does not re-start while already stopped', () => {
+    expect(autoCloseAction(false, false, tools, {}, 0)).toBeNull()
+  })
+
+  it('skips an error card — those stay open by default, nothing to animate', () => {
+    expect(autoCloseAction(true, false, [tool('a'), tool('b', 'boom')], {}, 0)).toBeNull()
+  })
+
+  it('skips a card the user holds an explicit override on', () => {
+    expect(autoCloseAction(true, false, tools, { b: false }, 0)).toBeNull()
+    expect(autoCloseAction(true, false, tools, { b: true }, 0)).toBeNull()
+  })
+
+  // A new tool call arriving before the previous card finished shrinking must
+  // land the old card instantly — otherwise its shrink overlaps the new card's
+  // arrival and the pair reads as everything animating open at once.
+  it('cancels an in-flight close when the group starts running again', () => {
+    expect(autoCloseAction(false, true, tools, {}, 1)).toEqual({ kind: 'cancel' })
+  })
+
+  it('does nothing while running with no close in flight', () => {
+    expect(autoCloseAction(false, true, tools, {}, 0)).toBeNull()
+    expect(autoCloseAction(true, true, tools, {}, 0)).toBeNull()
+  })
+
+  it('handles an empty tool list', () => {
+    expect(autoCloseAction(true, false, [], {}, 0)).toBeNull()
   })
 })

--- a/web/src/lib/toolFold.ts
+++ b/web/src/lib/toolFold.ts
@@ -49,3 +49,33 @@ export function applyToolToggle(
   if (open === defaultToolOpen(tool, lastId, streaming)) delete overrides[tool.id]
   else overrides[tool.id] = open
 }
+
+// What the auto-close animation should do on a render where the group's
+// running state may have changed.
+//
+// 'start' — the group just went running->not-running: begin the animated close
+// of the auto-opened last card (unless it's an error card, which stays open by
+// default, or the user holds an explicit override on it).
+//
+// 'cancel' — the group is running again while a close animation is still in
+// flight: a new tool call arrived before the previous card finished shrinking.
+// Land the old card instantly, otherwise its shrink overlaps the new card's
+// arrival and the pair reads as everything animating open at once.
+//
+// null — nothing to do. Note prevRunning === undefined (first render, e.g. a
+// replayed history transcript whose tools are already done) is not an edge.
+export type AutoCloseAction = { kind: 'start'; id: string } | { kind: 'cancel' } | null
+
+export function autoCloseAction(
+  prevRunning: boolean | undefined,
+  running: boolean,
+  tools: ToolLike[],
+  overrides: Record<string, boolean>,
+  closingCount: number,
+): AutoCloseAction {
+  if (running) return closingCount > 0 ? { kind: 'cancel' } : null
+  if (prevRunning !== true) return null
+  const last = tools[tools.length - 1]
+  if (!last || last.error || overrides[last.id] !== undefined) return null
+  return { kind: 'start', id: last.id }
+}

--- a/web/src/views/TasksView.svelte
+++ b/web/src/views/TasksView.svelte
@@ -68,10 +68,15 @@
         // the groups snapshot — a cron run files its session into the task's
         // group server-side, but that store is otherwise only ever populated
         // once at sidebar mount, so without this the session would render
-        // ungrouped until a manual reload (#1699).
-        const [data, org] = await Promise.all([api.listSessions(), api.listSessionGroups()])
+        // ungrouped until a manual reload (#1699). The groups fetch is
+        // best-effort: the task already started, so its failure must not
+        // abort activating the session or read as "Failed to run task".
+        const [data, org] = await Promise.all([
+          api.listSessions(),
+          api.listSessionGroups().catch(() => null),
+        ])
         sessions.set(data.sessions ?? [])
-        sessionGroups.set(org.groups)
+        if (org) sessionGroups.set(org.groups)
         setActiveSession(res.session_id)
         view.set('chat')
       }

--- a/web/src/views/TasksView.svelte
+++ b/web/src/views/TasksView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { tasks, showToast, sessions, activeSessionId, view, setActiveSession, openAgentSession } from '../lib/stores'
+  import { tasks, showToast, sessions, sessionGroups, activeSessionId, view, setActiveSession, openAgentSession } from '../lib/stores'
   import { t, tr, locale } from '../lib/i18n'
   import { confirmDialog } from '../lib/confirm'
   import { get } from 'svelte/store'
@@ -64,9 +64,14 @@
       if (res.session_id) {
         // Refresh the session list so the new session shows in the sidebar,
         // then activate it and switch to chat. The streamed turn events will
-        // appear automatically once the WebSocket subscribes.
-        const data = await api.listSessions()
+        // appear automatically once the WebSocket subscribes. Also refresh
+        // the groups snapshot — a cron run files its session into the task's
+        // group server-side, but that store is otherwise only ever populated
+        // once at sidebar mount, so without this the session would render
+        // ungrouped until a manual reload (#1699).
+        const [data, org] = await Promise.all([api.listSessions(), api.listSessionGroups()])
         sessions.set(data.sessions ?? [])
+        sessionGroups.set(org.groups)
         setActiveSession(res.session_id)
         view.set('chat')
       }


### PR DESCRIPTION
## Summary
Two web UI fixes, plus review follow-ups:

**1. Tool card auto-collapse animation**
- The last tool card in a `ToolGroup` auto-opens while tools run and auto-collapses when none are in flight; binding `<details open>` straight to that default made the collapse instant — a one-frame flash that read as a bug.
- The `<details>` now stays forced open ~750ms while a CSS `grid-template-rows` transition (0.6s) shrinks its content first, so the native collapse that lands afterward is invisible.
- The close decision is a pure function (`autoCloseAction` in `toolFold.ts`, unit-tested): it starts only on the group's running→not-running edge, skips error cards and user-overridden cards, and **cancels** an in-flight close the moment the group runs again (a next tool call arriving mid-shrink lands the old card instantly, so the outgoing shrink never overlaps the incoming card).
- The trigger runs in `$effect.pre` so the `open` attribute never flips false→true across flushes — a post-DOM effect fired a reopen toggle that got recorded as a user "keep open" override and snapped the card back open after the animation.
- User-driven clicks still collapse natively/instantly.

**2. Cron session appears ungrouped (or not at all) until reload — follow-up to #1699**
- `sessionGroups` is only populated once, at `Sidebar.svelte` mount; nothing refetched it live.
- A scheduled cron fire emitted **no global WS event at all**: every `RunTask` broadcast is per-session (dropped for a session no tab subscribed to), and cron sessions never trigger the auto-title `session_renamed` path — they're created with a date-time title, which `IsAutoNamePlaceholder` rejects.
- Fix: `CreateSession` (scheduler runner) now broadcasts the existing global `session_created` event **after** filing the session into its task group; the web app handles `session_created` by refetching both the session list and the groups snapshot. This also gives branch/fork sessions live sidebar presence in other tabs.
- `TasksView`'s Run Now handler refetches groups alongside sessions (best-effort — a groups failure no longer aborts session activation or shows a misleading "Failed to run task" toast).

An isolated code review ran over this branch; its critical finding (the `session_renamed`-based half of fix 2 was built on a false premise about cron auto-titles) and important finding (animation fired on mid-turn tool-round gaps) are addressed in the last commit.

## Test plan
- [x] `svelte-check` — 0 errors
- [x] `vitest run src/lib/toolFold.test.ts` — 17 passed (8 new for `autoCloseAction`)
- [x] `go test -race ./internal/server/`, `go vet`, `gofmt`
- [x] `make web-build`
- [ ] Manual: turn with several tool calls — previously-last card shrinks smoothly (~0.6s) when the turn finishes; mid-turn tool handoffs stay instant
- [ ] Manual: scheduled cron fire (not Run Now) with the tab already open — session appears nested under its task's group without a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)