### PR TITLE
fix(blog): unify default locale (no-prefix = English) across landing/docs/blog

### DIFF
--- a/blog/README.md
+++ b/blog/README.md
@@ -24,9 +24,9 @@ originalSlug: your-post-slug
 
 ## Bilingual support
 
-- Chinese posts live in `src/content/posts/zh/` and are served at `/blog/posts/<slug>/`.
-- English posts live in `src/content/posts/en/` and are served at `/blog/posts/en/<slug>/`.
-- The homepage has both `/blog/` (Chinese) and `/blog/en/` (English) versions.
+- English posts live in `src/content/posts/en/` and are served at `/blog/posts/<slug>/`.
+- Chinese posts live in `src/content/posts/zh/` and are served at `/blog/posts/zh/<slug>/`.
+- The homepage has both `/blog/` (English) and `/blog/zh/` (Chinese) versions.
 - Each post and page includes a language switcher to the corresponding alternate version.
 - Use `originalSlug` to link the two language versions of the same post.
 

--- a/blog/astro.config.mjs
+++ b/blog/astro.config.mjs
@@ -10,7 +10,7 @@ export default defineConfig({
 		sitemap({
 			customPages: [
 				'https://octo-agent.dev/blog/',
-				'https://octo-agent.dev/blog/en/',
+				'https://octo-agent.dev/blog/zh/',
 			],
 		}),
 	],

--- a/blog/public/octo-nav.js
+++ b/blog/public/octo-nav.js
@@ -117,13 +117,13 @@
 			const toggle = this.hasAttribute('lang-toggle');
 			const isZh = loc === 'zh';
 			const t = T[loc];
-			const blogHome = isZh ? '/blog/' : '/blog/en/';
+			const blogHome = isZh ? '/blog/zh/' : '/blog/';
 			const docsHref = isZh ? '/docs/zh/' : '/docs/';
 			const altAttr = this.getAttribute('alt');
 			const altUrl = altAttr == null ? null : parseUrl(altAttr);
 			const altSafe = altUrl && (altUrl.protocol === 'http:' || altUrl.protocol === 'https:')
 				? altUrl.href
-				: isZh ? '/blog/en/' : '/blog/';
+				: isZh ? '/blog/' : '/blog/zh/';
 			const alt = escapeHtml(altSafe);
 			const releases = 'https://github.com/open-octo/octo-agent/releases/latest';
 			const repo = 'https://github.com/open-octo/octo-agent';
@@ -168,7 +168,7 @@
 			const isZh = loc === 'zh';
 			const t = T[loc];
 			const docsHref = isZh ? '/docs/zh/' : '/docs/';
-			const blogHome = isZh ? '/blog/' : '/blog/en/';
+			const blogHome = isZh ? '/blog/zh/' : '/blog/';
 			const year = new Date().getFullYear();
 			const root = this.shadowRoot || this.attachShadow({ mode: 'open' });
 			root.innerHTML = `<style>${FOOT}</style>

--- a/blog/src/layouts/BlogPost.astro
+++ b/blog/src/layouts/BlogPost.astro
@@ -18,13 +18,13 @@ const siteUrl = 'https://octo-agent.dev';
 const pageSlug = slug ?? '';
 const canonicalUrl = `${siteUrl}/blog/posts/${pageSlug}/`;
 
-const blogHome = isZh ? '/blog/' : '/blog/en/';
+const blogHome = isZh ? '/blog/zh/' : '/blog/';
 const backLabel = isZh ? '返回博客' : 'Back to Blog';
 
 const alternateLocale = isZh ? 'en' : 'zh';
 const alternateUrl = alternateSlug
-	? `${siteUrl}/blog/posts/${alternateLocale === 'en' ? 'en/' : ''}${alternateSlug}/`
-	: `${siteUrl}/blog/${alternateLocale === 'zh' ? '' : 'en/'}`;
+	? `${siteUrl}/blog/posts/${alternateLocale === 'zh' ? 'zh/' : ''}${alternateSlug}/`
+	: `${siteUrl}/blog/${alternateLocale === 'en' ? '' : 'zh/'}`;
 
 const ogImage = image ? (image.startsWith('http') ? image : `${siteUrl}${image}`) : `${siteUrl}/blog/og-default.svg`;
 const siteName = isZh ? 'octo 博客' : 'octo blog';

--- a/blog/src/pages/index.astro
+++ b/blog/src/pages/index.astro
@@ -5,12 +5,12 @@ import SiteFooter from '../components/SiteFooter.astro';
 import '../styles/blog.css';
 
 const posts = (await getCollection('posts'))
-	.filter((post) => !post.data.draft && post.data.locale === 'zh')
+	.filter((post) => !post.data.draft && post.data.locale === 'en')
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
 const [featured, ...rest] = posts;
 
-const dateFormatter = new Intl.DateTimeFormat('zh-CN', {
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	year: 'numeric',
 	month: 'long',
 	day: 'numeric',
@@ -19,15 +19,14 @@ const href = (post) => `/blog/posts/${post.id.slice(3)}/`;
 
 const siteUrl = 'https://octo-agent.dev';
 const canonicalUrl = `${siteUrl}/blog/`;
-const alternateUrl = `${siteUrl}/blog/en/`;
-const title = 'octo 博客';
-const description =
-	'octo-agent 团队的工程笔记、版本更新与 AI Agent 技术深度文章，分享 Loop Engineering、工具链与实战经验。';
+const alternateUrl = `${siteUrl}/blog/zh/`;
+const title = 'octo blog';
+const description = 'Engineering notes, release updates, and deep dives from the octo-agent team.';
 const ogImage = `${siteUrl}/blog/og-default.svg`;
 ---
 
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -35,13 +34,13 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 		<meta name="description" content={description} />
 		<link rel="canonical" href={canonicalUrl} />
 		<link rel="icon" type="image/svg+xml" href="/blog/favicon.svg" />
-		<link rel="alternate" hreflang="en" href={alternateUrl} />
+		<link rel="alternate" hreflang="zh-CN" href={alternateUrl} />
 
 		<meta property="og:title" content={title} />
 		<meta property="og:description" content={description} />
 		<meta property="og:url" content={canonicalUrl} />
 		<meta property="og:type" content="website" />
-		<meta property="og:locale" content="zh-CN" />
+		<meta property="og:locale" content="en" />
 		<meta property="og:site_name" content={title} />
 		<meta property="og:image" content={ogImage} />
 
@@ -51,28 +50,28 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 		<meta name="twitter:image" content={ogImage} />
 	</head>
 	<body>
-		<SiteHeader locale="zh" active="blog" alternateUrl={alternateUrl} />
+		<SiteHeader locale="en" active="blog" alternateUrl={alternateUrl} />
 
 		<section class="hero">
 			<div class="container">
-				<span class="kicker">Octo 团队的工程笔记</span>
-				<h1>octo 博客</h1>
-				<p>版本说明、Loop Engineering 深度解析，以及构建私密、自托管 AI Agent 的一线实践。</p>
+				<span class="kicker">Engineering notes from the Octo team</span>
+				<h1>octo blog</h1>
+				<p>Release notes, deep dives on Loop Engineering, and field reports on building a private, self-hosted AI agent.</p>
 			</div>
 		</section>
 
 		<main class="post-list">
 			<div class="post-list-head">
-				<h2>最新文章</h2>
+				<h2>Latest posts</h2>
 				<div class="rule"></div>
 			</div>
 
-			{posts.length === 0 && <p>暂无文章。</p>}
+			{posts.length === 0 && <p>No posts yet.</p>}
 
 			{
 				featured && (
 					<a href={href(featured)} class="post-card featured">
-						<span class="flag">精选</span>
+						<span class="flag">Featured</span>
 						<span class="post-card-title">{featured.data.title}</span>
 						<p class="post-card-description">{featured.data.description}</p>
 						<p class="post-card-meta">
@@ -117,6 +116,6 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 			</ul>
 		</main>
 
-		<SiteFooter locale="zh" />
+		<SiteFooter locale="en" />
 	</body>
 </html>

--- a/blog/src/pages/posts/[...slug].astro
+++ b/blog/src/pages/posts/[...slug].astro
@@ -5,7 +5,7 @@ import BlogPost from '../../layouts/BlogPost.astro';
 export async function getStaticPaths() {
 	const posts = await getCollection('posts');
 	return posts.map((post) => {
-		const slug = post.id.startsWith('zh/') ? post.id.slice(3) : post.id;
+		const slug = post.id.startsWith('en/') ? post.id.slice(3) : post.id;
 		const locale = post.data.locale || (post.id.startsWith('zh/') ? 'zh' : 'en');
 		// Find alternate-language version of the same post
 		const alternate = posts.find(

--- a/blog/src/pages/zh/index.astro
+++ b/blog/src/pages/zh/index.astro
@@ -5,12 +5,12 @@ import SiteFooter from '../../components/SiteFooter.astro';
 import '../../styles/blog.css';
 
 const posts = (await getCollection('posts'))
-	.filter((post) => !post.data.draft && post.data.locale === 'en')
+	.filter((post) => !post.data.draft && post.data.locale === 'zh')
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
 const [featured, ...rest] = posts;
 
-const dateFormatter = new Intl.DateTimeFormat('en-US', {
+const dateFormatter = new Intl.DateTimeFormat('zh-CN', {
 	year: 'numeric',
 	month: 'long',
 	day: 'numeric',
@@ -18,15 +18,16 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 const href = (post) => `/blog/posts/${post.id}/`;
 
 const siteUrl = 'https://octo-agent.dev';
-const canonicalUrl = `${siteUrl}/blog/en/`;
+const canonicalUrl = `${siteUrl}/blog/zh/`;
 const alternateUrl = `${siteUrl}/blog/`;
-const title = 'octo blog';
-const description = 'Engineering notes, release updates, and deep dives from the octo-agent team.';
+const title = 'octo 博客';
+const description =
+	'octo-agent 团队的工程笔记、版本更新与 AI Agent 技术深度文章，分享 Loop Engineering、工具链与实战经验。';
 const ogImage = `${siteUrl}/blog/og-default.svg`;
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -34,13 +35,13 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 		<meta name="description" content={description} />
 		<link rel="canonical" href={canonicalUrl} />
 		<link rel="icon" type="image/svg+xml" href="/blog/favicon.svg" />
-		<link rel="alternate" hreflang="zh-CN" href={alternateUrl} />
+		<link rel="alternate" hreflang="en" href={alternateUrl} />
 
 		<meta property="og:title" content={title} />
 		<meta property="og:description" content={description} />
 		<meta property="og:url" content={canonicalUrl} />
 		<meta property="og:type" content="website" />
-		<meta property="og:locale" content="en" />
+		<meta property="og:locale" content="zh-CN" />
 		<meta property="og:site_name" content={title} />
 		<meta property="og:image" content={ogImage} />
 
@@ -50,28 +51,28 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 		<meta name="twitter:image" content={ogImage} />
 	</head>
 	<body>
-		<SiteHeader locale="en" active="blog" alternateUrl={alternateUrl} />
+		<SiteHeader locale="zh" active="blog" alternateUrl={alternateUrl} />
 
 		<section class="hero">
 			<div class="container">
-				<span class="kicker">Engineering notes from the Octo team</span>
-				<h1>octo blog</h1>
-				<p>Release notes, deep dives on Loop Engineering, and field reports on building a private, self-hosted AI agent.</p>
+				<span class="kicker">Octo 团队的工程笔记</span>
+				<h1>octo 博客</h1>
+				<p>版本说明、Loop Engineering 深度解析，以及构建私密、自托管 AI Agent 的一线实践。</p>
 			</div>
 		</section>
 
 		<main class="post-list">
 			<div class="post-list-head">
-				<h2>Latest posts</h2>
+				<h2>最新文章</h2>
 				<div class="rule"></div>
 			</div>
 
-			{posts.length === 0 && <p>No posts yet.</p>}
+			{posts.length === 0 && <p>暂无文章。</p>}
 
 			{
 				featured && (
 					<a href={href(featured)} class="post-card featured">
-						<span class="flag">Featured</span>
+						<span class="flag">精选</span>
 						<span class="post-card-title">{featured.data.title}</span>
 						<p class="post-card-description">{featured.data.description}</p>
 						<p class="post-card-meta">
@@ -116,6 +117,6 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 			</ul>
 		</main>
 
-		<SiteFooter locale="en" />
+		<SiteFooter locale="zh" />
 	</body>
 </html>

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -31,11 +31,11 @@ export default defineConfig({
 				{
 					// The sidebar's "Blog" entry is a single external link shared by every
 					// locale (Starlight's `translations` only localizes the label, not the
-					// href), so it hardcodes the zh blog. Point it at the English blog on
-					// non-zh-CN pages instead.
+					// href), so it hardcodes the English blog. Point it at the Chinese blog
+					// on zh-CN pages instead.
 					tag: 'script',
 					content:
-						"document.addEventListener('DOMContentLoaded',function(){if(document.documentElement.lang!=='zh-CN'){document.querySelectorAll('a[href=\"https://octo-agent.dev/blog/\"]').forEach(function(a){a.href='https://octo-agent.dev/blog/en/';});}});",
+						"document.addEventListener('DOMContentLoaded',function(){if(document.documentElement.lang==='zh-CN'){document.querySelectorAll('a[href=\"https://octo-agent.dev/blog/\"]').forEach(function(a){a.href='https://octo-agent.dev/blog/zh/';});}});",
 				},
 			],
 			defaultLocale: 'root',

--- a/landing/index.html
+++ b/landing/index.html
@@ -239,7 +239,7 @@
       <a href="#demo" data-en="Demo" data-zh="演示"></a>
       <a href="#faq" data-en="FAQ" data-zh="常见问题"></a>
       <a href="/docs/" data-href-en="/docs/" data-href-zh="/docs/zh/" data-en="Docs" data-zh="文档"></a>
-      <a href="/blog/" data-en="Blog" data-zh="博客"></a>
+      <a href="/blog/" data-href-en="/blog/" data-href-zh="/blog/zh/" data-en="Blog" data-zh="博客"></a>
     </div>
     <a class="ghost" href="https://github.com/open-octo/octo-agent">
       <iconify-icon icon="ant-design:github-outlined" width="16"></iconify-icon>
@@ -592,7 +592,7 @@
       <div class="foot-col">
         <span class="h" data-en="Resources" data-zh="资源"></span>
         <a href="/docs/" data-href-en="/docs/" data-href-zh="/docs/zh/" data-en="Docs" data-zh="文档"></a>
-        <a href="/blog/" data-en="Blog" data-zh="博客"></a>
+        <a href="/blog/" data-href-en="/blog/" data-href-zh="/blog/zh/" data-en="Blog" data-zh="博客"></a>
         <a href="https://github.com/open-octo/octo-agent/blob/main/README.md" data-href-en="https://github.com/open-octo/octo-agent/blob/main/README.md" data-href-zh="https://github.com/open-octo/octo-agent/blob/main/README_CN.md">README</a>
       </div>
       <div class="foot-col">

--- a/shared/octo-nav.js
+++ b/shared/octo-nav.js
@@ -117,13 +117,13 @@
 			const toggle = this.hasAttribute('lang-toggle');
 			const isZh = loc === 'zh';
 			const t = T[loc];
-			const blogHome = isZh ? '/blog/' : '/blog/en/';
+			const blogHome = isZh ? '/blog/zh/' : '/blog/';
 			const docsHref = isZh ? '/docs/zh/' : '/docs/';
 			const altAttr = this.getAttribute('alt');
 			const altUrl = altAttr == null ? null : parseUrl(altAttr);
 			const altSafe = altUrl && (altUrl.protocol === 'http:' || altUrl.protocol === 'https:')
 				? altUrl.href
-				: isZh ? '/blog/en/' : '/blog/';
+				: isZh ? '/blog/' : '/blog/zh/';
 			const alt = escapeHtml(altSafe);
 			const releases = 'https://github.com/open-octo/octo-agent/releases/latest';
 			const repo = 'https://github.com/open-octo/octo-agent';
@@ -168,7 +168,7 @@
 			const isZh = loc === 'zh';
 			const t = T[loc];
 			const docsHref = isZh ? '/docs/zh/' : '/docs/';
-			const blogHome = isZh ? '/blog/' : '/blog/en/';
+			const blogHome = isZh ? '/blog/zh/' : '/blog/';
 			const year = new Date().getFullYear();
 			const root = this.shadowRoot || this.attachShadow({ mode: 'open' });
 			root.innerHTML = `<style>${FOOT}</style>


### PR DESCRIPTION
## Summary
- Blog's no-prefix root (`/blog/`) previously served Chinese with English under `/en/`, while landing and docs both default to English with Chinese under `/zh/`. Landing's Blog nav link had no locale-aware href (unlike its Docs link), so English visitors clicking "Blog" always landed on the Chinese homepage.
- Flips blog routing so `/blog/` is English and `/blog/zh/` is Chinese, matching docs' existing scheme.
- Makes landing's Blog link locale-aware (`data-href-en`/`data-href-zh`) the same way its Docs link already is.
- Flips the Starlight sidebar Blog-link patch script in `docs/astro.config.mjs` accordingly (it now redirects to `/blog/zh/` only on zh-CN docs pages, instead of redirecting to `/blog/en/` on non-zh pages).

## Test plan
- [x] `npm run build` in `blog/` — 32 pages generated, `/`, `/zh/`, `/posts/<slug>/`, `/posts/zh/<slug>/` all present
- [x] `npm run build` in `docs/` — verified generated sidebar script redirects to `/blog/zh/` on zh-CN pages
- [x] Inspected generated HTML: canonical/hreflang tags, back-links, and nav `alt` attributes all correctly cross-reference the opposite locale on both blog index pages and a sample post (`why-octo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)