### PR TITLE
chore: bump version to 1.12.29

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.28"
+var Version = "1.12.29"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the v1.12.29 release. Changes since v1.12.28:

- #1710 fix(web): keep the last tool card expanded when the turn ends
- #1708 fix(web): tool card auto-collapse animation + cron session group live refresh
- #1706 feat(landing): demo video carousel with seek + play/pause controls
- #1705 feat(mobile): batch 1b — chat detail wired to the live stream
- #1704 feat(mobile): batch 1a — sessions feed wired to live data
- #1703 feat(mobile): batch 0 — mobile shell scaffold + neutral tokens
- #1702 docs(mobile): mobile UI implementation plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)