### PR TITLE
chore: bump version to 1.12.31

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.30"
+var Version = "1.12.31"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release: one-shot no longer orphans background sub-agents (#1737).

🤖 Generated with [Claude Code](https://claude.com/claude-code)