### PR TITLE
feat(mobile): batch 3b — Tasks tab

### DIFF
--- a/web/src/mobile/MobileApp.svelte
+++ b/web/src/mobile/MobileApp.svelte
@@ -9,6 +9,7 @@
   import ChatDetail from './ChatDetail.svelte'
   import ApprovalDetail from './ApprovalDetail.svelte'
   import SettingsTab from './SettingsTab.svelte'
+  import TasksTab from './TasksTab.svelte'
   import type { FeedKind } from './feedGroups'
   import { setActiveSession } from '../lib/stores'
 
@@ -43,8 +44,7 @@
         <Feed onOpen={openSession} />
       {/if}
     {:else if tab === 'tasks'}
-      <header class="m-head"><h1>任务</h1></header>
-      <div class="m-scroll"><div class="m-ph">定时与自动化 · 批 3 接入</div></div>
+      <TasksTab onOpenSession={(id) => { tab = 'chat'; openId = id; openKind = 'running' }} />
     {:else if tab === 'config'}
       <header class="m-head"><h1>配置</h1></header>
       <div class="m-scroll"><div class="m-ph">技能 / MCP / 工作流 / 数据 · 批 3 接入</div></div>

--- a/web/src/mobile/MobileApp.svelte
+++ b/web/src/mobile/MobileApp.svelte
@@ -44,7 +44,7 @@
         <Feed onOpen={openSession} />
       {/if}
     {:else if tab === 'tasks'}
-      <TasksTab onOpenSession={(id) => { tab = 'chat'; openId = id; openKind = 'running' }} />
+      <TasksTab onOpenSession={(id) => { tab = 'chat'; openSession(id, 'running') }} />
     {:else if tab === 'config'}
       <header class="m-head"><h1>配置</h1></header>
       <div class="m-scroll"><div class="m-ph">技能 / MCP / 工作流 / 数据 · 批 3 接入</div></div>

--- a/web/src/mobile/TasksTab.svelte
+++ b/web/src/mobile/TasksTab.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  // Tasks tab: scheduled (cron) tasks as mobile cards — stat chips up top, then
+  // one card per task with an enable switch and a run-now action. Management
+  // beyond that (create/edit/delete) stays on desktop; the phone is a remote
+  // control, so this view is monitor + toggle + fire.
+  import { onMount } from 'svelte'
+  import { sessions, setActiveSession, showToast } from '../lib/stores'
+  import * as api from '../lib/api'
+
+  let { onOpenSession }: { onOpenSession: (id: string) => void } = $props()
+
+  let loading = $state(true)
+  let tasks = $state<api.TaskResponse[]>([])
+  const activeCount = $derived(tasks.filter(t => t.enabled).length)
+
+  function fmtDate(iso: string): string {
+    if (!iso || iso === '0001-01-01T00:00:00Z') return '—'
+    try {
+      return new Intl.DateTimeFormat('zh-CN', {
+        month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+      }).format(new Date(iso))
+    } catch {
+      return iso
+    }
+  }
+
+  async function load() {
+    try {
+      tasks = await api.listTasks()
+    } catch (e: any) {
+      showToast(e?.message ?? '加载任务失败', 'error')
+    } finally {
+      loading = false
+    }
+  }
+  onMount(load)
+
+  async function toggle(t: api.TaskResponse) {
+    const next = !t.enabled
+    try {
+      await api.toggleTask(t.id, next)
+      tasks = tasks.map(r => (r.id === t.id ? { ...r, enabled: next } : r))
+      showToast(next ? '任务已恢复' : '任务已暂停')
+    } catch (e: any) {
+      showToast(e?.message ?? '更新任务失败', 'error')
+    }
+  }
+
+  let runningId = $state<string | null>(null)
+  async function runNow(t: api.TaskResponse) {
+    if (runningId) return
+    runningId = t.id
+    try {
+      const res = await api.runTask(t.id)
+      showToast('任务已启动')
+      if (res.session_id) {
+        // Refresh the session list so the feed knows the new session, then
+        // jump straight into its chat detail to watch the run live.
+        const data = await api.listSessions().catch(() => null)
+        if (data) sessions.set(data.sessions ?? [])
+        setActiveSession(res.session_id)
+        onOpenSession(res.session_id)
+      }
+    } catch (e: any) {
+      showToast(e?.message ?? '运行任务失败', 'error')
+    } finally {
+      runningId = null
+    }
+  }
+</script>
+
+<header class="head"><h1>任务</h1></header>
+
+<div class="scroll">
+  <div class="stats">
+    <div class="stat"><span class="num on">{activeCount}</span><span class="cap">启用</span></div>
+    <div class="stat"><span class="num">{tasks.length - activeCount}</span><span class="cap">暂停</span></div>
+    <div class="stat"><span class="num">{tasks.length}</span><span class="cap">总数</span></div>
+  </div>
+
+  {#if loading}
+    <div class="empty">加载中…</div>
+  {:else if tasks.length === 0}
+    <div class="empty">还没有定时任务 · 在桌面端用 /cron-task-creator 创建</div>
+  {:else}
+    {#each tasks as t (t.id)}
+      <div class="card" class:off={!t.enabled}>
+        <div class="top">
+          <div class="names">
+            <span class="name">{t.name}</span>
+            {#if t.agent || t.model}<span class="target">{t.agent || t.model}</span>{/if}
+          </div>
+          <button
+            class="switch"
+            class:on={t.enabled}
+            role="switch"
+            aria-checked={t.enabled}
+            aria-label={t.enabled ? '暂停任务' : '恢复任务'}
+            onclick={() => toggle(t)}
+          ><span class="knob"></span></button>
+        </div>
+        <div class="meta">
+          <span class="cron">{t.cron || '—'}</span>
+          <span class="runline">上次 {fmtDate(t.last_run)} · 下次 {t.enabled ? fmtDate(t.next_run) : '—'}</span>
+        </div>
+        <div class="acts">
+          <button class="run" disabled={runningId !== null} onclick={() => runNow(t)}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+            {runningId === t.id ? '启动中…' : '立即运行'}
+          </button>
+        </div>
+      </div>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .head { flex: none; padding: 8px 18px 12px; }
+  .head h1 { margin: 0; font-size: 24px; font-weight: 600; color: var(--m-text-strong); }
+  .scroll { flex: 1; min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 0 16px 20px; }
+
+  .stats { display: flex; gap: 10px; margin-bottom: 14px; }
+  .stat {
+    flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px;
+    background: var(--m-surface); border-radius: 14px; padding: 12px 0;
+    box-shadow: var(--m-shadow-card);
+  }
+  .stat .num { font-size: 20px; font-weight: 700; color: var(--m-text-strong); font-variant-numeric: tabular-nums; }
+  .stat .num.on { color: var(--m-accent); }
+  .stat .cap { font-size: 11px; color: var(--m-text-3); }
+
+  .empty { padding: 40px 16px; text-align: center; font-size: 13px; color: var(--m-text-3); }
+
+  .card {
+    background: var(--m-surface); border-radius: 14px; box-shadow: var(--m-shadow-card);
+    padding: 14px 16px; margin-bottom: 10px;
+  }
+  .card.off .name, .card.off .cron { color: var(--m-text-3); }
+  .top { display: flex; align-items: center; gap: 12px; }
+  .names { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+  .name { font-size: 14.5px; font-weight: 600; color: var(--m-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .target { font-size: 12px; color: var(--m-text-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .meta { display: flex; flex-direction: column; gap: 3px; margin-top: 8px; }
+  .cron { font-family: ui-monospace, Menlo, monospace; font-size: 12.5px; color: var(--m-text-2); }
+  .runline { font-size: 12px; color: var(--m-text-3); }
+  .acts { display: flex; justify-content: flex-end; margin-top: 10px; }
+  .run {
+    display: inline-flex; align-items: center; gap: 5px;
+    border: 1px solid var(--m-border); background: none; border-radius: 9999px;
+    padding: 6px 14px; font-size: 12.5px; color: var(--m-accent);
+    font-family: inherit; cursor: pointer;
+  }
+  .run:disabled { opacity: .5; }
+
+  .switch {
+    flex: none; width: 42px; height: 24px; border-radius: 9999px; border: none;
+    padding: 0; position: relative; cursor: pointer; background: var(--m-border);
+    transition: background .15s;
+  }
+  .switch.on { background: var(--m-accent); }
+  .switch .knob {
+    position: absolute; top: 2px; left: 2px; width: 20px; height: 20px; border-radius: 50%;
+    background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.2); transition: left .15s;
+  }
+  .switch.on .knob { left: 20px; }
+</style>

--- a/web/src/mobile/TasksTab.svelte
+++ b/web/src/mobile/TasksTab.svelte
@@ -4,12 +4,13 @@
   // beyond that (create/edit/delete) stays on desktop; the phone is a remote
   // control, so this view is monitor + toggle + fire.
   import { onMount } from 'svelte'
-  import { sessions, setActiveSession, showToast } from '../lib/stores'
+  import { sessions, showToast } from '../lib/stores'
   import * as api from '../lib/api'
 
   let { onOpenSession }: { onOpenSession: (id: string) => void } = $props()
 
   let loading = $state(true)
+  let loadError = $state(false)
   let tasks = $state<api.TaskResponse[]>([])
   const activeCount = $derived(tasks.filter(t => t.enabled).length)
 
@@ -25,9 +26,12 @@
   }
 
   async function load() {
+    loading = true
+    loadError = false
     try {
       tasks = await api.listTasks()
     } catch (e: any) {
+      loadError = true
       showToast(e?.message ?? '加载任务失败', 'error')
     } finally {
       loading = false
@@ -35,14 +39,22 @@
   }
   onMount(load)
 
+  let togglingId = $state<string | null>(null)
   async function toggle(t: api.TaskResponse) {
+    if (togglingId) return
+    togglingId = t.id
     const next = !t.enabled
     try {
       await api.toggleTask(t.id, next)
       tasks = tasks.map(r => (r.id === t.id ? { ...r, enabled: next } : r))
       showToast(next ? '任务已恢复' : '任务已暂停')
+      // The server recomputes next_run on resume; refresh silently so the
+      // card doesn't show a stale "下次 —" until the next tab visit.
+      api.listTasks().then(r => (tasks = r)).catch(() => {})
     } catch (e: any) {
       showToast(e?.message ?? '更新任务失败', 'error')
+    } finally {
+      togglingId = null
     }
   }
 
@@ -58,7 +70,6 @@
         // jump straight into its chat detail to watch the run live.
         const data = await api.listSessions().catch(() => null)
         if (data) sessions.set(data.sessions ?? [])
-        setActiveSession(res.session_id)
         onOpenSession(res.session_id)
       }
     } catch (e: any) {
@@ -80,6 +91,8 @@
 
   {#if loading}
     <div class="empty">加载中…</div>
+  {:else if loadError}
+    <button class="empty retry" onclick={load}>加载失败 · 点击重试</button>
   {:else if tasks.length === 0}
     <div class="empty">还没有定时任务 · 在桌面端用 /cron-task-creator 创建</div>
   {:else}
@@ -96,6 +109,7 @@
             role="switch"
             aria-checked={t.enabled}
             aria-label={t.enabled ? '暂停任务' : '恢复任务'}
+            disabled={togglingId !== null}
             onclick={() => toggle(t)}
           ><span class="knob"></span></button>
         </div>
@@ -130,6 +144,7 @@
   .stat .cap { font-size: 11px; color: var(--m-text-3); }
 
   .empty { padding: 40px 16px; text-align: center; font-size: 13px; color: var(--m-text-3); }
+  .retry { display: block; width: 100%; background: none; border: none; font-family: inherit; color: var(--m-accent); cursor: pointer; }
 
   .card {
     background: var(--m-surface); border-radius: 14px; box-shadow: var(--m-shadow-card);
@@ -145,9 +160,9 @@
   .runline { font-size: 12px; color: var(--m-text-3); }
   .acts { display: flex; justify-content: flex-end; margin-top: 10px; }
   .run {
-    display: inline-flex; align-items: center; gap: 5px;
+    display: inline-flex; align-items: center; gap: 5px; min-height: 36px;
     border: 1px solid var(--m-border); background: none; border-radius: 9999px;
-    padding: 6px 14px; font-size: 12.5px; color: var(--m-accent);
+    padding: 6px 16px; font-size: 12.5px; color: var(--m-accent);
     font-family: inherit; cursor: pointer;
   }
   .run:disabled { opacity: .5; }


### PR DESCRIPTION
Batch 3b of the mobile UI (dev-docs/mobile-ui-implementation.md): the Tasks tab.

## What
- **Stat chips** — enabled / paused / total.
- **Task cards** — name + agent/model target, cron expression (mono), last/next run, enable **switch** (pause/resume via task PATCH), **run-now**.
- **Run-now → live view**: starts the task, refreshes the session list, and jumps straight into the new cron session's chat detail to watch it stream.
- Create/edit/delete intentionally stay on desktop — the phone is a remote control (monitor + toggle + fire).

## Walkthrough (headless browser vs live server)
- 3 tasks render as cards; stats 3/0/3.
- Toggle pauses a task; stats update to 2/1/3, card dims, next-run shows —.
- Run-now started the task and landed in the streaming chat detail (stop bar visible).

Next in batch 3: Config tab (skills/MCP/workflows/memory/trash), NewTask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)