### PR TITLE
landing: mobile is a developer preview, not coming soon

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -408,7 +408,7 @@
           <rect fill="#ffffff" stroke="#e5e7eb" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.65" x="584" y="364" width="40" height="40" rx="11"/>
           <g fill="none" stroke="#6b7280" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" opacity="0.7" transform="translate(592,372)"><rect x="7" y="2" width="10" height="20" rx="2"/><line x1="11" y1="18" x2="13" y2="18"/></g>
           <text fill="#6b7280" font-size="14" font-weight="600" x="632" y="381" text-anchor="start">Mobile</text>
-          <text fill="#6b7280" font-size="10" font-weight="600" letter-spacing="0.02em" x="632" y="396" text-anchor="start" data-en="coming soon" data-zh="即将推出"></text>
+          <text fill="#6b7280" font-size="10" font-weight="600" letter-spacing="0.02em" x="632" y="396" text-anchor="start" data-en="dev preview" data-zh="开发者预览"></text>
         </svg>
       </figure>
       <div class="grid4">
@@ -451,9 +451,9 @@
           <iconify-icon icon="ant-design:mobile-outlined" width="22"></iconify-icon>
           <div class="arm-title">
             <h3 data-en="Mobile" data-zh="移动端"></h3>
-            <span class="soon-tag" data-en="Coming soon" data-zh="即将推出"></span>
+            <span class="soon-tag" data-en="Developer preview" data-zh="开发者预览"></span>
           </div>
-          <p data-en="A thin native client over an end-to-end encrypted link to your machine. The eighth arm." data-zh="通过端到端加密链路连回你机器的轻量原生客户端。第八条腕。"></p>
+          <p data-en="A thin native client (iOS + Android) over an end-to-end encrypted link to your machine. The eighth arm — buildable today from source with a self-hosted relay; hosted relay and app-store builds are next." data-zh="通过端到端加密链路连回你机器的轻量原生客户端（iOS + Android）。第八条腕 —— 现在即可从源码自建并配合自托管 relay 使用；托管 relay 与应用商店版本在路上。"></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The mobile client (iOS + Android) is now implemented and verified end to end — from-scratch turnkey build, real Noise tunnel, full mobile UI (this session verified both an Android emulator and an iOS simulator). It's no longer vaporware, but it's not a one-tap store app either: it needs a self-hosted relay and building from source (hosted relay ops + app-store distribution are the remaining productization).

So the eighth arm moves from **Coming soon → Developer preview**, and the card copy says plainly what's there (buildable today, self-host relay) vs. what's next (hosted relay + app stores). Keeps the 'eight interfaces' framing honest without over-promising.

- Card tag: 即将推出/Coming soon → 开发者预览/Developer preview.
- Hero-diagram arm label: coming soon → dev preview.
- Card copy: notes iOS + Android, buildable-today-with-self-hosted-relay, hosted-relay/app-store next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)