### PR TITLE
chore(deps): bump golang-jwt/jwt/v4 to 4.5.2 in /cmd/octo-relay

### DIFF
--- a/cmd/octo-relay/go.mod
+++ b/cmd/octo-relay/go.mod
@@ -22,7 +22,7 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.1 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/cmd/octo-relay/go.sum
+++ b/cmd/octo-relay/go.sum
@@ -6,8 +6,9 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/flynn/noise v1.1.0 h1:KjPQoQCEFdZDiP03phOvGi11+SVVhBG2wOWAorLsstg=
 github.com/flynn/noise v1.1.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
-github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=


### PR DESCRIPTION
## Summary

Fixes both open Dependabot alerts on the default branch:

- **#53 (high)** — GHSA-mh63-6h87-95cp: jwt-go allows excessive memory allocation during header parsing (< 4.5.2)
- **#52 (low)** — GHSA-29wx-vh33-7x7r: bad documentation of error handling in `ParseWithClaims` (< 4.5.1)

`golang-jwt/jwt/v4` is an indirect dependency of the relay's nested module, pulled in via `sideshow/apns2` (APNs push, M1c #1736). Bumping it to v4.5.2 clears both alerts. No code changes.

## Test plan

- [x] `go build ./...` in `cmd/octo-relay`
- [x] `go test ./...` in `cmd/octo-relay` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)