### PR TITLE
docs+refactor: fix stale sub_agent sync comments, drop unreachable no-session fallback

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -774,11 +774,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// The headless one-shot exits when its single turn ends, so a background
 	// sub-agent's completion notification has no follow-up turn to land in —
 	// children spawned with run_in_background=true would be orphaned and their
-	// results silently lost. Run sub-agents inline instead, like the other
-	// request/response transports (server, IM). Parallel fan-out is unaffected:
-	// sync sub_agent calls issued in one assistant message still dispatch
-	// concurrently. The TUI keeps async — it re-injects completions as
-	// follow-up turns.
+	// results silently lost. Run sub-agents inline instead, like the server's
+	// one-shot runTurn paths without a session. (The web session and IM paths
+	// keep async: they kick an idle follow-up turn on completion.) Parallel
+	// fan-out is unaffected: sync sub_agent calls issued in one assistant
+	// message still dispatch concurrently. The TUI keeps async too — it
+	// re-injects completions as follow-up turns.
 	if !useTUI {
 		subAgentMgr.SetSynchronous(true)
 	}

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -774,12 +774,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// The headless one-shot exits when its single turn ends, so a background
 	// sub-agent's completion notification has no follow-up turn to land in —
 	// children spawned with run_in_background=true would be orphaned and their
-	// results silently lost. Run sub-agents inline instead, like the server's
-	// one-shot runTurn paths without a session. (The web session and IM paths
-	// keep async: they kick an idle follow-up turn on completion.) Parallel
-	// fan-out is unaffected: sync sub_agent calls issued in one assistant
-	// message still dispatch concurrently. The TUI keeps async too — it
-	// re-injects completions as follow-up turns.
+	// results silently lost. Run sub-agents inline instead; this is the only
+	// transport that still forces sync. (Web session and IM turns keep async:
+	// they kick an idle follow-up turn on completion.) Parallel fan-out is
+	// unaffected: sync sub_agent calls issued in one assistant message still
+	// dispatch concurrently. The TUI keeps async too — it re-injects
+	// completions as follow-up turns.
 	if !useTUI {
 		subAgentMgr.SetSynchronous(true)
 	}

--- a/dev-docs/sub-agent-design.md
+++ b/dev-docs/sub-agent-design.md
@@ -54,10 +54,11 @@ spawn 入口(`internal/tools/agent.go`),经 spawner 注册门控——未配置 
 - 默认 **async**(CLI TUI / Web 会话 / IM):`run_in_background:true` 起后台、立即返回句柄,完成经
   通知注入对话——TUI 走 agent Inbox,Web/IM 走 `deliverModelNote` / `runChannelIdleTurn`,回合
   空闲时自动开一个 follow-up turn。
-- **无后续回合通道的 transport**(CLI one-shot、server 的无会话 one-shot runTurn)调
-  `SetSynchronous(true)` 让 `sub_agent` 走 `RunSync` 阻塞、把结果直接作为 tool_result 返回。
-  此时即使模型传了 `run_in_background:true` 也被强制为同步,且**结果里明说**降级了(不静默
-  吞掉模型的选择)。
+- **唯一强制同步的 transport 是 CLI one-shot**:单回合进程没有后续回合通道,`SetSynchronous(true)`
+  让 `sub_agent` 走 `RunSync` 阻塞、把结果直接作为 tool_result 返回。此时即使模型传了
+  `run_in_background:true` 也被强制为同步,且**结果里明说**降级了(不静默吞掉模型的选择)。
+  server 侧没有等价路径——`prepareToolTurn` 要求 ctx 带 session id(所有生产调用方都钉了),
+  缺失即报错;历史上曾有"无会话 one-shot"兜底分支,生产上不可达,已删除。
 
 ### 防递归
 

--- a/dev-docs/sub-agent-design.md
+++ b/dev-docs/sub-agent-design.md
@@ -51,10 +51,13 @@ spawn 入口(`internal/tools/agent.go`),经 spawner 注册门控——未配置 
 
 ### Sync vs Async
 
-- 默认 **async**(CLI/TUI):`run_in_background:true` 起后台、立即返回句柄,完成经通知注入对话。
-- **同步 transport**(HTTP server / IM 桥)没有后续回合通道,`SetSynchronous(true)` 让 `sub_agent`
-  走 `RunSync` 阻塞、把结果直接作为 tool_result 返回。此时即使模型传了 `run_in_background:true`
-  也被强制为同步,且**结果里明说**降级了(不静默吞掉模型的选择)。
+- 默认 **async**(CLI TUI / Web 会话 / IM):`run_in_background:true` 起后台、立即返回句柄,完成经
+  通知注入对话——TUI 走 agent Inbox,Web/IM 走 `deliverModelNote` / `runChannelIdleTurn`,回合
+  空闲时自动开一个 follow-up turn。
+- **无后续回合通道的 transport**(CLI one-shot、server 的无会话 one-shot runTurn)调
+  `SetSynchronous(true)` 让 `sub_agent` 走 `RunSync` 阻塞、把结果直接作为 tool_result 返回。
+  此时即使模型传了 `run_in_background:true` 也被强制为同步,且**结果里明说**降级了(不静默
+  吞掉模型的选择)。
 
 ### 防递归
 

--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -274,7 +274,7 @@ func TestKickIdleSteerTurn_SkipsWhenBoundToOtherEntry(t *testing.T) {
 
 // prepareToolTurn must hand back the SAME session-scoped manager on every
 // turn of a session (async mode), so spawns survive turn boundaries — and a
-// sid-less context still gets the old per-turn synchronous manager.
+// sid-less context is a wiring bug the call refuses loudly.
 func TestPrepareToolTurn_SessionScopedAsyncManager(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -301,15 +301,10 @@ func TestPrepareToolTurn_SessionScopedAsyncManager(t *testing.T) {
 		t.Error("session-scoped manager should be async")
 	}
 
-	_, _, anon, _, err := srv.prepareToolTurn(context.Background(), a, nil)
-	if err != nil {
-		t.Fatalf("prepareToolTurn (no sid): %v", err)
-	}
-	if !anon.Synchronous() {
-		t.Error("sid-less context should fall back to a synchronous manager")
-	}
-	if anon == m1 {
-		t.Error("sid-less manager must not be the session-scoped one")
+	// A sid-less ctx is a wiring bug: prepareToolTurn refuses rather than
+	// silently building a degraded turn.
+	if _, _, _, _, err := srv.prepareToolTurn(context.Background(), a, nil); err == nil {
+		t.Error("prepareToolTurn without a session id should fail loudly")
 	}
 }
 

--- a/internal/server/browser_helpers_test.go
+++ b/internal/server/browser_helpers_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -21,7 +20,7 @@ func TestPrepareToolTurn_WiresBrowserLLMHelpers(t *testing.T) {
 	tools.SetBrowserRecordingGenerator(nil)
 
 	a := agent.New(&stubSender{}, "stub-model")
-	ctx, _, _, _, err := srv.prepareToolTurn(context.Background(), a, nil)
+	ctx, _, _, _, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "browser-helpers"), a, nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -8,17 +8,22 @@ import (
 	"github.com/open-octo/octo-agent/internal/app"
 	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/permission"
-	"github.com/open-octo/octo-agent/internal/tasks"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
 
 // prepareToolTurn wires the per-turn tool environment for agent a: the strict,
-// non-interactive permission gate, plus a sub-agent manager and task store
-// bound to THIS turn's agent and stamped into ctx so the sub-agent / task tools
-// dispatch to them rather than the process-global gating sentinels. The manager
-// runs synchronously — a request/response turn has no follow-up channel for an
-// async sub-agent result — and each turn gets a private store, so concurrent
-// sessions never share sub-agent or task state.
+// non-interactive permission gate, plus the session-scoped sub-agent manager
+// and task store bound to THIS turn's agent and stamped into ctx so the
+// sub-agent / task tools dispatch to them rather than the process-global
+// gating sentinels. The sub-agent manager runs async: a spawn's completion
+// lands after the turn ends and is re-injected via the session's idle
+// follow-up turn (deliverModelNote / kickIdleSteerTurn), the same channel
+// background-process completions use.
+//
+// ctx MUST carry a session id (ctxKeySessionID) — every production caller
+// (runTurn, the WS turn loop, cron ticks) stamps one before calling. A
+// missing id is a wiring bug, so this fails loudly instead of silently
+// building a degraded turn.
 //
 // Callers must build this turn's tool list with tools.DefaultToolsForCtx(ctx,
 // ...) — using the ctx returned here — rather than the ctx-blind
@@ -29,20 +34,17 @@ import (
 // (see its doc comment — a different concern, since WorkflowTool.Definition()
 // has no ctx to read a.CWD from).
 func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agent.Session) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, func(), error) {
-	sid, hasSession := ctx.Value(ctxKeySessionID{}).(string)
+	sid, _ := ctx.Value(ctxKeySessionID{}).(string)
+	if sid == "" {
+		return ctx, nil, nil, func() {}, fmt.Errorf("prepareToolTurn: no session id in context — callers must stamp ctxKeySessionID")
+	}
 
 	// A session-scoped tracker (keyed by sid, cached across turns like the
 	// background/sub-agent/workflow managers below) so a file read_file'd in
 	// one turn is still "read" when a later turn in the same conversation
 	// writes it — a per-turn tracker would forget every read as soon as the
-	// turn ended. One-shot paths with no session identity keep a fresh
-	// per-call tracker (nothing to persist it against).
-	var executor tools.DefaultRegistry
-	if hasSession && sid != "" {
-		executor = tools.NewDefaultRegistryWithTracker(tools.SessionReadTracker(sid))
-	} else {
-		executor = tools.NewDefaultRegistry()
-	}
+	// turn ended.
+	executor := tools.NewDefaultRegistryWithTracker(tools.SessionReadTracker(sid))
 
 	// Goal tools dispatch to the turn's session on every tool-enabled path
 	// (WS, REST, scheduled) — advertising them (SetGoalsEnabled) while
@@ -111,99 +113,70 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 		return ctx, nil, nil, func() {}, fmt.Errorf("permission engine: %w", err)
 	}
 
-	var ask app.PermissionAsk
-	if hasSession && sid != "" {
-		ask = s.permissionAskFrom(sid)
-		engine.AttachRemembered(s.rememberedFor(sid))
-	}
+	ask := s.permissionAskFrom(sid)
+	engine.AttachRemembered(s.rememberedFor(sid))
 	a.Gate = app.NewPermissionGate(engine, ask)
 
-	mkSpawner := func() tools.Spawner {
-		return app.NewSpawner(a, executor, func(ctx context.Context) []agent.ToolDefinition {
-			return tools.DefaultToolsForCtx(ctx, a.Model)
-		})
+	// Clear-and-rebuild: a fully-completed plan is closed, so drop it BEFORE
+	// NewSessionToolEnv picks up the per-session task store — this turn's new
+	// tasks then start a fresh plan instead of piling onto old, done ones. An
+	// incomplete plan carries over so the agent keeps working on it. Turns are
+	// serialized per session, so this read-then-reset is safe.
+	if tools.AllTasksComplete(tools.PeekSessionTaskStore(sid)) {
+		tools.CloseSessionTaskStore(sid)
 	}
-
-	var mgr *tools.SubAgentManager
-	var cleanup func()
-
-	if hasSession && sid != "" {
-		// Clear-and-rebuild: a fully-completed plan is closed, so drop it BEFORE
-		// NewSessionToolEnv picks up the per-session task store — this turn's new
-		// tasks then start a fresh plan instead of piling onto old, done ones. An
-		// incomplete plan carries over so the agent keeps working on it. Turns are
-		// serialized per session, so this read-then-reset is safe.
-		if tools.AllTasksComplete(tools.PeekSessionTaskStore(sid)) {
-			tools.CloseSessionTaskStore(sid)
-		}
-		// Session-scoped path: reuse the concurrency-safe core from app.NewSessionToolEnv.
-		// Server-specific callbacks (WebSocket broadcast, model note delivery) are
-		// injected here; the core function stays free of *Server dependencies.
-		ctx, _, mgr, cleanup = app.NewSessionToolEnv(ctx, a, sid, executor, app.ToolEnvCallbacks{
-			SubAgentOnEvent: func(ev tools.SubAgentEvent) {
-				if s.wsHub == nil {
-					return
-				}
-				s.wsHub.broadcast(sid, map[string]any{
-					"type":        "sub_agent_event",
-					"session_id":  sid,
-					"agent_id":    ev.AgentID,
-					"description": ev.Description,
-					"agent_type":  ev.AgentType,
-					"kind":        ev.Kind,
-					"tool_name":   ev.ToolName,
-					"tool_input":  ev.ToolInput,
-					"stop_reason": ev.StopReason,
-				})
-			},
-			SubAgentOnExit: func(ev tools.SubAgentNotification) {
-				if s.wsHub == nil {
-					return
-				}
-				s.wsHub.broadcast(sid, wsEventSubAgentNotice{
-					Type:        "sub_agent_notice",
-					SessionID:   sid,
-					AgentID:     ev.AgentID,
-					Description: ev.Description,
-					Kind:        ev.Kind,
-					Status:      subAgentNoticeStatus(ev),
-				})
-				s.notifySubAgentExit(sid, ev)
-			},
-			WorkflowOnEvent: func(ev tools.WorkflowEvent) {
-				if s.wsHub == nil {
-					return
-				}
-				s.wsHub.broadcast(sid, map[string]any{
-					"type":        "workflow_event",
-					"session_id":  sid,
-					"run_id":      ev.RunID,
-					"description": ev.Description,
-					"kind":        ev.Kind,
-					"line":        ev.Line,
-					"status":      ev.Status,
-				})
-			},
-			WorkflowOnDone: func(ev tools.WorkflowNotification) {
-				s.deliverModelNote(sid, tools.FormatWorkflowNote(ev))
-			},
-		})
-	} else {
-		// No session identity (one-shot runTurn paths): keep the old
-		// request/response semantics — block on every sub-agent. Deliberately
-		// leave ctx without a background manager, same as before this
-		// function was split: resolveBackgroundManager's fallback to
-		// defaultBg is exactly the "no ctx-scoped manager" case it documents,
-		// and stamping tools.SessionBackgroundManager("") here would silently
-		// swap that documented fallback for an undocumented synthetic
-		// "" session cached forever in sessionMgrs.
-		ctx = tools.WithWorkingDir(ctx, a.CWD)
-		ctx = tools.WithTaskStore(ctx, tasks.New())
-		mgr = tools.NewSubAgentManager(mkSpawner())
-		mgr.SetSynchronous(true)
-		ctx = tools.WithSubAgentManager(ctx, mgr)
-		cleanup = func() {}
-	}
+	// Reuse the concurrency-safe core from app.NewSessionToolEnv. Server-
+	// specific callbacks (WebSocket broadcast, model note delivery) are
+	// injected here; the core function stays free of *Server dependencies.
+	ctx, _, mgr, cleanup := app.NewSessionToolEnv(ctx, a, sid, executor, app.ToolEnvCallbacks{
+		SubAgentOnEvent: func(ev tools.SubAgentEvent) {
+			if s.wsHub == nil {
+				return
+			}
+			s.wsHub.broadcast(sid, map[string]any{
+				"type":        "sub_agent_event",
+				"session_id":  sid,
+				"agent_id":    ev.AgentID,
+				"description": ev.Description,
+				"agent_type":  ev.AgentType,
+				"kind":        ev.Kind,
+				"tool_name":   ev.ToolName,
+				"tool_input":  ev.ToolInput,
+				"stop_reason": ev.StopReason,
+			})
+		},
+		SubAgentOnExit: func(ev tools.SubAgentNotification) {
+			if s.wsHub == nil {
+				return
+			}
+			s.wsHub.broadcast(sid, wsEventSubAgentNotice{
+				Type:        "sub_agent_notice",
+				SessionID:   sid,
+				AgentID:     ev.AgentID,
+				Description: ev.Description,
+				Kind:        ev.Kind,
+				Status:      subAgentNoticeStatus(ev),
+			})
+			s.notifySubAgentExit(sid, ev)
+		},
+		WorkflowOnEvent: func(ev tools.WorkflowEvent) {
+			if s.wsHub == nil {
+				return
+			}
+			s.wsHub.broadcast(sid, map[string]any{
+				"type":        "workflow_event",
+				"session_id":  sid,
+				"run_id":      ev.RunID,
+				"description": ev.Description,
+				"kind":        ev.Kind,
+				"line":        ev.Line,
+				"status":      ev.Status,
+			})
+		},
+		WorkflowOnDone: func(ev tools.WorkflowNotification) {
+			s.deliverModelNote(sid, tools.FormatWorkflowNote(ev))
+		},
+	})
 
 	// The workflow tool's Definition(), unlike its Execute, takes no ctx and
 	// so can't see a.CWD directly — that one remains a save-and-restore

--- a/internal/server/memory_backend_wiring_test.go
+++ b/internal/server/memory_backend_wiring_test.go
@@ -53,7 +53,7 @@ func TestPrepareToolTurn_WiresMemoryBackend(t *testing.T) {
 	tools.SetMemoryBackend(nil) // start disabled to prove prepareToolTurn is what enables it
 	t.Cleanup(func() { tools.SetMemoryBackend(nil) })
 
-	if _, _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "gpt-4o"), nil); err != nil {
+	if _, _, _, _, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "memory-backend"), agent.New(&stubSender{}, "gpt-4o"), nil); err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
 	if g := tools.MemoryBackendGuidance(); g == "" {
@@ -81,7 +81,7 @@ func TestPrepareToolTurn_WiresAutoRecall(t *testing.T) {
 		tools.SetMemoryBackendAutoRecall(false)
 	})
 
-	if _, _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "gpt-4o"), nil); err != nil {
+	if _, _, _, _, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "memory-backend"), agent.New(&stubSender{}, "gpt-4o"), nil); err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
 
@@ -163,7 +163,7 @@ func TestPrepareToolTurn_NoMemoryBackendConfigured(t *testing.T) {
 	tools.SetMemoryBackend(nil)
 	t.Cleanup(func() { tools.SetMemoryBackend(nil) })
 
-	if _, _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "gpt-4o"), nil); err != nil {
+	if _, _, _, _, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "memory-backend"), agent.New(&stubSender{}, "gpt-4o"), nil); err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
 	if g := tools.MemoryBackendGuidance(); g != "" {

--- a/internal/server/model_vision_test.go
+++ b/internal/server/model_vision_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"sync"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestPrepareToolTurn_WiresModelVision(t *testing.T) {
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
-	ctx, _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "qwen3.7-max"), nil)
+	ctx, _, _, _, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "vision-basic"), agent.New(&stubSender{}, "qwen3.7-max"), nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
@@ -36,7 +35,7 @@ func TestPrepareToolTurn_WiresModelVision(t *testing.T) {
 		t.Error("vision should be OFF for a text-only model (qwen3.7-max)")
 	}
 
-	ctx, _, _, _, err = srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "gpt-4o"), nil)
+	ctx, _, _, _, err = srv.prepareToolTurn(prepareToolTurnCtx(t, "vision-basic-2"), agent.New(&stubSender{}, "gpt-4o"), nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
@@ -63,6 +62,8 @@ func TestPrepareToolTurn_ModelVisionConcurrentSessions(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
 	const rounds = 50
+	ctxA := prepareToolTurnCtx(t, "vision-race-a")
+	ctxB := prepareToolTurnCtx(t, "vision-race-b")
 	var wg sync.WaitGroup
 	errs := make(chan string, rounds*2)
 	wg.Add(2)
@@ -70,7 +71,7 @@ func TestPrepareToolTurn_ModelVisionConcurrentSessions(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < rounds; i++ {
-			ctx, _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "qwen3.7-max"), nil)
+			ctx, _, _, _, err := srv.prepareToolTurn(ctxA, agent.New(&stubSender{}, "qwen3.7-max"), nil)
 			if err != nil {
 				errs <- err.Error()
 				continue
@@ -83,7 +84,7 @@ func TestPrepareToolTurn_ModelVisionConcurrentSessions(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < rounds; i++ {
-			ctx, _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "gpt-4o"), nil)
+			ctx, _, _, _, err := srv.prepareToolTurn(ctxB, agent.New(&stubSender{}, "gpt-4o"), nil)
 			if err != nil {
 				errs <- err.Error()
 				continue

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -680,6 +680,23 @@ func mustWorkspaceDir(cfg Config) string {
 	return dir
 }
 
+// prepareToolTurnCtx returns a ctx stamped with a test session id, as every
+// production caller of prepareToolTurn does (runTurn, the WS turn loop, cron
+// ticks — they stamp both the server-layer ctxKeySessionID and the tools-layer
+// tools.WithSessionID), and registers cleanup for the per-session state the
+// call creates.
+func prepareToolTurnCtx(t *testing.T, name string) context.Context {
+	t.Helper()
+	sid := "ptt-" + name
+	t.Cleanup(func() {
+		tools.CloseSessionSubAgentManager(sid)
+		tools.CloseSessionReadTracker(sid)
+		tools.CloseSessionTaskStore(sid)
+	})
+	ctx := context.WithValue(context.Background(), ctxKeySessionID{}, sid)
+	return tools.WithSessionID(ctx, sid)
+}
+
 // mustServer creates a Server for testing. It skips tests that need a real
 // provider by using a stub sender.
 func mustServer(t *testing.T, cfg Config) *Server {

--- a/internal/server/workingdir_propagation_test.go
+++ b/internal/server/workingdir_propagation_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -30,7 +29,7 @@ func TestPrepareToolTurn_CronSessionSelfHealsFromStaleInteractiveMode(t *testing
 	sess.Source = "cron"
 	sess.PermissionMode = "interactive" // stale value from before this fix
 
-	ctx, _, _, cleanup, err := srv.prepareToolTurn(context.Background(), a, sess)
+	ctx, _, _, cleanup, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "cron-self-heal"), a, sess)
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
@@ -57,7 +56,7 @@ func TestPrepareToolTurn_CronSessionHonorsExplicitStrictMode(t *testing.T) {
 	sess.Source = "cron"
 	sess.PermissionMode = "strict"
 
-	ctx, _, _, cleanup, err := srv.prepareToolTurn(context.Background(), a, sess)
+	ctx, _, _, cleanup, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "cron-strict"), a, sess)
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
@@ -85,7 +84,7 @@ func TestPrepareToolTurn_WiresWorkingDirFromAgentCWD(t *testing.T) {
 	a := agent.New(&stubSender{}, "qwen3.7-max")
 	a.CWD = "/some/custom/project/dir"
 
-	ctx, _, _, cleanup, err := srv.prepareToolTurn(context.Background(), a, nil)
+	ctx, _, _, cleanup, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "workingdir"), a, nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
@@ -112,7 +111,7 @@ func TestPrepareToolTurn_WorkflowDiscoveryCWDStartsCleanAcrossCalls(t *testing.T
 
 	a1 := agent.New(&stubSender{}, "qwen3.7-max")
 	a1.CWD = "/repo/A"
-	_, _, _, cleanup1, err := srv.prepareToolTurn(context.Background(), a1, nil)
+	_, _, _, cleanup1, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "clean-slate-a"), a1, nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn (a1): %v", err)
 	}
@@ -124,7 +123,7 @@ func TestPrepareToolTurn_WorkflowDiscoveryCWDStartsCleanAcrossCalls(t *testing.T
 
 	a2 := agent.New(&stubSender{}, "qwen3.7-max")
 	a2.CWD = "/repo/B"
-	_, _, _, cleanup2, err := srv.prepareToolTurn(context.Background(), a2, nil)
+	_, _, _, cleanup2, err := srv.prepareToolTurn(prepareToolTurnCtx(t, "clean-slate-b"), a2, nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn (a2): %v", err)
 	}

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -158,9 +158,11 @@ func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (a
 
 	// Determine sync vs async
 	runInBackground := boolArg(input, "run_in_background")
-	// Synchronous transports (server / IM) have no follow-up-turn channel, so
-	// force sync even if the model asked for background — and tell the model,
-	// rather than silently downgrading its choice.
+	// Transports with no follow-up-turn channel (CLI one-shot, server one-shot
+	// runTurn without a session) force sync even if the model asked for
+	// background — and tell the model, rather than silently downgrading its
+	// choice. TUI, web session, and IM turns all stay async: they re-inject
+	// completions as idle follow-up turns (see SetSynchronous).
 	forcedSync := false
 	if runInBackground && mgr.Synchronous() {
 		runInBackground = false

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -158,11 +158,11 @@ func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (a
 
 	// Determine sync vs async
 	runInBackground := boolArg(input, "run_in_background")
-	// Transports with no follow-up-turn channel (CLI one-shot, server one-shot
-	// runTurn without a session) force sync even if the model asked for
-	// background — and tell the model, rather than silently downgrading its
-	// choice. TUI, web session, and IM turns all stay async: they re-inject
-	// completions as idle follow-up turns (see SetSynchronous).
+	// A transport with no follow-up-turn channel (the CLI one-shot — the only
+	// synchronous mode) forces sync even if the model asked for background —
+	// and tells the model, rather than silently downgrading its choice. TUI,
+	// web session, and IM turns all stay async: they re-inject completions as
+	// idle follow-up turns (see SetSynchronous).
 	forcedSync := false
 	if runInBackground && mgr.Synchronous() {
 		runInBackground = false

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -236,10 +236,10 @@ func (m *SubAgentManager) Spawner() Spawner {
 // onExit, which the transport re-injects as a follow-up turn — the TUI
 // enqueues into the agent Inbox, and the web/IM servers kick an idle
 // follow-up turn on completion (deliverModelNote / runChannelIdleTurn).
-// Only transports with no follow-up-turn channel set this true — the CLI
-// one-shot and the server's one-shot runTurn paths without a session:
-// sub_agent then blocks the turn on RunSync and returns the child's reply
-// directly as the tool_result. Set once at startup, before any turn runs.
+// Only the CLI one-shot sets this true: its single turn has no follow-up
+// channel, so sub_agent blocks the turn on RunSync and returns the child's
+// reply directly as the tool_result. Set once at startup, before any turn
+// runs.
 func (m *SubAgentManager) SetSynchronous(v bool) {
 	m.mu.Lock()
 	m.synchronous = v

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -232,12 +232,14 @@ func (m *SubAgentManager) Spawner() Spawner {
 }
 
 // SetSynchronous selects the sub_agent dispatch model. The default (false)
-// is the interactive async path: Start returns immediately and the reply
-// arrives via onExit, which the REPL/TUI re-injects as a follow-up turn. A
-// request/response transport (HTTP server, IM bridge) has no follow-up-turn
-// channel, so it sets this true: sub_agent then blocks the turn on RunSync
-// and returns the child's reply directly as the tool_result. Set once at
-// startup, before any turn runs.
+// is the async path: Start returns immediately and the reply arrives via
+// onExit, which the transport re-injects as a follow-up turn — the TUI
+// enqueues into the agent Inbox, and the web/IM servers kick an idle
+// follow-up turn on completion (deliverModelNote / runChannelIdleTurn).
+// Only transports with no follow-up-turn channel set this true — the CLI
+// one-shot and the server's one-shot runTurn paths without a session:
+// sub_agent then blocks the turn on RunSync and returns the child's reply
+// directly as the tool_result. Set once at startup, before any turn runs.
 func (m *SubAgentManager) SetSynchronous(v bool) {
 	m.mu.Lock()
 	m.synchronous = v


### PR DESCRIPTION
## Summary

Two commits, one theme: the claim "server/IM transports force synchronous `sub_agent` dispatch because they have no follow-up-turn channel" is false, and the code that kept it alive is gone.

1. **Comment fixes** — four comments claimed HTTP server / IM have no follow-up-turn channel. In reality:
   - **Web session turns** (`prepareToolTurn` → `app.NewSessionToolEnv` → `SessionSubAgentManager`) run sub-agents **async**; completions go through `notifySubAgentExit` → `deliverModelNote`, kicking an idle follow-up turn.
   - **IM turns** (`server.go` sub-agent wiring) likewise stay async: `SetOnExit` enqueues into the agent Inbox and runs `runChannelIdleTurn`.
   - Only the **CLI one-shot** (`cmd/octo/chat.go`, `!useTUI`) forces sync.

2. **Delete the unreachable no-session fallback in `prepareToolTurn`** — the else branch (introduced in #546) built a per-turn synchronous sub-agent manager for "one-shot runTurn paths without a session identity". Repo-wide grep confirms every production caller (runTurn `handlers.go:980`, WS turn loop `ws_handlers.go:1301`, cron `tasks_handlers.go:288`) stamps `ctxKeySessionID` before calling — the branch was only reachable from tests. `prepareToolTurn` now returns an error when the ctx carries no session id (a wiring bug should fail loudly, not silently build a degraded turn). Tests updated via a new `prepareToolTurnCtx` helper that mirrors production by stamping both the server-layer and tools-layer session id.

## Test plan

- `go build ./...`, `go vet`, `gofmt -l` — clean
- `go test -race ./...` — green (one earlier run showed flaky failures in `internal/agent` hookgate and `internal/hooks` under full-suite parallel load; both packages pass with `-race` in isolation and the full-suite re-run is fully green — pre-existing load flakiness, untouched by this diff)
- `cmd/octo`'s `TestTUI_Paste_SubmitExpands` fails identically on origin/main (reads the real user history file — pre-existing environment issue, unrelated)
- Reviewed by an isolated code-review sub-agent: no Critical/Important findings; the one Minor adopted (helper now stamps `tools.WithSessionID` too)
