### PR TITLE
fix(subagent): capture fork history at call time, pin fork child's role

### DIFF
--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -380,13 +380,6 @@ func (lc *liveChild) syncSession() {
 	_ = lc.session.Save()
 }
 
-// filterChildTools drops Agent (a sub-agent cannot spawn another sub-agent —
-// that stays top-level-only) and, when allowed is non-empty, intersects with
-// that allowlist so the parent can hand the child a restricted toolbelt (e.g.
-// read-only research). When readOnly is set, the mutating tools (write_file,
-// edit_file) are dropped too — used by read-only presets so the child keeps
-// terminal/MCP/codegraph but can't change files. The two filters compose: a
-// readOnly preset still honours allowed.
 // ForkSnapshot captures the parent conversation for seeding a fork child,
 // trimmed of the in-flight assistant turn (see forkHistorySnapshot). It
 // implements tools.ForkSnapshotter: the sub_agent tool calls it synchronously
@@ -424,6 +417,13 @@ func messageHasToolUse(m agent.Message) bool {
 	return false
 }
 
+// filterChildTools drops Agent (a sub-agent cannot spawn another sub-agent —
+// that stays top-level-only) and, when allowed is non-empty, intersects with
+// that allowlist so the parent can hand the child a restricted toolbelt (e.g.
+// read-only research). When readOnly is set, the mutating tools (write_file,
+// edit_file) are dropped too — used by read-only presets so the child keeps
+// terminal/MCP/codegraph but can't change files. The two filters compose: a
+// readOnly preset still honours allowed.
 func filterChildTools(parent []agent.ToolDefinition, allowed, disallowed []string, readOnly bool) []agent.ToolDefinition {
 	var allowSet map[string]bool
 	if len(allowed) > 0 {

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -104,13 +104,22 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 	child.LiteSender = s.parent.LiteSender
 	child.LiteModel = s.parent.LiteModel
 
-	// True fork: seed the child with the parent's conversation so far so it
-	// continues with full context. runChild then appends req.Prompt as the next
-	// user turn. The in-flight assistant turn that called sub_agent is trimmed
-	// (see forkHistorySnapshot) so the copied history doesn't end on a dangling
-	// tool_use the provider would reject.
+	// True fork: seed the child with the parent's conversation so it continues
+	// with full context. runChild then appends the fork prompt as the next
+	// user turn. The seed is normally pre-captured by the sub_agent tool at
+	// tool-execution time (req.ForkHistory) — a background Spawn runs on its
+	// own goroutine, and snapshotting here would race the still-running parent
+	// turn, seeding the child with the parent's own "waiting for sub-agents"
+	// follow-ups. Snapshotting live is the fallback for direct synchronous
+	// callers; either way the in-flight assistant turn that called sub_agent
+	// is trimmed (see forkHistorySnapshot) so the copied history doesn't end
+	// on a dangling tool_use the provider would reject.
 	if req.ForkConversation {
-		child.History.ReplaceAll(forkHistorySnapshot(s.parent.History.Snapshot()))
+		hist := req.ForkHistory
+		if hist == nil {
+			hist = s.parent.History.Snapshot()
+		}
+		child.History.ReplaceAll(forkHistorySnapshot(hist))
 	}
 
 	// Create the session dir before registering the child: a permissions
@@ -147,7 +156,17 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 		ctx = tools.WithWorkingDir(ctx, wt.dir)
 	}
 
-	reply, in, out, stop, turns, err := s.runChild(ctx, lc, req.Prompt)
+	// A fork child's first prompt gets an explicit role pin: the seeded
+	// conversation usually reads as "I am orchestrating sub-agents", and
+	// without the pin a weaker model keeps playing the parent (replying
+	// "waiting for the sub-agents…") instead of doing the task appended at
+	// the end.
+	prompt := req.Prompt
+	if req.ForkConversation {
+		prompt = forkTaskFraming + prompt
+	}
+
+	reply, in, out, stop, turns, err := s.runChild(ctx, lc, prompt)
 	if err != nil {
 		if wt != nil {
 			wt.finish() // reconcile/clean even on error so we don't leak the worktree
@@ -202,6 +221,13 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 		StopReason:   stop,
 	}, nil
 }
+
+// forkTaskFraming prefixes a fork child's first prompt (see Spawn).
+const forkTaskFraming = "<system-reminder>You are a sub-agent forked from the conversation above. " +
+	"That conversation is background context only — do not continue its narrative, do not act as " +
+	"the orchestrator, and do not wait for or report on other sub-agents. Your entire job is the " +
+	"single task below: execute it yourself, using your tools as needed, and reply with its " +
+	"result.</system-reminder>\n\n"
 
 // schemaRetryPrompt re-prompts a child whose first reply wasn't valid JSON.
 const schemaRetryPrompt = "Your previous reply was not valid JSON. Respond with ONLY the raw JSON " +
@@ -361,6 +387,15 @@ func (lc *liveChild) syncSession() {
 // edit_file) are dropped too — used by read-only presets so the child keeps
 // terminal/MCP/codegraph but can't change files. The two filters compose: a
 // readOnly preset still honours allowed.
+// ForkSnapshot captures the parent conversation for seeding a fork child,
+// trimmed of the in-flight assistant turn (see forkHistorySnapshot). It
+// implements tools.ForkSnapshotter: the sub_agent tool calls it synchronously
+// at tool-execution time so a background fork seeds from the conversation as
+// the model saw it when it made the call.
+func (s *Spawner) ForkSnapshot() []agent.Message {
+	return forkHistorySnapshot(s.parent.History.Snapshot())
+}
+
 // forkHistorySnapshot trims a parent-history snapshot for seeding a fork. The
 // parent is mid-turn: the assistant message that called sub_agent is already in
 // history, but its tool_result hasn't been produced. Copying it verbatim would

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -456,12 +456,62 @@ func TestAgentSpawner_ForkSeedsConversation(t *testing.T) {
 	}
 	foundPrompt := false
 	for _, m := range msgs {
-		if m.Role == agent.RoleUser && m.Content == "go" {
+		if m.Role == agent.RoleUser && strings.HasSuffix(m.Content, "go") {
 			foundPrompt = true
+			// The fork prompt carries the role pin so the child doesn't keep
+			// playing the parent's orchestrator role from the seeded history.
+			if !strings.Contains(m.Content, "forked from the conversation above") {
+				t.Errorf("fork prompt should carry the fork framing, got: %q", m.Content)
+			}
 		}
 	}
 	if !foundPrompt {
 		t.Error("fork prompt should be appended after the seeded history")
+	}
+}
+
+// TestAgentSpawner_ForkUsesPreCapturedHistory verifies Spawn seeds a fork from
+// req.ForkHistory when set, not from the parent's live history — the live
+// history may have moved on by the time a background spawn goroutine runs.
+func TestAgentSpawner_ForkUsesPreCapturedHistory(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	parent.History.Append(agent.NewUserMessage("original question"))
+
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
+
+	// Capture the seed as the sub_agent tool would, then let the parent turn
+	// "move on" before Spawn runs.
+	seed := sp.ForkSnapshot()
+	parent.History.Append(agent.NewAssistantMessage("waiting for the sub-agents to finish"))
+
+	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{
+		Prompt: "go", ForkConversation: true, ForkHistory: seed,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, m := range sp.reg.m[onlyChildID(t, sp)].agent.History.Snapshot() {
+		if strings.Contains(m.Content, "waiting for the sub-agents") {
+			t.Fatalf("fork must seed from the pre-captured snapshot, not the parent's later messages: %+v", m)
+		}
+	}
+}
+
+// TestAgentSpawner_NonForkPromptUnframed verifies a fresh (preset) child gets
+// the raw prompt — the fork role pin only applies to forks.
+func TestAgentSpawner_NonForkPromptUnframed(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
+	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{Prompt: "go"}); err != nil {
+		t.Fatal(err)
+	}
+
+	last := send.lastMessages[len(send.lastMessages)-1]
+	if last.Content != "go" {
+		t.Errorf("non-fork prompt should be passed through unframed, got: %q", last.Content)
 	}
 }
 

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -14,7 +14,8 @@ import (
 //
 // Parameters:
 //   - description: short label for UI/logging
-//   - prompt:      the task (self-contained — the child can't see this conversation)
+//   - prompt:      the task (self-contained for a fresh agent; a fork sees the
+//     conversation, so just the task to do now)
 //   - subagent_type: optional agent type (explore, plan, general, code-review).
 //     Omit to fork yourself — the child inherits your full conversation context.
 //   - run_in_background: when true the agent runs async and you are notified
@@ -58,7 +59,7 @@ func (AgentTool) Definition() agent.ToolDefinition {
 				},
 				"prompt": map[string]any{
 					"type":        "string",
-					"description": "The task for the sub-agent. Self-contained: include all context the sub-agent needs (file paths, constraints, deliverable) since it can't see this conversation. State the expected output shape (a summary, a list, a YES/NO).",
+					"description": "The task for the sub-agent. For a fresh agent (subagent_type set) make it self-contained: include all context the sub-agent needs (file paths, constraints, deliverable) since it can't see this conversation. A fork already sees this conversation, so state just the task to do now. Either way, state the expected output shape (a summary, a list, a YES/NO).",
 				},
 				"subagent_type": map[string]any{
 					"type":        "string",
@@ -125,6 +126,17 @@ func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (a
 		Model:       callModel,
 		// No subagent_type → fork: seed the child with this conversation so far.
 		ForkConversation: subagentType == "",
+	}
+	// Capture the fork seed here, on the tool-execution path, rather than
+	// inside Spawn: a background spawn runs on its own goroutine and would
+	// otherwise snapshot the parent history after the turn has moved on —
+	// picking up the "Started sub-agent…" tool results and the parent's own
+	// follow-up messages, which prime the child to keep playing the parent's
+	// role instead of doing its task.
+	if req.ForkConversation {
+		if fs, ok := mgr.Spawner().(ForkSnapshotter); ok {
+			req.ForkHistory = fs.ForkSnapshot()
+		}
 	}
 	if preset != nil {
 		req.SystemSuffix = preset.persona

--- a/internal/tools/spawner.go
+++ b/internal/tools/spawner.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"sync"
+
+	"github.com/open-octo/octo-agent/internal/agent"
 )
 
 // Spawner runs one sub-agent task to completion and returns the final reply.
@@ -42,6 +44,16 @@ type SpawnRequest struct {
 	// copied history ends cleanly. Set by the sub_agent tool when no
 	// subagent_type is given; workflow agents leave it false.
 	ForkConversation bool
+
+	// ForkHistory, when non-nil, is the parent-conversation snapshot the fork
+	// child is seeded with. The sub_agent tool captures it at tool-execution
+	// time (via ForkSnapshotter) so the fork reflects the conversation as it
+	// stood when the model made the call — a background spawn's goroutine may
+	// run arbitrarily later, after the parent turn has appended its own
+	// "Started sub-agent…" results and follow-up messages, which a child must
+	// not mistake for its own role. Nil means "snapshot inside Spawn" (only
+	// safe for synchronous callers).
+	ForkHistory []agent.Message
 
 	// Tools, when non-empty, restricts the child to this subset of the
 	// parent's tool list. nil/empty means "inherit all of parent's tools
@@ -86,6 +98,16 @@ type SpawnRequest struct {
 	// full conversation transcript to <SessionDir>/<agent-id>.jsonl so it can
 	// be inspected after a failure.
 	SessionDir string
+}
+
+// ForkSnapshotter is implemented by Spawner implementations that can capture
+// the parent conversation synchronously. The sub_agent tool calls it on the
+// tool-execution path — while the parent turn is still parked on this tool
+// call — so a background fork seeds from the conversation the model actually
+// saw, not from wherever the parent turn has advanced to by the time the
+// spawn goroutine gets scheduled.
+type ForkSnapshotter interface {
+	ForkSnapshot() []agent.Message
 }
 
 // SpawnResult is the sub-agent's final output, plus its token usage so the

--- a/internal/tools/subagent_fork_test.go
+++ b/internal/tools/subagent_fork_test.go
@@ -1,0 +1,110 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+)
+
+// forkCaptureSpawner implements ForkSnapshotter and lets a test mutate its
+// "parent history" between the tool call returning and the background Spawn
+// goroutine running, to prove the fork seed was captured synchronously.
+type forkCaptureSpawner struct {
+	mu      sync.Mutex
+	history []agent.Message
+
+	hold    chan struct{} // Spawn blocks here until the test releases it
+	spawned chan SpawnRequest
+}
+
+func (s *forkCaptureSpawner) ForkSnapshot() []agent.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]agent.Message(nil), s.history...)
+}
+
+func (s *forkCaptureSpawner) setHistory(msgs ...agent.Message) {
+	s.mu.Lock()
+	s.history = msgs
+	s.mu.Unlock()
+}
+
+func (s *forkCaptureSpawner) Spawn(_ context.Context, req SpawnRequest) (SpawnResult, error) {
+	<-s.hold
+	s.spawned <- req
+	return SpawnResult{AgentID: "c1", Reply: "ok"}, nil
+}
+
+func (s *forkCaptureSpawner) Continue(_ context.Context, _, _ string) (SpawnResult, error) {
+	return SpawnResult{}, nil
+}
+
+// TestAgentTool_ForkSeedCapturedAtCallTime verifies the fork seed is captured
+// on the tool-execution path, not inside the background Spawn goroutine: the
+// parent turn keeps running after Start returns, and a late snapshot would
+// seed the child with the parent's own "waiting for sub-agents" follow-ups
+// (the session-1136b387 bug).
+func TestAgentTool_ForkSeedCapturedAtCallTime(t *testing.T) {
+	sp := &forkCaptureSpawner{hold: make(chan struct{}), spawned: make(chan SpawnRequest, 1)}
+	sp.setHistory(agent.NewUserMessage("original question"))
+	mgr := NewSubAgentManager(sp)
+	ctx := WithSubAgentManager(context.Background(), mgr)
+
+	res, err := (AgentTool{}).Execute(ctx, "sub_agent", map[string]any{
+		"description": "d", "prompt": "explore the trash module", "run_in_background": true,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "Started sub-agent") {
+		t.Fatalf("background start should return immediately, got: %q", res.Text)
+	}
+
+	// The parent turn moves on before the spawn goroutine gets to run.
+	sp.setHistory(
+		agent.NewUserMessage("original question"),
+		agent.NewAssistantMessage("waiting for the sub-agents to finish"),
+	)
+	close(sp.hold)
+
+	select {
+	case req := <-sp.spawned:
+		if !req.ForkConversation {
+			t.Fatal("omitted subagent_type should fork")
+		}
+		if len(req.ForkHistory) != 1 || req.ForkHistory[0].Content != "original question" {
+			t.Fatalf("fork seed should be the call-time snapshot, got: %+v", req.ForkHistory)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("background spawn never ran")
+	}
+}
+
+// TestAgentTool_FreshAgentSkipsForkSnapshot verifies a typed (fresh) child
+// doesn't get a conversation seed even when the spawner could provide one.
+func TestAgentTool_FreshAgentSkipsForkSnapshot(t *testing.T) {
+	sp := &forkCaptureSpawner{hold: make(chan struct{}), spawned: make(chan SpawnRequest, 1)}
+	sp.setHistory(agent.NewUserMessage("original question"))
+	close(sp.hold)
+	mgr := NewSubAgentManager(sp)
+	ctx := WithSubAgentManager(context.Background(), mgr)
+
+	if _, err := (AgentTool{}).Execute(ctx, "sub_agent", map[string]any{
+		"description": "d", "prompt": "p", "subagent_type": "explore", "run_in_background": true,
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	select {
+	case req := <-sp.spawned:
+		if req.ForkConversation || req.ForkHistory != nil {
+			t.Fatalf("typed child must not carry a fork seed: fork=%v history=%+v", req.ForkConversation, req.ForkHistory)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("background spawn never ran")
+	}
+}


### PR DESCRIPTION
## Problem

In session `1136b387` the model dispatched 3 background `sub_agent` calls (no `subagent_type` → fork mode) to explore three subsystems. All three children ignored their task and replied in the parent's voice — "waiting for the sub-agents to complete" — so the parent got zero exploration results.

Two causes stacked:

1. **Fork snapshot race.** `SubAgentManager.Start` returns immediately and `Spawn` runs on a goroutine; the fork history snapshot was taken inside `Spawn` (`spawner.go`), by which time the parent turn had already appended the `Started sub-agent…` tool results and its own "waiting" follow-ups. `forkHistorySnapshot` only trims a *trailing* assistant `tool_use` turn, so once tool results landed (<1s after Start in the incident), nothing was trimmed and the whole orchestration narrative seeded the child. Evidence: one child's reply matched the parent's own message verbatim; another (exploring trash) referenced the *other two* agents by name; its input tokens (22331) ≈ the parent's full context (23204).

2. **Role confusion on the seeded narrative.** Even a correct call-time seed reads as "I am orchestrating sub-agents". Strong models keep the fork prompt and the seeded context apart; weaker ones (LongCat-2.0 here) continue the parent's role. The tool description actively steers deep investigation toward fork mode, so this combination is by design and needs to be robust.

## Fix

- New `tools.ForkSnapshotter` (implemented by `app.Spawner`): the `sub_agent` tool captures the fork seed synchronously on the tool-execution path and passes it via `SpawnRequest.ForkHistory`. The fork now reflects the conversation as the model saw it when it made the call. `Spawn` keeps a live-snapshot fallback for direct synchronous callers.
- A fork child's first prompt is prefixed with an explicit role pin (`forkTaskFraming`): the seeded conversation is background context only; do not act as the orchestrator; the single task below is the entire job.
- Docs: the tool comment and `prompt` parameter description claimed the child "can't see this conversation" — true only for typed (fresh) children; now mode-aware.

## Tests

- `TestAgentTool_ForkSeedCapturedAtCallTime` — mutates the "parent history" after `Execute` returns but before the spawn goroutine runs; asserts the child got the call-time snapshot (reproduces the incident shape).
- `TestAgentTool_FreshAgentSkipsForkSnapshot` — typed children carry no fork seed.
- `TestAgentSpawner_ForkUsesPreCapturedHistory` — `Spawn` prefers `req.ForkHistory` over live parent history.
- `TestAgentSpawner_NonForkPromptUnframed` — role pin applies to forks only; existing fork-seed test extended to assert the framing.

`go test -race ./...` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
