### PR TITLE
chore: bump version to 1.12.30

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.29"
+var Version = "1.12.30"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Bump `internal/version.Version` from 1.12.29 to 1.12.30.

## Test plan
- N/A (version string only).