### PR TITLE
feat(mobile): batch 3d — NewTask sheet

### DIFF
--- a/web/src/mobile/ChatDetail.svelte
+++ b/web/src/mobile/ChatDetail.svelte
@@ -10,7 +10,15 @@
   import { ws } from '../lib/ws'
   import { wireMobileSession, loadMobileHistory, sendMobile } from './chatWiring'
 
-  let { onBack, onViewApproval }: { onBack: () => void; onViewApproval: () => void } = $props()
+  let { onBack, onViewApproval, initialPrompt = '', onInitialSent }: {
+    onBack: () => void
+    onViewApproval: () => void
+    // Queued first message from the new-task sheet, sent once the WS
+    // subscription is live (so the reply stream isn't missed). onInitialSent
+    // lets the owner clear it so a remount doesn't re-send.
+    initialPrompt?: string
+    onInitialSent?: () => void
+  } = $props()
 
   const sid = $derived($activeSessionId ?? '')
   const msgs = $derived($chatMessages[sid] ?? [])
@@ -38,7 +46,12 @@
     let cancelled = false
     // Subscribe only after history renders (same ordering the desktop relies on).
     loadMobileHistory(s).then(() => {
-      if (!cancelled) ws.subscribe(s)
+      if (cancelled) return
+      ws.subscribe(s)
+      if (initialPrompt) {
+        sendMobile(s, initialPrompt, [])
+        onInitialSent?.()
+      }
     })
     const cleanup = wireMobileSession(s)
     return () => {

--- a/web/src/mobile/Feed.svelte
+++ b/web/src/mobile/Feed.svelte
@@ -1,20 +1,12 @@
 <script lang="ts">
-  import { get } from 'svelte/store'
   import { feedGroups, type FeedKind } from './feedGroups'
-  import { createNewSession, activeSessionId } from '../lib/stores'
   import SessionCard from './SessionCard.svelte'
   import DeviceBanner from './DeviceBanner.svelte'
 
-  let { onOpen }: { onOpen: (id: string, kind: FeedKind) => void } = $props()
+  let { onOpen, onNew }: { onOpen: (id: string, kind: FeedKind) => void; onNew: () => void } = $props()
 
   const groups = feedGroups
   const empty = $derived($groups.todo.length + $groups.active.length + $groups.recent.length === 0)
-
-  async function newSession() {
-    await createNewSession()
-    const id = get(activeSessionId)
-    if (id) onOpen(id, 'done')
-  }
 </script>
 
 <header class="head">
@@ -53,7 +45,7 @@
   {/if}
 </div>
 
-<button class="fab" onclick={newSession} aria-label="新建会话">
+<button class="fab" onclick={onNew} aria-label="新建任务">
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><path d="M12 5v14M5 12h14"/></svg>
 </button>
 

--- a/web/src/mobile/MobileApp.svelte
+++ b/web/src/mobile/MobileApp.svelte
@@ -11,6 +11,7 @@
   import SettingsTab from './SettingsTab.svelte'
   import TasksTab from './TasksTab.svelte'
   import ConfigTab from './ConfigTab.svelte'
+  import NewTask from './NewTask.svelte'
   import type { FeedKind } from './feedGroups'
   import { setActiveSession } from '../lib/stores'
 
@@ -20,6 +21,9 @@
   // to show, taken from the tapped card's kind.
   let openId = $state<string | null>(null)
   let openKind = $state<FeedKind | null>(null)
+  // New-task sheet (FAB) + the first message it queued for the opened session.
+  let newTask = $state(false)
+  let initialPrompt = $state('')
 
   function openSession(id: string, kind: FeedKind) {
     setActiveSession(id)
@@ -29,20 +33,31 @@
   function closeDetail() {
     openId = null
     openKind = null
+    initialPrompt = ''
   }
 </script>
 
 <div class="m-root">
   <main class="m-view">
     {#if tab === 'chat'}
-      {#if openId}
+      {#if newTask}
+        <NewTask
+          onCancel={() => (newTask = false)}
+          onCreated={(id, prompt) => { newTask = false; initialPrompt = prompt; openSession(id, prompt ? 'running' : 'done') }}
+        />
+      {:else if openId}
         {#if openKind === 'approval'}
           <ApprovalDetail onBack={closeDetail} />
         {:else}
-          <ChatDetail onBack={closeDetail} onViewApproval={() => (openKind = 'approval')} />
+          <ChatDetail
+            onBack={closeDetail}
+            onViewApproval={() => (openKind = 'approval')}
+            {initialPrompt}
+            onInitialSent={() => (initialPrompt = '')}
+          />
         {/if}
       {:else}
-        <Feed onOpen={openSession} />
+        <Feed onOpen={openSession} onNew={() => (newTask = true)} />
       {/if}
     {:else if tab === 'tasks'}
       <TasksTab onOpenSession={(id) => { tab = 'chat'; openSession(id, 'running') }} />

--- a/web/src/mobile/MobileApp.svelte
+++ b/web/src/mobile/MobileApp.svelte
@@ -21,11 +21,14 @@
   // to show, taken from the tapped card's kind.
   let openId = $state<string | null>(null)
   let openKind = $state<FeedKind | null>(null)
-  // New-task sheet (FAB) + the first message it queued for the opened session.
+  // New-task sheet (FAB) + the first message it queued, bound to the session
+  // it was queued for — opening any other session must never inherit it.
   let newTask = $state(false)
-  let initialPrompt = $state('')
+  let initial = $state<{ id: string; prompt: string } | null>(null)
 
   function openSession(id: string, kind: FeedKind) {
+    newTask = false
+    if (initial && initial.id !== id) initial = null
     setActiveSession(id)
     openId = id
     openKind = kind
@@ -33,7 +36,7 @@
   function closeDetail() {
     openId = null
     openKind = null
-    initialPrompt = ''
+    initial = null
   }
 </script>
 
@@ -43,7 +46,7 @@
       {#if newTask}
         <NewTask
           onCancel={() => (newTask = false)}
-          onCreated={(id, prompt) => { newTask = false; initialPrompt = prompt; openSession(id, prompt ? 'running' : 'done') }}
+          onCreated={(id, prompt) => { newTask = false; openSession(id, prompt ? 'running' : 'done'); if (prompt) initial = { id, prompt } }}
         />
       {:else if openId}
         {#if openKind === 'approval'}
@@ -52,8 +55,8 @@
           <ChatDetail
             onBack={closeDetail}
             onViewApproval={() => (openKind = 'approval')}
-            {initialPrompt}
-            onInitialSent={() => (initialPrompt = '')}
+            initialPrompt={initial?.id === openId ? initial.prompt : ''}
+            onInitialSent={() => (initial = null)}
           />
         {/if}
       {:else}

--- a/web/src/mobile/NewTask.svelte
+++ b/web/src/mobile/NewTask.svelte
@@ -27,12 +27,21 @@
         for (const e of d.endpoints ?? []) {
           for (const m of e.models ?? []) flat.push({ id: `${e.id}::${m.model}`, label: m.model })
         }
-        models = flat
+        // The same model on two endpoints would render two identical options;
+        // qualify duplicates with their endpoint id.
+        const seen = new Map<string, number>()
+        for (const m of flat) seen.set(m.label, (seen.get(m.label) ?? 0) + 1)
+        models = flat.map(m => (seen.get(m.label)! > 1 ? { ...m, label: `${m.label} · ${m.id.split('::')[0]}` } : m))
       })
       .catch(() => {})
   })
 
-  let permMode = $state(get(globalPermissionMode) || 'interactive')
+  // globalPermissionMode is seeded 'ask' and only overwritten when config.yml
+  // sets one of the engine modes — normalize before using it as the segment
+  // default and the skip-if-unchanged baseline.
+  const g = get(globalPermissionMode)
+  const basePermMode = ['interactive', 'auto', 'strict'].includes(g) ? g : 'interactive'
+  let permMode = $state(basePermMode)
   const permModes = [
     { m: 'interactive', label: '询问' },
     { m: 'auto', label: '自动' },
@@ -50,10 +59,12 @@
       // Best-effort per-session overrides: a failed override shouldn't strand
       // the already-created session, so toast and continue.
       if (modelId) {
-        await api.updateSessionModel(sess.id, modelId).catch((e: any) =>
-          showToast(e?.message ?? '切换模型失败', 'error'))
+        await api.updateSessionModel(sess.id, modelId)
+          .then(res => sessions.update(list =>
+            list.map(s => (s.id === sess.id ? { ...s, model: res.model, model_id: res.model_id } : s))))
+          .catch((e: any) => showToast(e?.message ?? '切换模型失败', 'error'))
       }
-      if (permMode !== (get(globalPermissionMode) || 'interactive')) {
+      if (permMode !== basePermMode) {
         await api.updateSessionPermissionMode(sess.id, permMode).catch((e: any) =>
           showToast(e?.message ?? '设置权限模式失败', 'error'))
       }
@@ -70,7 +81,7 @@
 </script>
 
 <header class="head">
-  <button class="back" aria-label="取消" onclick={onCancel}>
+  <button class="back" aria-label="取消" disabled={creating} onclick={onCancel}>
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M15 18l-6-6 6-6"/></svg>
   </button>
   <h1>新建任务</h1>
@@ -83,6 +94,7 @@
       class="prompt"
       rows="5"
       placeholder="让 Octo 做什么?留空则只创建空会话"
+      aria-label="任务描述"
       bind:value={prompt}
     ></textarea>
   </div>
@@ -101,7 +113,7 @@
   <div class="card pad">
     <div class="seg">
       {#each permModes as p (p.m)}
-        <button class="segi" class:on={permMode === p.m} onclick={() => (permMode = p.m)}>{p.label}</button>
+        <button class="segi" class:on={permMode === p.m} aria-pressed={permMode === p.m} onclick={() => (permMode = p.m)}>{p.label}</button>
       {/each}
     </div>
     <p class="note">

--- a/web/src/mobile/NewTask.svelte
+++ b/web/src/mobile/NewTask.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  // New-task sheet, opened by the feed's FAB. The phone fires a task in one
+  // step: describe it, optionally pick model / permission mode / working
+  // directory, and land in the streaming chat detail. Leaving the prompt
+  // empty just creates a blank session (the old FAB behavior).
+  import { get } from 'svelte/store'
+  import { sessions, activeSessionId, activeSession, globalPermissionMode, showToast } from '../lib/stores'
+  import * as api from '../lib/api'
+
+  let { onCancel, onCreated }: {
+    onCancel: () => void
+    onCreated: (id: string, prompt: string) => void
+  } = $props()
+
+  let prompt = $state('')
+  let dir = $state('')
+  let creating = $state(false)
+
+  // '' = the server default sender; anything else is the composite
+  // "<endpoint>::<model>" id updateSessionModel resolves.
+  let modelId = $state('')
+  let models = $state<{ id: string; label: string }[]>([])
+  $effect(() => {
+    api.getEndpoints()
+      .then(d => {
+        const flat: { id: string; label: string }[] = []
+        for (const e of d.endpoints ?? []) {
+          for (const m of e.models ?? []) flat.push({ id: `${e.id}::${m.model}`, label: m.model })
+        }
+        models = flat
+      })
+      .catch(() => {})
+  })
+
+  let permMode = $state(get(globalPermissionMode) || 'interactive')
+  const permModes = [
+    { m: 'interactive', label: '询问' },
+    { m: 'auto', label: '自动' },
+    { m: 'strict', label: '严格' },
+  ]
+
+  async function create() {
+    if (creating) return
+    creating = true
+    try {
+      const sess = await api.createSession({ source: 'manual' })
+      sessions.update(ss => [sess, ...ss])
+      activeSessionId.set(sess.id)
+      activeSession.set(sess.id)
+      // Best-effort per-session overrides: a failed override shouldn't strand
+      // the already-created session, so toast and continue.
+      if (modelId) {
+        await api.updateSessionModel(sess.id, modelId).catch((e: any) =>
+          showToast(e?.message ?? '切换模型失败', 'error'))
+      }
+      if (permMode !== (get(globalPermissionMode) || 'interactive')) {
+        await api.updateSessionPermissionMode(sess.id, permMode).catch((e: any) =>
+          showToast(e?.message ?? '设置权限模式失败', 'error'))
+      }
+      if (dir.trim()) {
+        await api.updateSessionWorkingDir(sess.id, dir.trim()).catch((e: any) =>
+          showToast(e?.message ?? '设置工作目录失败', 'error'))
+      }
+      onCreated(sess.id, prompt.trim())
+    } catch (e: any) {
+      showToast(e?.message ?? '创建会话失败', 'error')
+      creating = false
+    }
+  }
+</script>
+
+<header class="head">
+  <button class="back" aria-label="取消" onclick={onCancel}>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M15 18l-6-6 6-6"/></svg>
+  </button>
+  <h1>新建任务</h1>
+</header>
+
+<div class="scroll">
+  <p class="lbl">任务描述</p>
+  <div class="card">
+    <textarea
+      class="prompt"
+      rows="5"
+      placeholder="让 Octo 做什么?留空则只创建空会话"
+      bind:value={prompt}
+    ></textarea>
+  </div>
+
+  <p class="lbl">模型</p>
+  <div class="card pad">
+    <select class="select" bind:value={modelId} aria-label="模型">
+      <option value="">默认</option>
+      {#each models as m (m.id)}
+        <option value={m.id}>{m.label}</option>
+      {/each}
+    </select>
+  </div>
+
+  <p class="lbl">权限模式</p>
+  <div class="card pad">
+    <div class="seg">
+      {#each permModes as p (p.m)}
+        <button class="segi" class:on={permMode === p.m} onclick={() => (permMode = p.m)}>{p.label}</button>
+      {/each}
+    </div>
+    <p class="note">
+      {permMode === 'auto' ? '自动批准工具执行,适合无人值守任务'
+        : permMode === 'strict' ? '自动拒绝需要授权的操作'
+        : '危险操作会挂起等你在手机上审批'}
+    </p>
+  </div>
+
+  <p class="lbl">工作目录</p>
+  <div class="card pad">
+    <input class="input" type="text" placeholder="服务器默认" bind:value={dir} aria-label="工作目录" />
+  </div>
+
+  <button class="go" disabled={creating} onclick={create}>
+    {creating ? '创建中…' : prompt.trim() ? '创建并开始' : '创建空会话'}
+  </button>
+</div>
+
+<style>
+  .head { flex: none; display: flex; align-items: center; gap: 10px; padding: 8px 18px 12px; }
+  .head h1 { margin: 0; font-size: 24px; font-weight: 600; color: var(--m-text-strong); }
+  .back {
+    width: 34px; height: 34px; border-radius: 50%; border: none; flex: none;
+    background: var(--m-surface-2); color: var(--m-text); cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .scroll { flex: 1; min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 0 16px 24px; }
+
+  .lbl { margin: 2px 2px 8px; font: 600 12px/1 system-ui; letter-spacing: .5px; text-transform: uppercase; color: var(--m-text-3); }
+  .card { background: var(--m-surface); border-radius: 14px; box-shadow: var(--m-shadow-card); margin-bottom: 18px; overflow: hidden; }
+  .card.pad { padding: 12px 16px; }
+
+  .prompt {
+    display: block; width: 100%; border: none; resize: none; padding: 14px 16px;
+    background: none; font: inherit; font-size: 15px; color: var(--m-text);
+    outline: none;
+  }
+  .prompt::placeholder { color: var(--m-text-4); }
+
+  .select, .input {
+    display: block; width: 100%; border: none; background: none; outline: none;
+    font: inherit; font-size: 14.5px; color: var(--m-text); padding: 2px 0;
+  }
+  .input::placeholder { color: var(--m-text-4); }
+
+  .seg { display: flex; gap: 4px; background: var(--m-bg); border-radius: 8px; padding: 3px; }
+  .segi {
+    flex: 1; text-align: center; padding: 8px 0; border-radius: 6px; border: none;
+    background: none; font-size: 13px; color: var(--m-text-2); font-family: inherit; cursor: pointer;
+  }
+  .segi.on { background: var(--m-accent); color: #fff; font-weight: 600; }
+  .note { margin: 10px 2px 0; font-size: 12px; color: var(--m-text-3); }
+
+  .go {
+    display: block; width: 100%; border: none; border-radius: 12px; padding: 14px 0;
+    background: var(--m-accent); color: #fff; font: 600 15px/1 inherit; font-family: inherit;
+    cursor: pointer;
+  }
+  .go:disabled { opacity: .6; }
+</style>


### PR DESCRIPTION
Batch 3d of the mobile UI (dev-docs/mobile-ui-implementation.md): the NewTask sheet — **batch 3 complete**.

## What
- Feed FAB → **new-task sheet**: task prompt, model picker (endpoint composite ids), permission-mode segment (询问/自动/严格 with a plain-language note per mode), working directory.
- Create applies per-session overrides best-effort (model / permission / dir each toast on failure but don't strand the session), then jumps into the streaming chat detail.
- First message rides ChatDetail's new `initialPrompt` prop and is sent **after** the WS subscription is live (no missed reply stream); `onInitialSent` clears it against remount re-sends.
- Empty prompt = blank session (the old FAB behavior, button reads 创建空会话).

## Walkthrough (headless browser vs live server)
- FAB opens the sheet, model list loads, button label flips 创建空会话 ↔ 创建并开始 with prompt.
- 自动 mode selected → note switches to the unattended-run explanation.
- 创建并开始 → chat detail, prompt bubble sent, agent reply streamed in, session title auto-generated. Test session cleaned up.

With this, all four tabs + FAB flow are live. Remaining: batch 4 polish (i18n, offline states, artifact viewer, native-app walkthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)