### PR TITLE
fix(web): keep the last tool card expanded when the turn ends

### DIFF
--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -3,7 +3,7 @@
   import { activeSessionId, showToast } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
-  import { toolOpenState, applyToolToggle, autoCloseAction } from '../../lib/toolFold'
+  import { toolOpenState, applyToolToggle, keepOpenAction } from '../../lib/toolFold'
 
   // Tracks which overwrite-undo buttons have already fired, keyed by tool id.
   let undone = $state<Record<string, boolean>>({})
@@ -209,67 +209,54 @@
   // re-render revert a manual collapse of the auto-opened last tool.
   let toolOpen = $state<Record<string, boolean>>({})
 
-  // The last tool card auto-collapses the instant the group stops running,
-  // which — bound straight to <details open> — hides the content in one
-  // frame and reads as a flash/bug. `closingIds` keeps that one card's
-  // <details> forced open for a beat while a CSS transition (see
-  // .tool-body.auto-closing) shrinks it first, so the native collapse that
-  // finally lands is invisible.
+  // The default open state collapses the last card the instant the group stops
+  // running (defaultToolOpen is false once streaming ends). Bound straight to
+  // <details open>, that collapse yanked the page around right as the user was
+  // reading the output — so on the running->not-running edge the last card is
+  // *pinned* open instead and simply stays expanded.
   //
   // "Stops running" means no in-flight tool in the group right now — usually
   // the turn finishing, but the same dip also happens between sequential tool
   // rounds inside one turn (result received, next call still an LLM round-trip
-  // away). If the next call arrives while the previous card is still
-  // shrinking, the 'cancel' branch in autoCloseAction lands it instantly —
-  // otherwise the outgoing shrink overlaps the incoming card and the pair
-  // reads as everything animating open at once.
+  // away). When the next round starts, the 'clear' branch in keepOpenAction
+  // drops the pins, so the previous card collapses as the new last tool opens —
+  // the same handoff as mid-turn.
   //
-  // A user-driven click still closes instantly (native <details> behaviour,
-  // untouched here); autoCloseAction skips a card the user holds an explicit
-  // override on.
+  // A user click still closes a pinned card instantly (onToggle drops the pin);
+  // keepOpenAction skips a card the user holds an explicit override on.
   //
   // This must be $effect.pre, not $effect: a post-DOM effect would let the
   // running->false render close the <details> first and force it back open a
   // flush later. That reopen fires a toggle whose open=true diverges from the
-  // now-false default, so applyToolToggle records it as a user "keep open"
-  // override — and when the animation ends and closingIds clears, that stale
-  // override snaps the card back open (animated shrink, then pop back). Running
-  // before the DOM update keeps `open` true continuously, so no toggle fires
-  // at all.
-  // AUTO_CLOSE_MS is slightly longer than the CSS transition so the shrink
-  // always finishes before the <details> is allowed to natively close.
-  let closingIds = $state<Record<string, boolean>>({})
+  // now-false default, so applyToolToggle would record it as a user "keep
+  // open" override — which the 'clear' on the next round could not collapse.
+  // Running before the DOM update keeps `open` true continuously, so no toggle
+  // fires at all.
+  let pinnedIds = $state<Record<string, boolean>>({})
   let prevRunning: boolean | undefined
-  const AUTO_CLOSE_MS = 750
   $effect.pre(() => {
     const ts = tools ?? []
     if (ts.length === 0) return
     const running = ts.some((t) => !t.done && !t.error)
-    const action = autoCloseAction(prevRunning, running, ts, toolOpen, Object.keys(closingIds).length)
+    const action = keepOpenAction(prevRunning, running, ts, toolOpen, Object.keys(pinnedIds).length)
     prevRunning = running
-    if (action?.kind === 'start') {
-      const id = action.id
-      closingIds = { ...closingIds, [id]: true }
-      setTimeout(() => {
-        const next = { ...closingIds }
-        delete next[id]
-        closingIds = next
-      }, AUTO_CLOSE_MS)
-    } else if (action?.kind === 'cancel') {
-      closingIds = {}
+    if (action?.kind === 'pin') {
+      pinnedIds = { ...pinnedIds, [action.id]: true }
+    } else if (action?.kind === 'clear') {
+      pinnedIds = {}
     }
   })
 
-  // Toggle handler that is animation-aware: while a card is mid-animated-close,
-  // the only genuine toggle is the user clicking to collapse it early — end the
-  // animation so the native close sticks, and record no override either way
-  // (the forced-open state must never be mistaken for a user choice).
+  // Toggle handler that is pin-aware: while a card is pinned open, the only
+  // genuine toggle is the user clicking to collapse it — drop the pin so the
+  // native close sticks, and record no override either way (the pinned state
+  // must never be mistaken for a user choice).
   function onToggle(tool: any, lastId: string | undefined, running: boolean, open: boolean) {
-    if (closingIds[tool.id]) {
+    if (pinnedIds[tool.id]) {
       if (!open) {
-        const next = { ...closingIds }
+        const next = { ...pinnedIds }
         delete next[tool.id]
-        closingIds = next
+        pinnedIds = next
       }
       return
     }
@@ -347,8 +334,7 @@
            ellipsizes it. Surfacing it via `title` + selectable text lets the
            user read/copy the whole thing despite the truncation. -->
       {@const argText = tool.summary || (tool.args ? argSummary(tool.name, tool.args) : '')}
-      {@const isClosing = !!closingIds[tool.id]}
-      <details open={toolOpenState(toolOpen, tool, lastId, anyRunning) || isClosing} ontoggle={(e) => onToggle(tool, lastId, anyRunning, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
+      <details open={toolOpenState(toolOpen, tool, lastId, anyRunning) || !!pinnedIds[tool.id]} ontoggle={(e) => onToggle(tool, lastId, anyRunning, (e.currentTarget as HTMLDetailsElement).open)} class="tool-item">
         <summary class="tool-summary">
           <iconify-icon icon="lucide:chevron-right" width="13" class="chev" style="color:var(--text-tertiary)"></iconify-icon>
           <iconify-icon icon={toolIcon(tool.name)} width="14" style="color:var(--text-tertiary);flex:0 0 auto"></iconify-icon>
@@ -393,7 +379,7 @@
           </span>
         </summary>
 
-        <div class="tool-body" class:auto-closing={isClosing}><div class="tool-body-inner">
+        <div class="tool-body"><div class="tool-body-inner">
         {#if tool.error}
           <div class="error-output mono">{tool.error}</div>
         {:else if fErr}
@@ -553,17 +539,7 @@
 /* Chevron rotates from ▸ (collapsed) to ▾ (open). */
 .chev { transition: transform 0.15s ease; flex: 0 0 auto; }
 details[open] > summary .chev { transform: rotate(90deg); }
-/* Auto-collapse animation: when the turn finishes, this wrapper shrinks to
-   nothing before the <details> is actually allowed to close (AUTO_CLOSE_MS
-   in the script keeps it forced open just past this duration), so the native
-   collapse that follows is invisible instead of an instant flash. A user
-   click still closes natively/instantly — untouched here. The base rule pins
-   transition-duration to 0s explicitly (not just omits it) — some engines
-   resolve a class-removal transition from the style being left rather than
-   the one being entered, which would otherwise replay the shrink in reverse
-   as a spurious "expand" animation once auto-closing is cleared. */
-.tool-body { display: grid; grid-template-rows: 1fr; transition: grid-template-rows 0s; }
-.tool-body.auto-closing { grid-template-rows: 0fr; transition: grid-template-rows 0.6s ease; }
+.tool-body { display: grid; grid-template-rows: 1fr; }
 .tool-body-inner { overflow: hidden; min-height: 0; }
 /* todo_write checklist */
 .todo-list { border-top: 1px solid var(--border-table); padding: 10px 14px; display: flex; flex-direction: column; gap: 8px; }

--- a/web/src/lib/toolFold.test.ts
+++ b/web/src/lib/toolFold.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { defaultToolOpen, toolOpenState, applyToolToggle, autoCloseAction, type ToolLike } from './toolFold'
+import { defaultToolOpen, toolOpenState, applyToolToggle, keepOpenAction, type ToolLike } from './toolFold'
 
 const tool = (id: string, error?: unknown): ToolLike => ({ id, error })
 
@@ -70,43 +70,42 @@ describe('toolOpenState + applyToolToggle', () => {
   })
 })
 
-describe('autoCloseAction', () => {
+describe('keepOpenAction', () => {
   const tools = [tool('a'), tool('b')]
 
-  it('starts the animated close of the last card on the running->false edge', () => {
-    expect(autoCloseAction(true, false, tools, {}, 0)).toEqual({ kind: 'start', id: 'b' })
+  it('pins the last card open on the running->false edge', () => {
+    expect(keepOpenAction(true, false, tools, {}, 0)).toEqual({ kind: 'pin', id: 'b' })
   })
 
-  it('does not start on first render (history replay lands already-done tools)', () => {
-    expect(autoCloseAction(undefined, false, tools, {}, 0)).toBeNull()
+  it('does not pin on first render (history replay lands already-done tools)', () => {
+    expect(keepOpenAction(undefined, false, tools, {}, 0)).toBeNull()
   })
 
-  it('does not re-start while already stopped', () => {
-    expect(autoCloseAction(false, false, tools, {}, 0)).toBeNull()
+  it('does not re-pin while already stopped', () => {
+    expect(keepOpenAction(false, false, tools, {}, 0)).toBeNull()
   })
 
-  it('skips an error card — those stay open by default, nothing to animate', () => {
-    expect(autoCloseAction(true, false, [tool('a'), tool('b', 'boom')], {}, 0)).toBeNull()
+  it('skips an error card — those stay open by default, nothing to pin', () => {
+    expect(keepOpenAction(true, false, [tool('a'), tool('b', 'boom')], {}, 0)).toBeNull()
   })
 
   it('skips a card the user holds an explicit override on', () => {
-    expect(autoCloseAction(true, false, tools, { b: false }, 0)).toBeNull()
-    expect(autoCloseAction(true, false, tools, { b: true }, 0)).toBeNull()
+    expect(keepOpenAction(true, false, tools, { b: false }, 0)).toBeNull()
+    expect(keepOpenAction(true, false, tools, { b: true }, 0)).toBeNull()
   })
 
-  // A new tool call arriving before the previous card finished shrinking must
-  // land the old card instantly — otherwise its shrink overlaps the new card's
-  // arrival and the pair reads as everything animating open at once.
-  it('cancels an in-flight close when the group starts running again', () => {
-    expect(autoCloseAction(false, true, tools, {}, 1)).toEqual({ kind: 'cancel' })
+  // A new tool round arriving must release the pinned card so it collapses as
+  // the new last tool opens — the same handoff as between mid-turn tools.
+  it('clears the pins when the group starts running again', () => {
+    expect(keepOpenAction(false, true, tools, {}, 1)).toEqual({ kind: 'clear' })
   })
 
-  it('does nothing while running with no close in flight', () => {
-    expect(autoCloseAction(false, true, tools, {}, 0)).toBeNull()
-    expect(autoCloseAction(true, true, tools, {}, 0)).toBeNull()
+  it('does nothing while running with no pins held', () => {
+    expect(keepOpenAction(false, true, tools, {}, 0)).toBeNull()
+    expect(keepOpenAction(true, true, tools, {}, 0)).toBeNull()
   })
 
   it('handles an empty tool list', () => {
-    expect(autoCloseAction(true, false, [], {}, 0)).toBeNull()
+    expect(keepOpenAction(true, false, [], {}, 0)).toBeNull()
   })
 })

--- a/web/src/lib/toolFold.ts
+++ b/web/src/lib/toolFold.ts
@@ -50,32 +50,35 @@ export function applyToolToggle(
   else overrides[tool.id] = open
 }
 
-// What the auto-close animation should do on a render where the group's
-// running state may have changed.
+// What the end-of-run keep-open handling should do on a render where the
+// group's running state may have changed.
 //
-// 'start' — the group just went running->not-running: begin the animated close
-// of the auto-opened last card (unless it's an error card, which stays open by
-// default, or the user holds an explicit override on it).
+// 'pin' — the group just went running->not-running: pin the auto-opened last
+// card open so the default (closed once streaming stops) doesn't collapse it.
+// This collapse used to be animated shut, but the shrink shifted the page
+// under the user right as they were reading the output — the card now simply
+// stays expanded. Skipped for an error card (open by default anyway) or one
+// the user holds an explicit override on.
 //
-// 'cancel' — the group is running again while a close animation is still in
-// flight: a new tool call arrived before the previous card finished shrinking.
-// Land the old card instantly, otherwise its shrink overlaps the new card's
-// arrival and the pair reads as everything animating open at once.
+// 'clear' — the group is running again: a new tool round arrived, so drop the
+// pins and let the pinned card follow the default again — it collapses as the
+// new last tool opens, exactly like the mid-turn handoff between tools.
 //
 // null — nothing to do. Note prevRunning === undefined (first render, e.g. a
-// replayed history transcript whose tools are already done) is not an edge.
-export type AutoCloseAction = { kind: 'start'; id: string } | { kind: 'cancel' } | null
+// replayed history transcript whose tools are already done) is not an edge —
+// replayed groups stay fully collapsed.
+export type KeepOpenAction = { kind: 'pin'; id: string } | { kind: 'clear' } | null
 
-export function autoCloseAction(
+export function keepOpenAction(
   prevRunning: boolean | undefined,
   running: boolean,
   tools: ToolLike[],
   overrides: Record<string, boolean>,
-  closingCount: number,
-): AutoCloseAction {
-  if (running) return closingCount > 0 ? { kind: 'cancel' } : null
+  pinnedCount: number,
+): KeepOpenAction {
+  if (running) return pinnedCount > 0 ? { kind: 'clear' } : null
   if (prevRunning !== true) return null
   const last = tools[tools.length - 1]
   if (!last || last.error || overrides[last.id] !== undefined) return null
-  return { kind: 'start', id: last.id }
+  return { kind: 'pin', id: last.id }
 }


### PR DESCRIPTION
## Problem

The last tool card in a tool group auto-collapsed the moment the group stopped running, with a slow shrink animation (#1708). In practice the shrink shifts the page under the user right as they are reading the output — it reads as jank, not polish.

## Change

Replace the animated close with a pin that keeps the last card expanded:

- On the running→not-running edge, the last tool card is pinned open and simply stays expanded — no collapse, no animation, no layout shift.
- When the next tool round starts, the pin is dropped, so the previous card collapses as the new last tool opens — the same handoff as between mid-turn tools.
- A user click still closes a pinned card instantly, and error cards / explicit user overrides are untouched.
- Replayed history transcripts still render fully collapsed (first render is not a running→false edge).

Removes the `closingIds` timer machinery and the `.auto-closing` CSS transition that existed only for the animated close. `autoCloseAction` becomes `keepOpenAction` in `web/src/lib/toolFold.ts`, tests updated accordingly.

## Testing

- `vitest run toolFold` — 17 tests pass
- `svelte-check` — 0 errors
- `make web-build` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)