### PR TITLE
fix(mobile): add viewport-fit=cover so iOS safe-area insets resolve

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- viewport-fit=cover makes env(safe-area-inset-*) resolve to real values
+       inside the iOS mobile shell's full-screen WebView; without it the insets
+       are 0 and the feed header draws under the notch / Dynamic Island. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Octo Agent</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>


### PR DESCRIPTION
Found during the **iOS simulator walkthrough** of the mobile UI (iPhone 15 Pro, iOS 17.5): the feed header drew *under* the status bar / Dynamic Island — `env(safe-area-inset-top)` was 0 in the full-screen WKWebView, so `.m-view`'s `padding-top: env(safe-area-inset-top)` had nothing to apply.

iOS only exposes non-zero safe-area insets to CSS when the viewport opts in with `viewport-fit=cover`. Adding it to the shared `web/index.html` fixes the mobile shell; it's a no-op for desktop web and non-notched displays.

## Verified (iOS simulator, end to end)
Deep-link pairing → Noise tunnel → feed rendering, and after the fix the header/title clears the Dynamic Island and the bottom tab bar clears the home indicator. Same Android real-app flow (#1742) already passed; this was the one iOS-specific rendering gap.

Note: the mobile bundle picks this up via `bundle-web` + `npx cap copy ios/android` (the Capacitor asset sync xcodebuild/gradle don't run themselves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)