### PR TITLE
feat: count grep tool results as reads for read-before-write

### DIFF
--- a/internal/tools/read_tracker_test.go
+++ b/internal/tools/read_tracker_test.go
@@ -509,3 +509,27 @@ func TestRegistry_GrepContextModeThenEdit_Allowed(t *testing.T) {
 		t.Errorf("edit after context-mode grep should succeed: %v", err)
 	}
 }
+
+// Filenames with embedded separator+digit runs (e.g. "report-2024-01-01.txt")
+// used to fail closed: the non-greedy regex settled on the first "-2024-"
+// boundary and the candidate "report" didn't stat. The multi-boundary fix
+// now tries every prefix, so the full filename is found.
+func TestRegistry_GrepNumericDashFilename_Allowed(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "report-2024-01-01.txt")
+	if err := os.WriteFile(p, []byte("line one\nconst a = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := reg.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "const a", "path": dir,
+	}); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if _, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "const a = 1", "new_string": "const a = 2",
+	}); err != nil {
+		t.Errorf("edit after grep on a numeric-dash filename should succeed: %v", err)
+	}
+}

--- a/internal/tools/read_tracker_test.go
+++ b/internal/tools/read_tracker_test.go
@@ -441,3 +441,71 @@ func TestRegistry_GrepThenEdit_UnmatchedFileStillBlocked(t *testing.T) {
 		t.Errorf("editing a file grep did not surface should stay blocked, got %v", err)
 	}
 }
+
+// A grep with zero matches returns "(no matches)" with a nil error. That
+// output must NOT stamp the input path — the model saw nothing, so a
+// following edit would be a blind write the read-before-write guard must
+// still block. This is the regression guard for the no-match stamp bug.
+func TestRegistry_GrepSingleFileNoMatch_EditStillBlocked(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\nconst a = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := reg.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "zzz_no_such_pattern", "path": p,
+	}); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	_, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "const a = 1", "new_string": "const a = 2",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not been read") {
+		t.Errorf("edit after a zero-match grep should stay blocked, got %v", err)
+	}
+}
+
+// Count mode outputs "path:N" lines. Those must count as a read too.
+func TestRegistry_GrepCountModeThenEdit_Allowed(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\nconst a = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := reg.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "const a", "path": dir, "mode": "count",
+	}); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if _, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "const a = 1", "new_string": "const a = 2",
+	}); err != nil {
+		t.Errorf("edit after count-mode grep should succeed: %v", err)
+	}
+}
+
+// Context mode adds "path-N-text" lines and "--" group separators. The
+// separator line must not break parsing, and the hit file must still count.
+func TestRegistry_GrepContextModeThenEdit_Allowed(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\nconst a = 1\nvar b = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := reg.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "const a", "path": dir, "context_lines": 1,
+	}); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if _, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "const a = 1", "new_string": "const a = 2",
+	}); err != nil {
+		t.Errorf("edit after context-mode grep should succeed: %v", err)
+	}
+}

--- a/internal/tools/read_tracker_test.go
+++ b/internal/tools/read_tracker_test.go
@@ -347,3 +347,97 @@ func TestRegistry_ZeroValue_NoEnforcement(t *testing.T) {
 		t.Errorf("zero-value registry should not enforce read-before-write: %v", err)
 	}
 }
+
+// ─── grep counts as a read ────────────────────────────────────────────────
+
+// A grep over a directory surfaces the matching lines of every hit file, so
+// those files count as "read": a following edit_file must not be refused.
+func TestRegistry_GrepDirThenEdit_Allowed(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\nconst a = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := reg.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "const a", "path": dir,
+	}); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if _, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "const a = 1", "new_string": "const a = 2",
+	}); err != nil {
+		t.Errorf("edit after grep should succeed: %v", err)
+	}
+}
+
+// files_with_matches mode shows only paths — still enough to count as seen.
+func TestRegistry_GrepFilesWithMatchesThenEdit_Allowed(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\nconst a = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := reg.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "const a", "path": dir, "mode": "files_with_matches",
+	}); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if _, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "const a = 1", "new_string": "const a = 2",
+	}); err != nil {
+		t.Errorf("edit after files_with_matches grep should succeed: %v", err)
+	}
+}
+
+// Single-file grep: rg omits the path prefix from its output, so the file
+// must be picked up from the input's own `path` argument.
+func TestRegistry_GrepSingleFileThenEdit_Allowed(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\nconst a = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := reg.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "const a", "path": p,
+	}); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if _, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "const a = 1", "new_string": "const a = 2",
+	}); err != nil {
+		t.Errorf("edit after single-file grep should succeed: %v", err)
+	}
+}
+
+// Only files the grep actually surfaced count. A sibling with no matches was
+// never shown to the model, so editing it stays blocked.
+func TestRegistry_GrepThenEdit_UnmatchedFileStillBlocked(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	hit := filepath.Join(dir, "hit.go")
+	miss := filepath.Join(dir, "miss.go")
+	if err := os.WriteFile(hit, []byte("package x\nconst a = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(miss, []byte("package x\nvar b = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := reg.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "const a", "path": dir,
+	}); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	_, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": miss, "old_string": "var b = 2", "new_string": "var b = 3",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not been read") {
+		t.Errorf("editing a file grep did not surface should stay blocked, got %v", err)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -226,15 +226,19 @@ func (r DefaultRegistry) recordTerminalReads(command string) {
 	}
 }
 
-// grepPathRe extracts the leading path from an rg output line: "path:12:text"
-// (content matches), "path-12-text" (context lines), "path-12-" etc. The
-// non-greedy path group settles on the first separator+digits boundary;
-// Windows drive prefixes survive because "C" alone is never followed by ":"
-// plus digits (same trick as grepUIMatchRe in grep.go).
-var grepPathRe = regexp.MustCompile(`^(.+?)[-:]\d+[-:]`)
+// sepDigitsSep matches a separator (hyphen or colon) followed by digits
+// and another separator — the boundary between a file path and the
+// line-number region of an rg content/context output line
+// ("path:12:text", "path-12-text"). A filename itself may contain
+// separator+digit runs (e.g. "report-2024-01-01.txt:5:hit" has them at
+// "-2024-" and ":5-"), so recordGrepReads collects EVERY such boundary
+// and tries each prefix; the rightmost one that stats to a real file
+// wins. Windows drive prefixes survive because the regex requires a
+// leading separator before the digits.
+var sepDigitsSep = regexp.MustCompile(`[-:]\d+[-:]`)
 
 // grepCountRe matches count-mode lines "path:3", which have no trailing
-// separator after the number and so escape grepPathRe.
+// separator after the number and so escape sepDigitsSep.
 var grepCountRe = regexp.MustCompile(`^(.+):\d+$`)
 
 // recordGrepReads stamps the read tracker with every file a successful grep
@@ -272,8 +276,14 @@ func (r DefaultRegistry) recordGrepReads(ctx context.Context, input map[string]a
 
 	for _, line := range strings.Split(output, "\n") {
 		record(line) // files_with_matches mode: the whole line is a path
-		if m := grepPathRe.FindStringSubmatch(line); m != nil {
-			record(m[1])
+		if idx := sepDigitsSep.FindAllStringIndex(line, -1); idx != nil {
+			// Content/context mode. The line may hold multiple
+			// "separator+digits+separator" boundaries when the filename
+			// itself contains them — try every prefix so the longest one
+			// that resolves to a real file wins.
+			for _, pos := range idx {
+				record(line[:pos[0]])
+			}
 		} else if m := grepCountRe.FindStringSubmatch(line); m != nil {
 			record(m[1])
 		}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -262,8 +262,11 @@ func (r DefaultRegistry) recordGrepReads(ctx context.Context, input map[string]a
 	}
 
 	// Single-file search: rg omits the path prefix from its output, so the
-	// only place the file appears is the input's own `path` argument.
-	if p, _ := input["path"].(string); p != "" {
+	// only place the file appears is the input's own `path` argument. A
+	// zero-match grep returns "(no matches)" with a nil error — in that case
+	// the model saw nothing, so don't stamp (it would wrongly unlock a blind
+	// edit of a file the search didn't actually surface).
+	if p, _ := input["path"].(string); p != "" && output != "(no matches)" {
 		record(p)
 	}
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -152,6 +153,8 @@ func (r DefaultRegistry) ExecuteStream(ctx context.Context, name string, input m
 							r.tracker.RecordRead(abs)
 						}
 					}
+				case "grep":
+					r.recordGrepReads(ctx, input, out.Text)
 				case "terminal":
 					if cmd, ok := input["command"].(string); ok {
 						r.recordTerminalReads(cmd)
@@ -219,6 +222,57 @@ func (r DefaultRegistry) recordTerminalReads(command string) {
 		}
 		if _, err := os.Stat(abs); err == nil {
 			r.tracker.RecordRead(abs)
+		}
+	}
+}
+
+// grepPathRe extracts the leading path from an rg output line: "path:12:text"
+// (content matches), "path-12-text" (context lines), "path-12-" etc. The
+// non-greedy path group settles on the first separator+digits boundary;
+// Windows drive prefixes survive because "C" alone is never followed by ":"
+// plus digits (same trick as grepUIMatchRe in grep.go).
+var grepPathRe = regexp.MustCompile(`^(.+?)[-:]\d+[-:]`)
+
+// grepCountRe matches count-mode lines "path:3", which have no trailing
+// separator after the number and so escape grepPathRe.
+var grepCountRe = regexp.MustCompile(`^(.+):\d+$`)
+
+// recordGrepReads stamps the read tracker with every file a successful grep
+// call surfaced, so a grep-then-edit flow doesn't hit "File has not been read
+// yet" — the model HAS seen the lines it is about to edit. Recording also
+// pins the current mtime, so the "modified since read" guard still fires if
+// the file changes out-of-band afterwards.
+//
+// The parser mirrors recordTerminalReads' lightweight philosophy: it tries
+// each output line as a whole path (files_with_matches mode), as "path:N:…"
+// or "path-N-…" (content mode), and as "path:N" (count mode), and records
+// whatever resolves to an existing regular file. Lines that aren't paths —
+// "(no matches)", "--" group separators, the truncation marker — simply fail
+// to stat and are skipped.
+func (r DefaultRegistry) recordGrepReads(ctx context.Context, input map[string]any, output string) {
+	base := WorkingDir(ctx)
+	record := func(candidate string) {
+		abs, err := resolvePathIn(base, candidate)
+		if err != nil {
+			return
+		}
+		if info, err := os.Stat(abs); err == nil && !info.IsDir() {
+			r.tracker.RecordRead(abs)
+		}
+	}
+
+	// Single-file search: rg omits the path prefix from its output, so the
+	// only place the file appears is the input's own `path` argument.
+	if p, _ := input["path"].(string); p != "" {
+		record(p)
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		record(line) // files_with_matches mode: the whole line is a path
+		if m := grepPathRe.FindStringSubmatch(line); m != nil {
+			record(m[1])
+		} else if m := grepCountRe.FindStringSubmatch(line); m != nil {
+			record(m[1])
 		}
 	}
 }


### PR DESCRIPTION
## 问题

`grep` 工具已经让模型看到了要改的那几行原文，但 ReadTracker 只给 `read_file`/`write_file`/`edit_file` 和 terminal 读命令盖章——所以 grep-then-edit 会撞 `File has not been read yet`，被迫对整个文件做一次冗余的 `read_file`（大文件尤其浪费 token）。

## 改动

`internal/tools/registry.go` 的 dispatch 成功分支新增 `case "grep"`：`recordGrepReads` 解析 grep 输出，给每个出现过的文件盖章——

- `files_with_matches` 模式：整行即路径
- `content` 模式：`path:N:text`（匹配行）、`path-N-text`（上下文行）
- `count` 模式：`path:N`
- 单文件搜索（rg 输出不带路径前缀）：取 input 的 `path` 参数

非路径行（`(no matches)`、`--` 分隔符、截断标记）stat 失败自然跳过。

## 安全性

- 盖章同时钉住 mtime，之后发生 out-of-band 修改时 "modified since read" 守卫照常触发
- grep 没有命中的文件仍然不可写（有测试覆盖）

## 测试

新增 4 个用例：目录 grep 后可编辑、files_with_matches 后可编辑、单文件 grep 后可编辑、未命中文件仍被拦截。`go test ./internal/tools/...` 全绿。
