### PR TITLE
docs: update multi-agent system design; deprecate agent team design

### DIFF
--- a/dev-docs/agent-team-design.md
+++ b/dev-docs/agent-team-design.md
@@ -1,5 +1,15 @@
 # 技术方案：Agent Team
 
+> ⚠️ **已废弃（2026-07-25）** — 本方案经讨论后否决，不进入实现。文档仅作历史存档保留。
+>
+> **否决原因**：
+> 1. **能力重复**：octo 的 `workflow` 工具（Ruby `parallel`/`pipeline` + `agent()`）已能表达"并行 spawn 多个带预设角色的子 agent 并聚合"。Team Template 本质是一个表达力更弱的 workflow DSL。
+> 2. **token 成本**：N 个 member 各自重复读取同一份上下文（multi-agent 固有开销，业界实践约 4~15x），`llm_summary` 聚合还需把所有产出再灌入一次 LLM 调用。
+> 3. **场景错位**：multi-agent 的明确收益场景是广度优先、弱耦合任务（如多源调研）；"多个角色审同一份代码"是强耦合任务，单 agent + checklist skill 通常效果相当而成本为 1/N。
+> 4. **固定角色组合前提不稳**：每次任务的审查重点随内容变化，主 Agent 临场 spawn sub_agent 比静态模板更适配。
+>
+> **替代路径**：重复性固定编排需求用 saved workflow（workflow-creator）解决；member 活动可见性（Activity Feed 的构想）如有需要，归入 sub_agent 可观测性增强，不作为 Team 特性。
+
 ## 1. 背景与目标
 
 ### 1.1 背景

--- a/dev-docs/multi-agent-system-design.md
+++ b/dev-docs/multi-agent-system-design.md
@@ -41,6 +41,8 @@
 | **Agent Router** | 根据 InboundEvent（平台、chatID、消息内容中的 @ 提及）决定消息路由到哪个 agent profile |
 | **Session Key** | `platform:chat_id:user_id`（私聊时）或 `platform:chat_id`（群聊时），标识一个 session pool 中的唯一会话 |
 | **Agent 绑定** | 会话创建时绑定 agent，一旦建立不可切换；通过新建会话选择其他 agent |
+| **能力片（CapabilitySpec）** | Profile 中 prompt/model/tools/skills 四元组，是对话模式和委派模式共享的能力定义 |
+| **委派模式** | `sub_agent` 以某 profile 的能力片发起的 ephemeral run：全新上下文、不进 session pool、任务结束即弃；profile 的平台片（别名/绑定/cron）被忽略 |
 
 ---
 
@@ -187,14 +189,22 @@ Profile 存储在 `~/.octo/agents/<profile-id>.json`，每个文件一个 profil
 // internal/agentprofile/profile.go
 package agentprofile
 
+// CapabilitySpec 是 profile 的"能力片"：prompt / model / tools / skills。
+// 它被两种运行模式共享：
+//   - 对话模式：channel.Manager 持久 session（用户直接对话）
+//   - 委派模式：sub_agent 发起的 ephemeral run（见 "sub_agent 委派模式" 一节）
+type CapabilitySpec struct {
+    Model        string   `json:"model"`
+    SystemPrompt string   `json:"system_prompt"`
+    Tools        []string `json:"tools"`
+    ToolSkills   []string `json:"tool_skills"` // 这些 skill 以工具形式暴露
+}
+
 type Profile struct {
     ID             string           `json:"id"`
     Name           string           `json:"name"`
     Description    string           `json:"description"`
-    Model          string           `json:"model"`
-    SystemPrompt   string           `json:"system_prompt"`
-    Tools          []string         `json:"tools"`
-    ToolSkills     []string         `json:"tool_skills"`  // 这些 skill 以工具形式暴露
+    CapabilitySpec                   `json:",inline"` // JSON 扁平展开，存储格式不变
     WorkingDir     string           `json:"working_dir,omitempty"`
     MentionAs      []string         `json:"mention_as"`
     ChannelBindings []ChannelBinding `json:"channel_bindings"`
@@ -754,6 +764,31 @@ func DefaultProfile() *Profile {
 
 ---
 
+## sub_agent 委派模式：preset 与 Expert Agent 定义层统一
+
+### 背景
+
+sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent Profile 在"能力定义"上同构——都是 prompt + model + tools 的组合。为避免两套 schema 并存，二者**定义层统一、运行层保持独立**。
+
+### 统一规则
+
+1. **Profile 是唯一的能力定义 schema**。能力片（`CapabilitySpec`：prompt/model/tools/skills）抽为独立结构，对话模式和委派模式共享；平台片（别名/频道绑定/session pool/cron 归属）仅对话模式使用
+2. **内置 preset 降级为内建 profile**。`explore` / `general` / `code-review` 由代码定义（与 DefaultProfile 同款待遇，无 JSON 文件），行为与现状完全一致，对用户透明
+3. **`subagent_type` 接受内建 profile 名或用户 expert profile id**。参数名保持 `subagent_type` 不变（向后兼容），语义扩展为"内建或用户 profile 的 id"
+
+### 委派模式的约束（红线）
+
+- **ephemeral、全新上下文**：委派 run 不携带目标 profile 的任何 session 历史，用完即弃
+- **不进 session pool**：委派 run 由 SubAgentManager 管理，不出现在该 agent 的会话列表，不写入其 session pool
+- **只取能力片**：profile 的 `mention_as` / `channel_bindings` / cron 归属在委派模式下被忽略
+- **model 解析优先级**：`sub_agent(model:)` 显式参数 > profile.model > 继承父 agent model
+
+### 一致性提示
+
+用户修改 profile 会影响所有引用它的 workflow / 会话。expert-agent-manager 元技能在执行 Update/Delete 时提示引用情况（如"有 N 个 saved workflow 在引用此 profile"）。
+
+---
+
 ## HTTP API 完整清单
 
 ### Agent Profile CRUD
@@ -821,6 +856,7 @@ func DefaultProfile() *Profile {
 | `internal/channel/manager.go` | 接受 profile 参数注入 system prompt / model |
 | `internal/agent/`（session 序列化处） | session metadata 新增 `agent_id` 字段；读取时缺失归 default |
 | `internal/tools/registry.go` | `DefaultToolsForProfile()` — 按 profile 过滤工具 |
+| `internal/tools/`（sub_agent 工具定义处） | `subagent_type` 解析扩展：内建 preset 名或 expert profile id；委派模式只取 CapabilitySpec |
 | `internal/skills/skills.go` | `ManifestForProfile()` — 按 profile 过滤 skill manifest；系统级 skill frontmatter 标记 `system: true` 后对 expert agent 隐藏；browser-recorded skill 在 profile 不含 browser 工具时隐藏 |
 | `internal/scheduler/` 或 task 存储 | cron task 新增 `agent_id` 字段；`GET /api/cron` 支持 `?agent_id=` 过滤；新增 `PUT /api/cron/:id/transfer` |
 | `internal/server/server.go` | `Server.Config`（server.go:56）新增 `agentName` 字段（仅客户端路径 `octo`/`octo-desktop` 设置；`octo serve` 不接受此 flag，由 session 绑定 agent） |
@@ -904,7 +940,7 @@ func DefaultProfile() *Profile {
 |----|------|----------|
 | 1 | `internal/agentprofile/` 纯新包（Profile / Store / Router）+ 单测 | 不接线，纯库 |
 | 2 | `MultiManager` + server.go 重构（`initChannels` → `initMultiManager`） | 兼容测试：无 profile 时 IM 路由、session 行为全等。**单独成 PR，不捆绑其他改动** |
-| 3 | tools/skills 按 profile 过滤（`DefaultToolsForProfile`、`ManifestForProfile`、`system:true`、browser skill 隐藏） | 只依赖 PR1，可与 PR2 并行 |
+| 3 | tools/skills 按 profile 过滤（`DefaultToolsForProfile`、`ManifestForProfile`、`system:true`、browser skill 隐藏）+ preset 内建 profile 化与 `subagent_type` 解析扩展 | 只依赖 PR1，可与 PR2 并行 |
 | 4 | CLI/TUI `--agent` + `/agent` 命令 | 第一个端到端验证切片：profile 创建 → 路由 → 工具过滤全链路 |
 | 5 | REST API `/api/agents/*` + cron `agent_id`/transfer + `expert-agent-manager` 元技能 | 对话式管理入口可用 |
 | 6 | Web UI（Agents 面板、Header 切换、各 View 过滤） | 纯前端，API 已就绪 |

--- a/dev-docs/multi-agent-system-design.md
+++ b/dev-docs/multi-agent-system-design.md
@@ -39,7 +39,7 @@
 | **sub_agent** | 工具名。所有 agent 都可通过此工具在会话内部调度匿名子 agent 执行隔离任务。子 agent 的生命周期、上下文、工具集完全独立，运行结束后结果回传给主 agent |
 | **Profile Store** | `~/.octo/agents/` 目录，每个 expert agent 一个 `<id>.json` 文件 |
 | **Agent Router** | 根据 InboundEvent（平台、chatID、消息内容中的 @ 提及）决定消息路由到哪个 agent profile |
-| **Session Key** | `platform:chat_id:user_id`（私聊时）或 `platform:chat_id`（群聊时），标识一个 session pool 中的唯一会话 |
+| **Session Key** | `platform:chat_id[:user_id]`；expert agent 加 `agentID#` 前缀形成命名空间（如 `a3f9b2c1#weixin:c1:u1`）。default agent 保持 legacy 格式字节级不变 |
 | **Agent 绑定** | 会话创建时绑定 agent，一旦建立不可切换；通过新建会话选择其他 agent |
 | **能力片（CapabilitySpec）** | Profile 中 prompt/model/tools/skills 四元组，是对话模式和委派模式共享的能力定义 |
 | **委派模式** | `sub_agent` 以某 profile 的能力片发起的 ephemeral run：全新上下文、不进 session pool、任务结束即弃；profile 的平台片（别名/绑定/cron）被忽略 |
@@ -54,67 +54,39 @@
                          InboundEvent (IM 消息)
                               │
                     ┌─────────▼─────────┐
-                    │    AgentRouter     │
-                    │  (profile 选择器)   │
-                    └─────────┬─────────┘
-                              │ 路由决策：
-                              │ 1. 频道绑定（最高优先）
-                              │ 2. @ 提及
-                              │ 3. fallback → Default Agent
-            ┌─────────────────┼─────────────────┐
-            ▼                 ▼                 ▼
-   ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
-   │ Manager[def] │  │ Manager[code]│  │ Manager[ops] │
-   │ Default      │  │ code-review  │  │ ops-helper   │
-   │ 独立 session  │  │ 独立 session  │  │ 独立 session  │
-   │ pool         │  │ pool         │  │ pool         │
-   └──────────────┘  └──────────────┘  └──────────────┘
-            │                 │                 │
-            ▼                 ▼                 ▼
-      Agent(Default)    Agent(code)       Agent(ops)
+                    │    AgentRouter     │   纯函数：ev → profile
+                    └─────────┬─────────┘   1. @ 提及  2. 频道绑定  3. fallback default
+                              │
+                              ▼
+              ┌───────────────────────────────┐
+              │   channel.Manager（单一实例）   │
+              │                               │
+              │  sessions sync.Map:           │
+              │   "weixin:c1:u1"        → default 的 session（legacy key，不变）
+              │   "a3f9b2c1#weixin:c1:u1" → code-review 的 session
+              │   "b7e2d408#weixin:c1:u1" → ops-helper 的 session
+              │                               │
+              │  隔离 = key 命名空间，不堆 Manager │
+              └───────────────────────────────┘
+                              │
+                              ▼
+              per-turn 按 session.AgentID 查 Store 取 profile
+              → system prompt / model / 工具白名单 / skill manifest
 ```
 
 ### 改造后的 Server 结构
 
-`internal/server/server.go` 的 `Server` 结构需要从单一 `channelMgr` 扩展为一组 manager：
+`internal/server/server.go` 的 `Server` **保留单一 `channelMgr`**，只新增 Store 与 Router 两个字段：
 
 ```go
 type Server struct {
     // ─── 多 agent 核心 ───
-    // channelMgr 已完全移除，由 multiMgr 统一派发所有 IM 事件
     agentStore   *agentprofile.Store          // ~/.octo/agents/ 的加载与热管理
-    multiMgr     *channel.MultiManager        // 替代 channelMgr，内持多个 per-agent Manager
-    defaultMgr   *channel.Manager             // Default Agent 的 Manager（快捷引用，冗余但省去每次 map 查找）
-```
+    agentRouter  *agentprofile.Router         // InboundEvent → profile（纯计算）
+    // channelMgr 保留：单 Manager，session 隔离由 key 的 agent 命名空间派生
+    // （见详细设计第 3 节）
 
-### IM 事件流
-
-废弃 `Server.channelMgr` 后，`multiMgr` 成为 IM 事件的唯一分派点：
-
-```
-Channel Adapter (IM 消息)
-    │
-    ▼
-Server.handleChannelMessage(ev)         ← 入口不变，body 改造
-    │
-    ▼
-mgr := multiMgr.Resolve(ev)             ← 路由决策：拿到正确的 per-agent Manager
-if mgr == nil {
-    // 群聊多绑定无 @：drop，不路由到任何 agent
-    return
-}
-    │
-    ▼
-mgr.GetOrCreateSession(ev) & run turn    ← 跟原有单 Manager 路径一致，但隔离到目标 agent 的 pool
-```
-
-**Resolve 返回 nil 的 drop 逻辑**：当群聊绑定多个 agent 但消息无 @ 时，`Router.Route()` 返回 nil，`Resolve` 透传返回 nil，handler 直接 return 不响应。
-
-**迁移期无并存**：没有 `channelMgr` / `multiMgr` 双轨。`initChannels()` 改为 `initMultiManager()`，一次切干净。
-
-**adapter 注入改造**：每个 channel adapter 启动时的回调从 `func(ev)` 改为内部直接调 `multiMgr.Resolve`。由于 Resolve 是纯计算（路由查找 + map 读取），adapter 不需要感知 agent 数量。
-
-    // ─── 以下字段基本不变 ───
+    // ─── 以下字段不变 ───
     cfg          Config
     sender       agent.Sender
     model        string
@@ -125,35 +97,31 @@ mgr.GetOrCreateSession(ev) & run turn    ← 跟原有单 Manager 路径一致�
 }
 ```
 
-`MultiManager` 负责：
-- 按 agent ID 持有各自的 `*channel.Manager`
-- 路由 InboundEvent 到对应 manager 的 session pool
-- 提供按 agent 维度列出/管理 session 的方法
+### IM 事件流
 
-```go
-// internal/channel/multi_manager.go
-type MultiManager struct {
-    mu       sync.RWMutex
-    managers map[string]*Manager  // agentID → Manager
-    router   *AgentRouter
-    store    *agentprofile.Store
-}
-
-// Resolve 根据 InboundEvent 找到应处理的 Manager。
-// profile 为 nil 时（群聊多绑定无 @）返回 nil，caller 应 drop 该消息。
-func (mm *MultiManager) Resolve(ev InboundEvent) *Manager {
-    profile := mm.router.Route(ev)
-    if profile == nil {
-        return nil
-    }
-    mm.mu.RLock()
-    defer mm.mu.RUnlock()
-    return mm.managers[profile.ID]
-}
-
-// Default 返回 Default Agent 的 Manager（始终存在）
-func (mm *MultiManager) Default() *Manager
 ```
+Channel Adapter (IM 消息)
+    │
+    ▼
+Server.handleChannelMessage(ev)              ← 入口不变，body 加一步路由
+    │
+    ▼
+profile := agentRouter.Route(ev)             ← 纯函数路由决策
+if profile == nil {
+    // 群聊多绑定无 @：drop，不路由到任何 agent
+    return
+}
+    │
+    ├─ slash 命令 → channelMgr.CommandRouter(ev, profile.ID)
+    │                （作用于路由到的 agent 的 key 命名空间）
+    │
+    └─ 普通消息  → channelMgr.GetOrCreateSession(ev, profile) & run turn
+                    （同 chat 不同 agent 各自独立 session，由 key 前缀区分）
+```
+
+**Route 返回 nil 的 drop 逻辑**：当群聊绑定多个 agent 但消息无 @ 时，`Router.Route()` 返回 nil，handler 直接 return 不响应（与"群聊未 @ 完全静默"的决策一致）。
+
+**adapter 无改造**：adapter 回调签名不变，路由发生在 `handleChannelMessage` 内部，adapter 不感知 agent 数量。
 
 ---
 
@@ -253,7 +221,7 @@ func (s *Store) ByMention(alias string) (*Profile, bool)       // 按 @ 别名�
 - `model` 必须在 `~/.octo/config.yml` 的 `models` 列表中
 
 **热加载**（决策 Q5：不做文件系统监听，直接编辑文件不会在运行期被感知，需重启或通过 API 触发）：
-- 所有经 REST API 的变更（`POST/PUT/DELETE /api/agents/*`）在写入磁盘后立即更新内存，并触发 `MultiManager` 重载（重建受影响的 per-agent Manager），无需重启
+- 所有经 REST API 的变更（`POST/PUT/DELETE /api/agents/*`）在写入磁盘后立即更新内存，无需重启——运行期 profile 均按 session 的 `agent_id` 从 Store 实时查询，变更下一 turn 自然生效（无 Manager 重建）
 - `POST /api/agents/:id/reload` 从磁盘重读指定 profile —— 手工改文件后免重启生效的入口
 - 直接编辑 `~/.octo/agents/*.json` 后不走上述两个入口的，重启进程才生效
 
@@ -306,54 +274,74 @@ func (r *Router) Route(ev InboundEvent) *Profile {
 | 群聊（绑定 code + ops） | 无 @ | 有（多） | **静默**（drop） |
 | 群聊（无绑定） | — | 无 | **Default Agent** |
 
-**注意**：AgentRouter 返回 nil 时，MultiManager 应 drop 该消息（不路由到任何 agent），这与"群聊未 @ 完全静默"的决策一致。
+**注意**：AgentRouter 返回 nil 时，handler 直接 drop 该消息（不路由到任何 agent），这与"群聊未 @ 完全静默"的决策一致。
 
-### 3. Multi-Manager Session Pool
+### 3. 单 Manager Session Pool：key 内嵌 agent 命名空间
 
-每个 agent profile 拥有独立的 `*channel.Manager`，即独立的 `sync.Map[SessionKey, *Session]`。
+**不引入 MultiManager**。保留单一 `*channel.Manager`，把 agentID 编码进 SessionKey 字符串，session 隔离由 key 命名空间派生：
 
+```go
+// 默认 agent：legacy key，字节级不变（向后兼容的根基）
+sessionKeyFor(mode, ev, "default")  = "weixin:chat123:user456"
+
+// expert agent：加命名空间前缀（'#' 不会出现在 platform 名或 agent id 中，无解析歧义）
+sessionKeyFor(mode, ev, "a3f9b2c1") = "a3f9b2c1#weixin:chat123:user456"
 ```
-Channel.MultiManager
-├── managers["default"]  → *channel.Manager (Default Agent)
-├── managers["code"]     → *channel.Manager (code-review)
-└── managers["ops"]      → *channel.Manager (ops-helper)
-```
 
-**Session Key** 生成规则不变（`channel.sessionKeyFor(mode, ev)` = `platform:chat_id[:user_id]`），但 manager 按 agent ID 隔离，不同 agent 可以有相同 Session Key 的不同 session。
+这一处设计连锁解决四个问题：
+
+| 问题 | 消解方式 |
+|------|----------|
+| 内存 session map 冲突 | 复合 key 天然不撞，`sync.Map` 结构不动 |
+| 磁盘 store 文件冲突 | `sessionStoreID(key)` 对复合 key 做 FNV → 每 agent 独立文件；default 保持旧 key → **存量 session 文件 ID 不变，零迁移** |
+| `/bind` 重定向表隔离 | `bindings` 按复合 key 索引，per-agent 命名空间自动成立 |
+| profile 热更新 | 无 Manager 重建；per-turn 经 `session.AgentID` 查 Store 取 profile，下一 turn 自然生效 |
+
+> 注：per-agent Manager 方案（本节的旧设计）即使隔离了内存 map，两个 agent 服务同一 chat 时 `sessionStoreID(key)` 仍会派生出**同一个磁盘文件**——磁盘层冲突只能靠 key 命名空间解决，这是本方案的关键论据。
 
 **关键行为**：
-- Session ID 本身已全局唯一（由 `agent.NewSession` 的时间戳 + 随机后缀保证），无需添加 agent 前缀
-- Session 文件保持现名 `~/.octo/sessions/<session_id>.jsonl`，但头部 metadata 新增 `agent_id` 字段，创建 session 时写入所属 agent
-- 加载时按 `agent_id` 将 session 分配到对应 manager 的 pool；缺失 `agent_id` 的历史 session 归 Default Agent —— 天然兼容旧数据，且重启后 expert agent 的会话列表不丢失
+- `Session` 结构新增 `AgentID` 字段（创建时写入）；session 文件头部 metadata 同步写 `agent_id`（见 10.2），二者是同一事实的两份表达
+- Session 文件保持现名 `~/.octo/sessions/<session_id>.jsonl`；default agent 的存量文件因 key 不变而完全兼容
+- 重启后 channel session 经 `resolveStoreID(复合 key)` 惰性恢复，自然回到正确 agent 的命名空间；session 列表按 `agent_id` 过滤（缺失归 default）
+- `/list` / `/bind` 只列当前路由 agent 的 session，跨 agent bind 拒绝（MVP 边界规则，避免 session 行为归属歧义）
+- `splitSessionKey` 先剥离可选的 `agentID#` 前缀，再按原规则解析
+
+**Manager 签名变化**（内部约 12 处 key 派生统一走新 `sessionKeyFor`；server 生产调用点仅 2 处——`handleChannelMessage` 路由后注入）：
+
+```go
+func (m *Manager) GetOrCreateSession(ev InboundEvent, profile *agentprofile.Profile) *Session
+func (m *Manager) CommandRouter(ev InboundEvent, agentID string) string
+
+// factory 按 profile 参数化（见第 4 节）
+type AgentFactory func(profile *agentprofile.Profile) *agent.Agent
+```
 
 ### 4. 改造 `buildChannelFactory`
 
 当前 `Server.buildChannelFactory()` 返回无参闭包。需要改为按 profile 参数化：
 
 ```go
-// 改造后：每个 Manager 在创建 session 时传入 profile
-func (s *Server) buildChannelFactoryFor(profile *agentprofile.Profile) func() *agent.Agent {
-    return func() *agent.Agent {
-        sender, model := s.senderForProfile(profile)
-        a := agent.New(sender, model)
-        a.MaxTokens = s.cfg.MaxTokens
+// 改造后：Manager 在创建 session 时传入路由到的 profile
+func (s *Server) buildChannelAgent(profile *agentprofile.Profile) *agent.Agent {
+    sender, model := s.senderForProfile(profile)
+    a := agent.New(sender, model)
+    a.MaxTokens = s.cfg.MaxTokens
 
-        // profile 覆盖默认 system prompt
-        if profile.SystemPrompt != "" {
-            a.System = profile.SystemPrompt
-        }
-
-        // profile 的 working_dir
-        if profile.WorkingDir != "" {
-            a.CWD = profile.WorkingDir  // 或设到 Session 上
-        }
-
-        return a
+    // profile 覆盖默认 system prompt
+    if profile.SystemPrompt != "" {
+        a.System = profile.SystemPrompt
     }
+
+    // profile 的 working_dir
+    if profile.WorkingDir != "" {
+        a.CWD = profile.WorkingDir
+    }
+
+    return a
 }
 ```
 
-`agent.Agent` 不需要大改。Profile 的 `Tools` 白名单在 per-turn 的 `tools.DefaultToolsForProfile(ctx, profile)` 处过滤，不在 factory 中处理。
+`agent.Agent` 不需要大改。Profile 的 `Tools` 白名单在 per-turn 的 `tools.DefaultToolsForProfile(ctx, profile)` 处过滤，不在 factory 中处理——profile 热更新因此下一 turn 即生效，无需重建任何 session 结构。
 
 ### 5. Agent 工具白名单注入
 
@@ -408,7 +396,7 @@ type Server struct {
     disabledMCPs   map[string][]string // agentID → 在该 agent 中禁用的 MCP 名称列表
 
     // 每个 agent 独立的 per-turn 状态（已有，按 session 隔离）
-    // turnLocks, sessionAgents 等保持不变，因为不同 manager 的 session key 已是隔离的
+    // turnLocks, sessionAgents 等保持不变，因为 session key 已含 agent 命名空间
 }
 ```
 
@@ -648,7 +636,7 @@ Default Agent 收到消息，匹配到 expert-agent-manager skill
   │      "给它起个什么名字？" → "用什么模型？" → "要启用哪些技能？"
   ├─ 3. 校验输入（模型是否在 config 列表中、alias 是否全局唯一）
   ├─ 4. 调用 Profile Store.Create() 写入 ~/.octo/agents/<id>.json
-  ├─ 5. 热加载事件触发 → MultiManager 重建
+  ├─ 5. 热加载生效（Store 内存更新，下一 turn 起用新配置）
   └─ 6. 回复: "代码审查 Agent 已创建，ID: code-review-v1。你可以用 @review 在群里 @ 它。"
 ```
 
@@ -840,7 +828,6 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 | `internal/agentprofile/profile.go` | Profile 结构 + 校验 |
 | `internal/agentprofile/store.go` | Store（加载/保存/热加载/索引） |
 | `internal/agentprofile/router.go` | AgentRouter（按事件路由到 profile） |
-| `internal/channel/multi_manager.go` | MultiManager（per-agent Manager 容器） |
 | `web/src/views/AgentsView.svelte` | Agent 管理主面板 |
 | `web/src/views/AgentEditView.svelte` | Agent 编辑表单 |
 | `web/src/components/agents/AgentList.svelte` | 下拉 agent 列表 |
@@ -850,10 +837,10 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 
 | 文件 | 改动 |
 |------|------|
-| `internal/server/server.go` | `Server` 增加 `agentStore`、`multiMgr`；`initChannels()` 改为 `initMultiManager()` |
+| `internal/server/server.go` | `Server` 增加 `agentStore`、`agentRouter`；`handleChannelMessage` 加路由步骤 |
 | `internal/server/server.go` | `buildChannelFactory()` 改为按 profile 创建 |
 | `internal/server/handlers.go` | 新增 agents handlers（CRUD + 资源子路由） |
-| `internal/channel/manager.go` | 接受 profile 参数注入 system prompt / model |
+| `internal/channel/manager.go` | `sessionKeyFor` 加 agent 命名空间；`GetOrCreateSession`/`CommandRouter` 加 agent 维度；`Session` 新增 `AgentID` 字段；`splitSessionKey` 剥离前缀 |
 | `internal/agent/`（session 序列化处） | session metadata 新增 `agent_id` 字段；读取时缺失归 default |
 | `internal/tools/registry.go` | `DefaultToolsForProfile()` — 按 profile 过滤工具 |
 | `internal/tools/`（sub_agent 工具定义处） | `subagent_type` 解析扩展：内建 preset 名或 expert profile id；委派模式只取 CapabilitySpec |
@@ -880,7 +867,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 
 1. `store.go`：CRUD、热加载事件、并发安全
 2. `router.go`：各种路由场景（绑定冲突、@ 别名、私聊、群聊）
-3. `multi_manager.go`：不同 manager 的 session 隔离
+3. manager 复合 key：同 chat 不同 agent 的 session 隔离、store 文件 ID 不冲突、default agent key 与改造前字节级一致
 4. tools/skills 过滤逻辑
 
 ### 集成测试
@@ -915,7 +902,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 1. **Profile 热加载失败**：文件写入过程中读取到半写状态 → 跳过本次变更，保留旧 profile 并打印警告日志（不崩溃）
 2. **Profile 文件损坏（JSON 解析失败）**：跳过该文件，其他 profile 正常加载
 3. **Default Agent 不可用时**：Default Agent 是代码内建的，不会"不可用"。agentStore 为空时 fallback 到 Default Agent（向后兼容）
-4. **MultiManager 部分 agent 启动失败**：隔离故障 — 单个 Manager 启动失败不影响其他 Manager（与现在单 Manager 启动失败导致 channel 全挂不同，这次是 per-agent 隔离的）
+4. **单个 profile 损坏或启动时缺失**：加载跳过该文件，路由 fallback 到 Default Agent（向后兼容）；单 Manager 架构下不存在 per-agent 启动失败面
 
 ---
 
@@ -939,7 +926,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 | PR | 内容 | 验收重点 |
 |----|------|----------|
 | 1 | `internal/agentprofile/` 纯新包（Profile / Store / Router）+ 单测 | 不接线，纯库 |
-| 2 | `MultiManager` + server.go 重构（`initChannels` → `initMultiManager`） | 兼容测试：无 profile 时 IM 路由、session 行为全等。**单独成 PR，不捆绑其他改动** |
+| 2 | Manager 加 agent 维度（key 命名空间 / 签名扩展 / `Session.AgentID`）+ `handleChannelMessage` 路由接入 | 兼容测试：default agent 的 key、store 文件 ID、IM 行为与改造前字节级全等。**单独成 PR，不捆绑其他改动** |
 | 3 | tools/skills 按 profile 过滤（`DefaultToolsForProfile`、`ManifestForProfile`、`system:true`、browser skill 隐藏）+ preset 内建 profile 化与 `subagent_type` 解析扩展 | 只依赖 PR1，可与 PR2 并行 |
 | 4 | CLI/TUI `--agent` + `/agent` 命令 | 第一个端到端验证切片：profile 创建 → 路由 → 工具过滤全链路 |
 | 5 | REST API `/api/agents/*` + cron `agent_id`/transfer + `expert-agent-manager` 元技能 | 对话式管理入口可用 |
@@ -948,7 +935,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 要点：
 
 - **CLI 先于 Web UI**：CLI 是全栈最薄的验证路径，让 PR2 这个高风险重构尽早获得端到端信号，而不是压到 Web UI 做完才第一次跑通全链路
-- **PR2 单独成 PR**：无双轨迁移期下它是唯一不可逆的切片，diff 越纯粹，评审越聚焦于"channelMgr 的每个调用点是否等价迁移"
+- **PR2 单独成 PR**：它是多 agent 的核心接线，评审聚焦一件事——"default agent 的 key、store 文件 ID、IM 行为是否与改造前完全等价"
 
 ### 发布后验证清单
 
@@ -988,8 +975,8 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 
 本次改造的所有代码改动集中在以下几个独立包中：
 - `internal/agentprofile/` — 全新包，可整体删除
-- `internal/channel/multi_manager.go` — 全新文件，可删除
-- `internal/server/` — 改动集中在 `initChannels()` 重构为 `initMultiManager()` + 新增 handlers，撤销后恢复旧 `initChannels()` 即可
+- `internal/server/` — 改动集中在 `handleChannelMessage` 路由步骤 + 新增 handlers，撤销路由步骤即可
+- `internal/channel/manager.go` — key 命名空间与签名扩展向后兼容（default agent key 不变），无需回滚数据
 - `web/src/views/AgentsView.svelte` + `AgentEditView.svelte` + `AgentAvatar.svelte` — 全新文件，可删除
 
 回滚步骤：

--- a/dev-docs/multi-agent-system-design.md
+++ b/dev-docs/multi-agent-system-design.md
@@ -222,7 +222,6 @@ type Store struct {
     mu       sync.RWMutex
     dir      string           // ~/.octo/agents/
     profiles map[string]*Profile
-    watcher  *fsnotify.Watcher // 监听文件变更
 }
 
 func New(dir string) (*Store, error)
@@ -232,7 +231,7 @@ func (s *Store) List() []*Profile               // 返回所有 profile（不含
 func (s *Store) Create(p *Profile) error
 func (s *Store) Update(p *Profile) error
 func (s *Store) Delete(id string) error
-func (s *Store) Watch(ctx context.Context)     // fsnotify 热加载循环
+func (s *Store) Reload(id string) error         // 从磁盘重读指定 profile（手动改文件后免重启生效）
 func (s *Store) ByChannel(platform, chatID string) []*Profile  // 按频道绑定索引
 func (s *Store) ByMention(alias string) (*Profile, bool)       // 按 @ 别名索引
 ```
@@ -243,11 +242,10 @@ func (s *Store) ByMention(alias string) (*Profile, bool)       // 按 @ 别名�
 - 所有字段在 `Create`/`Update` 时做非空校验
 - `model` 必须在 `~/.octo/config.yml` 的 `models` 列表中
 
-**热加载**：
-- `Watch()` 监听 `~/.octo/agents/` 目录的 `CREATE` / `WRITE` / `REMOVE` 事件
-- 文件改动后：`Load()` 全量重读（文件量小，O(N) 可接受）
-- 触发 `MultiManager` 重载（重建受影响的 per-agent Manager）
-- API 路径 `POST /api/agents/:id/reload` 提供手动触发入口
+**热加载**（决策 Q5：不做文件系统监听，直接编辑文件不会在运行期被感知，需重启或通过 API 触发）：
+- 所有经 REST API 的变更（`POST/PUT/DELETE /api/agents/*`）在写入磁盘后立即更新内存，并触发 `MultiManager` 重载（重建受影响的 per-agent Manager），无需重启
+- `POST /api/agents/:id/reload` 从磁盘重读指定 profile —— 手工改文件后免重启生效的入口
+- 直接编辑 `~/.octo/agents/*.json` 后不走上述两个入口的，重启进程才生效
 
 ### 2. Agent Router
 
@@ -260,7 +258,7 @@ type Router struct {
 }
 
 // Route 返回应处理该消息的 agent profile
-// 返回 *Profile（总不为 nil：fallback 到 Default Agent）
+// 可能返回 nil：群聊绑定多个 agent 且消息无 @ 时返回 nil，caller 应 drop 该消息
 func (r *Router) Route(ev InboundEvent) *Profile {
     // 1. 检查 @ 提及（群聊场景）
     if mentioned := extractMentionAlias(ev.Text); mentioned != "" {
@@ -315,8 +313,8 @@ Channel.MultiManager
 
 **关键行为**：
 - Session ID 本身已全局唯一（由 `agent.NewSession` 的时间戳 + 随机后缀保证），无需添加 agent 前缀
-- Session 文件保持现名 `~/.octo/sessions/<session_id>.jsonl`，仅按 manager 隔离 in-memory 引用
-- 首次加载时，所有已有 session 自动归属 Default Agent（session 文件名不带 agent 信息）
+- Session 文件保持现名 `~/.octo/sessions/<session_id>.jsonl`，但头部 metadata 新增 `agent_id` 字段，创建 session 时写入所属 agent
+- 加载时按 `agent_id` 将 session 分配到对应 manager 的 pool；缺失 `agent_id` 的历史 session 归 Default Agent —— 天然兼容旧数据，且重启后 expert agent 的会话列表不丢失
 
 ### 4. 改造 `buildChannelFactory`
 
@@ -747,9 +745,10 @@ func DefaultProfile() *Profile {
 #### 10.2 已有 Session 归属
 
 服务器首次启动多 agent 改造后：
-- 所有已有 session 归属于 Default Agent（它们都用旧格式存储，不带 agent 前缀）
-- `~/.octo/sessions/` 中的文件直接划入 Default Agent 的 session pool
+- 所有已有 session 归属于 Default Agent（旧格式存储，metadata 中无 `agent_id` 字段，按"缺失即 default"处理）
+- `~/.octo/sessions/` 中的历史文件直接划入 Default Agent 的 session pool
 - 这导致 Default Agent 首次加载时 session 列表包含所有历史 session — 符合预期（用户视角无感）
+- 改造后新建的 session 均在头部 metadata 写入 `agent_id`，重启后仍归属正确的 agent
 
 **Cron 迁移**：现有 cron JSON 含 `"agent": "general"`（死代码字段）。加载时忽略旧 `agent` 字段，`agent_id` 默认设为 `"default"`。无需数据迁移，旧值被静默丢弃。
 
@@ -820,6 +819,7 @@ func DefaultProfile() *Profile {
 | `internal/server/server.go` | `buildChannelFactory()` 改为按 profile 创建 |
 | `internal/server/handlers.go` | 新增 agents handlers（CRUD + 资源子路由） |
 | `internal/channel/manager.go` | 接受 profile 参数注入 system prompt / model |
+| `internal/agent/`（session 序列化处） | session metadata 新增 `agent_id` 字段；读取时缺失归 default |
 | `internal/tools/registry.go` | `DefaultToolsForProfile()` — 按 profile 过滤工具 |
 | `internal/skills/skills.go` | `ManifestForProfile()` — 按 profile 过滤 skill manifest；系统级 skill frontmatter 标记 `system: true` 后对 expert agent 隐藏；browser-recorded skill 在 profile 不含 browser 工具时隐藏 |
 | `internal/scheduler/` 或 task 存储 | cron task 新增 `agent_id` 字段；`GET /api/cron` 支持 `?agent_id=` 过滤；新增 `PUT /api/cron/:id/transfer` |
@@ -851,7 +851,7 @@ func DefaultProfile() *Profile {
 
 1. 创建 profile → assign → 重启 → 热加载 → 删除，全流程
 2. Default Agent 的 skill/MCP 定义新增后，expert agent 立即可见（在启用列表中）
-3. 热加载后新配置生效（无需重启）
+3. API 触发 reload（或 CRUD API 变更）后新配置生效，无需重启；直接改文件不走 API 的运行期不生效（符合 Q5 决策）
 4. Default Agent 的 system prompt 不可通过 profile 编辑器修改（只读显示"由 onboard 管理"）
 5. IM 频道绑定：发消息到绑定群 → 只有被绑 agent 响应；@ 提及 → 被 @ agent 响应
 6. `octo chat --agent code-review` 正常启动
@@ -896,24 +896,30 @@ func DefaultProfile() *Profile {
 
 ---
 
-## 发布顺序
+## 发布顺序（PR 切片）
 
-按依赖链从底向上：
+贯穿全程的不变量：**无 profile 文件时行为与改造前完全一致**——每个 PR 的验收都包含这条，主干随时可发。
 
-1. **`internal/agentprofile/`** — Profile / Store / Router 包（纯新代码，无依赖）
-2. **`internal/channel/` — MultiManager** — 引用 agentprofile
-3. **`internal/server/server.go`** — 重构 initChannels → initMultiManager，替换 channelMgr 为 multiMgr
-4. **`internal/tools/registry.go` + `internal/skills/skills.go`** — 过滤函数
-5. **Web UI** — AgentViews + 改造 Header/Skills/Mcp/Chat
-6. **`cmd/octo/`** — `--agent` flag + `/agent` 命令
-7. **测试 + 文档**
+| PR | 内容 | 验收重点 |
+|----|------|----------|
+| 1 | `internal/agentprofile/` 纯新包（Profile / Store / Router）+ 单测 | 不接线，纯库 |
+| 2 | `MultiManager` + server.go 重构（`initChannels` → `initMultiManager`） | 兼容测试：无 profile 时 IM 路由、session 行为全等。**单独成 PR，不捆绑其他改动** |
+| 3 | tools/skills 按 profile 过滤（`DefaultToolsForProfile`、`ManifestForProfile`、`system:true`、browser skill 隐藏） | 只依赖 PR1，可与 PR2 并行 |
+| 4 | CLI/TUI `--agent` + `/agent` 命令 | 第一个端到端验证切片：profile 创建 → 路由 → 工具过滤全链路 |
+| 5 | REST API `/api/agents/*` + cron `agent_id`/transfer + `expert-agent-manager` 元技能 | 对话式管理入口可用 |
+| 6 | Web UI（Agents 面板、Header 切换、各 View 过滤） | 纯前端，API 已就绪 |
+
+要点：
+
+- **CLI 先于 Web UI**：CLI 是全栈最薄的验证路径，让 PR2 这个高风险重构尽早获得端到端信号，而不是压到 Web UI 做完才第一次跑通全链路
+- **PR2 单独成 PR**：无双轨迁移期下它是唯一不可逆的切片，diff 越纯粹，评审越聚焦于"channelMgr 的每个调用点是否等价迁移"
 
 ### 发布后验证清单
 
 - [ ] 无 profile 文件时行为与改造前完全一致（向后兼容）
 - [ ] 创建 profile → 绑定频道 → IM 发消息 → 正确路由
 - [ ] Web 新建会话选 agent → 会话正确归属；skill/MCP 面板不按 agent 过滤
-- [ ] 热加载后新配置生效（无需重启）
+- [ ] API 触发 reload 后新配置生效（无需重启）；直接改文件不走 API 的运行期不生效
 - [ ] Default Agent 的 system prompt 不可通过 profile 编辑器修改（只读显示"由 onboard 管理"）
 - [ ] `octo --agent code-review` 正常启动
 - [ ] `octo serve` 桌面版 default 和新 profile 共存

--- a/dev-docs/multi-agent-system-design.md
+++ b/dev-docs/multi-agent-system-design.md
@@ -131,7 +131,7 @@ if profile == nil {
 
 #### 1.1 文件存储格式
 
-Profile 存储为 **Markdown + YAML frontmatter**（与现有 sub_agent 用户 preset 格式一致，对齐 `.claude/agents` 惯例）：
+Profile 存储为 **Markdown + YAML frontmatter**（与 octo 已有的用户 agent 定义格式一致，对齐 `.claude/agents` 惯例）：
 
 - 用户级：`~/.octo/agents/<id>.md` —— 对话模式 + 委派模式双可用
 - 项目级：`<repo>/.octo/agents/<id>.md` —— **仅委派模式**（sub_agent）；平台片（别名/绑定）只认用户级，项目文件不能抢 IM 路由
@@ -154,7 +154,7 @@ channel_bindings:
 
 > REST API 传输层仍用 JSON；Store 负责 JSON ↔ .md 的序列化。
 
-**为什么不用 JSON**（2026-07-25 决策）：仓库已有 sub_agent 用户 preset 机制，同样加载 `~/.octo/agents/*.md`（`internal/tools/agents.go`）。采用 .md 后，profile 与 preset 共享同一存储格式和 loader，"定义层统一"零迁移落地——现有 .md preset 自动成为 profile 的能力片；且 system prompt 以正文书写，比 JSON 转义字符串易写易读。
+**为什么不用 JSON**（2026-07-25 决策）：仓库已有用户 agent 定义机制，同样加载 `~/.octo/agents/*.md`（`internal/tools/agents.go`）。采用 .md 后，新旧定义共享同一存储格式和 loader，"定义层统一"零迁移落地——现有 .md 文件自动成为 profile 的能力片；且 system prompt 以正文书写，比 JSON 转义字符串易写易读。
 
 #### 1.2 Go 结构
 
@@ -207,7 +207,7 @@ func (p *Profile) IsDefault() bool { return p.ID == "default" }
 
 #### 1.3 Profile Store
 
-Store 统一加载三个来源的 profile，**取代现有 `internal/tools/agents.go` 的 `discoverAgents()`**（sub_agent 的 preset 查找改由 Store 提供）：
+Store 统一加载三个来源的 profile，**取代现有 `internal/tools/agents.go` 的 `discoverAgents()`**（sub_agent 的 profile 查找改由 Store 提供）：
 
 - 用户级 `~/.octo/agents/*.md`（对话 + 委派双模式）
 - 项目级 `<repo>/.octo/agents/*.md`（仅委派模式；同名覆盖用户级，对齐现有 `.claude/agents` 语义）
@@ -215,10 +215,10 @@ Store 统一加载三个来源的 profile，**取代现有 `internal/tools/agent
 
 ```go
 // internal/agentprofile/store.go
+// Store 是 read-through 的：每次读操作实时扫描目录，无内存缓存、无
+// fsnotify。任何路径的变更（API / Web UI / 直接编辑 .md）下一次读取即生效。
 type Store struct {
-    mu       sync.RWMutex
-    dir      string           // ~/.octo/agents/
-    profiles map[string]*Profile
+    dir string // ~/.octo/agents/
 }
 
 func New(dir string) (*Store, error)
@@ -228,7 +228,6 @@ func (s *Store) List() []*Profile               // 返回所有 profile（不含
 func (s *Store) Create(p *Profile) error        // 序列化为 .md 写入用户级目录
 func (s *Store) Update(p *Profile) error
 func (s *Store) Delete(id string) error
-func (s *Store) Reload(id string) error         // 从磁盘重读指定 profile（手动改文件后免重启生效）
 func (s *Store) ByChannel(platform, chatID string) []*Profile  // 按频道绑定索引（仅 user 级）
 func (s *Store) ByMention(alias string) (*Profile, bool)       // 按 @ 别名索引（仅 user 级）
 ```
@@ -236,13 +235,13 @@ func (s *Store) ByMention(alias string) (*Profile, bool)       // 按 @ 别名�
 **创建规则**：
 - ID = 文件名 slug：`[a-z0-9][a-z0-9-]*`，1-32 字符，创建时指定（Web UI / 元技能可从 name 生成建议值）
 - `id` 字段 immutable，创建后不可改（"重命名" = 新建 + 删除）
-- `description` 必填（与现有 preset 解析规则一致）；其余字段在 `Create`/`Update` 时做非空校验
+- `description` 必填（与现有解析规则一致）；其余字段在 `Create`/`Update` 时做非空校验
 - `model` 必须在 `~/.octo/config.yml` 的 `models` 列表中
 
-**热加载**（决策 Q5：不做文件系统监听，直接编辑文件不会在运行期被感知，需重启或通过 API 触发）：
-- 所有经 REST API 的变更（`POST/PUT/DELETE /api/agents/*`）在写入磁盘后立即更新内存，无需重启——运行期 profile 均按 session 的 `agent_id` 从 Store 实时查询，变更下一 turn 自然生效（无 Manager 重建）
-- `POST /api/agents/:id/reload` 从磁盘重读指定 profile —— 手工改文件后免重启生效的入口
-- 直接编辑 `~/.octo/agents/*.md` 后不走上述两个入口的，重启进程才生效
+**热加载**（2026-07-25 修正 Q5：read-through，无缓存、无 fsnotify、无 reload API）：
+- Store 每次读操作实时扫描目录——任何路径的变更（REST API、Web UI、直接编辑 .md）**下一次读取即生效**，无需重启
+- 与现有 agent 加载机制（`discoverAgents` 每次 lookup 全扫，`internal/tools/agents.go`）语义一致，已有 .md 用户无行为回退
+- 目录文件量小（几十个小文件），扫描成本可忽略——现状即如此运行
 
 ### 2. Agent Router
 
@@ -655,7 +654,7 @@ Default Agent 收到消息，匹配到 expert-agent-manager skill
   │      "给它起个什么名字？" → "用什么模型？" → "要启用哪些技能？"
   ├─ 3. 校验输入（模型是否在 config 列表中、alias 是否全局唯一）
   ├─ 4. 调用 Profile Store.Create() 写入 ~/.octo/agents/<id>.md
-  ├─ 5. 热加载生效（Store 内存更新，下一 turn 起用新配置）
+  ├─ 5. 生效：Store read-through，下一次读取即用新配置
   └─ 6. 回复: "代码审查 Agent 已创建，ID: code-review-v1。你可以用 @review 在群里 @ 它。"
 ```
 
@@ -727,7 +726,6 @@ PUT    /api/agents/:id           — 更新 profile
 DELETE /api/agents/:id           — 删除 profile
 POST   /api/agents/:id/bind      — 绑定频道   body: {"platform": "weixin", "chat_id": "xxx"}
 DELETE /api/agents/:id/bind      — 解绑频道
-POST   /api/agents/:id/reload    — 热加载指定 profile
 ```
 
 #### 9.2 Agent Profile 校验规则
@@ -771,18 +769,20 @@ func DefaultProfile() *Profile {
 
 ---
 
-## sub_agent 委派模式：preset 与 Expert Agent 定义层统一
+## sub_agent 委派模式：一套 Profile，两种消费方式
 
 ### 背景
 
-sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent Profile 在"能力定义"上同构——都是 prompt + model + tools 的组合。为避免两套 schema 并存，二者**定义层统一、运行层保持独立**。
+octo 已有的用户 agent 定义机制（`~/.octo/agents/*.md`，供 `subagent_type` 选用）与本方案的 Expert Agent 在"能力定义"上同构——都是 prompt + model + tools 的组合。本方案不做两套概念：**统一称为 profile，一套 schema、一个 loader、两种运行模式**（对话 / 委派），运行层保持独立。
+
+> 术语约定：仓库中 "preset" 一词废弃。原"内置 preset"（explore / general / code-review）即**内建 profile**；原"用户 preset"（.md 文件）即**用户 profile**。对外参数 `subagent_type` 名称不变（向后兼容），语义为"profile id"。
 
 ### 统一规则
 
 1. **Profile 是唯一的能力定义 schema**。能力片（`CapabilitySpec`：prompt/model/tools/skills）抽为独立结构，对话模式和委派模式共享；平台片（别名/频道绑定/session pool/cron 归属）仅对话模式使用
-2. **内置 preset 降级为内建 profile**。`explore` / `general` / `code-review` 由代码定义（与 DefaultProfile 同款待遇，无 .md 文件），行为与现状完全一致，对用户透明
-3. **`subagent_type` 解析顺序与现状一致**：项目级 .md > 用户级 .md > 内建 profile（即现有 `lookupAgentPreset` 的优先级，行为无回归）。参数名保持 `subagent_type` 不变（向后兼容），语义为"内建或用户 profile 的 id"
-4. **现有用户 .md preset 零迁移**：`~/.octo/agents/*.md` 和 `<repo>/.octo/agents/*.md` 自动成为 profile 的能力片；项目级文件保持仅委派模式（平台片只认用户级）
+2. **内建 profile 代码定义**。`explore` / `general` / `code-review`（外加 `default`）无 .md 文件，行为与现状完全一致，对用户透明
+3. **`subagent_type` 解析顺序与现状一致**：项目级 .md > 用户级 .md > 内建 profile（行为无回归）。参数名保持 `subagent_type` 不变（向后兼容），语义为"profile id"
+4. **现有用户 .md 零迁移**：`~/.octo/agents/*.md` 和 `<repo>/.octo/agents/*.md` 自动成为 profile 的能力片；项目级文件保持仅委派模式（平台片只认用户级）
 
 ### 委派模式的约束（红线）
 
@@ -810,7 +810,6 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 | DELETE | `/api/agents/:id` | 删除 profile |
 | POST | `/api/agents/:id/bind` | 绑定频道 |
 | DELETE | `/api/agents/:id/bind` | 解绑频道 |
-| POST | `/api/agents/:id/reload` | 热加载 |
 
 ### Per-Agent 资源
 
@@ -863,7 +862,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 | `internal/channel/manager.go` | `sessionKeyFor` 加 agent 命名空间；`GetOrCreateSession`/`CommandRouter` 加 agent 维度；`Session` 新增 `AgentID` 字段；`splitSessionKey` 剥离前缀 |
 | `internal/agent/`（session 序列化处） | session metadata 新增 `agent_id` 字段；读取时缺失归 default |
 | `internal/tools/registry.go` | `DefaultToolsForProfile()` — 按 profile 过滤工具 |
-| `internal/tools/`（sub_agent 工具定义处） | `subagent_type` 解析扩展：内建 preset 名或 expert profile id；委派模式只取 CapabilitySpec |
+| `internal/tools/`（sub_agent 工具定义处） | `subagent_type` 解析改走 Store（profile id）；委派模式只取 CapabilitySpec |
 | `internal/tools/agents.go` | `discoverAgents` 合并进 `agentprofile.Store`（删除或改为委托调用） |
 | `internal/skills/skills.go` | `ManifestForProfile()` — 按 profile 过滤 skill manifest；系统级 skill frontmatter 标记 `system: true` 后对 expert agent 隐藏；browser-recorded skill 在 profile 不含 browser 工具时隐藏 |
 | `internal/scheduler/` 或 task 存储 | cron task 新增 `agent_id` 字段；`GET /api/cron` 支持 `?agent_id=` 过滤；新增 `PUT /api/cron/:id/transfer` |
@@ -895,7 +894,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 
 1. 创建 profile → assign → 重启 → 热加载 → 删除，全流程
 2. Default Agent 的 skill/MCP 定义新增后，expert agent 立即可见（在启用列表中）
-3. API 触发 reload（或 CRUD API 变更）后新配置生效，无需重启；直接改文件不走 API 的运行期不生效（符合 Q5 决策）
+3. 任何路径的变更（CRUD API / 直接编辑 .md）下一次读取即生效，无需重启（read-through，与现有加载机制语义一致）
 4. Default Agent 的 system prompt 不可通过 profile 编辑器修改（只读显示"由 onboard 管理"）
 5. IM 频道绑定：发消息到绑定群 → 只有被绑 agent 响应；@ 提及 → 被 @ agent 响应
 6. `octo chat --agent code-review` 正常启动
@@ -920,7 +919,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 
 ## 高可用
 
-1. **Profile 热加载失败**：文件写入过程中读取到半写状态 → 跳过本次变更，保留旧 profile 并打印警告日志（不崩溃）
+1. **读取到半写状态的 profile 文件**：frontmatter 解析失败 → 跳过该文件并打印警告日志，下一次读取自愈（不崩溃、无脏缓存）
 2. **Profile 文件损坏（frontmatter 解析失败）**：跳过该文件，其他 profile 正常加载
 3. **Default Agent 不可用时**：Default Agent 是代码内建的，不会"不可用"。agentStore 为空时 fallback 到 Default Agent（向后兼容）
 4. **单个 profile 损坏或启动时缺失**：加载跳过该文件，路由 fallback 到 Default Agent（向后兼容）；单 Manager 架构下不存在 per-agent 启动失败面
@@ -948,7 +947,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 |----|------|----------|
 | 1 | `internal/agentprofile/` 纯新包（Profile / Store / Router）+ 单测 | 不接线，纯库 |
 | 2 | Manager 加 agent 维度（key 命名空间 / 签名扩展 / `Session.AgentID`）+ `handleChannelMessage` 路由接入 | 兼容测试：default agent 的 key、store 文件 ID、IM 行为与改造前字节级全等。**单独成 PR，不捆绑其他改动** |
-| 3 | tools/skills 按 profile 过滤（`DefaultToolsForProfile`、`ManifestForProfile`、`system:true`、browser skill 隐藏）+ preset 内建 profile 化、`subagent_type` 解析扩展、`discoverAgents` 合并进 Store | 只依赖 PR1，可与 PR2 并行 |
+| 3 | tools/skills 按 profile 过滤（`DefaultToolsForProfile`、`ManifestForProfile`、`system:true`、browser skill 隐藏）+ `subagent_type` 解析改走 Store、`discoverAgents` 合并进 Store、代码内 "preset" 标识符统一更名为 profile | 只依赖 PR1，可与 PR2 并行 |
 | 4 | CLI/TUI `--agent` + `/agent` 命令 | 第一个端到端验证切片：profile 创建 → 路由 → 工具过滤全链路 |
 | 5 | REST API `/api/agents/*` + cron `agent_id`/transfer + `expert-agent-manager` 元技能 | 对话式管理入口可用 |
 | 6 | Web UI（Agents 面板、Header 切换、各 View 过滤） | 纯前端，API 已就绪 |
@@ -963,7 +962,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 - [ ] 无 profile 文件时行为与改造前完全一致（向后兼容）
 - [ ] 创建 profile → 绑定频道 → IM 发消息 → 正确路由
 - [ ] Web 新建会话选 agent → 会话正确归属；skill/MCP 面板不按 agent 过滤
-- [ ] API 触发 reload 后新配置生效（无需重启）；直接改文件不走 API 的运行期不生效
+- [ ] API 变更与直接编辑 .md 均在下一次读取生效（无需重启、无 reload API）
 - [ ] Default Agent 的 system prompt 不可通过 profile 编辑器修改（只读显示"由 onboard 管理"）
 - [ ] `octo --agent code-review` 正常启动
 - [ ] `octo serve` 桌面版 default 和新 profile 共存
@@ -985,7 +984,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 | **`~/.octo/config.yml`** | 无影响 | Agent profile 是新引入的存储路径 (`~/.octo/agents/`)，不改动现有配置文件 |
 | **`onboard` 流程** | 无影响 | onboard 仍操作 `~/.octo/soul.md` 和 `~/.octo/user.md`，不引入新路径 |
 | **API 端点** | 向后兼容 | 新增 `/api/agents/*` 路由组；旧端点 `/api/sessions`、`/api/channels/*` 行为不变 |
-| **已有 .md preset（`~/.octo/agents/`、项目级）** | 无影响 | 自动成为 profile 的能力片；解析优先级（项目级 > 用户级 > 内建）与现状一致 |
+| **已有 .md agent 定义（`~/.octo/agents/`、项目级）** | 无影响 | 自动成为 profile 的能力片；解析优先级（项目级 > 用户级 > 内建）与现状一致 |
 | **WebSocket 事件** | 无影响 | WS 事件类型不变（still broadcast per-session）；但创建新 session 时需带 `agent_id` 字段（可选，默认 default） |
 | **`octo serve` CLI** | 无影响 | 无需新增 flag；桌面版和 serve 均自动加载 profile |
 
@@ -1010,7 +1009,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 
 ### 数据回滚
 
-- **新建的用户级 profile 文件**：逐个删除即可。注意 `~/.octo/agents/` 目录里可能还有**先于本特性存在的 .md preset**，不能整目录删除；删干净新建 profile 后，系统行为恢复为单 agent（Default Agent）+ 原有 preset 机制
+- **新建的用户级 profile 文件**：逐个删除即可。注意 `~/.octo/agents/` 目录里可能还有**先于本特性存在的 .md agent 定义**，不能整目录删除；删干净新建 profile 后，系统行为恢复为单 agent（Default Agent）+ 原有 `subagent_type` 加载机制
 - **已有 session 文件**：不需要迁移或删除；回滚后它们自动归属 Default Agent（读取时默认 agent_id = "default"），行为不变
 
 ### 回滚安全性

--- a/dev-docs/multi-agent-system-design.md
+++ b/dev-docs/multi-agent-system-design.md
@@ -34,10 +34,10 @@
 | 术语 | 含义 |
 |------|------|
 | **Agent Profile** | 描述一个 expert agent 完整配置的声明式对象，包含 ID、名称、描述、系统提示词、模型、工具白名单、mention 别名、频道绑定 |
-| **Default Agent** | 代码内建的顶级 agent，system prompt 由代码 base prompt + onboard 注入的 `~/.octo/soul.md` 和 `~/.octo/user.md` 构成，**不可通过 profile 编辑器修改**。拥有所有 skill/MCP 的定义权。没有对应的 JSON 文件 |
+| **Default Agent** | 代码内建的顶级 agent，system prompt 由代码 base prompt + onboard 注入的 `~/.octo/soul.md` 和 `~/.octo/user.md` 构成，**不可通过 profile 编辑器修改**。拥有所有 skill/MCP 的定义权。没有对应的 .md 文件 |
 | **Expert Agent** | 用户在 Default Agent 视图下创建的 Agent Profile，只能从 Default Agent 已有的资源池中启用/禁用，不能新增 |
 | **sub_agent** | 工具名。所有 agent 都可通过此工具在会话内部调度匿名子 agent 执行隔离任务。子 agent 的生命周期、上下文、工具集完全独立，运行结束后结果回传给主 agent |
-| **Profile Store** | `~/.octo/agents/` 目录，每个 expert agent 一个 `<id>.json` 文件 |
+| **Profile Store** | 统一加载三来源：`~/.octo/agents/*.md`（用户级，双模式）、`<repo>/.octo/agents/*.md`（项目级，仅委派）、内建 profile；每个 expert agent 一个 `<id>.md` 文件（Markdown + frontmatter） |
 | **Agent Router** | 根据 InboundEvent（平台、chatID、消息内容中的 @ 提及）决定消息路由到哪个 agent profile |
 | **Session Key** | `platform:chat_id[:user_id]`；expert agent 加 `agentID#` 前缀形成命名空间（如 `a3f9b2c1#weixin:c1:u1`）。default agent 保持 legacy 格式字节级不变 |
 | **Agent 绑定** | 会话创建时绑定 agent，一旦建立不可切换；通过新建会话选择其他 agent |
@@ -131,25 +131,30 @@ if profile == nil {
 
 #### 1.1 文件存储格式
 
-Profile 存储在 `~/.octo/agents/<profile-id>.json`，每个文件一个 profile：
+Profile 存储为 **Markdown + YAML frontmatter**（与现有 sub_agent 用户 preset 格式一致，对齐 `.claude/agents` 惯例）：
 
-```json
-{
-  "id": "code-review",
-  "name": "代码审查专家",
-  "description": "专责 review PR、发现 bug、建议改进",
-  "model": "claude-sonnet-4-20250514",
-  "system_prompt": "你是代码审查专家。当用户发来 PR 链接或代码变更时...",
-  "tools": ["read_file", "write_file", "edit_file", "grep", "glob", "terminal", "code-review"],
-  "tool_skills": ["code-review"],
-  "mention_as": ["@review", "@CR"],
-  "channel_bindings": [
-    {"platform": "weixin", "chat_id": "dev-group-xxx"}
-  ],
-  "created_at": "2026-07-15T10:00:00Z",
-  "updated_at": "2026-07-15T10:00:00Z"
-}
+- 用户级：`~/.octo/agents/<id>.md` —— 对话模式 + 委派模式双可用
+- 项目级：`<repo>/.octo/agents/<id>.md` —— **仅委派模式**（sub_agent）；平台片（别名/绑定）只认用户级，项目文件不能抢 IM 路由
+
+`id` 即文件名（去 `.md`），人类可读 slug。frontmatter 承载元数据，**正文即 system prompt**：
+
+```markdown
+---
+name: 代码审查专家
+description: 专责 review PR、发现 bug、建议改进
+model: claude-sonnet-4-20250514
+tools: [read_file, write_file, edit_file, grep, glob, terminal, code-review]
+tool_skills: [code-review]
+mention_as: ["@review", "@CR"]
+channel_bindings:
+  - {platform: weixin, chat_id: dev-group-xxx}
+---
+你是代码审查专家。当用户发来 PR 链接或代码变更时...
 ```
+
+> REST API 传输层仍用 JSON；Store 负责 JSON ↔ .md 的序列化。
+
+**为什么不用 JSON**（2026-07-25 决策）：仓库已有 sub_agent 用户 preset 机制，同样加载 `~/.octo/agents/*.md`（`internal/tools/agents.go`）。采用 .md 后，profile 与 preset 共享同一存储格式和 loader，"定义层统一"零迁移落地——现有 .md preset 自动成为 profile 的能力片；且 system prompt 以正文书写，比 JSON 转义字符串易写易读。
 
 #### 1.2 Go 结构
 
@@ -162,37 +167,51 @@ package agentprofile
 //   - 对话模式：channel.Manager 持久 session（用户直接对话）
 //   - 委派模式：sub_agent 发起的 ephemeral run（见 "sub_agent 委派模式" 一节）
 type CapabilitySpec struct {
-    Model        string   `json:"model"`
-    SystemPrompt string   `json:"system_prompt"`
-    Tools        []string `json:"tools"`
-    ToolSkills   []string `json:"tool_skills"` // 这些 skill 以工具形式暴露
+    Model        string   // frontmatter model；空 = 继承
+    SystemPrompt string   // .md 正文（不经 frontmatter）
+    Tools        []string // frontmatter tools
+    ToolSkills   []string // frontmatter tool_skills，这些 skill 以工具形式暴露
 }
 
+// Source 标记 profile 来源，决定可用模式与覆盖优先级。
+type Source string
+
+const (
+    SourceBuiltin Source = "builtin" // 代码内建（default / explore / general / code-review）
+    SourceUser    Source = "user"    // ~/.octo/agents/*.md，对话+委派双模式
+    SourceProject Source = "project" // <repo>/.octo/agents/*.md，仅委派模式
+)
+
 type Profile struct {
-    ID             string           `json:"id"`
-    Name           string           `json:"name"`
-    Description    string           `json:"description"`
-    CapabilitySpec                   `json:",inline"` // JSON 扁平展开，存储格式不变
-    WorkingDir     string           `json:"working_dir,omitempty"`
-    MentionAs      []string         `json:"mention_as"`
-    ChannelBindings []ChannelBinding `json:"channel_bindings"`
-    CreatedAt      time.Time        `json:"created_at"`
-    UpdatedAt      time.Time        `json:"updated_at"`
+    ID              string           // 文件名 slug（去 .md）；内建 profile 用固定名
+    Name            string           // frontmatter name
+    Description     string           // frontmatter description（必填）
+    CapabilitySpec                   // 能力片（见上）
+    WorkingDir      string           // frontmatter working_dir
+    MentionAs       []string         // frontmatter mention_as（仅 user 级生效）
+    ChannelBindings []ChannelBinding // frontmatter channel_bindings（仅 user 级生效）
+    Source          Source
+    CreatedAt       time.Time
+    UpdatedAt       time.Time
 }
 
 type ChannelBinding struct {
-    Platform string `json:"platform"`
-    ChatID   string `json:"chat_id"`
+    Platform string
+    ChatID   string
 }
 
 // IsDefault 判断该 profile 是否为 Default Agent
-// Default Agent 没有 JSON 文件，是代码内建的
+// Default Agent 没有 .md 文件，是代码内建的
 func (p *Profile) IsDefault() bool { return p.ID == "default" }
 ```
 
 #### 1.3 Profile Store
 
-Store 负责从 `~/.octo/agents/` 加载所有 profile，提供增删改查 API，并支持热加载。
+Store 统一加载三个来源的 profile，**取代现有 `internal/tools/agents.go` 的 `discoverAgents()`**（sub_agent 的 preset 查找改由 Store 提供）：
+
+- 用户级 `~/.octo/agents/*.md`（对话 + 委派双模式）
+- 项目级 `<repo>/.octo/agents/*.md`（仅委派模式；同名覆盖用户级，对齐现有 `.claude/agents` 语义）
+- 内建 profile（代码定义：default / explore / general / code-review）
 
 ```go
 // internal/agentprofile/store.go
@@ -203,27 +222,27 @@ type Store struct {
 }
 
 func New(dir string) (*Store, error)
-func (s *Store) Load() error                    // 全量加载
+func (s *Store) Load() error                    // 全量加载（用户级 + 项目级 + 内建）
 func (s *Store) Get(id string) (*Profile, bool)
-func (s *Store) List() []*Profile               // 返回所有 profile（不含 Default Agent）
-func (s *Store) Create(p *Profile) error
+func (s *Store) List() []*Profile               // 返回所有 profile（不含内建）
+func (s *Store) Create(p *Profile) error        // 序列化为 .md 写入用户级目录
 func (s *Store) Update(p *Profile) error
 func (s *Store) Delete(id string) error
 func (s *Store) Reload(id string) error         // 从磁盘重读指定 profile（手动改文件后免重启生效）
-func (s *Store) ByChannel(platform, chatID string) []*Profile  // 按频道绑定索引
-func (s *Store) ByMention(alias string) (*Profile, bool)       // 按 @ 别名索引
+func (s *Store) ByChannel(platform, chatID string) []*Profile  // 按频道绑定索引（仅 user 级）
+func (s *Store) ByMention(alias string) (*Profile, bool)       // 按 @ 别名索引（仅 user 级）
 ```
 
 **创建规则**：
-- ID 由 Web UI 或 `octo agents create` 生成，格式为 8 位随机小写字母（与 session ID 短格式一致）
-- `id` 字段 immutable，创建后不可改
-- 所有字段在 `Create`/`Update` 时做非空校验
+- ID = 文件名 slug：`[a-z0-9][a-z0-9-]*`，1-32 字符，创建时指定（Web UI / 元技能可从 name 生成建议值）
+- `id` 字段 immutable，创建后不可改（"重命名" = 新建 + 删除）
+- `description` 必填（与现有 preset 解析规则一致）；其余字段在 `Create`/`Update` 时做非空校验
 - `model` 必须在 `~/.octo/config.yml` 的 `models` 列表中
 
 **热加载**（决策 Q5：不做文件系统监听，直接编辑文件不会在运行期被感知，需重启或通过 API 触发）：
 - 所有经 REST API 的变更（`POST/PUT/DELETE /api/agents/*`）在写入磁盘后立即更新内存，无需重启——运行期 profile 均按 session 的 `agent_id` 从 Store 实时查询，变更下一 turn 自然生效（无 Manager 重建）
 - `POST /api/agents/:id/reload` 从磁盘重读指定 profile —— 手工改文件后免重启生效的入口
-- 直接编辑 `~/.octo/agents/*.json` 后不走上述两个入口的，重启进程才生效
+- 直接编辑 `~/.octo/agents/*.md` 后不走上述两个入口的，重启进程才生效
 
 ### 2. Agent Router
 
@@ -635,7 +654,7 @@ Default Agent 收到消息，匹配到 expert-agent-manager skill
   ├─ 2. 缺失字段走引导式问答：
   │      "给它起个什么名字？" → "用什么模型？" → "要启用哪些技能？"
   ├─ 3. 校验输入（模型是否在 config 列表中、alias 是否全局唯一）
-  ├─ 4. 调用 Profile Store.Create() 写入 ~/.octo/agents/<id>.json
+  ├─ 4. 调用 Profile Store.Create() 写入 ~/.octo/agents/<id>.md
   ├─ 5. 热加载生效（Store 内存更新，下一 turn 起用新配置）
   └─ 6. 回复: "代码审查 Agent 已创建，ID: code-review-v1。你可以用 @review 在群里 @ 它。"
 ```
@@ -714,8 +733,8 @@ POST   /api/agents/:id/reload    — 热加载指定 profile
 #### 9.2 Agent Profile 校验规则
 
 - `name`：1-32 字符，同一 Store 内唯一
-- `id`：创建时由服务端生成（8 位随机小写），创建后 immutable
-- `system_prompt`：最大 10000 字符
+- `id`：文件名 slug（`[a-z0-9][a-z0-9-]*`，1-32 字符），创建后 immutable
+- `system_prompt`（.md 正文）：最大 10000 字符
 - `tools`：必须是 `skillReg` + `tools.DefaultRegistry` 中存在名的子集
 - `model`：必须在 `~/.octo/config.yml` 的 `models` 列表中
 - `mention_as`：每个 alias 必须以 `@` 开头，且全局唯一（同一 alias 不能被两个 profile 声明）
@@ -724,7 +743,7 @@ POST   /api/agents/:id/reload    — 热加载指定 profile
 
 #### 10.1 Default Agent Profile（无文件）
 
-Default Agent 没有 JSON 文件。代码中硬编码：
+Default Agent 没有 .md 文件。代码中硬编码：
 
 ```go
 func DefaultProfile() *Profile {
@@ -761,8 +780,9 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 ### 统一规则
 
 1. **Profile 是唯一的能力定义 schema**。能力片（`CapabilitySpec`：prompt/model/tools/skills）抽为独立结构，对话模式和委派模式共享；平台片（别名/频道绑定/session pool/cron 归属）仅对话模式使用
-2. **内置 preset 降级为内建 profile**。`explore` / `general` / `code-review` 由代码定义（与 DefaultProfile 同款待遇，无 JSON 文件），行为与现状完全一致，对用户透明
-3. **`subagent_type` 接受内建 profile 名或用户 expert profile id**。参数名保持 `subagent_type` 不变（向后兼容），语义扩展为"内建或用户 profile 的 id"
+2. **内置 preset 降级为内建 profile**。`explore` / `general` / `code-review` 由代码定义（与 DefaultProfile 同款待遇，无 .md 文件），行为与现状完全一致，对用户透明
+3. **`subagent_type` 解析顺序与现状一致**：项目级 .md > 用户级 .md > 内建 profile（即现有 `lookupAgentPreset` 的优先级，行为无回归）。参数名保持 `subagent_type` 不变（向后兼容），语义为"内建或用户 profile 的 id"
+4. **现有用户 .md preset 零迁移**：`~/.octo/agents/*.md` 和 `<repo>/.octo/agents/*.md` 自动成为 profile 的能力片；项目级文件保持仅委派模式（平台片只认用户级）
 
 ### 委派模式的约束（红线）
 
@@ -825,8 +845,8 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 
 | 文件 | 说明 |
 |------|------|
-| `internal/agentprofile/profile.go` | Profile 结构 + 校验 |
-| `internal/agentprofile/store.go` | Store（加载/保存/热加载/索引） |
+| `internal/agentprofile/profile.go` | Profile 结构 + .md frontmatter 解析/序列化 + 校验 |
+| `internal/agentprofile/store.go` | Store（三来源加载/保存/索引） |
 | `internal/agentprofile/router.go` | AgentRouter（按事件路由到 profile） |
 | `web/src/views/AgentsView.svelte` | Agent 管理主面板 |
 | `web/src/views/AgentEditView.svelte` | Agent 编辑表单 |
@@ -844,6 +864,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 | `internal/agent/`（session 序列化处） | session metadata 新增 `agent_id` 字段；读取时缺失归 default |
 | `internal/tools/registry.go` | `DefaultToolsForProfile()` — 按 profile 过滤工具 |
 | `internal/tools/`（sub_agent 工具定义处） | `subagent_type` 解析扩展：内建 preset 名或 expert profile id；委派模式只取 CapabilitySpec |
+| `internal/tools/agents.go` | `discoverAgents` 合并进 `agentprofile.Store`（删除或改为委托调用） |
 | `internal/skills/skills.go` | `ManifestForProfile()` — 按 profile 过滤 skill manifest；系统级 skill frontmatter 标记 `system: true` 后对 expert agent 隐藏；browser-recorded skill 在 profile 不含 browser 工具时隐藏 |
 | `internal/scheduler/` 或 task 存储 | cron task 新增 `agent_id` 字段；`GET /api/cron` 支持 `?agent_id=` 过滤；新增 `PUT /api/cron/:id/transfer` |
 | `internal/server/server.go` | `Server.Config`（server.go:56）新增 `agentName` 字段（仅客户端路径 `octo`/`octo-desktop` 设置；`octo serve` 不接受此 flag，由 session 绑定 agent） |
@@ -890,7 +911,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 
 ## 安全
 
-1. **Agent Profile 文件写入限制**：Profile JSON 只能写入 `~/.octo/agents/` 目录，路径校验拒绝 `..` 和绝对路径（与 `session.resolveSessionPath` 同策略）
+1. **Agent Profile 文件写入限制**：Profile 文件只能写入 `~/.octo/agents/` 目录，slug 与路径校验拒绝 `..` 和绝对路径（与 `session.resolveSessionPath` 同策略）
 2. **Tools 白名单**：Expert Agent 不能通过 API 添加 Default Agent 未声明的工具；`PUT /api/agents/:id` 中 `tools` 字段必须在 `tools.DefaultRegistry` 和 `skillReg` 名单位有交集
 3. **Mention Alias 全局唯一**：创建/更新时校验 alias 不与其他 profile 冲突（防"身份冒充"）
 4. **删除保护**：有频道绑定或有活跃 session 的 profile 删除时返回错误，需先解绑/关闭 session
@@ -900,7 +921,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 ## 高可用
 
 1. **Profile 热加载失败**：文件写入过程中读取到半写状态 → 跳过本次变更，保留旧 profile 并打印警告日志（不崩溃）
-2. **Profile 文件损坏（JSON 解析失败）**：跳过该文件，其他 profile 正常加载
+2. **Profile 文件损坏（frontmatter 解析失败）**：跳过该文件，其他 profile 正常加载
 3. **Default Agent 不可用时**：Default Agent 是代码内建的，不会"不可用"。agentStore 为空时 fallback 到 Default Agent（向后兼容）
 4. **单个 profile 损坏或启动时缺失**：加载跳过该文件，路由 fallback 到 Default Agent（向后兼容）；单 Manager 架构下不存在 per-agent 启动失败面
 
@@ -927,7 +948,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 |----|------|----------|
 | 1 | `internal/agentprofile/` 纯新包（Profile / Store / Router）+ 单测 | 不接线，纯库 |
 | 2 | Manager 加 agent 维度（key 命名空间 / 签名扩展 / `Session.AgentID`）+ `handleChannelMessage` 路由接入 | 兼容测试：default agent 的 key、store 文件 ID、IM 行为与改造前字节级全等。**单独成 PR，不捆绑其他改动** |
-| 3 | tools/skills 按 profile 过滤（`DefaultToolsForProfile`、`ManifestForProfile`、`system:true`、browser skill 隐藏）+ preset 内建 profile 化与 `subagent_type` 解析扩展 | 只依赖 PR1，可与 PR2 并行 |
+| 3 | tools/skills 按 profile 过滤（`DefaultToolsForProfile`、`ManifestForProfile`、`system:true`、browser skill 隐藏）+ preset 内建 profile 化、`subagent_type` 解析扩展、`discoverAgents` 合并进 Store | 只依赖 PR1，可与 PR2 并行 |
 | 4 | CLI/TUI `--agent` + `/agent` 命令 | 第一个端到端验证切片：profile 创建 → 路由 → 工具过滤全链路 |
 | 5 | REST API `/api/agents/*` + cron `agent_id`/transfer + `expert-agent-manager` 元技能 | 对话式管理入口可用 |
 | 6 | Web UI（Agents 面板、Header 切换、各 View 过滤） | 纯前端，API 已就绪 |
@@ -964,6 +985,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 | **`~/.octo/config.yml`** | 无影响 | Agent profile 是新引入的存储路径 (`~/.octo/agents/`)，不改动现有配置文件 |
 | **`onboard` 流程** | 无影响 | onboard 仍操作 `~/.octo/soul.md` 和 `~/.octo/user.md`，不引入新路径 |
 | **API 端点** | 向后兼容 | 新增 `/api/agents/*` 路由组；旧端点 `/api/sessions`、`/api/channels/*` 行为不变 |
+| **已有 .md preset（`~/.octo/agents/`、项目级）** | 无影响 | 自动成为 profile 的能力片；解析优先级（项目级 > 用户级 > 内建）与现状一致 |
 | **WebSocket 事件** | 无影响 | WS 事件类型不变（still broadcast per-session）；但创建新 session 时需带 `agent_id` 字段（可选，默认 default） |
 | **`octo serve` CLI** | 无影响 | 无需新增 flag；桌面版和 serve 均自动加载 profile |
 
@@ -988,7 +1010,7 @@ sub_agent 的内置 preset（explore / general / code-review）与 Expert Agent 
 
 ### 数据回滚
 
-- **`~/.octo/agents/` 目录**：直接删除即可。profile 定义不写入任何其他位置，删除后系统行为恢复为单 agent（Default Agent）
+- **新建的用户级 profile 文件**：逐个删除即可。注意 `~/.octo/agents/` 目录里可能还有**先于本特性存在的 .md preset**，不能整目录删除；删干净新建 profile 后，系统行为恢复为单 agent（Default Agent）+ 原有 preset 机制
 - **已有 session 文件**：不需要迁移或删除；回滚后它们自动归属 Default Agent（读取时默认 agent_id = "default"），行为不变
 
 ### 回滚安全性


### PR DESCRIPTION
## Summary

Design-doc-only PR syncing the conclusions from the 2026-07-25 design discussion.

### `dev-docs/multi-agent-system-design.md`

- **Hot reload**: drop fsnotify `Watch()` from Store, keep API-driven reload only (Q5 decision — direct file edits require restart or `POST /api/agents/:id/reload`)
- **Router**: fix self-contradictory comment — `Route()` may return nil (group chat with multiple bindings and no @-mention → drop)
- **Session ownership**: add `agent_id` to session file metadata so expert-agent sessions survive restarts; missing `agent_id` falls back to default (backward compatible with historical sessions)
- **Release plan**: rewritten as a 6-PR slicing — PR1 agentprofile package → PR2 MultiManager/server refactor (standalone) → PR3 tools/skills filtering → PR4 CLI `--agent` (first end-to-end validation) → PR5 REST API + cron + meta-skill → PR6 Web UI. Invariant: no-profile behavior identical to today
- Test strategy / post-release checklist synced with the above

### `dev-docs/agent-team-design.md`

- Marked **DEPRECATED** with rationale: capability overlaps with saved workflows (Ruby `parallel`/`pipeline` + `agent()`), N× token cost, scenario mismatch (multi-agent wins on breadth-first loosely-coupled tasks, not multi-perspective review of the same code), and static role combos are less adaptive than ad-hoc sub_agent orchestration. Alternative path: saved workflows; activity-feed visibility belongs to sub_agent observability.

No code changes.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>


### Update (commit 2): preset / expert agent definition-layer unification

- `CapabilitySpec` (prompt/model/tools/skills) extracted as the single capability-definition schema, shared by conversation mode (persistent sessions) and delegation mode (`sub_agent` ephemeral runs)
- Built-in presets (`explore`/`general`/`code-review`) become code-defined built-in profiles; `subagent_type` now accepts builtin names or user expert profile ids (param name unchanged, backward compatible)
- Delegation-mode red lines: ephemeral fresh context, never enters the target profile's session pool, capability slice only; model priority `sub_agent(model:)` > profile.model > caller model
- Preset migration folded into PR3 of the release slicing


### Update (commit 3): session pool simplification — single Manager, agent-namespaced keys

- **MultiManager dropped entirely.** Session isolation derives from the SessionKey itself: expert agents prefix the legacy key with `agentID#`; the default agent keeps byte-identical legacy keys
- Cascading wins: sync.Map untouched; per-agent on-disk store files for free (`sessionStoreID` is an FNV of the key — also fixes a latent file-collision bug in the per-agent-Manager design); /bind table gains per-agent namespaces; profile hot updates take effect next turn with no Manager rebuild
- Manager gains agent threading (`GetOrCreateSession(ev, profile)`, `CommandRouter(ev, agentID)`, profile-parameterized factory); server keeps single `channelMgr` + adds `agentStore`/`agentRouter`
- MVP rule: `/list` and `/bind` scoped to the routed agent; cross-agent bind rejected
- Release PR2 shrinks from an irreversible `channelMgr` replacement to an equivalence-checked wiring change


### Update (commit 4): profiles stored as .md + frontmatter

The repo already has user-defined sub_agent presets loading `~/.octo/agents/*.md` and `<repo>/.octo/agents/*.md` (`internal/tools/agents.go`) — the same directory the JSON design targeted, with a near-isomorphic capability schema. Storing profiles as Markdown + YAML frontmatter (body = system prompt) makes definition-layer unification zero-migration:

- Existing .md presets automatically become a profile's capability slice; resolution order unchanged (project > user > builtin)
- Project-level .md stays delegation-only; platform slice honored only at user level
- Profile ID = human-readable filename slug (replaces random 8-char id); rename = create + delete
- `Profile.Source` (builtin/user/project); Store replaces `discoverAgents` as the single loader
- REST API transport stays JSON; Store serializes to .md
- Rollback: delete new profile files individually — the directory may contain pre-existing presets

**Open question raised in discussion**: with Store replacing `discoverAgents` (which rescans on every lookup), Q5's "direct file edits need restart / reload API" regresses preset freshness. Proposal: make Store read-through (rescan per read) — file edits then take effect immediately, exceeding Q5 without fsnotify. Pending decision.


### Update (commit 5): read-through Store; "preset" terminology retired

- **Store is read-through** (rescan per read) — supersedes the Q5 cache + reload-API semantics. `discoverAgents` already rescans per lookup today, so this preserves existing behavior: any change path (API / Web UI / direct .md edit) is effective on the next read. No watcher, no restart, and `/api/agents/:id/reload` is removed
- **"preset" retired as a concept word** — everything is a profile: old built-in presets = built-in profiles, old user .md files = user profiles. `subagent_type` keeps its name (backward compat; semantics: profile id); internal identifiers get renamed in PR3
