### PR TITLE
fix(server): skip soul IO-error test on Windows

### DIFF
--- a/internal/server/profile_handler_test.go
+++ b/internal/server/profile_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -126,7 +127,13 @@ func TestHandleGetProfileUser_Missing(t *testing.T) {
 // sitting where ~/.octo should be a directory trips ENOTDIR, which
 // os.IsNotExist does not recognize (#1237), giving a portable way to force
 // a non-not-exist error without relying on platform-specific chmod semantics.
+// Windows is the exception: it reports this case as ERROR_PATH_NOT_FOUND,
+// which os.IsNotExist treats as a plain missing file, so the handler cannot
+// (and needn't) distinguish it there.
 func TestHandleGetProfileSoul_IOError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ENOTDIR maps to path-not-found on Windows, indistinguishable from a missing file")
+	}
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)


### PR DESCRIPTION
TestHandleGetProfileSoul_IOError (from #1723) forces a read error by placing a regular file where `~/.octo` should be a directory. On Unix that trips ENOTDIR, which `os.IsNotExist` does not recognize — so the handler correctly 500s. Windows reports the same setup as `ERROR_PATH_NOT_FOUND`, which `os.IsNotExist` treats as a plain missing file, so the handler takes the empty-content 200 path and the assertion fails:

```
--- FAIL: TestHandleGetProfileSoul_IOError (0.00s)
    profile_handler_test.go:143: status = 200, want 500
```

This has been failing the `windows-latest` Go job on main since #1723 merged (see main push run 30004632749) and red-flagged unrelated PRs (#1724). The handler cannot distinguish not-exist from ENOTDIR on Windows, so the honest fix is to skip there, matching the existing pattern in `auth_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)