### PR TITLE
fix(web): cap message rail length to the conversation pane height

### DIFF
--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -2215,6 +2215,11 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
    the evenly-spaced column. */
 .msg-rail-node {
   position: relative; width: 20px; height: 8px;
+  /* Allow shrinking below the 8px hit area on extremely short panes with many
+     nodes (flex's min-height:auto would otherwise floor each node at 8px and
+     let the column overflow the pane again). Dots may overlap; the column
+     stays bounded. */
+  min-height: 0;
   padding: 0; margin: 0; border: none; background: none;
   display: flex; align-items: center; justify-content: center;
   cursor: pointer; pointer-events: auto; z-index: 2;

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1976,7 +1976,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
       {#if railTicks.length > 1}
         <div class="msg-rail">
-          <div class="msg-rail-inner">
+          <div class="msg-rail-inner" style="height:min(100%, {railTicks.length * 28 - 20}px)">
             <div class="msg-rail-track"></div>
             <div class="msg-rail-fill" style="height:calc((100% - 8px) * {railFillPct / 100})"></div>
             {#each railTicks as tick, i (tick.id)}
@@ -2191,10 +2191,15 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   pointer-events: none; z-index: 8;
   display: flex; align-items: center; justify-content: center;
 }
-/* Evenly-spaced node column, centered; track + fill are scoped to its height. */
+/* Evenly-spaced node column, centered; track + fill are scoped to its height.
+   Height is set inline to min(100%, natural length) — natural = 8px per node +
+   20px per gap (28 * N - 20) — so on short panes the column compresses evenly
+   via space-between instead of keeping its natural length and spilling past
+   the conversation area. */
 .msg-rail-inner {
   position: relative;
-  display: flex; flex-direction: column; align-items: center; gap: 20px;
+  display: flex; flex-direction: column; align-items: center;
+  justify-content: space-between;
 }
 /* Background track (node-column height) + blue progress fill (top → scroll). */
 .msg-rail-track, .msg-rail-fill {

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1171,6 +1171,10 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   // the viewport currently sits within the conversation.
   let railActive = $state(0)
   let railFillPct = $state(0)
+  // How much the node column is compressed versus its natural length (1 = not
+  // at all). Drives --rail-scale so the dots shrink along with the spacing on
+  // short panes instead of staying full-size while crammed together.
+  let railScale = $state(1)
 
   const RAIL_THROTTLE_MS = 100
   let railTimer: ReturnType<typeof setTimeout> | null = null
@@ -1184,6 +1188,12 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       ticks.push({ id: m.id, preview: (m.content || '').slice(0, 160) })
     }
     railTicks = ticks
+    // Compression factor: available rail height (pane minus the 8px top/bottom
+    // insets of .msg-rail) over the column's natural length (28px per node
+    // minus the trailing gap). Clamped to 1 so uncompressed panes are unscaled.
+    const natural = ticks.length * 28 - 20
+    const avail = (messagesEl?.clientHeight ?? 0) - 16
+    railScale = ticks.length > 1 && avail > 0 ? Math.min(1, avail / natural) : 1
     syncRailScroll()
   }
 
@@ -1249,6 +1259,10 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     if (!content) return
     const ro = new ResizeObserver(scheduleRailRecompute)
     ro.observe(content)
+    // Also watch the scroll pane itself: a height-only viewport resize changes
+    // the rail's available height (railScale) without reflowing the content,
+    // so observing the content alone would miss it.
+    if (messagesEl) ro.observe(messagesEl)
     return () => ro.disconnect()
   })
 
@@ -1976,7 +1990,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
       {#if railTicks.length > 1}
         <div class="msg-rail">
-          <div class="msg-rail-inner" style="height:min(100%, {railTicks.length * 28 - 20}px)">
+          <div class="msg-rail-inner" style="height:min(100%, {railTicks.length * 28 - 20}px);--rail-scale:{railScale}">
             <div class="msg-rail-track"></div>
             <div class="msg-rail-fill" style="height:calc((100% - 8px) * {railFillPct / 100})"></div>
             {#each railTicks as tick, i (tick.id)}
@@ -2225,8 +2239,13 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   cursor: pointer; pointer-events: auto; z-index: 2;
 }
 .msg-rail-node:focus-visible { outline: none; }
+/* Dots shrink with the column's compression (--rail-scale, 1 on panes tall
+   enough for the natural length) so a crammed rail reads as a smaller minimap
+   instead of full-size dots touching. Floored so they stay visible. */
 .msg-rail-dot {
-  width: 10px; height: 10px; border-radius: 9999px;
+  width: max(6px, calc(10px * var(--rail-scale, 1)));
+  height: max(6px, calc(10px * var(--rail-scale, 1)));
+  border-radius: 9999px;
   background: var(--bg-container); border: 2px solid var(--border);
   transition: width 0.14s ease, height 0.14s ease, background 0.14s ease,
     border-color 0.14s ease, box-shadow 0.14s ease;
@@ -2237,7 +2256,9 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   background: var(--blue-6); border-color: var(--blue-6);
 }
 .msg-rail-node.active .msg-rail-dot {
-  width: 12px; height: 12px; box-shadow: 0 0 0 4px rgba(22,119,255,0.16);
+  width: max(8px, calc(12px * var(--rail-scale, 1)));
+  height: max(8px, calc(12px * var(--rail-scale, 1)));
+  box-shadow: 0 0 0 4px rgba(22,119,255,0.16);
 }
 /* Hover/focus preview card, to the left of the rail, with a caret pointing back
    at the dot. --terminal-bg is the DS's intentionally-dark surface in both

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -2246,7 +2246,11 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   width: max(6px, calc(10px * var(--rail-scale, 1)));
   height: max(6px, calc(10px * var(--rail-scale, 1)));
   border-radius: 9999px;
-  background: var(--bg-container); border: 2px solid var(--border);
+  background: var(--bg-container);
+  /* Border and (below) the active ring scale too: at the 6px floor a fixed 2px
+     border would leave almost no fill, and a fixed 4px ring would cover
+     neighboring dots. */
+  border: max(1.5px, calc(2px * var(--rail-scale, 1))) solid var(--border);
   transition: width 0.14s ease, height 0.14s ease, background 0.14s ease,
     border-color 0.14s ease, box-shadow 0.14s ease;
 }
@@ -2258,7 +2262,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 .msg-rail-node.active .msg-rail-dot {
   width: max(8px, calc(12px * var(--rail-scale, 1)));
   height: max(8px, calc(12px * var(--rail-scale, 1)));
-  box-shadow: 0 0 0 4px rgba(22,119,255,0.16);
+  box-shadow: 0 0 0 max(2px, calc(4px * var(--rail-scale, 1))) rgba(22,119,255,0.16);
 }
 /* Hover/focus preview card, to the left of the rail, with a caret pointing back
    at the dot. --terminal-bg is the DS's intentionally-dark surface in both


### PR DESCRIPTION
## Problem

User report: the timeline rail next to the message flow looks right on large screens, but when the window shrinks its overall length does not shrink with it — the dot column spills past the conversation area toward the composer and looks disproportionate.

## Root cause

`.msg-rail-inner` laid out its nodes with a fixed `gap: 20px`, so the column's total length is `28px × N − 20px` — determined solely by the number of user messages, independent of viewport height. The outer `.msg-rail` tracks the pane height but only vertically centers the column without clipping, so a column taller than the pane overflows both ends. The same overflow also happens on large screens once a conversation has enough user messages.

## Fix

- Cap the column height at `min(100%, natural length)` (inline, since the natural length depends on the tick count) and switch from a fixed gap to `justify-content: space-between`: large panes are unchanged (natural length, original 20px spacing); short panes compress the spacing evenly so the rail always fits within the conversation area.
- `min-height: 0` on the nodes so extremely short panes with many messages can compress past the 8px hit-area floor instead of overflowing again (review follow-up).
- Dots scale down with the compression factor (10px → 6px floor; active 12px → 8px floor) via a `--rail-scale` CSS var, so a crammed rail reads as a smaller minimap instead of full-size dots touching. The rail ResizeObserver additionally watches the scroll pane itself, since a height-only viewport resize changes the available height without reflowing the content.

## Testing

- `svelte-check`: 0 errors / 0 warnings
- `make web-build` passes
- Isolated code review: no critical/important findings; the one minor finding (8px node floor) is fixed in the follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)