### PR TITLE
docs(mobile): update build docs to the now-turnkey from-scratch flow

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -43,6 +43,8 @@ webview fetch('/api/…') / new WebSocket('/ws')
 | Android native plugin (Noise XX) | `native/OctoTunnelPlugin.kt` | emulator E2E |
 | iOS native plugin (Noise XX) | `native/OctoTunnelPlugin.swift` | simulator E2E |
 | Capacitor config + web bundling | `capacitor.config.ts`, `scripts/bundle-web.mjs` | tsc |
+| Native wiring (both platforms, turnkey) | `scripts/wire-native.mjs` | emulator + simulator E2E |
+| Mobile UI shell (feed / chat / approvals / tasks / config / settings) | `web/src/mobile/` | emulator + simulator E2E |
 
 ```bash
 cd mobile
@@ -51,19 +53,27 @@ npm test          # vitest: pairing + frames + shim + buffering-transport
 npm run typecheck # tsc
 ```
 
-Both the **Android** and **iOS** apps are verified end to end: paired to a local
+Both the **Android** and **iOS** apps are verified end to end, from a
+**from-scratch build** (`cap add` → `wire-native` → build): paired to a local
 `octo serve --tunnel` + `octo-relay` over a real Noise XX session, and the
-bundled frontend drove `/api` + `/ws` through the tunnel. See `native/README.md`
-for the per-platform wiring.
+mobile UI shell drove `/api` + `/ws` through the tunnel. `wire-native` automates
+the whole native setup for both platforms — see `native/README.md` for what it
+does per platform.
 
 ## Not done yet
 
-- The other native plugins (biometric, push, notifications, share) and the
-  `mobileShell` branch re-pointing in the frontend.
+- **Push wakeups** — the host + relay side ship (`internal/tunnel` wakeup frame,
+  `cmd/octo-relay/internal/push`), but the app-side Capacitor push-token wiring
+  is deferred (a killed app can't be woken yet).
+- The other native niceties (biometric unlock, share).
 - **Self-tunnel transport** — `SelfTunnelTransport` dials a `/tunnel` endpoint
   the server doesn't expose yet; only the managed-relay path is wired end to end.
 
-## Build the app (on a Mac)
+## Build the app
+
+Android needs the Android SDK; iOS needs a Mac with Xcode. Both build from the
+same steps — `wire-native` does the entire native setup, so no hand-editing of
+the generated projects is required.
 
 ```bash
 # 1. Build the web frontend (repo root) and bundle it in.
@@ -71,18 +81,36 @@ make web-build
 cd mobile && npm install && npm run bundle-web
 
 # 2. Add the native platforms (generates ios/ and android/, both gitignored).
+#    Capacitor 7 uses Swift Package Manager on iOS — there is no Podfile and no
+#    `pod install`; Xcode resolves the packages on open.
 npx cap add ios
 npx cap add android
 
-# 3. Wire the native plugin into the generated projects (copies the reference
-#    source + patches Gradle / Manifest / Info.plist). Idempotent; re-run after
-#    any `cap add`. Add --local to inject the simulator/emulator cleartext
-#    switches (never for release). See native/README.md for what it does and the
-#    one manual step it leaves (iOS plugin-instance registration).
+# 3. Wire the native plugin into the generated projects. Fully automated and
+#    idempotent (re-run after any `cap add`): copies the plugin, registers it
+#    (Android MainActivity / iOS a generated bridge view controller), patches
+#    Gradle / Manifest / Info.plist / the Xcode project. Add --local to inject
+#    the simulator/emulator cleartext switches (NEVER for release).
 npm run wire-native -- --local
 
-# 4. Sync and open.
-npx cap sync
-npx cap open ios       # Xcode
-npx cap open android   # Android Studio
+# 4. Build & run. `cap copy` re-syncs the web bundle into the native projects —
+#    run it after EVERY web change; xcodebuild / gradle do not sync it themselves.
+npx cap copy
+
+#    Android:
+(cd android && ./gradlew assembleDebug) && \
+  adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+
+#    iOS (or just `npx cap open ios` and Run from Xcode):
+xcodebuild -project ios/App/App.xcodeproj -scheme App \
+  -destination 'platform=iOS Simulator,name=iPhone 15 Pro' build
 ```
+
+Then pair: run `octo serve --tunnel` on the host, and scan the printed QR (or,
+on a simulator/emulator, open the `octo-pair://` deep link directly —
+`xcrun simctl openurl booted '<url>'` / `adb shell am start -a android.intent.action.VIEW -d '<url>'`).
+
+> **Xcode 26 note:** building for iOS requires the iOS platform component
+> installed (Xcode → Settings → Components, or `xcodebuild -downloadPlatform iOS`).
+> It's a large one-time download; without it the build reports "iOS … not
+> installed" and offers no simulator destination.

--- a/mobile/native/README.md
+++ b/mobile/native/README.md
@@ -6,15 +6,18 @@ code, and never enter JavaScript (see `../src/native-bridge.ts` for the contract
 and `../src/transport.ts` for the caller).
 
 These files are the **reference source**, committed here because the generated
-`ios/` and `android/` folders (from `npx cap add`) are gitignored. On a Mac,
-after `npx cap add ios` / `add android`, place them into the platform projects:
+`ios/` and `android/` folders (from `npx cap add`) are gitignored.
 
-- **iOS** — `OctoTunnelPlugin.swift` → place at `ios/App/App/OctoTunnelPlugin.swift`.
-  It is a pure-Swift Capacitor plugin (conforms to `CAPBridgedPlugin`), so no
-  companion Objective-C `CAP_PLUGIN` macro file is needed. See the wiring below.
-- **Android** — `OctoTunnelPlugin.kt` → place at
-  `android/app/src/main/java/dev/octo/mobile/OctoTunnelPlugin.kt`. See the wiring
-  below.
+**You normally don't apply any of this by hand** — `../scripts/wire-native.mjs`
+does all of it (copy the plugin, register it, patch Gradle / Manifest /
+Info.plist / the Xcode project) idempotently. Run it after every `npx cap add`:
+
+```bash
+npm run wire-native -- --local   # drop --local for a release build
+```
+
+The rest of this document is the reference for **what wire-native does and
+why** — read it to understand or debug the wiring, not to perform it.
 
 ## Status
 
@@ -41,60 +44,64 @@ They interoperate with the Go host (`internal/tunnel`) and relay
   `"frame"` listener event. Cipher use is serialized — a Noise CipherState nonce
   is stateful.
 
-## Android wiring (after `npx cap add android`)
+## Android wiring (what wire-native does)
 
-The generated `android/` is gitignored, so redo these each time it is
-regenerated:
+Applied automatically after `npx cap add android`:
 
 1. **Kotlin plugin** — the project template is Java-only. In the root
    `android/build.gradle` buildscript dependencies add
    `classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22'`; in
    `android/app/build.gradle` add `apply plugin: 'kotlin-android'`, a
-   `kotlinOptions { jvmTarget = "17" }` block, and
+   `kotlinOptions { jvmTarget = "21" }` block (must match javac's target — the
+   Android Studio JBR is 21, and AGP fails the build on a mismatch), and
    `implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.22"`.
 2. **Dependencies** (`android/app/build.gradle`, resolved from Maven Central):
    - `implementation "com.github.auties00:noise-java:1.2"` — Noise XX; its
      `com.southernstorm.noise` classes are pure Java (no NDK).
    - `implementation "com.squareup.okhttp3:okhttp:4.12.0"` — relay WebSocket.
 3. **Register** the plugin in `MainActivity` **before** `super.onCreate`:
-   `registerPlugin(OctoTunnelPlugin.class);`. The pairing screen scans a QR with
-   `getUserMedia`, so also request `CAMERA` at runtime there.
+   `registerPlugin(OctoTunnelPlugin.class);`. Capacitor 7's template is a
+   bodyless `class MainActivity extends BridgeActivity {}`, so wire-native
+   expands it with an `onCreate` that registers the plugin. The pairing screen
+   scans a QR with `getUserMedia`, so `CAMERA` is requested at runtime there.
 4. **AndroidManifest.xml** — add `android.permission.CAMERA` (plus a non-required
    `android.hardware.camera` feature) and, on `MainActivity`, an
    `android.intent.action.VIEW` intent-filter for the `octo-pair` scheme so a
    scanned QR opens the app as a deep link.
-5. **Local testing only** — to reach a plaintext `ws://` relay from the emulator
-   (`10.0.2.2`), set `android:usesCleartextTraffic="true"` on `<application>`.
-   Production uses `wss://`; do not ship cleartext.
+5. **Local testing only** (`--local`) — to reach a plaintext `ws://` relay from
+   the emulator (`10.0.2.2`), set `android:usesCleartextTraffic="true"` on
+   `<application>`. Production uses `wss://`; do not ship cleartext.
 
-## iOS wiring (after `npx cap add ios` + `pod install`)
+## iOS wiring (what wire-native does)
 
-The generated `ios/` is gitignored, so redo these each time it is regenerated:
+Applied automatically after `npx cap add ios`. Capacitor 7 uses Swift Package
+Manager, so there is no `pod install`.
 
-1. **Plugin source** — add `OctoTunnelPlugin.swift` to the `App` target
-   (`ios/App/App/`). It is pure Swift and conforms to `CAPBridgedPlugin`; no
-   `.m` file is needed. It uses CryptoKit (Curve25519 / ChaChaPoly / SHA256 /
-   HMAC-HKDF) — no third-party dependency.
-2. **Register the plugin.** Capacitor's ObjC-runtime auto-scan does not reliably
+1. **Plugin source** — `OctoTunnelPlugin.swift` is copied into the `App` target
+   (`ios/App/App/`) **and added to `project.pbxproj`** (build file + file ref +
+   group + Sources phase). `cap add ios` copies nothing into the project, so
+   without the pbxproj entry the file wouldn't compile. It is pure Swift,
+   conforms to `CAPBridgedPlugin` (no `.m` file), and uses CryptoKit
+   (Curve25519 / ChaChaPoly / SHA256 / HMAC-HKDF) — no third-party dependency.
+2. **Register the plugin.** Capacitor's ObjC-runtime auto-scan doesn't reliably
    surface an app-target Swift plugin, and `registerPluginType` is a no-op while
-   `autoRegisterPlugins` is on. Register an instance explicitly: subclass
-   `CAPBridgeViewController` and override `capacitorDidLoad()` with
-   `bridge?.registerPluginInstance(OctoTunnelPlugin())`, then use that subclass
-   as the bridge view controller (Main.storyboard's custom class, or the
-   programmatic root VC).
+   `autoRegisterPlugins` is on. So wire-native generates
+   `OctoBridgeViewController.swift` — a `CAPBridgeViewController` subclass that
+   registers the **instance** in `capacitorDidLoad()`
+   (`bridge?.registerPluginInstance(OctoTunnelPlugin())`) — and rewrites
+   `AppDelegate` to build it as the window's root view controller in code.
+   Building the root VC programmatically also drops `Main.storyboard` (and
+   `UIMainStoryboardFile` from Info.plist): under Xcode 26's SDK with an older
+   simulator runtime, compiling the storyboard fails "Platform Not Installed",
+   and the programmatic root sidesteps it. This is always done now (not a
+   per-machine workaround).
 3. **Info.plist** — add `NSCameraUsageDescription` (getUserMedia QR scan) and a
    `CFBundleURLTypes` entry for the `octo-pair` scheme (the deep link Capacitor's
    `App` plugin delivers as `appUrlOpen`).
-4. **Local testing only** — add `NSAppTransportSecurity → NSAllowsLocalNetworking
-   = true` so the app can reach a plaintext `ws://127.0.0.1` relay on the
-   simulator (the simulator shares the Mac's network; no `10.0.2.2` needed).
-   Production uses `wss://`.
-
-> Note: on a machine whose installed simulator runtime matches the Xcode SDK,
-> keep the generated storyboards. This environment only had an older iOS runtime,
-> so the local `ios/` project was patched to drop the storyboards and build the
-> bridge view controller programmatically — a workaround for the toolchain
-> mismatch, not part of the plugin.
+4. **Local testing only** (`--local`) — add `NSAppTransportSecurity →
+   NSAllowsLocalNetworking = true` so the app can reach a plaintext
+   `ws://127.0.0.1` relay on the simulator (the simulator shares the Mac's
+   network; no `10.0.2.2` needed). Production uses `wss://`.
 
 The JS side (`../src/plugin.ts`) resolves every plugin — `OctoTunnel` and
 first-party ones like `App` — through `@capacitor/core`'s `registerPlugin`, not

--- a/mobile/scripts/wire-native.mjs
+++ b/mobile/scripts/wire-native.mjs
@@ -6,13 +6,13 @@
 //
 // Design: every mutation is idempotent (running twice is a no-op) and safe. A
 // step that copies a file always succeeds; a step that injects into a generated
-// file (Gradle / Manifest / Info.plist) first checks whether it is already there,
-// and if it cannot find its anchor it does NOT blindly edit — it records a
-// warning with the exact snippet to add by hand and moves on. One step is left
-// to the human: the iOS plugin-instance registration (a CAPBridgeViewController
-// subclass + storyboard custom class) depends on the generated project layout and
-// the local toolchain (see the storyboard note in native/README.md), so we detect
-// and instruct rather than rewrite it.
+// file (Gradle / Manifest / Info.plist / Xcode project) first checks whether it
+// is already there, and if it cannot find its anchor it does NOT blindly edit —
+// it records a warning with the exact snippet to add by hand and moves on.
+// Both platforms are fully automated end to end, including the iOS
+// plugin-instance registration (a generated CAPBridgeViewController subclass +
+// a programmatic root VC): no manual step remains for a standard
+// Capacitor-generated project.
 //
 // Usage:
 //   node scripts/wire-native.mjs            # wire whichever of ios/ android/ exist


### PR DESCRIPTION
The mobile READMEs predated the wire-native automation (#1742 Android, #1747 iOS) and the mobile UI shell — they still described a manual iOS plugin-registration step and a per-machine storyboard workaround, listed the UI as 'not done', and missed the gotchas that actually bite (cap copy after web changes, the Xcode 26 iOS-platform download). Brought them in line with what I just verified end to end on both an Android emulator and an iOS simulator.

## mobile/README.md
- Status table: add the wire-native automation + the mobile UI shell.
- 'Not done yet': now accurate — app-side push wiring is the deferred piece; the mobileShell/UI is done.
- Build section: no 'one manual iOS step' (there is none); `cap copy` after **every** web change; SPM (no `pod install`); deep-link pairing shortcut; the **Xcode 26 iOS-platform download** requirement.

## native/README.md
- Reframed as 'what wire-native does' reference, not a manual checklist.
- Fixed: jvmTarget 17→21, `pod install`→SPM, iOS registration is generated (bridge VC + programmatic root), storyboard is **always** dropped (not a per-machine workaround), and the pbxproj-add step `cap add ios` omits.

## wire-native.mjs
- Header comment: no manual step remains.

Docs + one comment; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)