### PR TITLE
feat(relay): M1a — TLS listening, /healthz, deploy assets, CI

### DIFF
--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -1,0 +1,50 @@
+name: Relay
+
+# Builds and tests cmd/octo-relay, the managed-tunnel relay. It is a nested Go
+# module with its own dependency tree (flynn/noise, gorilla/websocket) — none
+# of it enters the CLI's zero-dependency build, and the main `Go` workflow's
+# `go test ./...` skips nested modules entirely, so without this job the
+# relay's tests would never run in CI.
+#
+# Path-filtered so a relay-only change runs only this workflow, and a change
+# elsewhere never triggers it.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/octo-relay/**'
+      - '.github/workflows/relay.yml'
+  pull_request:
+    paths:
+      - 'cmd/octo-relay/**'
+      - '.github/workflows/relay.yml'
+
+# Only reads the checkout; no token write scope needed.
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Build + test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cmd/octo-relay
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cmd/octo-relay/go.mod
+          cache-dependency-path: cmd/octo-relay/go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: gofmt
+        run: |
+          out=$(gofmt -l .)
+          if [ -n "$out" ]; then echo "gofmt needed on:"; echo "$out"; exit 1; fi
+
+      - name: go test
+        run: go test -race ./...

--- a/cmd/octo-relay/deploy/deploy.sh
+++ b/cmd/octo-relay/deploy/deploy.sh
@@ -14,15 +14,23 @@ VERSION=${2:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}
 
 cd "$(dirname "$0")/.."
 
+OUT=$(mktemp -t octo-relay.XXXXXX)
+trap 'rm -f "${OUT}"' EXIT
+
 echo "==> building octo-relay ${VERSION} (linux/amd64)"
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
-	go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o /tmp/octo-relay .
+	go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o "${OUT}" .
 
+# Upload into the ssh user's home, not a world-writable /tmp path — a fixed
+# /tmp name could be pre-created by another local user and swapped between
+# the scp and the root install.
 echo "==> shipping to ${HOST}"
-scp /tmp/octo-relay "${HOST}:/tmp/octo-relay"
-ssh "${HOST}" 'sudo install -m 0755 /tmp/octo-relay /usr/local/bin/octo-relay && sudo systemctl restart octo-relay && rm /tmp/octo-relay'
+scp "${OUT}" "${HOST}:octo-relay.upload"
+ssh "${HOST}" 'sudo install -m 0755 ~/octo-relay.upload /usr/local/bin/octo-relay && sudo systemctl restart octo-relay && rm ~/octo-relay.upload'
 
+# Probe assumes the production shape (RELAY_ADDR=:443 + TLS); -k because we
+# self-connect via 127.0.0.1 so the domain cert won't match. Poll a few
+# seconds: systemd restart + TLS load isn't instant.
 echo "==> verifying /healthz"
-# -k: self-connecting via 127.0.0.1, so the domain cert won't match the SNI.
-ssh "${HOST}" 'sleep 1; curl -fsSk https://127.0.0.1/healthz'
+ssh "${HOST}" 'for i in 1 2 3 4 5; do curl -fsSk https://127.0.0.1/healthz && exit 0; sleep 1; done; echo "healthz never came up" >&2; exit 1'
 echo "==> done"

--- a/cmd/octo-relay/deploy/deploy.sh
+++ b/cmd/octo-relay/deploy/deploy.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+# Build octo-relay for linux/amd64 and push it to a relay VM over ssh.
+#
+#   ./deploy.sh <ssh-host> [version]
+#
+# <ssh-host> is any ssh destination (e.g. relay1.octo.dev or an alias from
+# ~/.ssh/config with the right user/key). [version] defaults to the current
+# git describe. First-time VM provisioning is in dev-docs/relay-runbook.md;
+# this script only ships a new binary and restarts the service.
+set -eu
+
+HOST=${1:?usage: deploy.sh <ssh-host> [version]}
+VERSION=${2:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}
+
+cd "$(dirname "$0")/.."
+
+echo "==> building octo-relay ${VERSION} (linux/amd64)"
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+	go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o /tmp/octo-relay .
+
+echo "==> shipping to ${HOST}"
+scp /tmp/octo-relay "${HOST}:/tmp/octo-relay"
+ssh "${HOST}" 'sudo install -m 0755 /tmp/octo-relay /usr/local/bin/octo-relay && sudo systemctl restart octo-relay && rm /tmp/octo-relay'
+
+echo "==> verifying /healthz"
+# -k: self-connecting via 127.0.0.1, so the domain cert won't match the SNI.
+ssh "${HOST}" 'sleep 1; curl -fsSk https://127.0.0.1/healthz'
+echo "==> done"

--- a/cmd/octo-relay/deploy/env.example
+++ b/cmd/octo-relay/deploy/env.example
@@ -1,0 +1,11 @@
+# /etc/octo-relay/env — environment for octo-relay.service.
+# Copy to /etc/octo-relay/env and adjust; never commit real paths/secrets.
+
+# Listen address. :443 needs CAP_NET_BIND_SERVICE (the unit grants it).
+RELAY_ADDR=:443
+
+# TLS material. M1a: single-domain cert for relay.octo.dev (Let's Encrypt).
+# The certbot deploy-hook below keeps these fresh; the relay is restarted by
+# the hook on renewal.
+RELAY_TLS_CERT=/etc/letsencrypt/live/relay.octo.dev/fullchain.pem
+RELAY_TLS_KEY=/etc/letsencrypt/live/relay.octo.dev/privkey.pem

--- a/cmd/octo-relay/deploy/octo-relay.service
+++ b/cmd/octo-relay/deploy/octo-relay.service
@@ -1,0 +1,36 @@
+# systemd unit for the hosted octo-relay (M1a: single node, TLS at the relay).
+# Install: cp to /etc/systemd/system/octo-relay.service, then
+#   systemctl daemon-reload && systemctl enable --now octo-relay
+# Configuration lives in /etc/octo-relay/env (see env.example) so the unit
+# itself never changes between environments.
+
+[Unit]
+Description=octo-relay - end-to-end-encrypted tunnel relay
+Documentation=https://github.com/open-octo/octo-agent/tree/main/cmd/octo-relay
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=octo-relay
+Group=octo-relay
+EnvironmentFile=/etc/octo-relay/env
+ExecStart=/usr/local/bin/octo-relay --addr ${RELAY_ADDR} --tls-cert ${RELAY_TLS_CERT} --tls-key ${RELAY_TLS_KEY}
+Restart=always
+RestartSec=2
+
+# Binding :443 as a non-root user.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+# The relay holds no state and writes nothing; lock it down accordingly.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/cmd/octo-relay/main.go
+++ b/cmd/octo-relay/main.go
@@ -26,11 +26,33 @@ func main() {
 	tlsCert := flag.String("tls-cert", "", "TLS certificate file (PEM); with --tls-key, serve wss instead of plaintext")
 	tlsKey := flag.String("tls-key", "", "TLS private key file (PEM)")
 	flag.Parse()
+	if err := rejectEmptyTLSFlags(flag.CommandLine); err != nil {
+		log.Fatalf("[relay] %v", err)
+	}
 
 	r := relay.New()
 	if err := serve(*addr, *tlsCert, *tlsKey, withHealthz(r.Handler(), version)); err != nil {
 		log.Fatalf("[relay] %v", err)
 	}
+}
+
+// rejectEmptyTLSFlags refuses a TLS flag that was explicitly passed with an
+// empty value. systemd's ${VAR} expansion turns an unset variable into an
+// empty argument (not a removed one), so a stale /etc/octo-relay/env with
+// both TLS variables missing would otherwise sail into the plaintext branch —
+// a silent downgrade on a public port. Not passing the flags at all (local
+// development) stays plaintext as documented.
+func rejectEmptyTLSFlags(fs *flag.FlagSet) error {
+	var bad string
+	fs.Visit(func(f *flag.Flag) {
+		if (f.Name == "tls-cert" || f.Name == "tls-key") && f.Value.String() == "" {
+			bad = f.Name
+		}
+	})
+	if bad != "" {
+		return fmt.Errorf("--%s was passed an empty value; unset both TLS flags for plaintext or set both to serve TLS", bad)
+	}
+	return nil
 }
 
 // serve listens with TLS when both cert and key are given, plaintext when

--- a/cmd/octo-relay/main.go
+++ b/cmd/octo-relay/main.go
@@ -1,27 +1,64 @@
-// Command octo-relay is the PoC relay: a single-node dumb pipe that brokers
-// pairing and bridges end-to-end-encrypted frames between a host and its paired
-// devices. It never decrypts — see package relay for the guarantee.
+// Command octo-relay is the relay: a dumb pipe that brokers pairing and
+// bridges end-to-end-encrypted frames between a host and its paired devices.
+// It never decrypts — see package relay for the guarantee.
 //
-// This is the transport-core proof only. Push wakeups (APNs/FCM) and multi-node
-// SNI-hash routing are deferred; the design in
+// M1a adds the hosted-deployment surface: TLS listening (--tls-cert/--tls-key)
+// and /healthz for the load balancer. Push wakeups (APNs/FCM) and multi-node
+// SNI-hash routing are still deferred; the design in
 // dev-docs/mobile-managed-tunnel-design.md covers where they slot in.
 package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/open-octo/octo-agent/cmd/octo-relay/internal/relay"
 )
 
+// version is stamped by the build (-ldflags "-X main.version=..."); "dev"
+// otherwise. Reported by /healthz so a rollout can be verified from the LB.
+var version = "dev"
+
 func main() {
 	addr := flag.String("addr", ":8090", "listen address")
+	tlsCert := flag.String("tls-cert", "", "TLS certificate file (PEM); with --tls-key, serve wss instead of plaintext")
+	tlsKey := flag.String("tls-key", "", "TLS private key file (PEM)")
 	flag.Parse()
 
 	r := relay.New()
-	log.Printf("[relay] listening on %s", *addr)
-	if err := http.ListenAndServe(*addr, r.Handler()); err != nil {
+	if err := serve(*addr, *tlsCert, *tlsKey, withHealthz(r.Handler(), version)); err != nil {
 		log.Fatalf("[relay] %v", err)
 	}
+}
+
+// serve listens with TLS when both cert and key are given, plaintext when
+// neither is (local development), and refuses the ambiguous half-configured
+// state — silently falling back to plaintext on a typo'd flag would be a
+// downgrade the operator never asked for.
+func serve(addr, certFile, keyFile string, h http.Handler) error {
+	switch {
+	case certFile != "" && keyFile != "":
+		log.Printf("[relay] listening on %s (TLS)", addr)
+		return http.ListenAndServeTLS(addr, certFile, keyFile, h)
+	case certFile == "" && keyFile == "":
+		log.Printf("[relay] listening on %s (plaintext)", addr)
+		return http.ListenAndServe(addr, h)
+	default:
+		return fmt.Errorf("--tls-cert and --tls-key must be set together")
+	}
+}
+
+// withHealthz mounts GET /healthz next to the relay endpoints. The LB health
+// check and rollout verification both read it; it reports nothing beyond
+// liveness and the running version (the relay stays content-free).
+func withHealthz(next http.Handler, version string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprintf(w, "ok %s\n", version)
+	})
+	mux.Handle("/", next)
+	return mux
 }

--- a/cmd/octo-relay/main_test.go
+++ b/cmd/octo-relay/main_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/open-octo/octo-agent/cmd/octo-relay/internal/relay"
+)
+
+// TestServeRejectsHalfTLSConfig: one of --tls-cert/--tls-key without the other
+// must be an error, not a silent plaintext fallback.
+func TestServeRejectsHalfTLSConfig(t *testing.T) {
+	for _, tc := range [][2]string{{"cert.pem", ""}, {"", "key.pem"}} {
+		if err := serve("127.0.0.1:0", tc[0], tc[1], http.NotFoundHandler()); err == nil {
+			t.Errorf("serve(cert=%q, key=%q) = nil, want error", tc[0], tc[1])
+		}
+	}
+}
+
+// TestHealthzPlaintext: /healthz responds 200 with the version, and the relay
+// endpoints stay mounted beside it.
+func TestHealthzPlaintext(t *testing.T) {
+	srv := httptest.NewServer(withHealthz(relay.New().Handler(), "1.2.3-test"))
+	defer srv.Close()
+
+	res, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if got := string(body); !strings.Contains(got, "1.2.3-test") {
+		t.Errorf("body = %q, want version in it", got)
+	}
+
+	// The relay endpoints must still answer through the wrapped handler:
+	// /host without a tunnel id is its documented 400.
+	res2, err := http.Get(srv.URL + "/host")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res2.Body.Close()
+	if res2.StatusCode != http.StatusBadRequest {
+		t.Errorf("/host status = %d, want 400", res2.StatusCode)
+	}
+}
+
+// TestServeTLS: with a cert/key pair, serve terminates TLS and /healthz
+// answers over it — the code path a hosted relay actually runs.
+func TestServeTLS(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeSelfSigned(t, dir)
+
+	// Grab a free port first: serve blocks, so run it in a goroutine and poll.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	errc := make(chan error, 1)
+	go func() { errc <- serve(addr, certFile, keyFile, withHealthz(relay.New().Handler(), "tls-test")) }()
+
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+		Timeout:   2 * time.Second,
+	}
+	var lastErr error
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		select {
+		case err := <-errc:
+			t.Fatalf("serve exited: %v", err)
+		default:
+		}
+		res, err := client.Get("https://" + addr + "/healthz")
+		if err == nil {
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+			if res.StatusCode != http.StatusOK || !strings.Contains(string(body), "tls-test") {
+				t.Fatalf("healthz over TLS: status=%d body=%q", res.StatusCode, body)
+			}
+			return
+		}
+		lastErr = err
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("healthz over TLS never came up: %v", lastErr)
+}
+
+// TestServeTLSBadCert: an unloadable cert must fail startup loudly.
+func TestServeTLSBadCert(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.pem")
+	if err := os.WriteFile(bad, []byte("not a pem"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := serve("127.0.0.1:0", bad, bad, http.NotFoundHandler()); err == nil {
+		t.Fatal("serve with a garbage cert = nil, want error")
+	}
+}
+
+// writeSelfSigned mints a throwaway self-signed cert for 127.0.0.1 and writes
+// the PEM pair into dir.
+func writeSelfSigned(t *testing.T, dir string) (certFile, keyFile string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "octo-relay-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certFile, keyFile
+}

--- a/cmd/octo-relay/main_test.go
+++ b/cmd/octo-relay/main_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"flag"
 	"io"
 	"math/big"
 	"net"
@@ -29,6 +30,48 @@ func TestServeRejectsHalfTLSConfig(t *testing.T) {
 		if err := serve("127.0.0.1:0", tc[0], tc[1], http.NotFoundHandler()); err == nil {
 			t.Errorf("serve(cert=%q, key=%q) = nil, want error", tc[0], tc[1])
 		}
+	}
+}
+
+// TestRejectEmptyTLSFlags: a TLS flag explicitly passed as "" (what systemd's
+// ${VAR} expansion produces for an unset variable) must fail startup instead
+// of silently downgrading to plaintext. Omitting the flags stays fine.
+func TestRejectEmptyTLSFlags(t *testing.T) {
+	mk := func() *flag.FlagSet {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.String("tls-cert", "", "")
+		fs.String("tls-key", "", "")
+		fs.String("addr", ":8090", "")
+		return fs
+	}
+	for _, args := range [][]string{
+		{"--tls-cert", "", "--tls-key", ""},
+		{"--tls-cert", ""},
+		{"--tls-key", ""},
+	} {
+		fs := mk()
+		if err := fs.Parse(args); err != nil {
+			t.Fatal(err)
+		}
+		if err := rejectEmptyTLSFlags(fs); err == nil {
+			t.Errorf("rejectEmptyTLSFlags(%q) = nil, want error", args)
+		}
+	}
+	// Flags not passed at all: plaintext local dev must keep working.
+	fs := mk()
+	if err := fs.Parse([]string{"--addr", ":9999"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rejectEmptyTLSFlags(fs); err != nil {
+		t.Errorf("rejectEmptyTLSFlags(no TLS flags) = %v, want nil", err)
+	}
+	// And explicitly set non-empty values pass through.
+	fs = mk()
+	if err := fs.Parse([]string{"--tls-cert", "c.pem", "--tls-key", "k.pem"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rejectEmptyTLSFlags(fs); err != nil {
+		t.Errorf("rejectEmptyTLSFlags(both set) = %v, want nil", err)
 	}
 }
 

--- a/dev-docs/relay-runbook.md
+++ b/dev-docs/relay-runbook.md
@@ -28,9 +28,9 @@ node it grows out of.
    ```sh
    sudo certbot certonly --standalone -d relay.octo.dev
    ```
-   Run this before the relay first starts (both want :80/:443 free at issue
-   time; renewals use the deploy hook below and don't conflict once switched
-   to webroot or a brief stop). Give the service user read access:
+   Standalone HTTP-01 binds :80 only, and the relay binds :443 only, so
+   issuance and renewals never conflict with a running relay. Give the
+   service user read access:
    ```sh
    sudo groupadd -f octo-certs
    sudo usermod -aG octo-certs octo-relay
@@ -77,10 +77,12 @@ node it grows out of.
 
 ## Local development
 
-No flags = plaintext on :8090, same as the PoC:
+No flags = plaintext on :8090, same as the PoC. The relay is a nested Go
+module, so run it from its own directory (the parent module doesn't contain
+it):
 
 ```sh
-go run ./cmd/octo-relay --addr :8090
+(cd cmd/octo-relay && go run . --addr :8090)
 octo serve --tunnel --relay ws://127.0.0.1:8090
 ```
 

--- a/dev-docs/relay-runbook.md
+++ b/dev-docs/relay-runbook.md
@@ -1,0 +1,88 @@
+# octo-relay runbook (M1a: single node, TLS)
+
+How to provision, operate, and verify a hosted octo-relay node. The relay is a
+stateless dumb pipe (see `dev-docs/mobile-managed-tunnel-design.md`): it holds
+no persistent data, terminates TLS, and bridges end-to-end-encrypted frames it
+cannot read. Everything below is reproducible from scratch; losing the VM
+loses nothing but uptime.
+
+## Topology (M1a)
+
+```
+DNS: relay.octo.dev ──► 1 VM (octo-relay, systemd, TLS at the relay)
+```
+
+Multi-node SNI routing behind an L4 LB is M1b; this runbook covers the single
+node it grows out of.
+
+## Provision a node
+
+1. **VM**: any small Linux VM (1 vCPU / 512 MB is plenty — the relay only
+   copies frames). Open inbound 443 (and 80 if using certbot's HTTP-01).
+2. **DNS**: point `relay.octo.dev` (A/AAAA) at the VM.
+3. **User**:
+   ```sh
+   sudo useradd --system --no-create-home --shell /usr/sbin/nologin octo-relay
+   ```
+4. **Certificate** (single domain, Let's Encrypt HTTP-01):
+   ```sh
+   sudo certbot certonly --standalone -d relay.octo.dev
+   ```
+   Run this before the relay first starts (both want :80/:443 free at issue
+   time; renewals use the deploy hook below and don't conflict once switched
+   to webroot or a brief stop). Give the service user read access:
+   ```sh
+   sudo groupadd -f octo-certs
+   sudo usermod -aG octo-certs octo-relay
+   sudo chgrp -R octo-certs /etc/letsencrypt/live /etc/letsencrypt/archive
+   sudo chmod -R g+rX /etc/letsencrypt/live /etc/letsencrypt/archive
+   ```
+5. **Renewal hook** — restart the relay when the cert renews:
+   ```sh
+   sudo tee /etc/letsencrypt/renewal-hooks/deploy/octo-relay <<'EOF'
+   #!/bin/sh
+   systemctl restart octo-relay
+   EOF
+   sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/octo-relay
+   ```
+6. **Config + unit** (files in `cmd/octo-relay/deploy/`):
+   ```sh
+   sudo mkdir -p /etc/octo-relay
+   sudo cp deploy/env.example /etc/octo-relay/env   # then edit paths if needed
+   sudo cp deploy/octo-relay.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now octo-relay
+   ```
+7. **Binary**: from a checkout, `cmd/octo-relay/deploy/deploy.sh <ssh-host>`
+   cross-builds linux/amd64, ships it, restarts the service, and curls
+   `/healthz`.
+
+## Verify
+
+- **Liveness + version**: `curl https://relay.octo.dev/healthz` → `ok <version>`.
+- **End to end**: on any machine, `octo serve --tunnel` (the default relay is
+  already `wss://relay.octo.dev`), pair a phone via the QR, send a message.
+- **Self-heal**: `sudo systemctl kill octo-relay` — systemd restarts it within
+  seconds (`Restart=always`); both tunnel ends reconnect on their own.
+
+## Operate
+
+- **Logs**: `journalctl -u octo-relay -f`. The relay logs connection lifecycle
+  only — never payloads, tokens, or anything content-derived. Keep it that way.
+- **Upgrade**: rerun `deploy.sh`. In-flight tunnels drop on restart and both
+  ends reconnect; no drain needed at this stage.
+- **State**: none. Pairing tokens and connections live only in process memory.
+  A restart invalidates unredeemed pairing QRs (the host re-offers its tokens
+  on reconnect automatically).
+
+## Local development
+
+No flags = plaintext on :8090, same as the PoC:
+
+```sh
+go run ./cmd/octo-relay --addr :8090
+octo serve --tunnel --relay ws://127.0.0.1:8090
+```
+
+Setting exactly one of `--tls-cert`/`--tls-key` is a startup error by design —
+a typo'd path must not silently downgrade a production node to plaintext.


### PR DESCRIPTION
M1a of relay productionization (architecture locked in dev-docs/mobile-managed-tunnel-design.md; this is the ops-surface step — the transport core is untouched).

## What
- **TLS**: `--tls-cert`/`--tls-key` → wss. Neither = plaintext (local dev, same as PoC). Exactly one = startup error, so a typo'd path can't silently downgrade a production node to plaintext.
- **`GET /healthz`** → `ok <version>` (build-stamped via `-X main.version`), for the LB health check and rollout verification. Reports liveness + version only — the relay stays content-free.
- **deploy/**: hardened systemd unit (dedicated `octo-relay` user, `CAP_NET_BIND_SERVICE` for :443, `ProtectSystem=strict` — the relay persists nothing), `env.example`, `deploy.sh` (cross-build → ship → restart → healthz probe).
- **dev-docs/relay-runbook.md**: provision (VM/DNS/certbot + renewal hook)/verify/operate/local-dev. Node is stateless; losing it loses only uptime.
- **New `Relay` CI workflow** (path-filtered): the relay is a nested Go module, so the main Go workflow never tested it — its tests were decoration until now. vet + gofmt + `go test -race`.

## Tests
TLS serving end-to-end (self-signed pair, healthz over https), plaintext fallback, half-configured rejection, garbage-cert rejection, relay endpoints mounted beside healthz. All green with -race.

## Client
Zero changes — `defaultRelayURL` has been `wss://relay.octo.dev` since the PoC (cmd/octo/serve_tunnel.go:20).

## Not in this PR
Real domain/VM/cert provisioning (ops steps in the runbook), M1b multi-node SNI routing, M1c push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)