### PR TITLE
fix(tui): send bare model id on the wire after /model switch

### DIFF
--- a/cmd/octo/ensure_sender_test.go
+++ b/cmd/octo/ensure_sender_test.go
@@ -54,7 +54,7 @@ func TestEnsureSender_ConfigLoadFailure(t *testing.T) {
 		stderr:       io.Discard,
 	}
 
-	if err := cfg.ensureSender("kimi-for-coding", senderTuning{}); err == nil {
+	if _, err := cfg.ensureSender("kimi-for-coding", senderTuning{}); err == nil {
 		t.Fatal("expected error when config.Load() fails, got nil")
 	}
 	if cfg.providerName != "openai" {
@@ -93,8 +93,12 @@ func TestEnsureSender_RebuildsOnProviderChange(t *testing.T) {
 		stderr:       io.Discard,
 	}
 
-	if err := cfg.ensureSender("kimi-for-coding", senderTuning{}); err != nil {
+	entry, err := cfg.ensureSender("kimi-for-coding", senderTuning{})
+	if err != nil {
 		t.Fatalf("ensureSender: %v", err)
+	}
+	if entry.Model != "kimi-for-coding" {
+		t.Errorf("resolved entry.Model = %q, want kimi-for-coding", entry.Model)
 	}
 	if cfg.providerName != "anthropic" {
 		t.Errorf("providerName = %q, want anthropic", cfg.providerName)
@@ -132,7 +136,7 @@ func TestEnsureSender_NoRebuildWhenUnchanged(t *testing.T) {
 		stderr:       io.Discard,
 	}
 
-	if err := cfg.ensureSender("gpt-4o-mini", senderTuning{}); err != nil {
+	if _, err := cfg.ensureSender("gpt-4o-mini", senderTuning{}); err != nil {
 		t.Fatalf("ensureSender: %v", err)
 	}
 	// Sender must be the same stub — no rebuild happened.
@@ -163,7 +167,7 @@ func TestEnsureSender_RebuildsOnBaseURLChange(t *testing.T) {
 		stderr:       io.Discard,
 	}
 
-	if err := cfg.ensureSender("kimi-for-coding", senderTuning{}); err != nil {
+	if _, err := cfg.ensureSender("kimi-for-coding", senderTuning{}); err != nil {
 		t.Fatalf("ensureSender: %v", err)
 	}
 	if cfg.configEntry.BaseURL != "https://api.moonshot.cn/anthropic" {
@@ -200,7 +204,7 @@ func TestEnsureSender_ErrorLeavesConfigUnchanged(t *testing.T) {
 		stderr:       io.Discard,
 	}
 
-	if err := cfg.ensureSender("kimi-for-coding", senderTuning{}); err == nil {
+	if _, err := cfg.ensureSender("kimi-for-coding", senderTuning{}); err == nil {
 		t.Fatal("expected error for missing anthropic API key, got nil")
 	}
 	if cfg.providerName != "openai" {
@@ -211,6 +215,44 @@ func TestEnsureSender_ErrorLeavesConfigUnchanged(t *testing.T) {
 	}
 	if cfg.a.GetSender() != stub {
 		t.Error("sender should be unchanged after failed rebuild")
+	}
+}
+
+// TestEnsureSender_CompositeIDReturnsBareModel pins the fix for the TUI
+// /model 401: the picker's accept path hands ensureSender a composite id
+// "<endpoint>::<model>", and the returned entry must carry the BARE model id
+// — the only form providers accept on the wire. Sending the composite id
+// verbatim made upstreams reject the request (HTTP 401 "model id does not
+// exist, recognized as Kimi::K3").
+func TestEnsureSender_CompositeIDReturnsBareModel(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+
+	writeTestConfig(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "deepseek", BaseURL: "https://api.deepseek.com", Models: []config.EndpointModel{{Model: "deepseek-v4-flash"}}},
+		},
+		Default: "ep-a::gpt-4o",
+	})
+
+	stub := &stubSender{reply: "ok"}
+	a := agent.New(stub, "gpt-4o")
+	cfg := &replConfig{
+		a:            a,
+		providerName: "openai",
+		configEntry:  config.ModelEntry{Model: "gpt-4o", Provider: "openai"},
+		stderr:       io.Discard,
+	}
+
+	entry, err := cfg.ensureSender("ep-b::deepseek-v4-flash", senderTuning{})
+	if err != nil {
+		t.Fatalf("ensureSender: %v", err)
+	}
+	if entry.Model != "deepseek-v4-flash" {
+		t.Errorf("resolved entry.Model = %q, want bare model deepseek-v4-flash", entry.Model)
+	}
+	if strings.Contains(entry.Model, "::") {
+		t.Errorf("resolved entry.Model %q must never contain the composite separator", entry.Model)
 	}
 }
 
@@ -240,7 +282,7 @@ func TestEnsureSender_UnconfiguredModel(t *testing.T) {
 		stderr:       io.Discard,
 	}
 
-	if err := cfg.ensureSender("deepseek-v4-pro", senderTuning{}); err == nil {
+	if _, err := cfg.ensureSender("deepseek-v4-pro", senderTuning{}); err == nil {
 		t.Fatal("expected error for unconfigured model, got nil")
 	} else if !strings.Contains(err.Error(), "gpt-4o") || !strings.Contains(err.Error(), "deepseek-v4-flash") {
 		t.Errorf("error should list available models, got: %v", err)

--- a/cmd/octo/model_picker_test.go
+++ b/cmd/octo/model_picker_test.go
@@ -161,10 +161,12 @@ func TestDispatchModel_PickerKeyEsc(t *testing.T) {
 }
 
 // TestDispatchModel_PickerKeyEnter verifies Enter switches to the highlighted
-// (endpoint, model) and clears the picker. The accept path now produces a
+// (endpoint, model) and clears the picker. The accept path produces a
 // composite id "<endpoint>::<model>" so the receiver resolves the right
-// endpoint's connection params (PR4b). Two models share a provider + base URL
-// so ensureSender returns early (no live rebuild needed).
+// endpoint's connection params (PR4b), but a.Model must end up as the BARE
+// model id — the composite id is endpoint addressing and providers 401 on it
+// on the wire. Two models share a provider + base URL so ensureSender returns
+// early (no live rebuild needed).
 func TestDispatchModel_PickerKeyEnter(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
 	writeModelsConfig(t, config.Config{
@@ -184,10 +186,8 @@ func TestDispatchModel_PickerKeyEnter(t *testing.T) {
 	if m.modelPicker != nil {
 		t.Error("picker should be cleared after Enter")
 	}
-	// m.a.Model is now the composite id; EntryByModel resolves it back to the
-	// same model id, so we assert the suffix rather than the bare name.
-	if !strings.HasSuffix(m.a.Model, "::deepseek-v4-pro") {
-		t.Errorf("active model = %q, want suffix ::deepseek-v4-pro", m.a.Model)
+	if m.a.Model != "deepseek-v4-pro" {
+		t.Errorf("active model = %q, want bare model deepseek-v4-pro", m.a.Model)
 	}
 }
 
@@ -281,16 +281,15 @@ func TestModelPicker_TwoLevelEndpointSwitch(t *testing.T) {
 			m.modelPicker.endpoints[m.modelPicker.epIdx].items[0].name)
 	}
 
-	// Enter on deepseek-v4-flash dispatches the composite id. The endpoint id
-	// is whatever the seed assigned (PR5: tests seed Endpoints directly, so
-	// the id is "ep-b" rather than the legacy-<host>-<n> form Load synthesises
-	// from old models: blocks).
+	// Enter on deepseek-v4-flash dispatches the composite id internally, but
+	// a.Model must land as the bare model id — the composite form is endpoint
+	// addressing and providers reject it on the wire (HTTP 401).
 	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.modelPicker != nil {
 		t.Fatal("picker should be cleared after Enter")
 	}
-	if !strings.HasSuffix(m.a.Model, "::deepseek-v4-flash") {
-		t.Errorf("active model = %q, want suffix ::deepseek-v4-flash", m.a.Model)
+	if m.a.Model != "deepseek-v4-flash" {
+		t.Errorf("active model = %q, want bare model deepseek-v4-flash", m.a.Model)
 	}
 }
 

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -99,10 +99,15 @@ type replConfig struct {
 // cfg.providerName / cfg.configEntry are updated to match the new sender. On
 // error (missing key for the target provider, unknown model) cfg is left
 // unchanged.
-func (cfg *replConfig) ensureSender(targetModel string, tuning senderTuning) error {
+//
+// Returns the resolved config entry. targetModel may be a composite id
+// "<endpoint>::<model>" (the picker's accept form); the returned entry's
+// Model is always the bare model id — the only form providers accept on the
+// wire — so callers must take a.Model from it rather than from targetModel.
+func (cfg *replConfig) ensureSender(targetModel string, tuning senderTuning) (config.ModelEntry, error) {
 	models, err := config.Load()
 	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
+		return config.ModelEntry{}, fmt.Errorf("loading config: %w", err)
 	}
 	// Reject models not present in the config — resolveProviderModel would
 	// silently fall back to the current provider (matching on flagProvider),
@@ -119,23 +124,23 @@ func (cfg *replConfig) ensureSender(targetModel string, tuning senderTuning) err
 			}
 		}
 		sort.Strings(available)
-		return fmt.Errorf("model %q is not configured (available: %s)", targetModel, strings.Join(available, ", "))
+		return config.ModelEntry{}, fmt.Errorf("model %q is not configured (available: %s)", targetModel, strings.Join(available, ", "))
 	}
 	provName, _, entry, ok := resolveProviderModel(cfg.providerName, targetModel, models)
 	if !ok {
-		return fmt.Errorf("cannot resolve provider for model %q", targetModel)
+		return config.ModelEntry{}, fmt.Errorf("cannot resolve provider for model %q", targetModel)
 	}
 	if provName == cfg.providerName && entry.BaseURL == cfg.configEntry.BaseURL {
-		return nil // no rebuild needed
+		return entry, nil // no rebuild needed
 	}
 	newSender, err := buildSender(provName, entry, cfg.stderr, tuning)
 	if err != nil {
-		return err
+		return config.ModelEntry{}, err
 	}
 	cfg.a.SetSender(newSender)
 	cfg.providerName = provName
 	cfg.configEntry = entry
-	return nil
+	return entry, nil
 }
 
 // mcpBootstrap carries the inputs runTUI needs to connect MCP servers from a

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1212,15 +1212,22 @@ func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
 	}
 
 	tuning := senderTuning{showReasoning: m.cfg.showReasoning}
-	if err := m.cfg.ensureSender(name, tuning); err != nil {
+	entry, err := m.cfg.ensureSender(name, tuning)
+	if err != nil {
 		m.println(errorStyle.Render(fmt.Sprintf("error switching model: %v", err)))
 		return m, nil
 	}
-	m.a.Model = name
-	m.cfg.modelName = name
+	// The wire model is the bare model id from the resolved entry. name may
+	// be a composite "<endpoint>::<model>" reference (the picker's accept
+	// form) — that is endpoint addressing, not a model id providers accept;
+	// sending it verbatim makes upstreams 401 (e.g. "model id does not
+	// exist, recognized as Kimi::K3"). Mirrors the server/IM switch paths,
+	// which also set Agent.Model from the resolved entry.
+	m.a.Model = entry.Model
+	m.cfg.modelName = entry.Model
 	// Tool surface may differ per model (e.g. vision vs non-vision).
 	if m.cfg.tools != nil {
-		m.cfg.tools = tools.DefaultToolsFor(name)
+		m.cfg.tools = tools.DefaultToolsFor(entry.Model)
 	}
 
 	if setDefault {


### PR DESCRIPTION
## Problem

After switching models in the TUI (`/model`, picker or explicit composite id), every turn fails with:

```
error: agent: loop[0]: anthropic: HTTP 401 (authentication_error): Your model id does not exist, recognized as other:Kimi::K3. Please set model id as `k3`.
```

## Root cause

The two-level model picker's accept path (PR4b) hands `dispatchModel` a **composite id** `<endpoint>::<model>` — endpoint addressing used to resolve connection params. `dispatchModel` then assigned that composite id verbatim to `a.Model` (`tuirepl_view.go`), and the agent sends `a.Model` as the request's `model` field (`internal/agent/agent.go`). Providers rightly reject `Kimi::K3` as a model id.

The server (`sess.Agent.Model = entry.Model`) and IM (`sess.Agent.Model = res.Model`) switch paths already set the agent's model from the **resolved entry's bare model id** — only the TUI path leaked the composite id onto the wire.

## Fix

- `replConfig.ensureSender` now returns the resolved `config.ModelEntry` (it already resolves it internally).
- `dispatchModel` takes the wire model (`a.Model`), the status-bar name, and the tool surface from `entry.Model` — always the bare model id.
- The `--default` path is untouched: `setModelAsDefault` still receives the composite id and persists it as the `Default` binding in `~/.octo/config.yml` (covered by `TestDispatchModel_DefaultFlag`).

## Tests

- New `TestEnsureSender_CompositeIDReturnsBareModel` pins that a composite-id switch resolves to the bare model id.
- `TestDispatchModel_PickerKeyEnter` / `TestModelPicker_TwoLevelEndpointSwitch` now assert `a.Model` is the bare model after picker accept (they previously pinned the buggy composite-id behaviour).
- `go test -race ./...` green.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
