### PR TITLE
fix(web): unify active session tracking — remove redundant activeSession store

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, sidebar, sessions, sessionGroups, pinnedSessions, groupMenuFor, editGroupId, editGroupDraft, activeSession, activeSessionId, selMode, sel, menuFor, editId, editDraft, showToast, mcpServers, createNewSession } from '../../lib/stores'
+  import { view, sidebar, sessions, sessionGroups, pinnedSessions, groupMenuFor, editGroupId, editGroupDraft, activeSessionId, selMode, sel, menuFor, editId, editDraft, showToast, mcpServers, createNewSession } from '../../lib/stores'
   import * as api from '../../lib/api'
   import { t, tr } from '../../lib/i18n'
   import { confirmDialog } from '../../lib/confirm'
@@ -396,7 +396,7 @@
       </div>
 
       {#snippet sessionRow(s: any)}
-        {@const active = s.id === $activeSession && $view === 'chat'}
+        {@const active = s.id === $activeSessionId && $view === 'chat'}
         {@const selected = !!$sel[s.id]}
         {@const editing = $editId === s.id}
         {@const menuOpen = $menuFor === s.id && !$selMode}
@@ -407,7 +407,7 @@
           class="nav-row"
           class:solid={solid}
           class:selected={selected && !solid}
-          onclick={() => { if ($selMode) toggleSel(s.id); else { view.set('chat'); activeSession.set(s.id); activeSessionId.set(s.id); menuFor.set(null); groupMenuFor.set(null) } }}
+          onclick={() => { if ($selMode) toggleSel(s.id); else { view.set('chat'); activeSessionId.set(s.id); menuFor.set(null); groupMenuFor.set(null) } }}
         >
           {#if $selMode}
           <span

--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cmdkOpen, view, sessions, activeSessionId, activeSession, skills, openAgentSession, createNewSession, showToast } from '../../lib/stores'
+  import { cmdkOpen, view, sessions, activeSessionId, skills, openAgentSession, createNewSession, showToast } from '../../lib/stores'
   import { t } from '../../lib/i18n'
 
   let query = $state('')
@@ -25,7 +25,6 @@
 
   function openSession(id: string) {
     activeSessionId.set(id)
-    activeSession.set(id)
     view.set('chat')
     close()
   }

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -84,7 +84,6 @@ export const editGroupDraft = writable('')
 // 'ask' alone would ignore whatever the user actually configured.
 export const globalPermissionMode = writable<string>('ask')
 // Sidebar session UI state
-export const activeSession = writable<string | null>(null)
 export const selMode = writable(false)
 export const sel = writable<Record<string, boolean>>({})
 export const menuFor = writable<string | null>(null)
@@ -222,7 +221,6 @@ export async function createNewSession(): Promise<void> {
   const sess = await api.createSession({ source: 'manual' })
   sessions.update(ss => [sess, ...ss])
   activeSessionId.set(sess.id)
-  activeSession.set(sess.id)
   view.set('chat')
 }
 

--- a/web/src/mobile/NewTask.svelte
+++ b/web/src/mobile/NewTask.svelte
@@ -4,7 +4,7 @@
   // directory, and land in the streaming chat detail. Leaving the prompt
   // empty just creates a blank session (the old FAB behavior).
   import { get } from 'svelte/store'
-  import { sessions, activeSessionId, activeSession, globalPermissionMode, showToast } from '../lib/stores'
+  import { sessions, activeSessionId, globalPermissionMode, showToast } from '../lib/stores'
   import * as api from '../lib/api'
   import { t, tr } from '../lib/i18n'
 
@@ -56,7 +56,6 @@
       const sess = await api.createSession({ source: 'manual' })
       sessions.update(ss => [sess, ...ss])
       activeSessionId.set(sess.id)
-      activeSession.set(sess.id)
       // Best-effort per-session overrides: a failed override shouldn't strand
       // the already-created session, so toast and continue.
       if (modelId) {

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -3,7 +3,6 @@
   import { fade } from 'svelte/transition'
   import {
     activeSessionId,
-    activeSession,
     sessions,
     chatMessages,
     chatStreaming,
@@ -1422,7 +1421,6 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       const newSess = created.session ?? created
       sessions.update(ss => [newSess, ...ss])
       activeSessionId.set(newSess.id)
-      activeSession.set(newSess.id)
       return newSess.id
     } catch (e: any) {
       showToast(e.message, 'error')
@@ -1564,7 +1562,6 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       const newSess = await api.branchSession(sid, branchModal.index, branchModal.draft)
       sessions.update(ss => [newSess, ...ss])
       activeSessionId.set(newSess.id)
-      activeSession.set(newSess.id)
       branchModal.open = false
       // Defer the send until the new session's chat state registers.
       if (branchSendTimer) clearTimeout(branchSendTimer)


### PR DESCRIPTION
## Summary

The sidebar highlighted the active session based on a separate `activeSession` store, while the main chat window used `activeSessionId`. Many code paths only updated `activeSessionId`, leaving `activeSession` stale — so the highlight and the main window drifted apart whenever a background session completed a turn or the session list changed.

- Remove `activeSession` entirely; `activeSessionId` is now the single source of truth
- Sidebar highlight (`s.id === $activeSessionId`) now always matches the main window

## Root cause

Two writable stores tracking the same concept. Paths that set `activeSessionId` without `activeSession`: `session_list` broadcast, `session_deleted`, `applyHash`, notification click handler, `openAgentSession`, `setActiveSession`, and the delete handlers in Sidebar.

## Test plan

- [ ] Open multiple sessions, click between them — highlight follows selection
- [ ] Let a background session (cron / sub-agent) complete a turn while viewing another session — highlight stays put
- [ ] Delete the active session — no leftover highlight on a non-existent row
- [ ] Cmd+K command palette → open session — highlight matches
- [ ] New session button — highlight matches
- [ ] Refresh page, hash routing restores session — highlight matches