### PR TITLE
docs(readme): mobile is a developer preview, not 'landing next'

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,10 @@ Codex 的 record & replay 只在 macOS 应用里提供，octo 的浏览器录制
 - **Obsidian 插件** —— [`open-octo/octo-obsidian`](https://github.com/open-octo/octo-obsidian)
 - **Go SDK** —— [`pkg/octoagent`](pkg/octoagent)，把 agent 循环嵌进你自己的程序
 
-第八个界面移动端 App 即将上线。哪些接口可以放心依赖见
-[COMPATIBILITY.md](COMPATIBILITY.md)；安全边界见 [SECURITY.md](SECURITY.md)。
+第八个界面——移动端 App（iOS + Android）——已实现，目前是**开发者预览**：现在即可从源码
+自建、配合自托管 relay 使用（见 [`mobile/`](mobile/)），托管 relay 与应用商店版本在路上。
+哪些接口可以放心依赖见 [COMPATIBILITY.md](COMPATIBILITY.md)；安全边界见
+[SECURITY.md](SECURITY.md)。
 
 ## 深入了解
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -145,8 +145,11 @@ both: Claude Code for the heavy lifting, octo on DeepSeek for everything else.
 - **Obsidian plugin** — [`open-octo/octo-obsidian`](https://github.com/open-octo/octo-obsidian)
 - **Go SDK** — [`pkg/octoagent`](pkg/octoagent), embed the agent loop in your own programs
 
-The eighth, a mobile app, is landing next. What you can build on is declared in
-[COMPATIBILITY.md](COMPATIBILITY.md); the security boundary in [SECURITY.md](SECURITY.md).
+The eighth — a mobile app (iOS + Android) — is implemented and in **developer
+preview**: buildable from source today against a self-hosted relay (see
+[`mobile/`](mobile/)), with a hosted relay and app-store builds next. What you
+can build on is declared in [COMPATIBILITY.md](COMPATIBILITY.md); the security
+boundary in [SECURITY.md](SECURITY.md).
 
 ## Learn more
 


### PR DESCRIPTION
Aligns the README with the landing page (#1749): the eighth interface (mobile, iOS + Android) is now implemented and verified end to end, so it moves from 'coming/landing next' to **developer preview** — buildable from source today against a self-hosted relay, with hosted relay + app-store builds as the remaining productization.

Updated README.md (default, zh) and README_EN.md; README_CN.md is a redirect stub (no interface section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)