### PR TITLE
fix(mobile): wire-native — Capacitor 7 template + JBR 21 build fixes

### DIFF
--- a/mobile/scripts/wire-native.mjs
+++ b/mobile/scripts/wire-native.mjs
@@ -174,7 +174,10 @@ function wireAndroid() {
       label: 'Android: kotlinOptions jvmTarget',
       marker: 'kotlinOptions',
       anchor: /^android\s*\{/m,
-      insert: '    kotlinOptions { jvmTarget = "17" }',
+      // Must match javac's target, which defaults to the running JDK —
+      // Android Studio's bundled JBR is 21, and AGP hard-fails the build on
+      // a kotlinc/javac target mismatch.
+      insert: '    kotlinOptions { jvmTarget = "21" }',
     })
     injectOnce(appGradle, {
       label: 'Android: dependencies (kotlin-stdlib, noise-java, okhttp)',
@@ -194,15 +197,43 @@ function wireAndroid() {
     androidRoot, 'app', 'src', 'main', 'java', 'dev', 'octo', 'mobile', 'MainActivity.java',
   )
   if (existsSync(mainActivity)) {
-    injectOnce(mainActivity, {
-      label: 'Android: registerPlugin in MainActivity',
-      marker: 'registerPlugin(OctoTunnelPlugin.class)',
-      anchor: /super\.onCreate/,
-      insert: '        registerPlugin(OctoTunnelPlugin.class);',
-    })
-    // The anchor inserts AFTER super.onCreate; native/README wants it before, so
-    // if we injected, warn to move it up one line. (Kept simple + safe.)
-    warn('Android: ensure `registerPlugin(OctoTunnelPlugin.class);` sits BEFORE super.onCreate in MainActivity.')
+    const text = readFileSync(mainActivity, 'utf8')
+    if (text.includes('registerPlugin(OctoTunnelPlugin.class)')) {
+      // already wired
+    } else if (/extends BridgeActivity\s*\{\}/.test(text)) {
+      // Capacitor 7's template is a bodyless one-liner with no onCreate —
+      // expand it with the registration BEFORE super.onCreate, which is
+      // where the bridge expects plugins to exist.
+      const expanded = text
+        .replace(
+          /^import com\.getcapacitor\.BridgeActivity;/m,
+          'import android.os.Bundle;\n\nimport com.getcapacitor.BridgeActivity;',
+        )
+        .replace(
+          /extends BridgeActivity\s*\{\}/,
+          'extends BridgeActivity {\n' +
+            '    @Override\n' +
+            '    public void onCreate(Bundle savedInstanceState) {\n' +
+            '        // Must run before super.onCreate so the bridge sees the plugin\n' +
+            '        // when it boots the webview (see mobile/native/README.md).\n' +
+            '        registerPlugin(OctoTunnelPlugin.class);\n' +
+            '        super.onCreate(savedInstanceState);\n' +
+            '    }\n' +
+            '}',
+        )
+      writeFileSync(mainActivity, expanded)
+      did('Android: registerPlugin in MainActivity (expanded bodyless template)')
+    } else {
+      injectOnce(mainActivity, {
+        label: 'Android: registerPlugin in MainActivity',
+        marker: 'registerPlugin(OctoTunnelPlugin.class)',
+        anchor: /super\.onCreate/,
+        insert: '        registerPlugin(OctoTunnelPlugin.class);',
+      })
+      // The anchor inserts AFTER super.onCreate; native/README wants it
+      // before, so if we injected, warn to move it up one line.
+      warn('Android: ensure `registerPlugin(OctoTunnelPlugin.class);` sits BEFORE super.onCreate in MainActivity.')
+    }
   } else {
     warn(`Android: ${mainActivity} not found (package may differ); register the plugin by hand.`)
   }


### PR DESCRIPTION
Two first-run breakages hit while building the Android app from a fresh `npx cap add android`, found during the first **real-app UI walkthrough** (Android 14 emulator):

1. **MainActivity anchor dead**: Capacitor 7's template is a bodyless one-liner (`extends BridgeActivity {}`) — no `super.onCreate` to anchor on, so plugin registration degraded to a manual TODO. wire-native now expands the bodyless template with an `onCreate` that registers `OctoTunnelPlugin` **before** `super.onCreate`; the old anchor path remains for templates that have one.
2. **jvmTarget 17 → 21**: javac targets the running JDK (Android Studio's JBR = 21) and AGP hard-fails on the kotlinc/javac mismatch.

## Verified (emulator, end to end)
From-scratch flow `bundle-web → cap add android → wire-native --local → assembleDebug` → install → **deep-link pairing → Noise tunnel to a local relay → full mobile UI in the real WebView**: feed with live sessions, Tasks/Config/Settings tabs (Config inventory over the tunnel), dark mode, NewTask → streamed agent reply. This closes the 'new mobile UI never verified in the real app' gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)