### PR TITLE
fix(cli): one-shot must not orphan background sub-agents

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -771,6 +771,18 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	toolExecutor = toolEnv.Executor
 	subAgentMgr = toolEnv.SubAgentMgr
 
+	// The headless one-shot exits when its single turn ends, so a background
+	// sub-agent's completion notification has no follow-up turn to land in —
+	// children spawned with run_in_background=true would be orphaned and their
+	// results silently lost. Run sub-agents inline instead, like the other
+	// request/response transports (server, IM). Parallel fan-out is unaffected:
+	// sync sub_agent calls issued in one assistant message still dispatch
+	// concurrently. The TUI keeps async — it re-injects completions as
+	// follow-up turns.
+	if !useTUI {
+		subAgentMgr.SetSynchronous(true)
+	}
+
 	// send_message / send_file for the CLI/TUI: delegate to a local `octo serve`
 	// (live adapters — needed for WeChat) or fall back to a one-shot send from
 	// config. Only wired when the user has configured at least one channel, so

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -105,6 +106,120 @@ func TestRunChat_HonoursAnthropicBaseURL(t *testing.T) {
 	}
 	if gotPath != "/v1/messages" {
 		t.Errorf("path = %q, want /v1/messages", gotPath)
+	}
+}
+
+// TestRunChat_OneShot_BackgroundSubAgentForcedSync locks the one-shot
+// transport contract for sub-agents: the headless one-shot exits when its
+// single turn ends, so a sub-agent spawned with run_in_background=true has no
+// follow-up turn for its completion to land in — without forced-sync dispatch
+// the child is orphaned and its result silently lost. The one-shot must run
+// the child inline and hand its reply back in the tool_result, like the
+// server and IM transports do.
+func TestRunChat_OneShot_BackgroundSubAgentForcedSync(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		requests []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		requests = append(requests, string(body))
+		n := len(requests)
+		mu.Unlock()
+		switch {
+		case strings.Contains(string(body), `"tool_result"`):
+			// Parent follow-up turn — the sub_agent tool_result came back.
+			_, _ = w.Write([]byte(`{
+				"id":"m","type":"message","role":"assistant","model":"x",
+				"content":[{"type":"text","text":"SUMMARY DONE"}],
+				"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}
+			}`))
+		case n == 1:
+			// Parent turn 1: request a background sub-agent.
+			_, _ = w.Write([]byte(`{
+				"id":"m","type":"message","role":"assistant","model":"x",
+				"content":[{"type":"tool_use","id":"tu_1","name":"sub_agent",
+					"input":{"description":"probe trash","prompt":"say done","subagent_type":"explore","run_in_background":true}}],
+				"stop_reason":"tool_use","usage":{"input_tokens":1,"output_tokens":1}
+			}`))
+		default:
+			// The child's conversation. The parent runs buffered
+			// (--stream=false) but a sub-agent always runs through
+			// RunStream, so answer in whichever shape the request asked for.
+			if strings.Contains(string(body), `"stream":true`) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte("" +
+					`data: {"type":"message_start","message":{"id":"m","model":"x","usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
+					`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"CHILD DONE"}}` + "\n\n" +
+					`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":0,"output_tokens":2}}` + "\n\n"))
+				return
+			}
+			_, _ = w.Write([]byte(`{
+				"id":"m","type":"message","role":"assistant","model":"x",
+				"content":[{"type":"text","text":"CHILD DONE"}],
+				"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}
+			}`))
+		}
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("ANTHROPIC_API_KEY", "k")
+	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+
+	var stdout, stderr bytes.Buffer
+	code := runChat([]string{"--model", "x", "--stream=false", "--no-memory", "hello"},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	// The tool_result the parent saw must carry the child's actual reply plus
+	// the forced-sync note — not an async "Started sub-agent" stub. Pull the
+	// tool_result content out of the captured request body rather than
+	// string-matching the whole request: the sub_agent tool's own description
+	// (always present in the tools catalog) contains async wording.
+	mu.Lock()
+	defer mu.Unlock()
+	var toolResultContent string
+	for _, req := range requests {
+		var body struct {
+			Messages []struct {
+				Content json.RawMessage `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.Unmarshal([]byte(req), &body); err != nil {
+			continue
+		}
+		for _, msg := range body.Messages {
+			var blocks []struct {
+				Type    string `json:"type"`
+				Content string `json:"content"`
+			}
+			if err := json.Unmarshal(msg.Content, &blocks); err != nil {
+				continue
+			}
+			for _, b := range blocks {
+				if b.Type == "tool_result" {
+					toolResultContent = b.Content
+				}
+			}
+		}
+	}
+	if toolResultContent == "" {
+		t.Fatalf("no follow-up request with a tool_result reached the endpoint; requests=%d", len(requests))
+	}
+	if !strings.Contains(toolResultContent, "CHILD DONE") {
+		t.Errorf("tool_result should contain the child's reply; got: %q", toolResultContent)
+	}
+	if !strings.Contains(toolResultContent, "ran synchronously") {
+		t.Errorf("tool_result should carry the forced-sync note; got: %q", toolResultContent)
+	}
+	if strings.Contains(toolResultContent, "Started sub-agent") {
+		t.Errorf("one-shot must not take the async path; got: %q", toolResultContent)
 	}
 }
 

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -178,9 +178,12 @@ func runOnce(cfg replConfig, prompt string, stream bool) int {
 	defer hooks.DrainSpill(5 * time.Second)
 	defer tools.CleanSpillFiles()
 
-	// Sub-agent completions and background-process notices ride the inbox, so a
-	// later iteration of this single agentic turn picks them up (the agent
-	// drains the inbox at the start of each loop step).
+	// Background-process notices ride the inbox, so a later iteration of this
+	// single agentic turn picks them up (the agent drains the inbox at the
+	// start of each loop step). Sub-agent completions can no longer arrive
+	// this way — the one-shot forces sub-agents synchronous (see runChat), so
+	// the OnExit hook below is a defensive backstop only; the wiring stays for
+	// the KillAll cleanup.
 	if cfg.subAgentMgr != nil {
 		tools.SetDefaultSubAgentManager(cfg.subAgentMgr)
 		cfg.subAgentMgr.SetOnExit(func(ev tools.SubAgentNotification) {

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -252,14 +252,6 @@ func (m *SubAgentManager) Synchronous() bool {
 	return m.synchronous
 }
 
-// subAgentsSynchronous reports whether the process-global manager runs
-// sub-agents inline. In synchronous mode a sub-agent completes before
-// sub_agent returns, so agent_status / kill_agent have nothing to act on —
-// DefaultToolsFor withholds them there rather than advertise dead tools.
-func subAgentsSynchronous() bool {
-	return defaultSubAgentMgr != nil && defaultSubAgentMgr.Synchronous()
-}
-
 // BeginSync registers a new SyncSession for the current synchronous sub-agent
 // run. Call EndSync with the returned session (via defer) when the run finishes
 // or is promoted. At most one synchronous sub-agent runs per manager at a time —


### PR DESCRIPTION
## Problem

The headless one-shot exits when its single turn ends. A sub-agent spawned with `run_in_background=true` therefore has no follow-up turn for its completion notification to land in — the model ends the turn with *"waiting for the sub-agents to finish…"*, the process exits, and the children plus their results are silently lost. (The runOnce inbox only re-injects completions while the turn is still looping; a model that dispatches and immediately ends the turn — the common case — defeats it.)

This isn't theoretical: models reliably pick background mode for any parallel dispatch (the tool description recommends it for fan-outs). A prompt like *"use 3 sub-agents to explore X, then summarize"* reproduced it 2 out of 3 times on a stock one-shot — three orphaned children, no summary, exit 0.

## Fix

Mark the one-shot's `SubAgentManager` synchronous, exactly like the server and IM transports already do (`internal/server/server.go:594`). `sub_agent` then runs the child inline and hands its reply back in the `tool_result`, with the existing forced-sync note explaining why. One `if !useTUI` in `cmd/octo/chat.go` — the mechanism was already there.

- Parallel fan-out unaffected: sync calls issued in one assistant message still dispatch concurrently.
- The TUI keeps async — it re-injects completions as follow-up turns.
- Also updates the now-stale runOnce inbox comment (sub-agent completions can no longer arrive async in one-shot).

## Test

End-to-end against a scripted Anthropic `httptest` endpoint: parent turn requests a background sub-agent → child conversation answers over SSE (sub-agents always run through `RunStream`, even when the parent is buffered with `--stream=false`) → assert the parent's follow-up `tool_result` carries the child's actual reply and the forced-sync note, not the async "Started sub-agent" stub. Red-green verified: the test fails without the one-liner.

`go test -race ./cmd/octo/ ./internal/tools/` green; `gofmt`/`go vet` clean. Reviewed by an isolated agent: no Critical/Important findings.

## Known follow-ups (out of scope, pre-existing)

- ~~Dead `subAgentsSynchronous()`~~ — deleted in this PR. Note the gating its comment described would be wrong to implement: the web UI can promote a running sync child to background, after which `sub_agent_status`/`sub_agent_kill` have live targets in later turns.
- Ctrl+C during a long forced-sync child blocks until the child finishes (`RunSync` doesn't select on `ctx.Done()`; child runs on a background context). Same semantics server/IM already have for foreground children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)