### PR TITLE
feat(agentprofile): add agent profile package (PR1 of multi-agent system)

### DIFF
--- a/dev-docs/multi-agent-system-design.md
+++ b/dev-docs/multi-agent-system-design.md
@@ -286,13 +286,15 @@ func (r *Router) Route(ev InboundEvent) *Profile {
 |------|--------|----------|----------|
 | 私聊（未绑定） | — | 无 | **Default Agent** |
 | 私聊（绑定 code-review） | — | 有（唯一） | **code-review** |
-| 群聊（绑定 code-review） | @ops 但 ops 未绑定此群 | 有 | **Default Agent**（@ 到不存在的 alias 回退） |
+| 群聊（绑定 code-review） | @ops 但 ops 未绑定此群 | 有 | **ops-helper**（@ 解析是全局的：显式召唤不受绑定限制） |
 | 群聊（绑定 code-review） | @review | 有 | **code-review** |
 | 群聊（绑定 code + ops） | @ops | 有（多） | **ops-helper** |
 | 群聊（绑定 code + ops） | 无 @ | 有（多） | **静默**（drop） |
 | 群聊（无绑定） | — | 无 | **Default Agent** |
 
 **注意**：AgentRouter 返回 nil 时，handler 直接 drop 该消息（不路由到任何 agent），这与"群聊未 @ 完全静默"的决策一致。
+
+**@ 解析是全局的**（2026-07-25 拍板）：`ByMention` 在所有用户级 profile 中查找，不要求被 @ 的 profile 绑定当前频道——@ 是显式召唤，绑定只决定"未 @ 时谁响应"。仅当 @ 的 alias 不存在时才回退 Default Agent。
 
 ### 3. 单 Manager Session Pool：key 内嵌 agent 命名空间
 

--- a/internal/agentprofile/builtins.go
+++ b/internal/agentprofile/builtins.go
@@ -1,0 +1,53 @@
+package agentprofile
+
+// builtinProfiles returns the code-defined profiles, lowest precedence. The
+// explore/general/code-review personas are verbatim copies of the former
+// built-in sub_agent presets (internal/tools/agent_presets.go) — delegation
+// behavior is unchanged, the term "preset" is simply retired in favor of
+// "profile". PR3 deletes the old copies and routes subagent_type resolution
+// through the Store.
+func builtinProfiles() []*Profile {
+	return []*Profile{
+		{
+			ID:          "explore",
+			Name:        "explore",
+			Description: "Read-only exploration agent",
+			Source:      SourceBuiltin,
+			CapabilitySpec: CapabilitySpec{
+				ReadOnly:    true,
+				LeanContext: true,
+				SystemPrompt: "You are a read-only exploration sub-agent. Your job is to locate and understand " +
+					"code, then report findings — not to modify anything. Use read_file, grep, glob, " +
+					"read-only terminal commands (git, find, ls), and any code-intelligence tools available. " +
+					"Do NOT write or edit files. Deliverable: a concise report answering the task directly — " +
+					"the relevant file paths with line numbers, how the pieces connect, and the minimal code " +
+					"quoted to make the point. Don't dump whole files.",
+			},
+		},
+		{
+			ID:          "general",
+			Name:        "general",
+			Description: "General-purpose agent with full toolbelt",
+			Source:      SourceBuiltin,
+			CapabilitySpec: CapabilitySpec{
+				SystemPrompt: "You are an autonomous general-purpose sub-agent handling a delegated task end-to-end. " +
+					"You have the full toolbelt. Complete the task, verify your work, and return a clear, " +
+					"self-contained result the caller can act on without seeing your intermediate steps.",
+			},
+		},
+		{
+			ID:          "code-review",
+			Name:        "code-review",
+			Description: "Read-only code review agent",
+			Source:      SourceBuiltin,
+			CapabilitySpec: CapabilitySpec{
+				ReadOnly: true,
+				SystemPrompt: "You are a code-review sub-agent. Review the changes — use `git diff`, `git status`, " +
+					"and read the touched files — for correctness bugs, convention violations, performance " +
+					"issues, missing tests, and security problems. Do NOT modify files. Deliverable: a " +
+					"prioritized list of findings, each with file:line, a severity, what is wrong, and a " +
+					"suggested fix. If you find nothing material, say so explicitly rather than inventing nits.",
+			},
+		},
+	}
+}

--- a/internal/agentprofile/parse.go
+++ b/internal/agentprofile/parse.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v3"
 )
@@ -125,8 +126,8 @@ func splitFrontmatter(content string) (front, body string, ok bool) {
 	return "", "", false
 }
 
-// maxSystemPrompt mirrors the design doc's 10000-char body limit; enforced by
-// validateForWrite before any file is written.
+// maxSystemPrompt mirrors the design doc's 10000-char body limit (counted in
+// runes, not bytes); enforced by validateForWrite before any file is written.
 const maxSystemPrompt = 10000
 
 // validateForWrite is the Store-level write gate: schema validation plus the
@@ -135,8 +136,9 @@ func validateForWrite(p *Profile) error {
 	if err := p.Validate(); err != nil {
 		return err
 	}
-	if len(p.SystemPrompt) > maxSystemPrompt {
-		return fmt.Errorf("system_prompt too long: %d chars (max %d)", len(p.SystemPrompt), maxSystemPrompt)
+	if utf8.RuneCountInString(p.SystemPrompt) > maxSystemPrompt {
+		return fmt.Errorf("system_prompt too long: %d chars (max %d)",
+			utf8.RuneCountInString(p.SystemPrompt), maxSystemPrompt)
 	}
 	return nil
 }

--- a/internal/agentprofile/parse.go
+++ b/internal/agentprofile/parse.go
@@ -1,0 +1,142 @@
+package agentprofile
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// frontmatter is the YAML header of a profile .md file. Unmapped keys are
+// ignored, so files written for newer versions remain readable.
+type frontmatter struct {
+	Name            string           `yaml:"name,omitempty"`
+	Description     string           `yaml:"description"`
+	Model           string           `yaml:"model,omitempty"`
+	Tools           []string         `yaml:"tools,omitempty"`
+	ToolSkills      []string         `yaml:"tool_skills,omitempty"`
+	DisallowedTools []string         `yaml:"disallowed_tools,omitempty"`
+	ReadOnly        bool             `yaml:"read_only,omitempty"`
+	LeanContext     bool             `yaml:"lean_context,omitempty"`
+	WorkingDir      string           `yaml:"working_dir,omitempty"`
+	MentionAs       []string         `yaml:"mention_as,omitempty"`
+	ChannelBindings []ChannelBinding `yaml:"channel_bindings,omitempty"`
+}
+
+// parseFile reads one profile .md file. The profile ID is the file name
+// without the .md suffix, assigned by the caller (Store.scanDir). The
+// markdown body after the closing frontmatter fence becomes the system
+// prompt. A missing description is an error, matching the pre-existing agent
+// file parser's rule.
+func parseFile(path string) (*Profile, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	front, body, ok := splitFrontmatter(string(b))
+	if !ok {
+		return nil, fmt.Errorf("no YAML frontmatter")
+	}
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
+		return nil, fmt.Errorf("parsing frontmatter: %w", err)
+	}
+	if strings.TrimSpace(fm.Description) == "" {
+		return nil, fmt.Errorf("description is required")
+	}
+	// "inherit" means no model override — treat it as empty (matches the
+	// pre-existing parser and the .claude/agents convention).
+	model := strings.TrimSpace(fm.Model)
+	if strings.EqualFold(model, "inherit") {
+		model = ""
+	}
+	p := &Profile{
+		Name:        fm.Name,
+		Description: fm.Description,
+		CapabilitySpec: CapabilitySpec{
+			Model:           model,
+			SystemPrompt:    strings.TrimSpace(body),
+			Tools:           fm.Tools,
+			ToolSkills:      fm.ToolSkills,
+			ReadOnly:        fm.ReadOnly,
+			DisallowedTools: fm.DisallowedTools,
+			LeanContext:     fm.LeanContext,
+		},
+		WorkingDir:      fm.WorkingDir,
+		MentionAs:       fm.MentionAs,
+		ChannelBindings: fm.ChannelBindings,
+	}
+	if info, err := os.Stat(path); err == nil {
+		p.CreatedAt = info.ModTime()
+		p.UpdatedAt = info.ModTime()
+	}
+	return p, nil
+}
+
+// serialize renders p as a .md file: YAML frontmatter between --- fences,
+// then the system prompt as the markdown body. Field order follows the
+// frontmatter struct so output is stable for tests and reviews.
+func serialize(p *Profile) ([]byte, error) {
+	fm := frontmatter{
+		Name:            p.Name,
+		Description:     p.Description,
+		Model:           p.Model,
+		Tools:           p.Tools,
+		ToolSkills:      p.ToolSkills,
+		DisallowedTools: p.DisallowedTools,
+		ReadOnly:        p.ReadOnly,
+		LeanContext:     p.LeanContext,
+		WorkingDir:      p.WorkingDir,
+		MentionAs:       p.MentionAs,
+		ChannelBindings: p.ChannelBindings,
+	}
+	head, err := yaml.Marshal(&fm)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling frontmatter: %w", err)
+	}
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.Write(head)
+	b.WriteString("---\n")
+	if body := strings.TrimSpace(p.SystemPrompt); body != "" {
+		b.WriteString("\n")
+		b.WriteString(body)
+		b.WriteString("\n")
+	}
+	return []byte(b.String()), nil
+}
+
+// splitFrontmatter returns the text between the opening and closing ---
+// fences and everything after the closing fence. ok is false unless the
+// first line is a --- fence with a matching closing fence. (Same rule as the
+// pre-existing agent file parser in internal/tools/agents.go; PR3 retires
+// that copy in favor of this one.)
+func splitFrontmatter(content string) (front, body string, ok bool) {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", "", false
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return strings.Join(lines[1:i], "\n"), strings.Join(lines[i+1:], "\n"), true
+		}
+	}
+	return "", "", false
+}
+
+// maxSystemPrompt mirrors the design doc's 10000-char body limit; enforced by
+// validateForWrite before any file is written.
+const maxSystemPrompt = 10000
+
+// validateForWrite is the Store-level write gate: schema validation plus the
+// system prompt length cap.
+func validateForWrite(p *Profile) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	if len(p.SystemPrompt) > maxSystemPrompt {
+		return fmt.Errorf("system_prompt too long: %d chars (max %d)", len(p.SystemPrompt), maxSystemPrompt)
+	}
+	return nil
+}

--- a/internal/agentprofile/parse_test.go
+++ b/internal/agentprofile/parse_test.go
@@ -132,4 +132,9 @@ func TestValidateForWritePromptCap(t *testing.T) {
 	if err := validateForWrite(p); err == nil || !strings.Contains(err.Error(), "system_prompt too long") {
 		t.Fatalf("validateForWrite() = %v", err)
 	}
+	// The cap counts runes: 10000 CJK chars (30KB) must pass.
+	p.SystemPrompt = strings.Repeat("审", maxSystemPrompt)
+	if err := validateForWrite(p); err != nil {
+		t.Fatalf("10000-rune CJK prompt rejected: %v", err)
+	}
 }

--- a/internal/agentprofile/parse_test.go
+++ b/internal/agentprofile/parse_test.go
@@ -1,0 +1,135 @@
+package agentprofile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleProfileMD = `---
+name: 代码审查专家
+description: 专责 review PR
+model: claude-sonnet-4-20250514
+tools: [read_file, grep, glob]
+tool_skills: [code-review]
+read_only: true
+mention_as: ["@review"]
+channel_bindings:
+  - {platform: weixin, chat_id: dev-group-1}
+---
+你是代码审查专家。
+
+逐行审查，给出 file:line。
+`
+
+func writeMD(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "code-review.md")
+	writeMD(t, dir, "code-review.md", sampleProfileMD)
+
+	p, err := parseFile(path)
+	if err != nil {
+		t.Fatalf("parseFile() error = %v", err)
+	}
+	if p.Name != "代码审查专家" || p.Description != "专责 review PR" {
+		t.Fatalf("identity fields = %q / %q", p.Name, p.Description)
+	}
+	if p.Model != "claude-sonnet-4-20250514" || !p.ReadOnly {
+		t.Fatalf("capability fields = %+v", p.CapabilitySpec)
+	}
+	if len(p.Tools) != 3 || len(p.ToolSkills) != 1 || p.ToolSkills[0] != "code-review" {
+		t.Fatalf("tools = %v skills = %v", p.Tools, p.ToolSkills)
+	}
+	if len(p.MentionAs) != 1 || p.MentionAs[0] != "@review" {
+		t.Fatalf("mention_as = %v", p.MentionAs)
+	}
+	if len(p.ChannelBindings) != 1 || p.ChannelBindings[0].Platform != "weixin" {
+		t.Fatalf("bindings = %+v", p.ChannelBindings)
+	}
+	if !strings.Contains(p.SystemPrompt, "你是代码审查专家。") || !strings.Contains(p.SystemPrompt, "逐行审查") {
+		t.Fatalf("system prompt body = %q", p.SystemPrompt)
+	}
+	if p.CreatedAt.IsZero() {
+		t.Fatal("CreatedAt should come from file mtime")
+	}
+}
+
+func TestParseFileModelInherit(t *testing.T) {
+	dir := t.TempDir()
+	writeMD(t, dir, "x.md", "---\ndescription: d\nmodel: inherit\n---\nbody\n")
+	p, err := parseFile(filepath.Join(dir, "x.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Model != "" {
+		t.Fatalf("model inherit should become empty, got %q", p.Model)
+	}
+}
+
+func TestParseFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string]string{
+		"no-frontmatter": "just a body\n",
+		"no-description": "---\nname: x\n---\nbody\n",
+		"bad-yaml":       "---\n: : :\n---\nbody\n",
+	}
+	for name, content := range cases {
+		writeMD(t, dir, name+".md", content)
+		if _, err := parseFile(filepath.Join(dir, name+".md")); err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+	}
+}
+
+func TestSerializeRoundTrip(t *testing.T) {
+	orig := &Profile{
+		ID:          "code-review",
+		Name:        "代码审查专家",
+		Description: "专责 review PR",
+		CapabilitySpec: CapabilitySpec{
+			Model:        "claude-sonnet-4-20250514",
+			SystemPrompt: "你是代码审查专家。",
+			Tools:        []string{"read_file", "grep"},
+			ToolSkills:   []string{"code-review"},
+			ReadOnly:     true,
+		},
+		MentionAs:       []string{"@review"},
+		ChannelBindings: []ChannelBinding{{Platform: "weixin", ChatID: "g1"}},
+	}
+	b, err := serialize(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	writeMD(t, dir, "code-review.md", string(b))
+	got, err := parseFile(filepath.Join(dir, "code-review.md"))
+	if err != nil {
+		t.Fatalf("roundtrip parse: %v", err)
+	}
+	if got.Name != orig.Name || got.Description != orig.Description ||
+		got.Model != orig.Model || got.SystemPrompt != orig.SystemPrompt ||
+		!got.ReadOnly || len(got.Tools) != 2 || len(got.ToolSkills) != 1 ||
+		len(got.MentionAs) != 1 || len(got.ChannelBindings) != 1 {
+		t.Fatalf("roundtrip mismatch:\n got %+v\nwant %+v", got, orig)
+	}
+}
+
+func TestValidateForWritePromptCap(t *testing.T) {
+	p := &Profile{ID: "ok", Description: "d", CapabilitySpec: CapabilitySpec{
+		SystemPrompt: strings.Repeat("x", maxSystemPrompt+1),
+	}}
+	if err := validateForWrite(p); err == nil || !strings.Contains(err.Error(), "system_prompt too long") {
+		t.Fatalf("validateForWrite() = %v", err)
+	}
+}

--- a/internal/agentprofile/profile.go
+++ b/internal/agentprofile/profile.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Source marks where a profile comes from. It determines which run modes the
@@ -85,7 +86,10 @@ type Profile struct {
 	MentionAs       []string         // conversation mode only; user-level only
 	ChannelBindings []ChannelBinding // conversation mode only; user-level only
 
-	Source    Source
+	Source Source
+
+	// Timestamps are best-effort: both track the file's mtime (there is no
+	// separate creation record), so CreatedAt advances on every rewrite.
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -108,6 +112,10 @@ func DefaultProfile() *Profile {
 // idRule is the profile ID shape: a lowercase slug usable as a file name.
 var idRule = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,31}$`)
 
+// aliasRule is the mention alias shape: @ plus the same charset the router's
+// mention extractor recognizes, so a validated alias can always match.
+var aliasRule = regexp.MustCompile(`^@[A-Za-z0-9][A-Za-z0-9_-]*$`)
+
 // Validate checks the fields every write path (REST API, meta-skill, Store)
 // must enforce. Model-against-config validation lives in the API layer, which
 // is the only place that can see the server config.
@@ -118,12 +126,12 @@ func (p *Profile) Validate() error {
 	if strings.TrimSpace(p.Description) == "" {
 		return errors.New("description is required")
 	}
-	if len(p.Name) > 32 {
-		return fmt.Errorf("name too long: %d chars (max 32)", len(p.Name))
+	if utf8.RuneCountInString(p.Name) > 32 {
+		return fmt.Errorf("name too long: %d chars (max 32)", utf8.RuneCountInString(p.Name))
 	}
 	for _, alias := range p.MentionAs {
-		if !strings.HasPrefix(alias, "@") || len(alias) < 2 {
-			return fmt.Errorf("invalid mention alias %q: must start with @", alias)
+		if !aliasRule.MatchString(alias) {
+			return fmt.Errorf("invalid mention alias %q: must be @ followed by [A-Za-z0-9_-]", alias)
 		}
 	}
 	return nil

--- a/internal/agentprofile/profile.go
+++ b/internal/agentprofile/profile.go
@@ -1,0 +1,130 @@
+// Package agentprofile defines octo's agent profiles — the single schema for
+// an agent's capability definition (system prompt, model, tool whitelist,
+// skills) plus the platform slice (mention aliases, channel bindings) used
+// when a profile is addressed directly by users.
+//
+// Profiles come from three sources, in increasing precedence:
+//
+//   - builtin: code-defined (default, explore, general, code-review)
+//   - user:    ~/.octo/agents/<id>.md       (conversation + delegation modes)
+//   - project: <repo>/.octo/agents/<id>.md  (delegation mode only)
+//
+// A profile is consumed in two modes:
+//
+//   - conversation: a persistent channel.Manager session the user talks to
+//     directly (IM routing, web sessions, CLI --agent)
+//   - delegation: an ephemeral sub_agent run that uses only the capability
+//     slice — fresh context, never enters the profile's session pool
+//
+// The Store is read-through: every read rescans the profile directories, so
+// changes made through any path (REST API, Web UI, direct .md edits) take
+// effect on the next read. There is no fsnotify watcher and no reload API.
+package agentprofile
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Source marks where a profile comes from. It determines which run modes the
+// profile supports and its override precedence (project > user > builtin).
+type Source string
+
+const (
+	// SourceBuiltin profiles are code-defined (default, explore, general,
+	// code-review) and have no .md file.
+	SourceBuiltin Source = "builtin"
+	// SourceUser profiles live in ~/.octo/agents/*.md and support both
+	// conversation and delegation modes.
+	SourceUser Source = "user"
+	// SourceProject profiles live in <repo>/.octo/agents/*.md and are
+	// delegation-only: the platform slice (mention aliases, channel
+	// bindings) is ignored, so a project file can never hijack IM routing.
+	SourceProject Source = "project"
+)
+
+// DefaultID is the reserved ID of the code-defined default agent.
+const DefaultID = "default"
+
+// CapabilitySpec is the profile's capability slice: prompt / model / tools /
+// skills. It is shared by both run modes; the platform slice (MentionAs,
+// ChannelBindings) only applies to conversation mode.
+type CapabilitySpec struct {
+	Model        string   // frontmatter model; empty = inherit the caller's
+	SystemPrompt string   // .md body (never carried in frontmatter)
+	Tools        []string // frontmatter tools allowlist; empty = all tools
+	ToolSkills   []string // frontmatter tool_skills: skills exposed as tools
+
+	// Delegation refinements, parsed for zero-migration compatibility with
+	// the pre-existing .md agent format (internal/tools/agents.go).
+	ReadOnly        bool     // frontmatter read_only: strip write-capable tools
+	DisallowedTools []string // frontmatter disallowed_tools: subtracted from the tool set
+	LeanContext     bool     // frontmatter lean_context: seed with the lean system prompt
+}
+
+// ChannelBinding pins a profile to one IM chat: messages from that chat route
+// to this profile without needing an @-mention.
+type ChannelBinding struct {
+	Platform string `yaml:"platform"`
+	ChatID   string `yaml:"chat_id"`
+}
+
+// Profile describes one agent: identity, capability slice, and platform
+// slice. User-level profiles are stored as ~/.octo/agents/<id>.md (Markdown
+// body = system prompt, YAML frontmatter = everything else).
+type Profile struct {
+	ID          string // file-name slug (without .md); fixed name for builtins
+	Name        string
+	Description string // required, both by validation and the .md parser
+	CapabilitySpec
+
+	WorkingDir      string
+	MentionAs       []string         // conversation mode only; user-level only
+	ChannelBindings []ChannelBinding // conversation mode only; user-level only
+
+	Source    Source
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// IsDefault reports whether p is the code-defined default agent.
+func (p *Profile) IsDefault() bool { return p != nil && p.ID == DefaultID }
+
+// DefaultProfile returns the built-in default agent: full tool access, system
+// prompt assembled by the server (base prompt + onboard soul.md/user.md), no
+// .md file. It is the routing fallback and therefore always exists.
+func DefaultProfile() *Profile {
+	return &Profile{
+		ID:          DefaultID,
+		Name:        "Default",
+		Description: "Default agent with full access",
+		Source:      SourceBuiltin,
+	}
+}
+
+// idRule is the profile ID shape: a lowercase slug usable as a file name.
+var idRule = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,31}$`)
+
+// Validate checks the fields every write path (REST API, meta-skill, Store)
+// must enforce. Model-against-config validation lives in the API layer, which
+// is the only place that can see the server config.
+func (p *Profile) Validate() error {
+	if !idRule.MatchString(p.ID) {
+		return fmt.Errorf("invalid id %q: must match [a-z0-9][a-z0-9-]{0,31}", p.ID)
+	}
+	if strings.TrimSpace(p.Description) == "" {
+		return errors.New("description is required")
+	}
+	if len(p.Name) > 32 {
+		return fmt.Errorf("name too long: %d chars (max 32)", len(p.Name))
+	}
+	for _, alias := range p.MentionAs {
+		if !strings.HasPrefix(alias, "@") || len(alias) < 2 {
+			return fmt.Errorf("invalid mention alias %q: must start with @", alias)
+		}
+	}
+	return nil
+}

--- a/internal/agentprofile/profile_test.go
+++ b/internal/agentprofile/profile_test.go
@@ -23,9 +23,11 @@ func TestValidate(t *testing.T) {
 		{"id 32 chars ok", func(p *Profile) { p.ID = strings.Repeat("a", 32) }, ""},
 		{"description required", func(p *Profile) { p.Description = "  " }, "description is required"},
 		{"name too long", func(p *Profile) { p.Name = strings.Repeat("n", 33) }, "name too long"},
-		{"alias missing @", func(p *Profile) { p.MentionAs = []string{"review"} }, "must start with @"},
-		{"alias bare @", func(p *Profile) { p.MentionAs = []string{"@"} }, "must start with @"},
+		{"alias missing @", func(p *Profile) { p.MentionAs = []string{"review"} }, "invalid mention alias"},
+		{"alias bare @", func(p *Profile) { p.MentionAs = []string{"@"} }, "invalid mention alias"},
+		{"alias bad charset", func(p *Profile) { p.MentionAs = []string{"@$$"} }, "invalid mention alias"},
 		{"alias ok", func(p *Profile) { p.MentionAs = []string{"@review", "@CR"} }, ""},
+		{"name 32 CJK chars ok", func(p *Profile) { p.Name = strings.Repeat("审", 32) }, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/agentprofile/profile_test.go
+++ b/internal/agentprofile/profile_test.go
@@ -1,0 +1,55 @@
+package agentprofile
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	base := func() *Profile {
+		return &Profile{ID: "code-review", Description: "reviews code"}
+	}
+	tests := []struct {
+		name    string
+		mutate  func(*Profile)
+		wantErr string
+	}{
+		{"ok", func(p *Profile) {}, ""},
+		{"id empty", func(p *Profile) { p.ID = "" }, "invalid id"},
+		{"id uppercase", func(p *Profile) { p.ID = "Code" }, "invalid id"},
+		{"id underscore", func(p *Profile) { p.ID = "code_review" }, "invalid id"},
+		{"id leading dash", func(p *Profile) { p.ID = "-code" }, "invalid id"},
+		{"id too long", func(p *Profile) { p.ID = strings.Repeat("a", 33) }, "invalid id"},
+		{"id 32 chars ok", func(p *Profile) { p.ID = strings.Repeat("a", 32) }, ""},
+		{"description required", func(p *Profile) { p.Description = "  " }, "description is required"},
+		{"name too long", func(p *Profile) { p.Name = strings.Repeat("n", 33) }, "name too long"},
+		{"alias missing @", func(p *Profile) { p.MentionAs = []string{"review"} }, "must start with @"},
+		{"alias bare @", func(p *Profile) { p.MentionAs = []string{"@"} }, "must start with @"},
+		{"alias ok", func(p *Profile) { p.MentionAs = []string{"@review", "@CR"} }, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := base()
+			tt.mutate(p)
+			err := p.Validate()
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Validate() = %v, want error containing %q", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultProfile(t *testing.T) {
+	p := DefaultProfile()
+	if !p.IsDefault() || p.Source != SourceBuiltin {
+		t.Fatalf("DefaultProfile() = %+v", p)
+	}
+	if (&Profile{ID: "x"}).IsDefault() {
+		t.Fatal("non-default profile claims IsDefault")
+	}
+}

--- a/internal/agentprofile/router.go
+++ b/internal/agentprofile/router.go
@@ -1,0 +1,67 @@
+package agentprofile
+
+import "regexp"
+
+// RouteInput carries the fields of an inbound IM event the router needs. It
+// is deliberately defined here rather than reusing channel.InboundEvent so
+// agentprofile stays importable from both internal/channel (PR2) and
+// internal/server without an import cycle.
+type RouteInput struct {
+	Platform string
+	ChatID   string
+	UserID   string
+	Text     string
+}
+
+// Router maps an inbound event to the profile that should handle it. It is a
+// pure function over the Store (which is read-through), so profile edits take
+// effect on the very next message.
+type Router struct {
+	store *Store
+}
+
+// NewRouter builds a Router over store.
+func NewRouter(store *Store) *Router { return &Router{store: store} }
+
+// mentionRule matches @alias tokens in message text. The captured alias is
+// looked up (with the @) against profiles' mention_as lists.
+var mentionRule = regexp.MustCompile(`@([A-Za-z0-9][A-Za-z0-9_-]*)`)
+
+// MentionAlias extracts the first @-alias from text, "" when there is none.
+func MentionAlias(text string) string {
+	m := mentionRule.FindStringSubmatch(text)
+	if m == nil {
+		return ""
+	}
+	return "@" + m[1]
+}
+
+// Route returns the profile that should handle the event, or nil when the
+// message must be dropped (group chat with multiple bound profiles and no
+// @-mention — the "stay silent" rule). The decision table:
+//
+//	| scenario                        | result            |
+//	|---------------------------------|-------------------|
+//	| @alias bound to a profile       | that profile      |
+//	| @alias not bound anywhere       | default (fallback)|
+//	| exactly one channel binding     | the bound profile |
+//	| multiple bindings, no @-mention | nil (drop)        |
+//	| no binding                      | default           |
+//
+// @-mentions win over channel bindings: an explicit @ is never ambiguous.
+func (r *Router) Route(in RouteInput) *Profile {
+	if alias := MentionAlias(in.Text); alias != "" {
+		if p, ok := r.store.ByMention(alias); ok {
+			return p
+		}
+		return DefaultProfile()
+	}
+	switch bound := r.store.ByChannel(in.Platform, in.ChatID); len(bound) {
+	case 0:
+		return DefaultProfile()
+	case 1:
+		return bound[0]
+	default:
+		return nil
+	}
+}

--- a/internal/agentprofile/router_test.go
+++ b/internal/agentprofile/router_test.go
@@ -1,0 +1,77 @@
+package agentprofile
+
+import "testing"
+
+// routerStore builds a store with two user profiles bound as in the design
+// doc's decision table: "code" (@review, bound to weixin:g1) and "ops"
+// (@ops, bound to weixin:g1 as well — the ambiguous group).
+func routerStore(t *testing.T) *Store {
+	t.Helper()
+	s, userDir, _ := newTestStore(t)
+	writeMD(t, userDir, "code.md", "---\ndescription: dc\nmention_as: [\"@review\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
+	writeMD(t, userDir, "ops.md", "---\ndescription: do\nmention_as: [\"@ops\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n  - {platform: weixin, chat_id: g2}\n---\nbody\n")
+	writeMD(t, userDir, "solo.md", "---\ndescription: ds\nchannel_bindings:\n  - {platform: feishu, chat_id: dm1}\n---\nbody\n")
+	return s
+}
+
+func TestMentionAlias(t *testing.T) {
+	cases := map[string]string{
+		"@review this PR":   "@review",
+		"please @ops check": "@ops",
+		"no mention":        "",
+		"email a@b.com":     "@b", // documented limitation: first @-token wins
+		"@":                 "",
+		"@${not}":           "",
+		"@code-review hi":   "@code-review",
+	}
+	for in, want := range cases {
+		if got := MentionAlias(in); got != want {
+			t.Errorf("MentionAlias(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRouterDecisionTable(t *testing.T) {
+	r := NewRouter(routerStore(t))
+	tests := []struct {
+		name string
+		in   RouteInput
+		want string // profile ID; "" means drop (nil); "default" for fallback
+	}{
+		{"DM unbound → default",
+			RouteInput{Platform: "weixin", ChatID: "dm-9", Text: "hi"}, "default"},
+		{"DM bound uniquely → bound profile",
+			RouteInput{Platform: "feishu", ChatID: "dm1", Text: "hi"}, "solo"},
+		{"group @unknown alias → default fallback",
+			RouteInput{Platform: "weixin", ChatID: "g1", Text: "@nobody hi"}, "default"},
+		{"group @review → code",
+			RouteInput{Platform: "weixin", ChatID: "g1", Text: "@review pr 123"}, "code"},
+		{"group multi-binding @ops → ops",
+			RouteInput{Platform: "weixin", ChatID: "g1", Text: "@ops check logs"}, "ops"},
+		{"group multi-binding no @ → drop",
+			RouteInput{Platform: "weixin", ChatID: "g1", Text: "hello"}, ""},
+		{"group single-binding no @ → bound profile",
+			RouteInput{Platform: "weixin", ChatID: "g2", Text: "hello"}, "ops"},
+		{"group unbound → default",
+			RouteInput{Platform: "weixin", ChatID: "g9", Text: "hello"}, "default"},
+		{"@ mention wins over channel binding",
+			RouteInput{Platform: "feishu", ChatID: "dm1", Text: "@ops look"}, "ops"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.Route(tt.in)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("Route() = %q, want nil (drop)", got.ID)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("Route() = nil, want %q", tt.want)
+			}
+			if got.ID != tt.want {
+				t.Fatalf("Route() = %q, want %q", got.ID, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agentprofile/store.go
+++ b/internal/agentprofile/store.go
@@ -1,0 +1,197 @@
+package agentprofile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Store loads profiles from the user-level and project-level agent
+// directories plus the code-defined builtins, and answers every query by
+// rescanning: it is deliberately read-through, so a change made through any
+// path (REST API, Web UI, direct .md edit) is visible on the next read. The
+// directories hold a handful of small files, so a rescan is cheap — this is
+// exactly how the pre-existing discoverAgents loader already behaved.
+//
+// Precedence is project > user > builtin: a user .md can shadow a builtin
+// (e.g. a personal "explore"), and a project .md can shadow both.
+type Store struct {
+	userDir    string
+	projectDir func() string // resolved per scan (cwd-dependent); nil disables
+}
+
+// New builds a Store over the user-level directory. projectDir, when non-nil,
+// is consulted on every scan for the delegation-only project-level directory.
+func New(userDir string, projectDir func() string) *Store {
+	return &Store{userDir: userDir, projectDir: projectDir}
+}
+
+// load scans all sources and returns the merged id → profile map. Files that
+// fail to parse are skipped (a broken profile must never take the others down
+// with it, and the next read self-heals once the file is fixed).
+func (s *Store) load() map[string]*Profile {
+	profiles := make(map[string]*Profile)
+	for _, p := range builtinProfiles() {
+		profiles[p.ID] = p
+	}
+	s.scanDir(s.userDir, SourceUser, profiles)
+	if s.projectDir != nil {
+		s.scanDir(s.projectDir(), SourceProject, profiles)
+	}
+	return profiles
+}
+
+// scanDir merges *.md profiles from dir into dst, overwriting same-named
+// entries of lower precedence. A missing or unreadable dir is a no-op.
+func (s *Store) scanDir(dir string, src Source, dst map[string]*Profile) {
+	if dir == "" {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".md")
+		if !idRule.MatchString(id) {
+			continue
+		}
+		p, err := parseFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue // broken file: skip, warn upstream if needed, self-heal next read
+		}
+		p.ID = id
+		p.Source = src
+		if src == SourceProject {
+			// Delegation-only: the platform slice from a project file must
+			// never influence IM routing.
+			p.MentionAs = nil
+			p.ChannelBindings = nil
+		}
+		dst[id] = p
+	}
+}
+
+// Load performs a full scan. With the read-through design it has no cached
+// state to refresh — it exists so callers (and tests) can validate that the
+// directories are at least readable, and to keep the documented API shape.
+func (s *Store) Load() error {
+	s.load()
+	return nil
+}
+
+// Get returns the profile with the given id, honoring the project > user >
+// builtin precedence. The default profile is always available.
+func (s *Store) Get(id string) (*Profile, bool) {
+	p, ok := s.load()[id]
+	return p, ok
+}
+
+// List returns every non-builtin profile (user- and project-level), sorted by
+// ID for stable output.
+func (s *Store) List() []*Profile {
+	var out []*Profile
+	for _, p := range s.load() {
+		if p.Source == SourceBuiltin {
+			continue
+		}
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// Create validates p and writes it as <userDir>/<id>.md. It refuses to
+// overwrite an existing file (including one shadowing a builtin — shadowing
+// stays a deliberate, hand-written affair).
+func (s *Store) Create(p *Profile) error {
+	if err := validateForWrite(p); err != nil {
+		return err
+	}
+	path := filepath.Join(s.userDir, p.ID+".md")
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("profile %q already exists", p.ID)
+	}
+	return s.writeFile(path, p)
+}
+
+// Update rewrites an existing user-level profile. Builtin and project-level
+// profiles are immutable through the Store: edit code or the project file.
+func (s *Store) Update(p *Profile) error {
+	if err := validateForWrite(p); err != nil {
+		return err
+	}
+	path := filepath.Join(s.userDir, p.ID+".md")
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("profile %q not found at user level (builtin/project profiles are read-only here)", p.ID)
+	}
+	return s.writeFile(path, p)
+}
+
+// Delete removes a user-level profile. A profile with channel bindings must
+// be unbound first, so an IM chat is never left routing to a ghost.
+func (s *Store) Delete(id string) error {
+	p, ok := s.Get(id)
+	if !ok {
+		return fmt.Errorf("profile %q not found", id)
+	}
+	if p.Source != SourceUser {
+		return fmt.Errorf("profile %q is %s-level and cannot be deleted through the Store", id, p.Source)
+	}
+	if len(p.ChannelBindings) > 0 {
+		return fmt.Errorf("profile %q still has %d channel binding(s): unbind them first", id, len(p.ChannelBindings))
+	}
+	return os.Remove(filepath.Join(s.userDir, id+".md"))
+}
+
+// writeFile serializes p and writes it atomically-ish (0600, single write) so
+// a concurrent read-through scan never sees a partially written file for long.
+func (s *Store) writeFile(path string, p *Profile) error {
+	b, err := serialize(p)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+// ByChannel returns the user-level profiles bound to the given IM chat. The
+// router treats >1 as "ambiguous: stay silent unless @-mentioned".
+func (s *Store) ByChannel(platform, chatID string) []*Profile {
+	var out []*Profile
+	for _, p := range s.load() {
+		if p.Source != SourceUser {
+			continue
+		}
+		for _, b := range p.ChannelBindings {
+			if b.Platform == platform && b.ChatID == chatID {
+				out = append(out, p)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// ByMention resolves an @-alias (including the @) to a user-level profile.
+func (s *Store) ByMention(alias string) (*Profile, bool) {
+	for _, p := range s.load() {
+		if p.Source != SourceUser {
+			continue
+		}
+		for _, a := range p.MentionAs {
+			if a == alias {
+				return p, true
+			}
+		}
+	}
+	return nil, false
+}

--- a/internal/agentprofile/store.go
+++ b/internal/agentprofile/store.go
@@ -2,6 +2,7 @@ package agentprofile
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -45,6 +46,11 @@ func (s *Store) load() map[string]*Profile {
 
 // scanDir merges *.md profiles from dir into dst, overwriting same-named
 // entries of lower precedence. A missing or unreadable dir is a no-op.
+//
+// The read path accepts any .md basename as an ID (zero-migration
+// compatibility with the pre-existing agent loader); the slug rule is
+// enforced on writes instead. The reserved "default" ID is skipped so a
+// stray default.md can never shadow the code-defined default agent.
 func (s *Store) scanDir(dir string, src Source, dst map[string]*Profile) {
 	if dir == "" {
 		return
@@ -58,12 +64,13 @@ func (s *Store) scanDir(dir string, src Source, dst map[string]*Profile) {
 			continue
 		}
 		id := strings.TrimSuffix(e.Name(), ".md")
-		if !idRule.MatchString(id) {
+		if id == "" || id == DefaultID {
 			continue
 		}
 		p, err := parseFile(filepath.Join(dir, e.Name()))
 		if err != nil {
-			continue // broken file: skip, warn upstream if needed, self-heal next read
+			log.Printf("agentprofile: skipping %s: %v", filepath.Join(dir, e.Name()), err)
+			continue // broken file: skip, self-heal next read
 		}
 		p.ID = id
 		p.Source = src
@@ -78,16 +85,20 @@ func (s *Store) scanDir(dir string, src Source, dst map[string]*Profile) {
 }
 
 // Load performs a full scan. With the read-through design it has no cached
-// state to refresh — it exists so callers (and tests) can validate that the
-// directories are at least readable, and to keep the documented API shape.
+// state to refresh and unreadable directories are tolerated as empty — it
+// exists to keep the documented API shape and as a scan smoke hook for tests.
 func (s *Store) Load() error {
 	s.load()
 	return nil
 }
 
 // Get returns the profile with the given id, honoring the project > user >
-// builtin precedence. The default profile is always available.
+// builtin precedence. The default profile is code-defined and always
+// available.
 func (s *Store) Get(id string) (*Profile, bool) {
+	if id == DefaultID {
+		return DefaultProfile(), true
+	}
 	p, ok := s.load()[id]
 	return p, ok
 }
@@ -108,9 +119,10 @@ func (s *Store) List() []*Profile {
 
 // Create validates p and writes it as <userDir>/<id>.md. It refuses to
 // overwrite an existing file (including one shadowing a builtin — shadowing
-// stays a deliberate, hand-written affair).
+// stays a deliberate, hand-written affair), to use the reserved default ID,
+// or to claim a mention alias another profile already holds.
 func (s *Store) Create(p *Profile) error {
-	if err := validateForWrite(p); err != nil {
+	if err := s.validateForStoreWrite(p); err != nil {
 		return err
 	}
 	path := filepath.Join(s.userDir, p.ID+".md")
@@ -123,7 +135,7 @@ func (s *Store) Create(p *Profile) error {
 // Update rewrites an existing user-level profile. Builtin and project-level
 // profiles are immutable through the Store: edit code or the project file.
 func (s *Store) Update(p *Profile) error {
-	if err := validateForWrite(p); err != nil {
+	if err := s.validateForStoreWrite(p); err != nil {
 		return err
 	}
 	path := filepath.Join(s.userDir, p.ID+".md")
@@ -131,6 +143,32 @@ func (s *Store) Update(p *Profile) error {
 		return fmt.Errorf("profile %q not found at user level (builtin/project profiles are read-only here)", p.ID)
 	}
 	return s.writeFile(path, p)
+}
+
+// validateForStoreWrite is the write gate shared by Create and Update: schema
+// validation, the reserved default ID, and global mention-alias uniqueness
+// (the design's anti-impersonation rule — only the Store can see all
+// profiles, so the check lives here).
+func (s *Store) validateForStoreWrite(p *Profile) error {
+	if err := validateForWrite(p); err != nil {
+		return err
+	}
+	if p.ID == DefaultID {
+		return fmt.Errorf("id %q is reserved for the code-defined default agent", DefaultID)
+	}
+	for id, other := range s.load() {
+		if id == p.ID || other.Source != SourceUser {
+			continue
+		}
+		for _, alias := range p.MentionAs {
+			for _, taken := range other.MentionAs {
+				if alias == taken {
+					return fmt.Errorf("mention alias %q is already claimed by profile %q", alias, id)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // Delete removes a user-level profile. A profile with channel bindings must
@@ -149,27 +187,53 @@ func (s *Store) Delete(id string) error {
 	return os.Remove(filepath.Join(s.userDir, id+".md"))
 }
 
-// writeFile serializes p and writes it atomically-ish (0600, single write) so
-// a concurrent read-through scan never sees a partially written file for long.
+// writeFile serializes p and writes it via temp-file + rename, so a
+// concurrent read-through scan never observes a partially written file.
 func (s *Store) writeFile(path string, p *Profile) error {
 	b, err := serialize(p)
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(path, b, 0o600)
+	tmp, err := os.CreateTemp(dir, ".profile-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// userProfiles scans only the user-level directory. IM routing queries
+// (ByChannel/ByMention) build on this — not on the merged map — so a
+// project-level file shadowing a user profile's ID (delegation override)
+// can never silence that profile's conversation-mode routing.
+func (s *Store) userProfiles() map[string]*Profile {
+	m := make(map[string]*Profile)
+	s.scanDir(s.userDir, SourceUser, m)
+	return m
 }
 
 // ByChannel returns the user-level profiles bound to the given IM chat. The
 // router treats >1 as "ambiguous: stay silent unless @-mentioned".
 func (s *Store) ByChannel(platform, chatID string) []*Profile {
 	var out []*Profile
-	for _, p := range s.load() {
-		if p.Source != SourceUser {
-			continue
-		}
+	for _, p := range s.userProfiles() {
 		for _, b := range p.ChannelBindings {
 			if b.Platform == platform && b.ChatID == chatID {
 				out = append(out, p)
@@ -183,10 +247,7 @@ func (s *Store) ByChannel(platform, chatID string) []*Profile {
 
 // ByMention resolves an @-alias (including the @) to a user-level profile.
 func (s *Store) ByMention(alias string) (*Profile, bool) {
-	for _, p := range s.load() {
-		if p.Source != SourceUser {
-			continue
-		}
+	for _, p := range s.userProfiles() {
 		for _, a := range p.MentionAs {
 			if a == alias {
 				return p, true

--- a/internal/agentprofile/store_test.go
+++ b/internal/agentprofile/store_test.go
@@ -1,8 +1,11 @@
 package agentprofile
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -62,16 +65,35 @@ func TestStoreProjectStripsPlatformSlice(t *testing.T) {
 	}
 }
 
-func TestStoreSkipsBrokenAndNonSlugFiles(t *testing.T) {
+func TestStoreSkipsBrokenFilesAndReservedID(t *testing.T) {
 	s, userDir, _ := newTestStore(t)
 	writeMD(t, userDir, "broken.md", "no frontmatter here\n")
-	writeMD(t, userDir, "Bad_Name.md", "---\ndescription: d\n---\nbody\n")
+	writeMD(t, userDir, "default.md", "---\ndescription: impostor\n---\nbody\n") // reserved ID: skipped
 	writeMD(t, userDir, "good.md", "---\ndescription: d\n---\nbody\n")
 	writeMD(t, userDir, "notes.txt", "---\ndescription: d\n---\nbody\n") // not .md
 
 	got := s.List()
 	if len(got) != 1 || got[0].ID != "good" {
 		t.Fatalf("List() = %+v, want only [good]", got)
+	}
+	// The default profile is code-defined, never the impostor file.
+	if p, _ := s.Get(DefaultID); p.Description == "impostor" {
+		t.Fatal("default.md shadowed the code-defined default agent")
+	}
+}
+
+// The pre-existing agent loader accepts any .md basename as an ID; the Store
+// must too (zero-migration), even names that fail the write-side slug rule.
+func TestStoreAcceptsNonSlugFilenames(t *testing.T) {
+	s, userDir, _ := newTestStore(t)
+	writeMD(t, userDir, "Code_Review.md", "---\ndescription: legacy\n---\nbody\n")
+
+	p, ok := s.Get("Code_Review")
+	if !ok || p.Description != "legacy" {
+		t.Fatalf("non-slug legacy file not readable: %v, %v", p, ok)
+	}
+	if got := s.List(); len(got) != 1 || got[0].ID != "Code_Review" {
+		t.Fatalf("List() = %+v", got)
 	}
 }
 
@@ -173,4 +195,76 @@ func TestStoreByChannelByMention(t *testing.T) {
 	if _, ok := s.ByMention("@nobody"); ok {
 		t.Fatal("ByMention(@nobody) should miss")
 	}
+}
+
+// A project-level file shadowing a user profile's ID overrides delegation
+// (Get) but must never silence the user profile's IM routing.
+func TestStoreProjectShadowKeepsUserRouting(t *testing.T) {
+	s, userDir, projectDir := newTestStore(t)
+	writeMD(t, userDir, "reviewer.md", "---\ndescription: user\nmention_as: [\"@review\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nuser body\n")
+	writeMD(t, projectDir, "reviewer.md", "---\ndescription: project\n---\nproject body\n")
+
+	if p, _ := s.Get("reviewer"); p.Source != SourceProject {
+		t.Fatalf("delegation precedence broken: %+v", p)
+	}
+	if got := s.ByChannel("weixin", "g1"); len(got) != 1 || got[0].ID != "reviewer" {
+		t.Fatalf("project shadow silenced user routing: %+v", got)
+	}
+	if p, ok := s.ByMention("@review"); !ok || p.ID != "reviewer" {
+		t.Fatalf("project shadow broke alias routing: %v, %v", p, ok)
+	}
+}
+
+func TestStoreDefaultReserved(t *testing.T) {
+	s, userDir, _ := newTestStore(t)
+
+	if p, ok := s.Get(DefaultID); !ok || !p.IsDefault() {
+		t.Fatalf("Get(default) = %v, %v — the default profile must always resolve", p, ok)
+	}
+	if err := s.Create(&Profile{ID: DefaultID, Description: "impostor"}); err == nil {
+		t.Fatal("Create with reserved id 'default' should fail")
+	}
+	if _, err := os.Stat(filepath.Join(userDir, "default.md")); !os.IsNotExist(err) {
+		t.Fatal("impostor default.md was written")
+	}
+}
+
+func TestStoreAliasUniqueness(t *testing.T) {
+	s, userDir, _ := newTestStore(t)
+	writeMD(t, userDir, "a.md", "---\ndescription: da\nmention_as: [\"@review\"]\n---\nbody\n")
+
+	// Create with a taken alias fails.
+	err := s.Create(&Profile{ID: "b", Description: "db", MentionAs: []string{"@review"}})
+	if err == nil || !strings.Contains(err.Error(), "already claimed") {
+		t.Fatalf("Create with duplicate alias = %v", err)
+	}
+	// Update of the owner itself keeps the alias.
+	writeMD(t, userDir, "a.md", "---\ndescription: da\nmention_as: [\"@review\"]\n---\nbody\n")
+	if err := s.Update(&Profile{ID: "a", Description: "da2", MentionAs: []string{"@review"}}); err != nil {
+		t.Fatalf("Update of alias owner = %v", err)
+	}
+	// Update claiming someone else's alias fails.
+	writeMD(t, userDir, "b.md", "---\ndescription: db\n---\nbody\n")
+	if err := s.Update(&Profile{ID: "b", Description: "db", MentionAs: []string{"@review"}}); err == nil {
+		t.Fatal("Update stealing alias should fail")
+	}
+}
+
+func TestStoreConcurrentAccess(t *testing.T) {
+	s, _, _ := newTestStore(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("p%d", i%4)
+			p := &Profile{ID: id, Description: "d"}
+			_ = s.Create(p)
+			_, _ = s.Get(id)
+			_ = s.List()
+			_ = s.Update(p)
+			_ = s.Delete(id)
+		}(i)
+	}
+	wg.Wait()
 }

--- a/internal/agentprofile/store_test.go
+++ b/internal/agentprofile/store_test.go
@@ -1,0 +1,176 @@
+package agentprofile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newTestStore builds a Store over two temp dirs (user + project).
+func newTestStore(t *testing.T) (*Store, string, string) {
+	t.Helper()
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+	return New(userDir, func() string { return projectDir }), userDir, projectDir
+}
+
+func TestStoreBuiltinFallback(t *testing.T) {
+	s, _, _ := newTestStore(t)
+	for _, id := range []string{"explore", "general", "code-review"} {
+		p, ok := s.Get(id)
+		if !ok || p.Source != SourceBuiltin {
+			t.Fatalf("Get(%q) = %v, %v", id, p, ok)
+		}
+	}
+	if got := s.List(); len(got) != 0 {
+		t.Fatalf("List() with no user files = %d profiles, want 0 (builtins excluded)", len(got))
+	}
+	if err := s.Load(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStorePrecedence(t *testing.T) {
+	s, userDir, projectDir := newTestStore(t)
+	// User file shadows the builtin "explore".
+	writeMD(t, userDir, "explore.md", "---\ndescription: user explore\n---\nuser persona\n")
+	// Project file shadows the user file.
+	writeMD(t, projectDir, "explore.md", "---\ndescription: project explore\n---\nproject persona\n")
+
+	p, ok := s.Get("explore")
+	if !ok {
+		t.Fatal("Get(explore) not found")
+	}
+	if p.Source != SourceProject || p.SystemPrompt != "project persona" {
+		t.Fatalf("precedence project > user > builtin broken: %+v", p)
+	}
+}
+
+func TestStoreProjectStripsPlatformSlice(t *testing.T) {
+	s, _, projectDir := newTestStore(t)
+	writeMD(t, projectDir, "ops.md", "---\ndescription: d\nmention_as: [\"@ops\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
+
+	if _, ok := s.ByMention("@ops"); ok {
+		t.Fatal("project-level alias must not be routable")
+	}
+	if got := s.ByChannel("weixin", "g1"); len(got) != 0 {
+		t.Fatal("project-level binding must not be routable")
+	}
+	p, _ := s.Get("ops")
+	if len(p.MentionAs) != 0 || len(p.ChannelBindings) != 0 {
+		t.Fatalf("project profile kept platform slice: %+v", p)
+	}
+}
+
+func TestStoreSkipsBrokenAndNonSlugFiles(t *testing.T) {
+	s, userDir, _ := newTestStore(t)
+	writeMD(t, userDir, "broken.md", "no frontmatter here\n")
+	writeMD(t, userDir, "Bad_Name.md", "---\ndescription: d\n---\nbody\n")
+	writeMD(t, userDir, "good.md", "---\ndescription: d\n---\nbody\n")
+	writeMD(t, userDir, "notes.txt", "---\ndescription: d\n---\nbody\n") // not .md
+
+	got := s.List()
+	if len(got) != 1 || got[0].ID != "good" {
+		t.Fatalf("List() = %+v, want only [good]", got)
+	}
+}
+
+func TestStoreReadThrough(t *testing.T) {
+	s, userDir, _ := newTestStore(t)
+	writeMD(t, userDir, "a.md", "---\ndescription: v1\n---\nbody v1\n")
+
+	p, _ := s.Get("a")
+	if p.Description != "v1" {
+		t.Fatalf("first read = %q", p.Description)
+	}
+	// Direct .md edit takes effect on the very next read — no reload, no restart.
+	writeMD(t, userDir, "a.md", "---\ndescription: v2\n---\nbody v2\n")
+	p, _ = s.Get("a")
+	if p.Description != "v2" || p.SystemPrompt != "body v2" {
+		t.Fatalf("read-through failed: %+v", p)
+	}
+	// Deletion too.
+	if err := os.Remove(filepath.Join(userDir, "a.md")); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.Get("a"); ok {
+		t.Fatal("deleted profile still visible")
+	}
+}
+
+func TestStoreCreateUpdateDelete(t *testing.T) {
+	s, userDir, _ := newTestStore(t)
+
+	p := &Profile{ID: "reviewer", Name: "Reviewer", Description: "d",
+		CapabilitySpec: CapabilitySpec{SystemPrompt: "prompt", Tools: []string{"read_file"}}}
+	if err := s.Create(p); err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(userDir, "reviewer.md")); err != nil {
+		t.Fatalf("file not written: %v", err)
+	}
+	if err := s.Create(p); err == nil {
+		t.Fatal("duplicate Create should fail")
+	}
+
+	p.Description = "d2"
+	if err := s.Update(p); err != nil {
+		t.Fatalf("Update() = %v", err)
+	}
+	got, _ := s.Get("reviewer")
+	if got.Description != "d2" || got.SystemPrompt != "prompt" {
+		t.Fatalf("after Update: %+v", got)
+	}
+
+	if err := s.Update(&Profile{ID: "ghost", Description: "d"}); err == nil {
+		t.Fatal("Update of non-existent user profile should fail")
+	}
+	if err := s.Delete("explore"); err == nil {
+		t.Fatal("Delete of builtin should fail")
+	}
+	if err := s.Delete("ghost"); err == nil {
+		t.Fatal("Delete of unknown profile should fail")
+	}
+
+	// Bound profile must be unbound before deletion.
+	p.ChannelBindings = []ChannelBinding{{Platform: "weixin", ChatID: "g1"}}
+	if err := s.Update(p); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("reviewer"); err == nil {
+		t.Fatal("Delete with channel bindings should fail")
+	}
+	p.ChannelBindings = nil
+	if err := s.Update(p); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("reviewer"); err != nil {
+		t.Fatalf("Delete() = %v", err)
+	}
+	if _, ok := s.Get("reviewer"); ok {
+		t.Fatal("profile still visible after Delete")
+	}
+}
+
+func TestStoreByChannelByMention(t *testing.T) {
+	s, userDir, _ := newTestStore(t)
+	writeMD(t, userDir, "a.md", "---\ndescription: da\nmention_as: [\"@review\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
+	writeMD(t, userDir, "b.md", "---\ndescription: db\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n  - {platform: feishu, chat_id: g2}\n---\nbody\n")
+
+	if got := s.ByChannel("weixin", "g1"); len(got) != 2 {
+		t.Fatalf("ByChannel(weixin,g1) = %d, want 2", len(got))
+	}
+	if got := s.ByChannel("feishu", "g2"); len(got) != 1 || got[0].ID != "b" {
+		t.Fatalf("ByChannel(feishu,g2) = %+v", got)
+	}
+	if got := s.ByChannel("weixin", "unknown"); len(got) != 0 {
+		t.Fatalf("ByChannel unknown = %+v", got)
+	}
+	p, ok := s.ByMention("@review")
+	if !ok || p.ID != "a" {
+		t.Fatalf("ByMention(@review) = %v, %v", p, ok)
+	}
+	if _, ok := s.ByMention("@nobody"); ok {
+		t.Fatal("ByMention(@nobody) should miss")
+	}
+}


### PR DESCRIPTION
## Summary

PR1 of the [multi-agent system design](dev-docs/multi-agent-system-design.md) release slicing: the pure `internal/agentprofile` package. **Nothing is wired yet — zero impact on existing behavior.**

- **Profile / CapabilitySpec / Source** — the single capability-definition schema shared by conversation mode (persistent sessions) and delegation mode (ephemeral `sub_agent` runs). Carries `read_only` / `disallowed_tools` / `lean_context` for zero-migration compatibility with the existing `.md` agent format (`internal/tools/agents.go`)
- **.md + YAML frontmatter** parse/serialize — body = system prompt, filename slug = profile ID, `model: inherit` → empty
- **Store** — read-through (rescan per read; no cache, no watcher, no reload API), three sources with **project > user > builtin** precedence; project-level files are stripped of the platform slice (delegation-only); CRUD with slug validation, 10k prompt cap, and delete protection for channel-bound profiles
- **Router** — the documented decision table: @-mention > channel binding > default fallback; multiple bindings without @ → nil (drop)
- **Built-in profiles** — explore/general/code-review personas copied verbatim from `internal/tools/agent_presets.go`; PR3 will delete the old copies and route `subagent_type` through this Store

## Design deviations flagged for review

1. `CapabilitySpec` gains `ReadOnly` / `DisallowedTools` / `LeanContext` — not in the design doc's struct sketch, but required to parse the existing `.md` format without migration (the doc's "zero-migration" claim depends on them)
2. `Router.Route` takes `agentprofile.RouteInput` instead of `channel.InboundEvent` — avoids an `agentprofile ↔ channel` import cycle in PR2

## Test plan

- 30+ unit tests: validation, parse roundtrip, precedence, read-through semantics (direct .md edit visible next read), CRUD rules, project platform-slice stripping, full router decision table
- `go vet` + `go test ./internal/agentprofile/...` + `go build ./...` all green

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
