### PR TITLE
fix(web): auto-scroll to bottom when user sends a message

### DIFF
--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1477,6 +1477,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       })
     }
     ws.sendMessage(sid, text, files)
+    pinToBottom()
   }
 
   // ── force bind ─────────────────────────────────────────────────────────────
@@ -1493,6 +1494,17 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     }
     bindRequiredFor = null
     ws.sendMessage(sid, meta.text, meta.files, true)
+    pinToBottom()
+  }
+
+  // Re-pin the scroll view to the bottom: reset the stick flag so the
+  // ResizeObserver keeps us there, and scroll immediately in case the observer
+  // doesn't fire (e.g. content height hasn't changed yet).
+  function pinToBottom() {
+    stick = true
+    requestAnimationFrame(() => {
+      if (messagesEl) messagesEl.scrollTop = messagesEl.scrollHeight
+    })
   }
 
   // ── plan progress helpers ──────────────────────────────────────────────────
@@ -1539,6 +1551,9 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       // before the message, and reruns with the edited prompt itself — no
       // resend from here (a resend would append the prompt a second time).
       await api.editMessage(sid, msgs[idx].messageIndex, content)
+      // Server truncated history and reran — re-pin so the new reply streams
+      // into view even if the user had scrolled up before editing.
+      pinToBottom()
       editingIndex = null
       editingDraft = ''
     } catch (e: any) {


### PR DESCRIPTION
## Summary

- Previously, if the user scrolled up to read history (setting `stick = false`) and then sent a new message, the view stayed frozen — the new bubble and its streaming reply were added below the fold, invisible until manually scrolled down
- Added a shared `pinToBottom()` helper that re-arms the stick flag and scrolls immediately via `requestAnimationFrame`
- Wired into all send paths: `send()`, `forceBindAndSend()`, `saveEdit()`. `confirmBranch()` is already covered by the session-change effect that resets `stick`

## Paths covered

| Path | Function | Fix |
|------|----------|-----|
| Normal send | `send` | ✅ `pinToBottom()` |
| Force bind & send | `forceBindAndSend` | ✅ `pinToBottom()` |
| Inline edit resend | `saveEdit` | ✅ `pinToBottom()` |
| Branch + send | `confirmBranch` | ✅ session-change effect (line 1144) |

## Test plan

- [ ] Open a conversation, scroll up to read history, then send a message → view should snap to bottom and show the new bubble + streaming reply
- [ ] Same scenario but trigger force-send (session bound to another entry)
- [ ] Same scenario but edit a previous user message and resend
- [ ] Verify streaming replies stay pinned to bottom as text arrives
- [ ] Verify manual scroll-up during streaming still disengages auto-scroll (existing behavior preserved)