### PR TITLE
fix(web): don't error when soul.md/user.md don't exist yet

### DIFF
--- a/internal/server/profile_handler.go
+++ b/internal/server/profile_handler.go
@@ -17,8 +17,14 @@ func (s *Server) handleGetProfileSoul(w http.ResponseWriter, r *http.Request) {
 	path := prompt.IdentityPath(octoDir(), "soul.md")
 	content, err := os.ReadFile(path)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "soul.md not found")
-		return
+		// No soul.md yet is the normal not-customized-yet state, not an error the
+		// UI should surface — the Profile view already renders an empty-state
+		// message when content is blank.
+		if !os.IsNotExist(err) {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		content = nil
 	}
 	writeJSON(w, http.StatusOK, map[string]string{
 		"content": string(content),
@@ -30,8 +36,11 @@ func (s *Server) handleGetProfileUser(w http.ResponseWriter, r *http.Request) {
 	path := prompt.IdentityPath(octoDir(), "user.md")
 	content, err := os.ReadFile(path)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "user.md not found")
-		return
+		if !os.IsNotExist(err) {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		content = nil
 	}
 	writeJSON(w, http.StatusOK, map[string]string{
 		"content": string(content),

--- a/internal/server/profile_handler_test.go
+++ b/internal/server/profile_handler_test.go
@@ -72,6 +72,9 @@ func TestHandleGetProfileUser_CanonicalLowercase(t *testing.T) {
 	}
 }
 
+// TestHandleGetProfileSoul_Missing: no soul.md yet is the normal
+// not-customized-yet state, not an error — the endpoint must return 200 with
+// empty content so the UI renders its empty state instead of an error toast.
 func TestHandleGetProfileSoul_Missing(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -82,7 +85,61 @@ func TestHandleGetProfileSoul_Missing(t *testing.T) {
 	w := httptest.NewRecorder()
 	serveLoopback(srv.mux, w, req)
 
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["content"] != "" {
+		t.Errorf("content = %q, want empty", body["content"])
+	}
+}
+
+// TestHandleGetProfileUser_Missing mirrors the soul.md case for user.md.
+func TestHandleGetProfileUser_Missing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	req := httptest.NewRequest(http.MethodGet, "/api/profile/user", nil)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["content"] != "" {
+		t.Errorf("content = %q, want empty", body["content"])
+	}
+}
+
+// TestHandleGetProfileSoul_IOError: a genuine read error — as opposed to
+// "no soul.md yet" — must still surface as a 500, not be swallowed into the
+// same empty-content response as the missing-file case. A regular file
+// sitting where ~/.octo should be a directory trips ENOTDIR, which
+// os.IsNotExist does not recognize (#1237), giving a portable way to force
+// a non-not-exist error without relying on platform-specific chmod semantics.
+func TestHandleGetProfileSoul_IOError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	if err := os.WriteFile(filepath.Join(tmp, ".octo"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	req := httptest.NewRequest(http.MethodGet, "/api/profile/soul", nil)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", w.Code, w.Body.String())
 	}
 }

--- a/web/src/views/ProfileView.svelte
+++ b/web/src/views/ProfileView.svelte
@@ -149,8 +149,8 @@
         </div>
         {#if loadingSoul}
           <div class="card-loading">{$t('common.loading')}</div>
-        {:else if soulData}
-          <div class="card-body md-content">{@html renderMarkdown(soulData.content)}</div>
+        {:else if isCustom(soulData)}
+          <div class="card-body md-content">{@html renderMarkdown(soulData!.content)}</div>
         {:else}
           <div class="card-loading">{$t('profile.soul_empty')}</div>
         {/if}
@@ -177,8 +177,8 @@
         </div>
         {#if loadingUser}
           <div class="card-loading">{$t('common.loading')}</div>
-        {:else if userData}
-          <div class="card-body md-content">{@html renderMarkdown(userData.content)}</div>
+        {:else if isCustom(userData)}
+          <div class="card-body md-content">{@html renderMarkdown(userData!.content)}</div>
         {:else}
           <div class="card-loading">{$t('profile.user_empty')}</div>
         {/if}


### PR DESCRIPTION
## Summary
- Missing `~/.octo/soul.md`/`user.md` is the normal not-customized-yet state, but `GET /api/profile/soul`/`user` returned 404, which the Profile view surfaced as an error toast instead of its intended empty-state message.
- The two handlers now return 200 with empty `content` when the file is absent, still 500 on genuine I/O errors (e.g. a file sitting where `~/.octo` should be a directory).
- `ProfileView.svelte`'s empty-state check moved from "response object is non-null" to `isCustom()` (content non-empty), since the response is now always non-null on success.

## Test plan
- [x] `go test ./internal/server/... -run TestHandleGetProfile -v` — covers missing-file (200+empty), legacy-uppercase, canonical-lowercase, and a genuine I/O error (ENOTDIR) forcing 500
- [x] `gofmt -l` / `go vet ./internal/server/...`
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] Independent subagent code review — no Critical/Important findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)