### PR TITLE
feat(channel): route IM events to agent profiles via namespaced session keys (PR2)

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -33,6 +33,10 @@ type Session struct {
 	System    string    `json:"system,omitempty"`
 	Title     string    `json:"title,omitempty"`
 	Source    string    `json:"source,omitempty"` // how the session was created: "" (manual) | "cron" | "channel" | "setup"
+	// AgentID is the ID of the agent profile (agentprofile.Profile) that owns
+	// this session. Empty means the default agent — also the value for every
+	// session predating multi-agent, so legacy files need no migration.
+	AgentID string `json:"agent_id,omitempty"`
 	// ModelConfig is the model string of the config entry this session is bound
 	// to. Empty means "the default entry at turn time" — also the value for
 	// every session predating per-session model binding. (Sessions written
@@ -394,6 +398,7 @@ func BranchFrom(s *Session, count int) *Session {
 	branch.WorkingDir = s.WorkingDir
 	branch.PermissionMode = s.PermissionMode
 	branch.ModelConfig = s.ModelConfig
+	branch.AgentID = s.AgentID
 	branch.BranchedFrom = s.ID
 	if count > 0 {
 		branch.Messages = make([]Message, count)
@@ -405,6 +410,16 @@ func BranchFrom(s *Session, count int) *Session {
 // TurnCount returns the number of complete user+assistant turn pairs.
 func (s *Session) TurnCount() int {
 	return len(s.Messages) / 2
+}
+
+// EffectiveAgentID returns the owning agent profile's ID: "default" for the
+// default agent and for every session predating the AgentID field (kept as a
+// literal here so the agent package stays free of an agentprofile import).
+func (s *Session) EffectiveAgentID() string {
+	if s.AgentID == "" {
+		return "default"
+	}
+	return s.AgentID
 }
 
 // UsedTools reports whether any assistant message in the session emitted
@@ -507,6 +522,7 @@ type sessionRecord struct {
 	Title             string    `json:"title,omitempty"`
 	Source            string    `json:"source,omitempty"`
 	ModelConfig       string    `json:"model_config,omitempty"`
+	AgentID           string    `json:"agent_id,omitempty"`
 	WorkingDir        string    `json:"working_dir,omitempty"`
 	PermissionMode    string    `json:"permission_mode,omitempty"`
 	BoundEntry        string    `json:"bound_entry,omitempty"`
@@ -532,7 +548,7 @@ func (s *Session) metaRecord() sessionRecord {
 		goal = &g
 	}
 	s.mu.Unlock()
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, AgentID: s.AgentID, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
 }
 
 // MarkHookStarted records that SessionStart has fired for this session, so a
@@ -1156,6 +1172,7 @@ func LoadSession(id string) (*Session, error) {
 			s.Title = rec.Title // a compacted file carries the title in its meta header
 			s.Source = rec.Source
 			s.ModelConfig = rec.ModelConfig
+			s.AgentID = rec.AgentID
 			s.WorkingDir = rec.WorkingDir
 			s.PermissionMode = rec.PermissionMode
 			s.LastContextTokens = rec.LastContextTokens // a rewritten file carries it in its meta header

--- a/internal/agentprofile/profile.go
+++ b/internal/agentprofile/profile.go
@@ -112,6 +112,11 @@ func DefaultProfile() *Profile {
 // idRule is the profile ID shape: a lowercase slug usable as a file name.
 var idRule = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,31}$`)
 
+// IsValidID reports whether id is a well-formed profile ID slug. Exported for
+// the channel manager, which must distinguish a real "<agentID>#" key prefix
+// from a chat ID that merely contains '#'.
+func IsValidID(id string) bool { return idRule.MatchString(id) }
+
 // aliasRule is the mention alias shape: @ plus the same charset the router's
 // mention extractor recognizes, so a validated alias can always match.
 var aliasRule = regexp.MustCompile(`^@[A-Za-z0-9][A-Za-z0-9_-]*$`)

--- a/internal/agentprofile/profile.go
+++ b/internal/agentprofile/profile.go
@@ -88,8 +88,10 @@ type Profile struct {
 
 	Source Source
 
-	// Timestamps are best-effort: both track the file's mtime (there is no
-	// separate creation record), so CreatedAt advances on every rewrite.
+	// Timestamps track the profile file's mtime (there is no separate creation
+	// record on most filesystems): CreatedAt advances on every rewrite, so it
+	// is best-effort "last modified" rather than a true birth time. Empty for
+	// profiles predating this field.
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -119,6 +121,8 @@ func IsValidID(id string) bool { return idRule.MatchString(id) }
 
 // aliasRule is the mention alias shape: @ plus the same charset the router's
 // mention extractor recognizes, so a validated alias can always match.
+// Sync with agentprofile/router.go's mentionRule (@[A-Za-z0-9][A-Za-z0-9_-]*) if
+// either changes.
 var aliasRule = regexp.MustCompile(`^@[A-Za-z0-9][A-Za-z0-9_-]*$`)
 
 // Validate checks the fields every write path (REST API, meta-skill, Store)

--- a/internal/agentprofile/router.go
+++ b/internal/agentprofile/router.go
@@ -9,8 +9,11 @@ import "regexp"
 type RouteInput struct {
 	Platform string
 	ChatID   string
-	UserID   string
-	Text     string
+	// UserID is reserved for PR3+ (per-user session scoping under a shared
+	// group chat). It is currently unused but kept so the router signature is
+	// stable once binding modes like BindByChatUser need it.
+	UserID string
+	Text   string
 }
 
 // Router maps an inbound event to the profile that should handle it. It is a

--- a/internal/agentprofile/store.go
+++ b/internal/agentprofile/store.go
@@ -52,6 +52,14 @@ func (s *Store) load() map[string]*Profile {
 // enforced on writes instead. The reserved "default" ID is skipped so a
 // stray default.md can never shadow the code-defined default agent.
 func (s *Store) scanDir(dir string, src Source, dst map[string]*Profile) {
+	s.scanDirFiltered(dir, src, dst, nil)
+}
+
+// scanDirFiltered is scanDir with an optional ID filter (nil = accept all).
+// The IM-routing path passes IsValidID so a non-slug filename can never
+// become a routable profile; the delegation path passes nil to keep loading
+// legacy .md files written before the slug rule existed.
+func (s *Store) scanDirFiltered(dir string, src Source, dst map[string]*Profile, accept func(string) bool) {
 	if dir == "" {
 		return
 	}
@@ -65,6 +73,9 @@ func (s *Store) scanDir(dir string, src Source, dst map[string]*Profile) {
 		}
 		id := strings.TrimSuffix(e.Name(), ".md")
 		if id == "" || id == DefaultID {
+			continue
+		}
+		if accept != nil && !accept(id) {
 			continue
 		}
 		p, err := parseFile(filepath.Join(dir, e.Name()))
@@ -223,9 +234,15 @@ func (s *Store) writeFile(path string, p *Profile) error {
 // (ByChannel/ByMention) build on this — not on the merged map — so a
 // project-level file shadowing a user profile's ID (delegation override)
 // can never silence that profile's conversation-mode routing.
+//
+// IM routing only honors slug-shaped profile IDs (the same rule enforced on
+// writes): a hand-placed `a#b.md` would otherwise produce an ID whose '#'
+// defeats the session-key namespace splitter, so the router would misroute
+// messages to it. Delegation-mode lookups (sub_agent) keep the legacy lenient
+// loader via scanDir, which still accepts any basename.
 func (s *Store) userProfiles() map[string]*Profile {
 	m := make(map[string]*Profile)
-	s.scanDir(s.userDir, SourceUser, m)
+	s.scanDirFiltered(s.userDir, SourceUser, m, IsValidID)
 	return m
 }
 

--- a/internal/agentprofile/store_test.go
+++ b/internal/agentprofile/store_test.go
@@ -82,18 +82,50 @@ func TestStoreSkipsBrokenFilesAndReservedID(t *testing.T) {
 	}
 }
 
-// The pre-existing agent loader accepts any .md basename as an ID; the Store
-// must too (zero-migration), even names that fail the write-side slug rule.
-func TestStoreAcceptsNonSlugFilenames(t *testing.T) {
+// Delegation lookups (sub_agent) and the profile API keep the zero-migration
+// lenient loader: any .md basename is a valid profile ID on the read path,
+// even names that fail the write-side slug rule. The write path still
+// enforces slug via validateForWrite.
+func TestStore_DelegationAcceptsNonSlugFilenames(t *testing.T) {
 	s, userDir, _ := newTestStore(t)
 	writeMD(t, userDir, "Code_Review.md", "---\ndescription: legacy\n---\nbody\n")
 
 	p, ok := s.Get("Code_Review")
 	if !ok || p.Description != "legacy" {
-		t.Fatalf("non-slug legacy file not readable: %v, %v", p, ok)
+		t.Fatalf("non-slug legacy file not readable via delegation: %v, %v", p, ok)
 	}
 	if got := s.List(); len(got) != 1 || got[0].ID != "Code_Review" {
 		t.Fatalf("List() = %+v", got)
+	}
+}
+
+// IM routing only honors slug-shaped profile IDs: a hand-placed `a#b.md`
+// must never become a routable profile (its '#' would defeat the
+// session-key namespace splitter). userProfiles() — the ByChannel/ByMention
+// source — skips non-slug files, even though Get() (delegation) still reads
+// them.
+func TestStore_UserProfilesSkipsNonSlug(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a#b.md"), []byte("---\ndescription: d\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "valid.md"), []byte("---\ndescription: d\n---\nbody\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := New(dir, nil)
+	// userProfiles() (IM-routing source) skips non-slug files.
+	if p := s.ByChannel("weixin", "g1"); len(p) > 0 {
+		t.Fatalf("non-slug profile is routable via IM: %+v", p)
+	}
+	if p, ok := s.ByMention("@anything"); ok {
+		t.Fatalf("non-slug profile is @-routable: %+v", p)
+	}
+	// But Get()/List() (delegation + API) still see it.
+	if _, ok := s.Get("a#b"); !ok {
+		t.Fatal("non-slug profile not visible to delegation Get")
+	}
+	if _, ok := s.Get("valid"); !ok {
+		t.Fatal("slug profile not found")
 	}
 }
 

--- a/internal/channel/agent_namespace_test.go
+++ b/internal/channel/agent_namespace_test.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -67,13 +68,14 @@ func TestManager_AgentNamespacesIsolateSessions(t *testing.T) {
 	if def.Store.ID == exp.Store.ID {
 		t.Fatal("sessions of different agents must not share a store file")
 	}
-	// The expert store carries agent_id; the default store keeps it empty
-	// (legacy shape).
+	// The expert store carries agent_id; the default store is stamped
+	// "default" (new sessions) or empty (restored legacy files) — both
+	// EffectiveAgentID "default".
 	if exp.Store.EffectiveAgentID() != "code-review" {
 		t.Fatalf("expert store agent_id = %q", exp.Store.AgentID)
 	}
-	if def.Store.AgentID != "" && def.Store.AgentID != "default" {
-		t.Fatalf("default store agent_id = %q", def.Store.AgentID)
+	if def := def.Store.EffectiveAgentID(); def != "default" {
+		t.Fatalf("default store effective agent = %q, want default", def)
 	}
 	// Re-resolving either agent returns its own session.
 	if got := m.GetSession(ev, "code-review"); got != exp {
@@ -152,8 +154,10 @@ func TestManager_LegacyStoreRestoresUnderDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 	legacyStoreID := sess.Store.ID
-	if sess.Store.AgentID != "" && sess.Store.AgentID != "default" {
-		t.Fatalf("legacy-shaped store agent_id = %q", sess.Store.AgentID)
+	// Newly-created default-agent session is stamped "default"; a restored
+	// legacy file has agent_id empty — both are "default"EffectiveAgentID.
+	if sess.Store.EffectiveAgentID() != "default" {
+		t.Fatalf("new default session effective agent = %q", sess.Store.EffectiveAgentID())
 	}
 
 	m2 := testManager()
@@ -166,5 +170,79 @@ func TestManager_LegacyStoreRestoresUnderDefault(t *testing.T) {
 	}
 	if restored.Store.EffectiveAgentID() != "default" {
 		t.Fatalf("legacy store effective agent = %q", restored.Store.EffectiveAgentID())
+	}
+}
+
+// /bind recovery after the owning profile was deleted must keep the session
+// in the routed agent's key namespace (AgentID == agentID) — never silently
+// drift to "default" — even though the profile lookup now falls back to the
+// default profile for shaping the agent.
+func TestManager_BindRecoversDeletedProfileInAgentNamespace(t *testing.T) {
+	tempHome(t)
+	m := testManager()
+	evExpert := InboundEvent{Platform: "feishu", ChatID: "cX", UserID: "uX"}
+
+	// Create an expert-agent session, persist it, then "delete" the profile
+	// (simulate by dropping all profile definitions — the Store is
+	// read-through, so Get on the ID now misses).
+	sess := m.GetOrCreateSession(evExpert, expertProfile("expert-1"))
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	storeID := sess.Store.ID
+
+	// A chat /binds to that session. The profile is gone, so resolveProfile
+	// falls back to the default profile — but the session's AgentID and key
+	// must stay in the expert-1 namespace.
+	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
+	if reply := m.cmdBind(evB, []string{storeID}, "expert-1"); !strings.Contains(strings.ToLower(reply), "bound") {
+		t.Fatalf("bind of deleted-profile session = %q, want success", reply)
+	}
+	got := m.GetSession(evB, "expert-1")
+	if got == nil {
+		t.Fatal("bound session is not in the expert-1 namespace")
+	}
+	if got.AgentID != "expert-1" {
+		t.Fatalf("recovered session AgentID = %q, want expert-1", got.AgentID)
+	}
+	if got.Store.ID != storeID {
+		t.Fatalf("recovered store ID = %q, want %q", got.Store.ID, storeID)
+	}
+}
+
+// /list indices must match the indices /bind resolves against — both built
+// from the same "all sessions → filter by owner → cap 20" pipeline. Before
+// the fix, /list capped at 20 before filtering, so a session filtered out
+// of the top-20 by owner would still claim an index that /bind could not
+// resolve.
+func TestManager_ListAndBindIndicesMatch(t *testing.T) {
+	tempHome(t)
+	m := testManager()
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	// Create 25 default-agent sessions so the global top-20 excludes some of
+	// them; then create an expert session that /list must show at index 1.
+	for i := 0; i < 25; i++ {
+		s := m.GetOrCreateSession(InboundEvent{Platform: "feishu", ChatID: fmt.Sprintf("cX%d", i), UserID: "uX"}, nil)
+		if err := s.Persist(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	expert := m.GetOrCreateSession(ev, expertProfile("code-review"))
+	if err := expert.Persist(); err != nil {
+		t.Fatal(err)
+	}
+
+	listReply := m.cmdList("code-review")
+	if !strings.Contains(listReply, "1. ") {
+		t.Fatalf("expert /list = %q, want index 1", listReply)
+	}
+	// /bind 1 from a fresh chat should resolve to the expert session.
+	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
+	if reply := m.cmdBind(evB, []string{"1"}, "code-review"); !strings.Contains(strings.ToLower(reply), "bound") {
+		t.Fatalf("/bind 1 under code-review = %q, want success", reply)
+	}
+	if got := m.GetSession(evB, "code-review"); got == nil || got.Store.ID != expert.Store.ID {
+		t.Fatalf("/bind 1 resolved to wrong session: %+v", got)
 	}
 }

--- a/internal/channel/agent_namespace_test.go
+++ b/internal/channel/agent_namespace_test.go
@@ -1,0 +1,170 @@
+package channel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
+)
+
+// The multi-agent session-key contract (dev-docs/multi-agent-system-design.md
+// §3): the default agent keeps byte-identical legacy keys and store IDs —
+// zero migration — while expert agents derive isolation from the
+// "<agentID>#" prefix.
+
+func expertProfile(id string) *agentprofile.Profile {
+	return &agentprofile.Profile{ID: id, Description: "test expert"}
+}
+
+func TestSessionKeyFor_AgentNamespace(t *testing.T) {
+	ev := InboundEvent{Platform: "weixin", ChatID: "c1", UserID: "u1"}
+	legacy := SessionKey("weixin:c1:u1")
+
+	if got := sessionKeyFor(BindByChatUser, ev, ""); got != legacy {
+		t.Errorf("empty agentID = %q, want legacy %q", got, legacy)
+	}
+	if got := sessionKeyFor(BindByChatUser, ev, "default"); got != legacy {
+		t.Errorf("default agentID = %q, want legacy %q", got, legacy)
+	}
+	if got := sessionKeyFor(BindByChatUser, ev, "code-review"); got != "code-review#weixin:c1:u1" {
+		t.Errorf("expert key = %q", got)
+	}
+}
+
+func TestSessionStoreID_AgentNamespace(t *testing.T) {
+	ev := InboundEvent{Platform: "weixin", ChatID: "c1", UserID: "u1"}
+	legacyKey := sessionKeyFor(BindByChatUser, ev, "")
+	expertKey := sessionKeyFor(BindByChatUser, ev, "code-review")
+
+	if legacyKey != SessionKey("weixin:c1:u1") {
+		t.Fatalf("legacy key changed shape: %q", legacyKey)
+	}
+	if sessionStoreID(expertKey) == sessionStoreID(legacyKey) {
+		t.Error("expert and default agents must not share a store file")
+	}
+	// The default agent's store ID is byte-identical to the pre-multi-agent
+	// derivation: the key is the same string, hashed the same way.
+	if !strings.HasPrefix(sessionStoreID(legacyKey), "im-weixin-c1-u1-") {
+		t.Errorf("legacy store ID shape changed: %q", sessionStoreID(legacyKey))
+	}
+}
+
+func TestManager_AgentNamespacesIsolateSessions(t *testing.T) {
+	tempHome(t)
+	m := testManager()
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	def := m.GetOrCreateSession(ev, nil)
+	exp := m.GetOrCreateSession(ev, expertProfile("code-review"))
+
+	if def == exp {
+		t.Fatal("same chat under two agents must yield two sessions")
+	}
+	if def.AgentID != "default" || exp.AgentID != "code-review" {
+		t.Fatalf("AgentID stamps = %q / %q", def.AgentID, exp.AgentID)
+	}
+	if def.Store.ID == exp.Store.ID {
+		t.Fatal("sessions of different agents must not share a store file")
+	}
+	// The expert store carries agent_id; the default store keeps it empty
+	// (legacy shape).
+	if exp.Store.EffectiveAgentID() != "code-review" {
+		t.Fatalf("expert store agent_id = %q", exp.Store.AgentID)
+	}
+	if def.Store.AgentID != "" && def.Store.AgentID != "default" {
+		t.Fatalf("default store agent_id = %q", def.Store.AgentID)
+	}
+	// Re-resolving either agent returns its own session.
+	if got := m.GetSession(ev, "code-review"); got != exp {
+		t.Fatal("GetSession with expert ID returned wrong session")
+	}
+	if got := m.GetSession(ev, ""); got != def {
+		t.Fatal("GetSession with default ID returned wrong session")
+	}
+}
+
+func TestManager_CrossAgentBindRejected(t *testing.T) {
+	tempHome(t)
+	m := testManager()
+
+	// An expert-agent session exists on disk.
+	exp := m.GetOrCreateSession(InboundEvent{Platform: "feishu", ChatID: "cX", UserID: "uX"}, expertProfile("code-review"))
+	if err := exp.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	// A default-agent session exists too.
+	def := m.GetOrCreateSession(InboundEvent{Platform: "feishu", ChatID: "cY", UserID: "uY"}, nil)
+	if err := def.Persist(); err != nil {
+		t.Fatal(err)
+	}
+
+	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
+
+	// /list under default sees only default-owned sessions.
+	if got := m.cmdList(""); !strings.Contains(got, def.Store.ShortID()) || strings.Contains(got, exp.Store.ShortID()) {
+		t.Fatalf("default /list leaked expert session: %q", got)
+	}
+	// /list under the expert sees only its own.
+	if got := m.cmdList("code-review"); !strings.Contains(got, exp.Store.ShortID()) || strings.Contains(got, def.Store.ShortID()) {
+		t.Fatalf("expert /list leaked default session: %q", got)
+	}
+	// Binding the expert's session from a default-routed chat is rejected.
+	if reply := m.cmdBind(evB, []string{exp.Store.ID}, ""); !strings.Contains(reply, "No session matches") {
+		t.Fatalf("cross-agent bind = %q, want rejection", reply)
+	}
+	// Same-agent bind works.
+	if reply := m.cmdBind(evB, []string{def.Store.ID}, ""); !strings.Contains(strings.ToLower(reply), "bound") {
+		t.Fatalf("same-agent bind = %q, want success", reply)
+	}
+}
+
+func TestSplitSessionKey_AgentPrefix(t *testing.T) {
+	cases := []struct {
+		key                  SessionKey
+		platform, chat, user string
+	}{
+		{"weixin:c1:u1", "weixin", "c1", "u1"},
+		{"code-review#weixin:c1:u1", "weixin", "c1", "u1"},
+		// A chat ID containing '#' is NOT mistaken for an agent prefix: the
+		// segment before '#' is not a valid profile ID.
+		{"feishu:oc_4a/b#c:ou_x", "feishu", "oc_4a/b#c", "ou_x"},
+		{"feishu:c1", "feishu", "c1", ""},
+	}
+	for _, tt := range cases {
+		p, c, u := splitSessionKey(tt.key)
+		if p != tt.platform || c != tt.chat || u != tt.user {
+			t.Errorf("splitSessionKey(%q) = %q,%q,%q want %q,%q,%q", tt.key, p, c, u, tt.platform, tt.chat, tt.user)
+		}
+	}
+}
+
+// A restored legacy store (no agent_id) keeps working under the default
+// agent: byte-identical key, byte-identical store ID, effective default.
+func TestManager_LegacyStoreRestoresUnderDefault(t *testing.T) {
+	tempHome(t)
+	m := testManager()
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	sess := m.GetOrCreateSession(ev, nil)
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "legacy"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	legacyStoreID := sess.Store.ID
+	if sess.Store.AgentID != "" && sess.Store.AgentID != "default" {
+		t.Fatalf("legacy-shaped store agent_id = %q", sess.Store.AgentID)
+	}
+
+	m2 := testManager()
+	restored := m2.GetOrCreateSession(ev, nil)
+	if restored.Store.ID != legacyStoreID {
+		t.Fatalf("default agent store ID changed: %q → %q", legacyStoreID, restored.Store.ID)
+	}
+	if got := len(restored.Agent.History.Snapshot()); got != 1 {
+		t.Fatalf("restored history = %d messages, want 1", got)
+	}
+	if restored.Store.EffectiveAgentID() != "default" {
+		t.Fatalf("legacy store effective agent = %q", restored.Store.EffectiveAgentID())
+	}
+}

--- a/internal/channel/goal_test.go
+++ b/internal/channel/goal_test.go
@@ -14,12 +14,12 @@ func TestCmdGoal_AppliesSharedGrammarOnStore(t *testing.T) {
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 
 	// No session yet.
-	if r := mgr.cmdGoal(ev, "anything"); !strings.Contains(r, "No active session") {
+	if r := mgr.cmdGoal(ev, "anything", ""); !strings.Contains(r, "No active session") {
 		t.Errorf("no-session reply = %q", r)
 	}
 
-	sess := mgr.GetOrCreateSession(ev)
-	if r := mgr.cmdGoal(ev, "ship the release"); !strings.Contains(r, "Goal set") {
+	sess := mgr.GetOrCreateSession(ev, nil)
+	if r := mgr.cmdGoal(ev, "ship the release", ""); !strings.Contains(r, "Goal set") {
 		t.Errorf("create reply = %q", r)
 	}
 
@@ -41,13 +41,13 @@ func TestCmdGoal_AppliesSharedGrammarOnStore(t *testing.T) {
 		t.Errorf("goal must persist to disk: %+v", rg)
 	}
 
-	if r := mgr.cmdGoal(ev, "pause"); !strings.Contains(r, "paused") {
+	if r := mgr.cmdGoal(ev, "pause", ""); !strings.Contains(r, "paused") {
 		t.Errorf("pause reply = %q", r)
 	}
 
 	// A tombstoned store (concurrent /unbind) degrades gracefully.
 	_ = sess.deleteStore()
-	if r := mgr.cmdGoal(ev, ""); !strings.Contains(r, "unavailable") {
+	if r := mgr.cmdGoal(ev, "", ""); !strings.Contains(r, "unavailable") {
 		t.Errorf("tombstoned-store reply = %q", r)
 	}
 }
@@ -64,9 +64,9 @@ func TestCmdGoal_RespectsGoalsEnabledGate(t *testing.T) {
 
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 	mgr.SetGoalsEnabled(false)
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 
-	if r := mgr.cmdGoal(ev, "ship the release"); !strings.Contains(r, "disabled") {
+	if r := mgr.cmdGoal(ev, "ship the release", ""); !strings.Contains(r, "disabled") {
 		t.Errorf("goals-disabled reply = %q, want a disabled notice", r)
 	}
 	if _, ok := sess.GoalStore().GoalSnapshot(); ok {
@@ -75,7 +75,7 @@ func TestCmdGoal_RespectsGoalsEnabledGate(t *testing.T) {
 
 	// Re-enabling restores the normal behavior.
 	mgr.SetGoalsEnabled(true)
-	if r := mgr.cmdGoal(ev, "ship the release"); !strings.Contains(r, "Goal set") {
+	if r := mgr.cmdGoal(ev, "ship the release", ""); !strings.Contains(r, "Goal set") {
 		t.Errorf("re-enabled create reply = %q", r)
 	}
 }

--- a/internal/channel/known_chats_test.go
+++ b/internal/channel/known_chats_test.go
@@ -27,7 +27,7 @@ func TestManager_KnownChats(t *testing.T) {
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 
 	// A live session (this process run) → Active.
-	mgr.GetOrCreateSession(InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"})
+	mgr.GetOrCreateSession(InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}, nil)
 	// A persisted binding for a different chat → Bound.
 	if err := mgr.bindings.set(SessionKey("telegram:42:u2"), "sess-x"); err != nil {
 		t.Fatalf("bind: %v", err)

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -333,7 +333,10 @@ func (m *Manager) SetModelOps(ops *ModelOps) {
 }
 
 // SetProfileLookup injects the server's agent-profile resolver. Called once
-// at manager construction, before any adapter goroutine runs.
+// at manager construction, before any adapter goroutine runs. The closure's
+// ok return value is currently unused (the manager's resolveProfile always
+// falls back to the default profile on a miss) — it exists so callers can
+// report "known unknowns" in future without an API break.
 func (m *Manager) SetProfileLookup(fn func(id string) (*agentprofile.Profile, bool)) {
 	m.profileLookup = fn
 }

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -234,17 +234,21 @@ type ModelOps struct {
 
 // newSession builds a Session with a fresh agent and per-conversation task
 // store. Centralised so every binding path (explicit /bind, auto-create on
-// first message, GetOrCreateSession) wires sessions identically. profile is
-// the routed agent (nil → default): it shapes the factory-built agent and is
-// stamped onto Session.AgentID and the persisted store's agent_id.
-func (m *Manager) newSession(key SessionKey, ev InboundEvent, profile *agentprofile.Profile) *Session {
+// first message, GetOrCreateSession) wires sessions identically. agentID is
+// the routed agent (never empty — callers normalize "" to "default"); it is
+// stamped onto Session.AgentID and the persisted store's agent_id, and it
+// determines the session-key namespace. profile shapes the factory-built
+// agent (system prompt / model) and may fall back to the default profile if
+// the routed profile was deleted — but the session's AgentID always stays the
+// routed agent, so its key namespace and store identity never drift.
+func (m *Manager) newSession(key SessionKey, ev InboundEvent, agentID string, profile *agentprofile.Profile) *Session {
 	if profile == nil {
 		profile = agentprofile.DefaultProfile()
 	}
 	s := &Session{
 		Key:     key,
 		Agent:   m.factory(profile),
-		AgentID: profile.ID,
+		AgentID: agentID,
 		Tasks:   tasks.New(),
 		ChatID:  ev.ChatID,
 		UserID:  ev.UserID,
@@ -707,8 +711,12 @@ func (m *Manager) cmdBind(ev InboundEvent, args []string, agentID string) string
 		m.sessions.Store(key, sess)
 	} else {
 		// No running session found — create a new one from the store file.
+		// The session keeps the routed agent's namespace (agentID) even if the
+		// profile was deleted in the meantime — resolveProfile falls back to
+		// the default profile for shaping the agent, but the key and AgentID
+		// stay anchored to the routed agent.
 		m.sessions.LoadAndDelete(key)
-		m.sessions.Store(key, m.newSession(key, ev, m.resolveProfile(agentID)))
+		m.sessions.Store(key, m.newSession(key, ev, agentID, m.resolveProfile(agentID)))
 	}
 	if res == agent.Stolen {
 		return fmt.Sprintf("Taken over %q [%s] from %s. History preserved.", target.DisplayTitle(), target.ShortID(), previousEntry)
@@ -851,15 +859,21 @@ func (m *Manager) cmdStatus(ev InboundEvent, agentID string) string {
 // the index /bind accepts.
 func (m *Manager) cmdList(agentID string) string {
 	agentID = normalizeAgentID(agentID)
-	sessions, err := agent.ListSessions(20)
+	// Match resolveBindTarget: fetch all sessions, filter by owner, then cap
+	// at 20. A /list that stopped at 20 before filtering would assign indices
+	// that don't match the indices /bind resolves against.
+	sessions, err := agent.ListSessions(0)
 	if err != nil {
 		return fmt.Sprintf("Could not list sessions: %v", err)
 	}
-	var owned []*agent.Session
+	owned := make([]*agent.Session, 0, len(sessions))
 	for _, s := range sessions {
 		if s.EffectiveAgentID() == agentID {
 			owned = append(owned, s)
 		}
+	}
+	if len(owned) > 20 {
+		owned = owned[:20]
 	}
 	if len(owned) == 0 {
 		return "No saved sessions yet."
@@ -892,7 +906,9 @@ func (m *Manager) GetSession(ev InboundEvent, agentID string) *Session {
 }
 
 // GetOrCreateSession returns the existing session for the routed agent's key
-// namespace, or creates a new one shaped by profile (nil → default).
+// namespace, or creates a new one shaped by profile (nil → default). The
+// session's AgentID is always the routed agent, even when profile falls back
+// to the default — so a deleted profile's /bind recovery keeps its namespace.
 func (m *Manager) GetOrCreateSession(ev InboundEvent, profile *agentprofile.Profile) *Session {
 	if profile == nil {
 		profile = agentprofile.DefaultProfile()
@@ -900,7 +916,7 @@ func (m *Manager) GetOrCreateSession(ev InboundEvent, profile *agentprofile.Prof
 	key := sessionKeyFor(m.mode, ev, profile.ID)
 	val, loaded := m.sessions.Load(key)
 	if !loaded {
-		sess := m.newSession(key, ev, profile)
+		sess := m.newSession(key, ev, profile.ID, profile)
 		val, _ = m.sessions.LoadOrStore(key, sess)
 	}
 	return val.(*Session)

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/permission"
 	"github.com/open-octo/octo-agent/internal/tasks"
 )
@@ -34,8 +35,25 @@ const (
 // SessionKey uniquely identifies a conversation session.
 type SessionKey string
 
-// sessionKeyFor returns the session key for an inbound event based on the binding mode.
-func sessionKeyFor(mode BindingMode, ev InboundEvent) SessionKey {
+// sessionKeyFor returns the session key for an inbound event based on the
+// binding mode and the routed agent. The default agent ("" or "default")
+// keeps the legacy key byte-for-byte — its in-memory sessions, on-disk store
+// files (sessionStoreID hashes the key), and /bind entries are all unchanged
+// from before multi-agent. Expert agents prefix the legacy key with
+// "<agentID>#": this one convention derives per-agent isolation of the
+// sessions map, the /bind table, and the deterministic store file ID. '#'
+// appears in neither platform names nor profile IDs, so splitSessionKey can
+// strip the prefix unambiguously.
+func sessionKeyFor(mode BindingMode, ev InboundEvent, agentID string) SessionKey {
+	base := sessionKeyBase(mode, ev)
+	if agentID == "" || agentID == agentprofile.DefaultID {
+		return base
+	}
+	return SessionKey(agentID + "#" + string(base))
+}
+
+// sessionKeyBase is the pre-multi-agent key shape: platform:chat[:user].
+func sessionKeyBase(mode BindingMode, ev InboundEvent) SessionKey {
 	switch mode {
 	case BindByChatUser:
 		return SessionKey(ev.Platform + ":" + ev.ChatID + ":" + ev.UserID)
@@ -46,10 +64,25 @@ func sessionKeyFor(mode BindingMode, ev InboundEvent) SessionKey {
 	}
 }
 
+// normalizeAgentID maps the empty routed-agent sentinel to the default ID.
+func normalizeAgentID(agentID string) string {
+	if agentID == "" {
+		return agentprofile.DefaultID
+	}
+	return agentID
+}
+
 // Session holds the agent and its binding state for one conversation.
 type Session struct {
 	Key   SessionKey
 	Agent *agent.Agent
+
+	// AgentID is the routed agent profile's ID, captured at session creation.
+	// Per-turn behavior (system prompt, model, tool whitelist) is derived from
+	// it by looking the profile up fresh each turn, so profile edits take
+	// effect without rebuilding anything. Matches the persisted store's
+	// agent_id metadata.
+	AgentID string
 
 	// Store is the on-disk history backing this conversation (persist.go).
 	// Loaded/initialised at session creation, written via Persist after
@@ -154,8 +187,9 @@ func (s *Session) Interrupt() bool {
 	return true
 }
 
-// AgentFactory creates a new agent.Agent for a session.
-type AgentFactory func() *agent.Agent
+// AgentFactory creates a new agent.Agent for a session, parameterized by the
+// routed profile (system prompt / model overrides; nil means default).
+type AgentFactory func(profile *agentprofile.Profile) *agent.Agent
 
 // ModelInfo describes one configured model entry for /model listings.
 //
@@ -200,11 +234,17 @@ type ModelOps struct {
 
 // newSession builds a Session with a fresh agent and per-conversation task
 // store. Centralised so every binding path (explicit /bind, auto-create on
-// first message, GetOrCreateSession) wires sessions identically.
-func (m *Manager) newSession(key SessionKey, ev InboundEvent) *Session {
+// first message, GetOrCreateSession) wires sessions identically. profile is
+// the routed agent (nil → default): it shapes the factory-built agent and is
+// stamped onto Session.AgentID and the persisted store's agent_id.
+func (m *Manager) newSession(key SessionKey, ev InboundEvent, profile *agentprofile.Profile) *Session {
+	if profile == nil {
+		profile = agentprofile.DefaultProfile()
+	}
 	s := &Session{
 		Key:     key,
-		Agent:   m.factory(),
+		Agent:   m.factory(profile),
+		AgentID: profile.ID,
 		Tasks:   tasks.New(),
 		ChatID:  ev.ChatID,
 		UserID:  ev.UserID,
@@ -250,6 +290,11 @@ type Manager struct {
 	// factory; nil means /model replies that switching is unavailable rather
 	// than guessing at config it cannot see from this package.
 	modelOps *ModelOps
+
+	// profileLookup resolves an agent ID to its profile for paths that only
+	// have the routed ID (e.g. /new's agentModel). Set by the server alongside
+	// the factory; nil means every ID resolves to the default profile.
+	profileLookup func(id string) (*agentprofile.Profile, bool)
 }
 
 // NewManager creates a Manager. If mode is empty it defaults to BindByChatUser.
@@ -283,6 +328,23 @@ func (m *Manager) SetModelOps(ops *ModelOps) {
 	m.modelOps = ops
 }
 
+// SetProfileLookup injects the server's agent-profile resolver. Called once
+// at manager construction, before any adapter goroutine runs.
+func (m *Manager) SetProfileLookup(fn func(id string) (*agentprofile.Profile, bool)) {
+	m.profileLookup = fn
+}
+
+// resolveProfile maps an agent ID to its profile, defaulting on a miss (nil
+// lookup, or the profile was deleted mid-session).
+func (m *Manager) resolveProfile(agentID string) *agentprofile.Profile {
+	if m.profileLookup != nil {
+		if p, ok := m.profileLookup(agentID); ok {
+			return p
+		}
+	}
+	return agentprofile.DefaultProfile()
+}
+
 // resolveStoreID returns the on-disk session store ID a chat should use: the
 // session it was explicitly bound to via /bind, or its deterministic default.
 func (m *Manager) resolveStoreID(key SessionKey) string {
@@ -292,8 +354,11 @@ func (m *Manager) resolveStoreID(key SessionKey) string {
 	return sessionStoreID(key)
 }
 
-// CommandRouter processes slash commands and returns a reply text.
-func (m *Manager) CommandRouter(ev InboundEvent) string {
+// CommandRouter processes slash commands and returns a reply text. agentID is
+// the routed agent for this event: commands operate within that agent's
+// session-key namespace, and /list + /bind only see sessions it owns.
+func (m *Manager) CommandRouter(ev InboundEvent, agentID string) string {
+	agentID = normalizeAgentID(agentID)
 	parts := strings.Fields(strings.TrimSpace(ev.Text))
 	if len(parts) == 0 {
 		return ""
@@ -303,25 +368,25 @@ func (m *Manager) CommandRouter(ev InboundEvent) string {
 
 	switch cmd {
 	case "/bind":
-		return m.cmdBind(ev, args)
+		return m.cmdBind(ev, args, agentID)
 	case "/stop":
-		return m.cmdStop(ev)
+		return m.cmdStop(ev, agentID)
 	case "/unbind":
-		return m.cmdUnbind(ev)
+		return m.cmdUnbind(ev, agentID)
 	case "/status":
-		return m.cmdStatus(ev)
+		return m.cmdStatus(ev, agentID)
 	case "/list":
-		return m.cmdList()
+		return m.cmdList(agentID)
 	case "/clear":
-		return m.cmdClear(ev)
+		return m.cmdClear(ev, agentID)
 	case "/new":
-		return m.cmdNew(ev)
+		return m.cmdNew(ev, agentID)
 	case "/compact":
-		return m.cmdCompact(ev)
+		return m.cmdCompact(ev, agentID)
 	case "/goal":
-		return m.cmdGoal(ev, strings.Join(args, " "))
+		return m.cmdGoal(ev, strings.Join(args, " "), agentID)
 	case "/model":
-		return m.cmdModel(ev, strings.Join(args, " "))
+		return m.cmdModel(ev, strings.Join(args, " "), agentID)
 	case "/help":
 		return "Available: /bind [--force] <number|id>, /unbind, /list, /clear, /new, /compact, /goal, /model [name|default], /loop [interval] <task>, /stop, /status, /help"
 	default:
@@ -334,11 +399,11 @@ func (m *Manager) CommandRouter(ev InboundEvent) string {
 // bound to the same session. Mutations are safe against a running turn — the
 // session's goal methods are mutex-guarded and the turn's accounting picks
 // the change up at its next tick.
-func (m *Manager) cmdGoal(ev InboundEvent, args string) string {
+func (m *Manager) cmdGoal(ev InboundEvent, args string, agentID string) string {
 	if !m.goalsEnabled.Load() {
 		return "Goals are disabled (goal.enabled)."
 	}
-	key := sessionKeyFor(m.mode, ev)
+	key := sessionKeyFor(m.mode, ev, agentID)
 	val, loaded := m.sessions.Load(key)
 	if !loaded {
 		return "No active session. Send a message first, or /bind one."
@@ -358,11 +423,11 @@ func (m *Manager) cmdGoal(ev InboundEvent, args string) string {
 // server's sender cache. A successful switch swaps the live agent's sender
 // and persists the binding via SetModelConfig, so the web UI sees the same
 // binding and a restart doesn't lose it.
-func (m *Manager) cmdModel(ev InboundEvent, arg string) string {
+func (m *Manager) cmdModel(ev InboundEvent, arg string, agentID string) string {
 	if m.modelOps == nil {
 		return "Model switching is unavailable on this server."
 	}
-	key := sessionKeyFor(m.mode, ev)
+	key := sessionKeyFor(m.mode, ev, agentID)
 	val, loaded := m.sessions.Load(key)
 	if !loaded {
 		return "No active session. Send a message first, or /bind one."
@@ -495,8 +560,8 @@ func (m *Manager) modelListReply(sess *Session) string {
 // cmdClear wipes the current session's conversation history while keeping its
 // binding and persisted store — the chat starts fresh without re-binding. The
 // emptied history is persisted so a restart doesn't bring it back.
-func (m *Manager) cmdClear(ev InboundEvent) string {
-	key := sessionKeyFor(m.mode, ev)
+func (m *Manager) cmdClear(ev InboundEvent, agentID string) string {
+	key := sessionKeyFor(m.mode, ev, agentID)
 	val, loaded := m.sessions.Load(key)
 	if !loaded {
 		return "No active session to clear."
@@ -520,8 +585,8 @@ func (m *Manager) cmdClear(ev InboundEvent) string {
 // cmdCompact force-compacts the current session's conversation history now,
 // summarizing older turns to free up context. It refuses to run while an agent
 // turn is in flight so it can't race the turn's own history mutations.
-func (m *Manager) cmdCompact(ev InboundEvent) string {
-	key := sessionKeyFor(m.mode, ev)
+func (m *Manager) cmdCompact(ev InboundEvent, agentID string) string {
+	key := sessionKeyFor(m.mode, ev, agentID)
 	val, loaded := m.sessions.Load(key)
 	if !loaded {
 		return "No active session to compact."
@@ -554,12 +619,13 @@ func (m *Manager) cmdCompact(ev InboundEvent) string {
 // cmdNew creates a brand-new session and binds the current chat to it. The old
 // store (if any) is left on disk but detached from this chat, so /new is safe
 // to use even when another entry owns the chat's usual session.
-func (m *Manager) cmdNew(ev InboundEvent) string {
-	key := sessionKeyFor(m.mode, ev)
+func (m *Manager) cmdNew(ev InboundEvent, agentID string) string {
+	key := sessionKeyFor(m.mode, ev, agentID)
 
-	// Create a fresh session owned by channel.
-	st := agent.NewSession(m.agentModel(), "")
+	// Create a fresh session owned by channel, stamped with the routed agent.
+	st := agent.NewSession(m.agentModel(agentID), "")
 	st.Source = "channel"
+	st.AgentID = agentID
 	st.Bind(agent.EntryChannel, false)
 	_ = st.SetPermissionMode(string(permission.ResolveDefaultMode()))
 	if err := st.Save(); err != nil {
@@ -580,13 +646,14 @@ func (m *Manager) cmdNew(ev InboundEvent) string {
 	return fmt.Sprintf("Started a new session [%s]. Send a message to begin.", st.ShortID())
 }
 
-// agentModel returns the model name the factory uses, so /new can create a
-// session that matches the agent configuration without running a turn.
-func (m *Manager) agentModel() string {
+// agentModel returns the model name the factory uses for the given agent, so
+// /new can create a session that matches the agent configuration without
+// running a turn.
+func (m *Manager) agentModel(agentID string) string {
 	if m.factory == nil {
 		return ""
 	}
-	return m.factory().Model
+	return m.factory(m.resolveProfile(normalizeAgentID(agentID))).Model
 }
 
 // cmdBind attaches the current chat to an existing session chosen from /list,
@@ -596,14 +663,14 @@ func (m *Manager) agentModel() string {
 // By default, if the target session is bound to another entry, the bind is
 // rejected so IM cannot silently take over a session owned by CLI/TUI/Web.
 // Pass --force to take over a session whose turn lease has expired.
-func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
+func (m *Manager) cmdBind(ev InboundEvent, args []string, agentID string) string {
 	steal, targetArg, ok := parseBindArgs(args)
 	if !ok {
 		return "Usage: /bind [--force] <number|id> — run /list to see sessions, then attach this chat to one. History is preserved."
 	}
-	target := m.resolveBindTarget(targetArg)
+	target := m.resolveBindTarget(targetArg, agentID)
 	if target == nil {
-		return fmt.Sprintf("No session matches %q. Run /list to see available sessions.", targetArg)
+		return fmt.Sprintf("No session matches %q for agent %q. Run /list to see available sessions.", targetArg, agentID)
 	}
 
 	previousEntry := target.BoundEntry
@@ -615,7 +682,7 @@ func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
 		return fmt.Sprintf("Could not persist entry binding: %v", err)
 	}
 
-	key := sessionKeyFor(m.mode, ev)
+	key := sessionKeyFor(m.mode, ev, agentID)
 	if err := m.bindings.set(key, target.ID); err != nil {
 		// Roll back the entry binding so we don't leave the session claimed.
 		target.Unbind(agent.EntryChannel)
@@ -641,7 +708,7 @@ func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
 	} else {
 		// No running session found — create a new one from the store file.
 		m.sessions.LoadAndDelete(key)
-		m.sessions.Store(key, m.newSession(key, ev))
+		m.sessions.Store(key, m.newSession(key, ev, m.resolveProfile(agentID)))
 	}
 	if res == agent.Stolen {
 		return fmt.Sprintf("Taken over %q [%s] from %s. History preserved.", target.DisplayTitle(), target.ShortID(), previousEntry)
@@ -672,19 +739,28 @@ func parseBindArgs(args []string) (steal bool, target string, ok bool) {
 
 // resolveBindTarget maps a /bind argument to a persisted session: a 1-based
 // index into the /list ordering (newest first), or a full / short ID match.
-// Returns nil when nothing matches.
-func (m *Manager) resolveBindTarget(arg string) *agent.Session {
+// Only sessions owned by the routed agent are eligible — cross-agent binds
+// are rejected so a session's behavior never diverges from its owning
+// profile. Returns nil when nothing matches.
+func (m *Manager) resolveBindTarget(arg string, agentID string) *agent.Session {
+	agentID = normalizeAgentID(agentID)
 	sessions, err := agent.ListSessions(0)
 	if err != nil || len(sessions) == 0 {
 		return nil
 	}
+	owned := make([]*agent.Session, 0, len(sessions))
+	for _, s := range sessions {
+		if s.EffectiveAgentID() == agentID {
+			owned = append(owned, s)
+		}
+	}
 	if n, err := strconv.Atoi(arg); err == nil {
-		if n >= 1 && n <= len(sessions) {
-			return sessions[n-1]
+		if n >= 1 && n <= len(owned) {
+			return owned[n-1]
 		}
 		return nil
 	}
-	for _, s := range sessions {
+	for _, s := range owned {
 		if s.ID == arg || s.ShortID() == arg {
 			return s
 		}
@@ -695,8 +771,8 @@ func (m *Manager) resolveBindTarget(arg string) *agent.Session {
 // cmdStop interrupts the session's in-flight agent turn (mirrors the Ctrl-C /
 // web "interrupt" semantics; history is repaired by finishInterrupted and the
 // session stays usable).
-func (m *Manager) cmdStop(ev InboundEvent) string {
-	key := sessionKeyFor(m.mode, ev)
+func (m *Manager) cmdStop(ev InboundEvent, agentID string) string {
+	key := sessionKeyFor(m.mode, ev, agentID)
 	val, loaded := m.sessions.Load(key)
 	if !loaded {
 		return "No active session for this context."
@@ -717,8 +793,8 @@ func (m *Manager) cmdStop(ev InboundEvent) string {
 // makes the in-flight UIController silently drop everything it has not sent
 // yet, and the session is treated as handed to web, so any idle follow-up
 // turns the chat suppresses too.
-func (m *Manager) cmdUnbind(ev InboundEvent) string {
-	key := sessionKeyFor(m.mode, ev)
+func (m *Manager) cmdUnbind(ev InboundEvent, agentID string) string {
+	key := sessionKeyFor(m.mode, ev, agentID)
 
 	released := false
 	if val, ok := m.sessions.Load(key); ok {
@@ -748,8 +824,8 @@ func (m *Manager) cmdUnbind(ev InboundEvent) string {
 }
 
 // cmdStatus reports the current session state.
-func (m *Manager) cmdStatus(ev InboundEvent) string {
-	key := sessionKeyFor(m.mode, ev)
+func (m *Manager) cmdStatus(ev InboundEvent, agentID string) string {
+	key := sessionKeyFor(m.mode, ev, agentID)
 	val, ok := m.sessions.Load(key)
 	if !ok {
 		return "No active session. Send a message to start one, or /bind to attach to a saved session."
@@ -770,33 +846,44 @@ func (m *Manager) cmdStatus(ev InboundEvent) string {
 }
 
 // cmdList shows the persisted sessions a chat can attach to with /bind,
-// newest first. The number printed here is the index /bind accepts.
-func (m *Manager) cmdList() string {
+// newest first — scoped to the routed agent (cross-agent binds are rejected,
+// so listing them would only offer dead ends). The number printed here is
+// the index /bind accepts.
+func (m *Manager) cmdList(agentID string) string {
+	agentID = normalizeAgentID(agentID)
 	sessions, err := agent.ListSessions(20)
 	if err != nil {
 		return fmt.Sprintf("Could not list sessions: %v", err)
 	}
-	if len(sessions) == 0 {
+	var owned []*agent.Session
+	for _, s := range sessions {
+		if s.EffectiveAgentID() == agentID {
+			owned = append(owned, s)
+		}
+	}
+	if len(owned) == 0 {
 		return "No saved sessions yet."
 	}
 	var b strings.Builder
 	b.WriteString("Sessions (newest first) — /bind <number> to attach:\n")
-	for i, s := range sessions {
+	for i, s := range owned {
 		fmt.Fprintf(&b, "%d. %s  [%s]\n", i+1, s.DisplayTitle(), s.ShortID())
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
 
 // KeyFor exposes the session key an inbound event maps to under this
-// manager's binding mode, for callers that keep per-session state outside
-// the manager (e.g. the server's remembered-permission stores).
-func (m *Manager) KeyFor(ev InboundEvent) SessionKey {
-	return sessionKeyFor(m.mode, ev)
+// manager's binding mode and the routed agent, for callers that keep
+// per-session state outside the manager (e.g. the server's
+// remembered-permission stores).
+func (m *Manager) KeyFor(ev InboundEvent, agentID string) SessionKey {
+	return sessionKeyFor(m.mode, ev, agentID)
 }
 
-// GetSession returns the session for the given inbound event, or nil if none exists.
-func (m *Manager) GetSession(ev InboundEvent) *Session {
-	key := sessionKeyFor(m.mode, ev)
+// GetSession returns the session for the given inbound event and routed
+// agent, or nil if none exists.
+func (m *Manager) GetSession(ev InboundEvent, agentID string) *Session {
+	key := sessionKeyFor(m.mode, ev, agentID)
 	val, ok := m.sessions.Load(key)
 	if !ok {
 		return nil
@@ -804,12 +891,16 @@ func (m *Manager) GetSession(ev InboundEvent) *Session {
 	return val.(*Session)
 }
 
-// GetOrCreateSession returns the existing session or creates a new one.
-func (m *Manager) GetOrCreateSession(ev InboundEvent) *Session {
-	key := sessionKeyFor(m.mode, ev)
+// GetOrCreateSession returns the existing session for the routed agent's key
+// namespace, or creates a new one shaped by profile (nil → default).
+func (m *Manager) GetOrCreateSession(ev InboundEvent, profile *agentprofile.Profile) *Session {
+	if profile == nil {
+		profile = agentprofile.DefaultProfile()
+	}
+	key := sessionKeyFor(m.mode, ev, profile.ID)
 	val, loaded := m.sessions.Load(key)
 	if !loaded {
-		sess := m.newSession(key, ev)
+		sess := m.newSession(key, ev, profile)
 		val, _ = m.sessions.LoadOrStore(key, sess)
 	}
 	return val.(*Session)
@@ -887,17 +978,23 @@ func (m *Manager) KnownChats() []KnownChat {
 }
 
 // splitSessionKey recovers (platform, chatID, userID) from a session key.
-// Keys are "platform:chatID[:userID]" (sessionKeyFor); a platform never
-// contains a colon, so the first segment is unambiguous, and the remainder is
-// split once more for the optional user segment.
+// Keys are "platform:chatID[:userID]" (sessionKeyBase), optionally prefixed
+// with "<agentID>#" for expert agents (sessionKeyFor). The prefix is only
+// stripped when it actually looks like a profile ID — a chat ID may itself
+// contain '#' (see TestSessionStoreID_DeterministicAndSafe), so a bare
+// index-of-'#' strip would misparse those keys.
 func splitSessionKey(key SessionKey) (platform, chatID, userID string) {
-	parts := strings.SplitN(string(key), ":", 3)
+	s := string(key)
+	if i := strings.IndexByte(s, '#'); i > 0 && agentprofile.IsValidID(s[:i]) {
+		s = s[i+1:]
+	}
+	parts := strings.SplitN(s, ":", 3)
 	switch len(parts) {
 	case 3:
 		return parts[0], parts[1], parts[2]
 	case 2:
 		return parts[0], parts[1], ""
 	default:
-		return string(key), "", ""
+		return s, "", ""
 	}
 }

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 )
 
 // mockAdapter is a test double that records sent messages.
@@ -120,7 +121,7 @@ func (m *mockAdapter) lastSentText() sentText {
 	return m.sentTexts[len(m.sentTexts)-1]
 }
 
-func fakeAgentFactory() *agent.Agent {
+func fakeAgentFactory(*agentprofile.Profile) *agent.Agent {
 	return agent.New(fakeSender{}, "test-model")
 }
 
@@ -143,7 +144,7 @@ func TestManager_SessionBindingModes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := sessionKeyFor(tt.mode, ev)
+		got := sessionKeyFor(tt.mode, ev, "")
 		if got != tt.want {
 			t.Errorf("mode %q: got %q, want %q", tt.mode, got, tt.want)
 		}
@@ -165,32 +166,32 @@ func TestManager_CommandRouter(t *testing.T) {
 
 	// A session exists once the chat has spoken.
 	ev := InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"}
-	mgr.GetOrCreateSession(ev)
+	mgr.GetOrCreateSession(ev, nil)
 	if mgr.SessionCount() != 1 {
 		t.Fatalf("expected 1 session, got %d", mgr.SessionCount())
 	}
 
 	// /bind with no target explains usage and creates nothing.
 	ev.Text = "/bind"
-	if reply := mgr.CommandRouter(ev); !strings.Contains(strings.ToLower(reply), "usage") {
+	if reply := mgr.CommandRouter(ev, ""); !strings.Contains(strings.ToLower(reply), "usage") {
 		t.Fatalf("expected usage hint for bare /bind, got %q", reply)
 	}
 
 	// /status
 	ev.Text = "/status"
-	if reply := mgr.CommandRouter(ev); reply == "" {
+	if reply := mgr.CommandRouter(ev, ""); reply == "" {
 		t.Fatal("expected non-empty reply for /status")
 	}
 
 	// /list
 	ev.Text = "/list"
-	if reply := mgr.CommandRouter(ev); reply == "" {
+	if reply := mgr.CommandRouter(ev, ""); reply == "" {
 		t.Fatal("expected non-empty reply for /list")
 	}
 
 	// /stop with no turn in flight (does not delete the session)
 	ev.Text = "/stop"
-	if reply := mgr.CommandRouter(ev); !strings.Contains(reply, "No task is running") {
+	if reply := mgr.CommandRouter(ev, ""); !strings.Contains(reply, "No task is running") {
 		t.Fatalf("expected idle /stop reply, got %q", reply)
 	}
 	if mgr.SessionCount() != 1 {
@@ -199,7 +200,7 @@ func TestManager_CommandRouter(t *testing.T) {
 
 	// /unbind detaches the live session (history is kept on disk).
 	ev.Text = "/unbind"
-	mgr.CommandRouter(ev)
+	mgr.CommandRouter(ev, "")
 	if mgr.SessionCount() != 0 {
 		t.Fatalf("expected 0 live sessions after /unbind, got %d", mgr.SessionCount())
 	}
@@ -211,13 +212,13 @@ func TestManager_StopInterruptsRunningTurn(t *testing.T) {
 	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
 
 	ev := InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"}
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 
 	runCtx, done := sess.BeginRun(context.Background())
 	defer done()
 
 	ev.Text = "/stop"
-	reply := mgr.CommandRouter(ev)
+	reply := mgr.CommandRouter(ev, "")
 	if !strings.Contains(reply, "Task interrupted") {
 		t.Fatalf("expected interrupt reply, got %q", reply)
 	}
@@ -226,7 +227,7 @@ func TestManager_StopInterruptsRunningTurn(t *testing.T) {
 	}
 
 	// A second /stop finds nothing to interrupt.
-	if reply := mgr.CommandRouter(ev); !strings.Contains(reply, "No task is running") {
+	if reply := mgr.CommandRouter(ev, ""); !strings.Contains(reply, "No task is running") {
 		t.Fatalf("expected idle reply on second /stop, got %q", reply)
 	}
 }
@@ -267,7 +268,7 @@ func TestManager_UnbindMidTurn_SuppressesButKeepsRunning(t *testing.T) {
 	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
 
 	ev := InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"}
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "q"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
@@ -282,7 +283,7 @@ func TestManager_UnbindMidTurn_SuppressesButKeepsRunning(t *testing.T) {
 	defer done()
 
 	ev.Text = "/unbind"
-	reply := mgr.CommandRouter(ev)
+	reply := mgr.CommandRouter(ev, "")
 	if !strings.Contains(strings.ToLower(reply), "unbound") {
 		t.Fatalf("expected unbind reply, got %q", reply)
 	}
@@ -315,7 +316,7 @@ func TestManager_UnbindThenBindBackRecoversRunningSession(t *testing.T) {
 	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
 
 	ev := InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"}
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "q"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
@@ -328,14 +329,14 @@ func TestManager_UnbindThenBindBackRecoversRunningSession(t *testing.T) {
 
 	// /unbind: suppress delivery, remove from sessions map.
 	ev.Text = "/unbind"
-	reply := mgr.CommandRouter(ev)
+	reply := mgr.CommandRouter(ev, "")
 	if !strings.Contains(strings.ToLower(reply), "unbound") {
 		t.Fatalf("expected unbind reply, got %q", reply)
 	}
 	if !sess.SuppressDelivery() {
 		t.Fatal("/unbind must set suppressDelivery")
 	}
-	key := sessionKeyFor(BindByChatUser, ev)
+	key := sessionKeyFor(BindByChatUser, ev, "")
 	if _, ok := mgr.sessions.Load(key); ok {
 		t.Fatal("/unbind must remove session from sessions map")
 	}
@@ -345,7 +346,7 @@ func TestManager_UnbindThenBindBackRecoversRunningSession(t *testing.T) {
 
 	// /bind back to the same session by its store ID.
 	ev.Text = "/bind " + storeID
-	reply = mgr.CommandRouter(ev)
+	reply = mgr.CommandRouter(ev, "")
 	if !strings.Contains(strings.ToLower(reply), "bound") {
 		t.Fatalf("expected bind reply, got %q", reply)
 	}
@@ -390,17 +391,17 @@ func TestManager_BindCreatesNewWhenNoRunningSession(t *testing.T) {
 	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
 
 	ev := InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"}
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "q"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
 	}
 	storeID := sess.Store.ID
-	key := sessionKeyFor(BindByChatUser, ev)
+	key := sessionKeyFor(BindByChatUser, ev, "")
 
 	// Unbind and let the old session object be GC'd (no references kept).
 	ev.Text = "/unbind"
-	mgr.CommandRouter(ev)
+	mgr.CommandRouter(ev, "")
 
 	// Also remove from sessionsByStore to simulate the case where the running
 	// session has been evicted (e.g., a later message already created a new
@@ -409,7 +410,7 @@ func TestManager_BindCreatesNewWhenNoRunningSession(t *testing.T) {
 
 	// /bind the same store ID — must fall through to creating a new session.
 	ev.Text = "/bind " + storeID
-	reply := mgr.CommandRouter(ev)
+	reply := mgr.CommandRouter(ev, "")
 	if !strings.Contains(strings.ToLower(reply), "bound") {
 		t.Fatalf("expected bind reply, got %q", reply)
 	}
@@ -458,13 +459,13 @@ func TestManager_AutoSessionCreation(t *testing.T) {
 	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
 
 	ev := InboundEvent{Platform: "mock2", ChatID: "c1", UserID: "u1", Text: "hello"}
-	mgr.GetOrCreateSession(ev)
+	mgr.GetOrCreateSession(ev, nil)
 
 	if mgr.SessionCount() != 1 {
 		t.Fatalf("expected 1 auto-created session, got %d", mgr.SessionCount())
 	}
 
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 	if sess == nil {
 		t.Fatal("expected session to exist")
 	}
@@ -477,7 +478,7 @@ func TestManager_UnknownCommand(t *testing.T) {
 	tempHome(t)
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 	ev := InboundEvent{Text: "/foobar"}
-	reply := mgr.CommandRouter(ev)
+	reply := mgr.CommandRouter(ev, "")
 	if reply == "" {
 		t.Fatal("expected error reply for unknown command")
 	}
@@ -492,11 +493,11 @@ func TestCmdClear_RefusesWhileRunning(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 	runCtx, done := sess.BeginRun(context.Background())
 	defer done()
 
-	reply := mgr.cmdClear(ev)
+	reply := mgr.cmdClear(ev, "")
 	if !strings.Contains(strings.ToLower(reply), "can't clear") {
 		t.Fatalf("expected refusal while running, got %q", reply)
 	}
@@ -512,7 +513,7 @@ func TestCmdCompact_FoldsHistory(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 	// Shrink the keep budget so the small test history still has something to fold.
 	sess.Agent.CompactKeepFraction = 0.001
 
@@ -525,7 +526,7 @@ func TestCmdCompact_FoldsHistory(t *testing.T) {
 	}
 	before := len(sess.Agent.History.Snapshot())
 
-	reply := mgr.cmdCompact(ev)
+	reply := mgr.cmdCompact(ev, "")
 	if !strings.Contains(strings.ToLower(reply), "compact") &&
 		!strings.Contains(strings.ToLower(reply), "folded") &&
 		!strings.Contains(strings.ToLower(reply), "reclaimed") {
@@ -576,9 +577,9 @@ func TestCmdModel_ListMarksCurrent(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 	mgr.SetModelOps(fakeModelOps())
-	mgr.GetOrCreateSession(ev)
+	mgr.GetOrCreateSession(ev, nil)
 
-	reply := mgr.cmdModel(ev, "")
+	reply := mgr.cmdModel(ev, "", "")
 	for _, want := range []string{"test-model", "other-model", "current"} {
 		if !strings.Contains(reply, want) {
 			t.Fatalf("listing should contain %q, got %q", want, reply)
@@ -606,12 +607,12 @@ func TestCmdModel_ListGroupsByEndpoint(t *testing.T) {
 			return ModelResolution{}, fmt.Errorf("unused in this test")
 		},
 	})
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 	// The "current" mark is keyed off the persisted binding (composite id),
 	// not the bare model on the agent — so set AppliedModelConfig.
 	sess.AppliedModelConfig = "relay-a::claude-sonnet-4-6"
 
-	reply := mgr.cmdModel(ev, "")
+	reply := mgr.cmdModel(ev, "", "")
 	for _, want := range []string{
 		"relay-a (中转站A)",
 		"relay-a::claude-sonnet-4-6",
@@ -638,9 +639,9 @@ func TestCmdModel_SwitchPersistsBinding(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 	mgr.SetModelOps(fakeModelOps())
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 
-	reply := mgr.cmdModel(ev, "other-model")
+	reply := mgr.cmdModel(ev, "other-model", "")
 	if !strings.Contains(reply, "other-model") {
 		t.Fatalf("unexpected switch reply %q", reply)
 	}
@@ -660,7 +661,7 @@ func TestCmdModel_SwitchPersistsBinding(t *testing.T) {
 	}
 
 	// /model default unbinds back to the default.
-	if reply := mgr.cmdModel(ev, "default"); !strings.Contains(reply, "test-model") {
+	if reply := mgr.cmdModel(ev, "default", ""); !strings.Contains(reply, "test-model") {
 		t.Fatalf("unexpected default reply %q", reply)
 	}
 	if sess.Store.ModelConfig != "" {
@@ -675,9 +676,9 @@ func TestCmdModel_RejectsUnknownAndRunning(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 	mgr.SetModelOps(fakeModelOps())
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 
-	reply := mgr.cmdModel(ev, "nope")
+	reply := mgr.cmdModel(ev, "nope", "")
 	if !strings.Contains(reply, "not configured") {
 		t.Fatalf("expected not-configured error, got %q", reply)
 	}
@@ -690,7 +691,7 @@ func TestCmdModel_RejectsUnknownAndRunning(t *testing.T) {
 
 	_, done := sess.BeginRun(context.Background())
 	defer done()
-	reply = mgr.cmdModel(ev, "other-model")
+	reply = mgr.cmdModel(ev, "other-model", "")
 	if !strings.Contains(strings.ToLower(reply), "can't switch") {
 		t.Fatalf("expected refusal while running, got %q", reply)
 	}
@@ -703,12 +704,12 @@ func TestCmdModel_GracefulWithoutOpsOrSession(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
-	if reply := mgr.cmdModel(ev, "other-model"); !strings.Contains(reply, "unavailable") {
+	if reply := mgr.cmdModel(ev, "other-model", ""); !strings.Contains(reply, "unavailable") {
 		t.Fatalf("expected unavailable reply without ModelOps, got %q", reply)
 	}
 
 	mgr.SetModelOps(fakeModelOps())
-	if reply := mgr.cmdModel(ev, "other-model"); !strings.Contains(reply, "No active session") {
+	if reply := mgr.cmdModel(ev, "other-model", ""); !strings.Contains(reply, "No active session") {
 		t.Fatalf("expected no-session reply, got %q", reply)
 	}
 }
@@ -720,9 +721,9 @@ func TestCmdCompact_NoOpOnTinyHistory(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
-	mgr.GetOrCreateSession(ev)
+	mgr.GetOrCreateSession(ev, nil)
 
-	reply := mgr.cmdCompact(ev)
+	reply := mgr.cmdCompact(ev, "")
 	if !strings.Contains(strings.ToLower(reply), "nothing to compact") {
 		t.Fatalf("expected no-op reply, got %q", reply)
 	}
@@ -734,11 +735,11 @@ func TestCmdCompact_RefusesWhileRunning(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
-	sess := mgr.GetOrCreateSession(ev)
+	sess := mgr.GetOrCreateSession(ev, nil)
 	runCtx, done := sess.BeginRun(context.Background())
 	defer done()
 
-	reply := mgr.cmdCompact(ev)
+	reply := mgr.cmdCompact(ev, "")
 	if !strings.Contains(strings.ToLower(reply), "can't compact") {
 		t.Fatalf("expected refusal while running, got %q", reply)
 	}

--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -41,8 +41,9 @@ func sessionStoreID(key SessionKey) string {
 }
 
 // newChannelStore builds a fresh, persisted-shape store for a channel
-// session: source "channel", bound to EntryChannel. Title stays at
-// agent.NewSession's "*Octo Agent" placeholder — never the raw SessionKey
+// session: source "channel", bound to EntryChannel, stamped with the owning
+// agent's ID ("" → default, for sessions predating multi-agent). Title stays
+// at agent.NewSession's "*Octo Agent" placeholder — never the raw SessionKey
 // (e.g. "weixin:o9cq…@im.wechat:o9cq…@im.wechat") — until the first turn's
 // async title generation replaces it; meanwhile DisplayTitle() surfaces the
 // first user message snippet instead of the placeholder. Shared by
@@ -50,11 +51,12 @@ func sessionStoreID(key SessionKey) string {
 // (#1079 — recovering after the file was deleted out from under an
 // already-running session), so both give a fresh channel session the exact
 // same shape.
-func newChannelStore(id, model string) *agent.Session {
+func newChannelStore(id, model, agentID string) *agent.Session {
 	st := agent.NewSession(model, "")
 	st.ID = id
 	st.CreatedAt = time.Now()
 	st.Source = "channel"
+	st.AgentID = agentID
 	st.BoundEntry = agent.EntryChannel
 	st.BoundAt = time.Now()
 	_ = st.SetPermissionMode(string(permission.ResolveDefaultMode()))
@@ -81,7 +83,7 @@ func (s *Session) restoreOrInitStore(id string) {
 	}
 	// Persist immediately so the entry binding is visible to other processes
 	// (and to the server's authoritative LoadSession in handleChannelMessage).
-	st := newChannelStore(id, s.Agent.Model)
+	st := newChannelStore(id, s.Agent.Model, s.AgentID)
 	_ = st.Save()
 	s.Store = st
 }
@@ -111,7 +113,7 @@ func (s *Session) EnsureStoreExists() {
 	if _, err := agent.SessionMTime(s.Store.ID); err == nil {
 		return
 	}
-	st := newChannelStore(s.Store.ID, s.Agent.Model)
+	st := newChannelStore(s.Store.ID, s.Agent.Model, s.AgentID)
 	_ = st.Save()
 	s.Store = st
 	s.Agent.History = agent.NewHistory()

--- a/internal/channel/persist_test.go
+++ b/internal/channel/persist_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 )
 
 func tempHome(t *testing.T) {
@@ -17,7 +18,7 @@ func tempHome(t *testing.T) {
 }
 
 func testManager() *Manager {
-	return NewManager(&Config{}, func() *agent.Agent {
+	return NewManager(&Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(nil, "stub-model")
 	}, BindByChatUser)
 }
@@ -43,7 +44,7 @@ func TestSession_PersistAndRestore(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1", Text: "hi"}
 
 	m1 := testManager()
-	sess := m1.GetOrCreateSession(ev)
+	sess := m1.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "remember the number 42"})
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleAssistant, Content: "noted: 42"})
 	if err := sess.Persist(); err != nil {
@@ -53,7 +54,7 @@ func TestSession_PersistAndRestore(t *testing.T) {
 	// A fresh manager simulates the post-restart process: same event key must
 	// come back with the conversation history.
 	m2 := testManager()
-	restored := m2.GetOrCreateSession(ev)
+	restored := m2.GetOrCreateSession(ev, nil)
 	msgs := restored.Agent.History.Snapshot()
 	if len(msgs) != 2 {
 		t.Fatalf("restored history has %d messages, want 2", len(msgs))
@@ -71,7 +72,7 @@ func TestSession_PersistAcrossTurnsAppends(t *testing.T) {
 	ev := InboundEvent{Platform: "tg", ChatID: "c", UserID: "u"}
 
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "one"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
@@ -81,7 +82,7 @@ func TestSession_PersistAcrossTurnsAppends(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	restored := testManager().GetOrCreateSession(ev)
+	restored := testManager().GetOrCreateSession(ev, nil)
 	if got := len(restored.Agent.History.Snapshot()); got != 2 {
 		t.Errorf("history after two persists = %d messages, want 2", got)
 	}
@@ -94,7 +95,7 @@ func TestCmdUnbind_KeepsStore(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "secret"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
@@ -107,7 +108,7 @@ func TestCmdUnbind_KeepsStore(t *testing.T) {
 		t.Fatalf("store file missing before unbind: %v", err)
 	}
 
-	if reply := m.cmdUnbind(ev); !strings.Contains(strings.ToLower(reply), "unbound") &&
+	if reply := m.cmdUnbind(ev, ""); !strings.Contains(strings.ToLower(reply), "unbound") &&
 		!strings.Contains(strings.ToLower(reply), "wasn't bound") {
 		t.Fatalf("unexpected unbind reply %q", reply)
 	}
@@ -124,7 +125,7 @@ func TestCmdBind_AttachesToExistingSession(t *testing.T) {
 
 	// Chat A builds up a session and persists it.
 	evA := InboundEvent{Platform: "feishu", ChatID: "cA", UserID: "uA"}
-	sessA := m.GetOrCreateSession(evA)
+	sessA := m.GetOrCreateSession(evA, nil)
 	sessA.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "shared context"})
 	if err := sessA.Persist(); err != nil {
 		t.Fatal(err)
@@ -133,10 +134,10 @@ func TestCmdBind_AttachesToExistingSession(t *testing.T) {
 
 	// Chat B binds to A's session by ID and should see A's history.
 	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
-	if reply := m.cmdBind(evB, []string{targetID}); !strings.Contains(strings.ToLower(reply), "bound") {
+	if reply := m.cmdBind(evB, []string{targetID}, ""); !strings.Contains(strings.ToLower(reply), "bound") {
 		t.Fatalf("unexpected bind reply %q", reply)
 	}
-	bound := m.GetSession(evB)
+	bound := m.GetSession(evB, "")
 	if bound == nil {
 		t.Fatal("expected a session after /bind")
 	}
@@ -152,7 +153,7 @@ func TestCmdBind_AttachesToExistingSession(t *testing.T) {
 
 	// The binding survives a rebuild (persisted): a fresh manager re-attaches.
 	m2 := testManager()
-	again := m2.GetOrCreateSession(evB)
+	again := m2.GetOrCreateSession(evB, nil)
 	if again.Store.ID != targetID {
 		t.Errorf("binding did not persist: store = %q, want %q", again.Store.ID, targetID)
 	}
@@ -174,11 +175,11 @@ func TestCmdBind_RejectedWhenBoundToOtherEntry(t *testing.T) {
 	}
 
 	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
-	reply := m.cmdBind(evB, []string{webSess.ID})
+	reply := m.cmdBind(evB, []string{webSess.ID}, "")
 	if !strings.Contains(strings.ToLower(reply), "cannot bind") {
 		t.Fatalf("expected rejection, got %q", reply)
 	}
-	if m.GetSession(evB) != nil {
+	if m.GetSession(evB, "") != nil {
 		t.Fatal("expected no session after rejected /bind")
 	}
 }
@@ -199,7 +200,7 @@ func TestCmdBind_ForceTakesOverOtherEntry(t *testing.T) {
 	}
 
 	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
-	reply := m.cmdBind(evB, []string{"--force", webSess.ID})
+	reply := m.cmdBind(evB, []string{"--force", webSess.ID}, "")
 	if !strings.Contains(strings.ToLower(reply), "taken over") {
 		t.Fatalf("expected takeover success, got %q", reply)
 	}
@@ -207,7 +208,7 @@ func TestCmdBind_ForceTakesOverOtherEntry(t *testing.T) {
 		t.Fatalf("expected reply to name previous owner %q, got %q", agent.EntryWeb, reply)
 	}
 
-	bound := m.GetSession(evB)
+	bound := m.GetSession(evB, "")
 	if bound == nil {
 		t.Fatal("expected a session after /bind --force")
 	}
@@ -217,7 +218,7 @@ func TestCmdBind_ForceTakesOverOtherEntry(t *testing.T) {
 
 	// The binding is persisted: a fresh manager sees channel ownership.
 	m2 := testManager()
-	again := m2.GetOrCreateSession(evB)
+	again := m2.GetOrCreateSession(evB, nil)
 	if !again.Store.BoundTo(agent.EntryChannel) {
 		t.Errorf("persisted entry after takeover = %q, want %q", again.Store.BoundEntry, agent.EntryChannel)
 	}
@@ -240,11 +241,11 @@ func TestCmdBind_ForceRejectedWhenLeaseActive(t *testing.T) {
 	}
 
 	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
-	reply := m.cmdBind(evB, []string{webSess.ID, "--force"})
+	reply := m.cmdBind(evB, []string{webSess.ID, "--force"}, "")
 	if !strings.Contains(strings.ToLower(reply), "cannot bind") {
 		t.Fatalf("expected rejection due to active lease, got %q", reply)
 	}
-	if m.GetSession(evB) != nil {
+	if m.GetSession(evB, "") != nil {
 		t.Fatal("expected no session after rejected forced /bind")
 	}
 }
@@ -256,13 +257,13 @@ func TestCmdUnbind_ReleasesBoundEntry(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "secret"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
 	}
 
-	m.cmdUnbind(ev)
+	m.cmdUnbind(ev, "")
 
 	reloaded, err := agent.LoadSession(sess.Store.ID)
 	if err != nil {
@@ -280,7 +281,7 @@ func TestCmdClear_WipesHistoryKeepsStore(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "remember me"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
@@ -291,7 +292,7 @@ func TestCmdClear_WipesHistoryKeepsStore(t *testing.T) {
 	}
 	storeID := sess.Store.ID
 
-	if reply := m.cmdClear(ev); !strings.Contains(strings.ToLower(reply), "cleared") {
+	if reply := m.cmdClear(ev, ""); !strings.Contains(strings.ToLower(reply), "cleared") {
 		t.Fatalf("unexpected clear reply %q", reply)
 	}
 	if got := len(sess.Agent.History.Snapshot()); got != 0 {
@@ -342,21 +343,21 @@ func TestCmdNew_CreatesFreshSessionAndBindsChat(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	m := testManager()
-	old := m.GetOrCreateSession(ev)
+	old := m.GetOrCreateSession(ev, nil)
 	old.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "old context"})
 	if err := old.Persist(); err != nil {
 		t.Fatal(err)
 	}
 	oldID := old.Store.ID
 
-	reply := m.cmdNew(ev)
+	reply := m.cmdNew(ev, "")
 	if !strings.Contains(strings.ToLower(reply), "started a new session") {
 		t.Fatalf("unexpected /new reply %q", reply)
 	}
 
 	// A fresh manager must resolve to the new session, not the old one.
 	m2 := testManager()
-	fresh := m2.GetOrCreateSession(ev)
+	fresh := m2.GetOrCreateSession(ev, nil)
 	if fresh.Store.ID == oldID {
 		t.Errorf("chat still resolves to old session %q after /new", oldID)
 	}
@@ -383,19 +384,19 @@ func TestCmdNew_DetachesEvenWhenBoundToOtherEntry(t *testing.T) {
 	// Chat A owns a session that is now bound to web.
 	evA := InboundEvent{Platform: "feishu", ChatID: "cA", UserID: "uA"}
 	m := testManager()
-	sessA := m.GetOrCreateSession(evA)
+	sessA := m.GetOrCreateSession(evA, nil)
 	sessA.Store.Bind(agent.EntryWeb, true)
 	if err := sessA.Store.Save(); err != nil {
 		t.Fatal(err)
 	}
 
-	reply := m.cmdNew(evA)
+	reply := m.cmdNew(evA, "")
 	if !strings.Contains(strings.ToLower(reply), "started a new session") {
 		t.Fatalf("unexpected /new reply %q", reply)
 	}
 
 	m2 := testManager()
-	fresh := m2.GetOrCreateSession(evA)
+	fresh := m2.GetOrCreateSession(evA, nil)
 	if fresh.Store.ID == sessA.Store.ID {
 		t.Error("chat still resolves to the web-bound session after /new")
 	}
@@ -412,7 +413,7 @@ func TestDeleteStore_TombstonesAgainstZombiePersist(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "private"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
@@ -446,7 +447,7 @@ func TestEnsureStoreExists_RecreatesDeletedFile(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "hello"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
@@ -485,7 +486,7 @@ func TestEnsureStoreExists_NoOpWhenFileStillExists(t *testing.T) {
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "hello"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
@@ -508,7 +509,7 @@ func TestEnsureStoreExists_NoOpWhenStoreIsNil(t *testing.T) {
 	tempHome(t)
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	if err := sess.deleteStore(); err != nil {
 		t.Fatal(err)
 	}
@@ -533,7 +534,7 @@ func TestAdoptGeneratedTitle_ReplacesPlaceholder(t *testing.T) {
 	m := testManager()
 
 	for _, placeholder := range []string{"*Octo Agent", "Session 3", ""} {
-		sess := m.GetOrCreateSession(ev)
+		sess := m.GetOrCreateSession(ev, nil)
 		sess.Store.Title = placeholder // direct assignment: SetTitle("") is a no-op
 		adopted, err := sess.AdoptGeneratedTitle("deploy staging build")
 		if err != nil {
@@ -548,13 +549,13 @@ func TestAdoptGeneratedTitle_ReplacesPlaceholder(t *testing.T) {
 		if err := sess.deleteStore(); err != nil { // reset for the next case
 			t.Fatal(err)
 		}
-		m.sessions.Delete(sessionKeyFor(m.mode, ev))
+		m.sessions.Delete(sessionKeyFor(m.mode, ev, ""))
 	}
 
 	// The store is meta-only (no messages persisted yet), so the title folds
 	// into the meta header on the next Persist — the order the server's
 	// channel persist closure always uses.
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	adopted, err := sess.AdoptGeneratedTitle("deploy staging build")
 	if err != nil || !adopted {
 		t.Fatalf("AdoptGeneratedTitle: adopted=%v err=%v", adopted, err)
@@ -578,7 +579,7 @@ func TestAdoptGeneratedTitle_KeepsUserTitle(t *testing.T) {
 	tempHome(t)
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	if err := sess.Store.SetTitle("my rename"); err != nil {
 		t.Fatal(err)
 	}
@@ -601,7 +602,7 @@ func TestAdoptGeneratedTitle_TombstonedStore(t *testing.T) {
 	tempHome(t)
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
+	sess := m.GetOrCreateSession(ev, nil)
 	if err := sess.deleteStore(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/channel/session_tasks_test.go
+++ b/internal/channel/session_tasks_test.go
@@ -12,7 +12,7 @@ func TestSessionTaskStorePersists(t *testing.T) {
 
 	ev := InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"}
 
-	s1 := mgr.GetOrCreateSession(ev)
+	s1 := mgr.GetOrCreateSession(ev, nil)
 	if s1.Tasks == nil {
 		t.Fatal("session should have a task store")
 	}
@@ -21,7 +21,7 @@ func TestSessionTaskStorePersists(t *testing.T) {
 	}
 
 	// A later message for the same chat reuses the session and its store.
-	s2 := mgr.GetOrCreateSession(ev)
+	s2 := mgr.GetOrCreateSession(ev, nil)
 	if s2 != s1 {
 		t.Fatal("same chat should reuse the session")
 	}
@@ -30,7 +30,7 @@ func TestSessionTaskStorePersists(t *testing.T) {
 	}
 
 	// A different chat gets its own, independent store.
-	other := mgr.GetOrCreateSession(InboundEvent{Platform: "mock", ChatID: "c2", UserID: "u2"})
+	other := mgr.GetOrCreateSession(InboundEvent{Platform: "mock", ChatID: "c2", UserID: "u2"}, nil)
 	if len(other.Tasks.List()) != 0 {
 		t.Error("a different chat should have an independent task store")
 	}

--- a/internal/server/agent_routing_test.go
+++ b/internal/server/agent_routing_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/channel"
 )
 
@@ -36,15 +39,34 @@ func routingHome(t *testing.T) {
 // waitSession polls for the asynchronously spawned turn to create the
 // session (routeChannelEvent runs handleChannelMessage in a goroutine).
 func waitSession(t *testing.T, srv *Server, agentID string) *channel.Session {
+	return waitSessionFor(t, srv, agentID, evFor("x"))
+}
+
+// waitSessionFor polls for a session matching the routed event.
+func waitSessionFor(t *testing.T, srv *Server, agentID string, ev channel.InboundEvent) *channel.Session {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if sess := srv.channelMgr.GetSession(evFor("x"), agentID); sess != nil {
+		if sess := srv.channelMgr.GetSession(ev, agentID); sess != nil {
 			return sess
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 	return nil
+}
+
+// waitPrompt polls for the per-turn system prompt to be composed (the turn
+// that composes it runs in a goroutine).
+func waitPrompt(t *testing.T, sess *channel.Session, substring string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(sess.Agent.System, substring) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("prompt never contained %q; got %q", substring, sess.Agent.System)
 }
 
 func TestRouteChannelEvent_RoutesToBoundExpertAgent(t *testing.T) {
@@ -164,5 +186,129 @@ You review code.
 	// legacy, un-prefixed shape.
 	if sess.Key != channel.SessionKey("fake:c1") {
 		t.Fatalf("default session key = %q, want legacy byte-identical key", sess.Key)
+	}
+}
+
+// Per-turn: a profile with its own SystemPrompt replaces the base system
+// prompt (the profile has full control). A profile WITHOUT a system prompt
+// falls back to the server's base system.
+func TestRunChannelTurns_ProfileComposesPerTurn(t *testing.T) {
+	routingHome(t)
+	writeAgentProfile(t, "ops", `---
+description: ops
+model: claude-sonnet-4-20250514
+channel_bindings:
+  - {platform: fake, chat_id: c1}
+---
+You are the OPS expert. Base prompt.
+`)
+	// A profile WITHOUT a system prompt — should fall back to base.
+	writeAgentProfile(t, "bare", `---
+description: bare
+channel_bindings:
+  - {platform: fake, chat_id: c2}
+---
+`)
+	dir := filepath.Join(os.Getenv("HOME"), ".octo", "agents")
+	store := agentprofile.New(dir, func() string { return "" })
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.system = "SERVER BASE SYSTEM"
+	srv.agentStore = store
+	srv.agentRouterVal = agentprofile.NewRouter(store)
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(p *agentprofile.Profile) *agent.Agent {
+		return agent.New(&stubSender{}, "model-"+p.ID)
+	}, channel.BindByChat)
+	ad := &fullFakeAdapter{}
+
+	// Profile with system prompt → its prompt replaces base.
+	srv.routeChannelEvent(context.Background(), ad, channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "diag"})
+	opsSess := waitSession(t, srv, "ops")
+	if opsSess == nil {
+		t.Fatal("ops session not created")
+	}
+	waitPrompt(t, opsSess, "OPS expert")
+
+	// Profile without system prompt → falls back to server base.
+	evBare := channel.InboundEvent{Platform: "fake", ChatID: "c2", UserID: "u2", Text: "diag"}
+	srv.routeChannelEvent(context.Background(), ad, evBare)
+	bareSess := waitSessionFor(t, srv, "bare", evBare)
+	if bareSess == nil {
+		t.Fatal("bare session not created")
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(bareSess.Agent.System, "SERVER BASE SYSTEM") {
+			return // passed
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("bare profile did not fall back to base system: %q", bareSess.Agent.System)
+}
+
+// A profile deleted mid-session must fall back to the default system prompt
+// on the next turn. After the profile is removed, the read-through Store
+// misses on the next route, so the same chat now resolves to the default
+// agent — whose base system prompt is used (not the deleted profile's).
+func TestRunChannelTurns_DeletedProfileFallsBackToDefault(t *testing.T) {
+	routingHome(t)
+	dir := filepath.Join(os.Getenv("HOME"), ".octo", "agents")
+	writeAgentProfile(t, "temp", `---
+description: temp
+channel_bindings:
+  - {platform: fake, chat_id: c1}
+---
+TEMP PROFILE PROMPT.
+`)
+	store := agentprofile.New(dir, func() string { return "" })
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.system = "SERVER BASE"
+	srv.agentStore = store
+	srv.agentRouterVal = agentprofile.NewRouter(store)
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(p *agentprofile.Profile) *agent.Agent {
+		return agent.New(&stubSender{}, "stub-model")
+	}, channel.BindByChat)
+	ad := &fullFakeAdapter{}
+
+	// First turn: profile exists → routes to "temp" → temp prompt applied.
+	srv.routeChannelEvent(context.Background(), ad, channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "hi"})
+	tempSess := waitSession(t, srv, "temp")
+	if tempSess == nil {
+		t.Fatal("temp session not created")
+	}
+	waitPrompt(t, tempSess, "TEMP PROFILE PROMPT")
+	// Delete the profile file — read-through Store misses on next route.
+	if err := os.Remove(filepath.Join(dir, "temp.md")); err != nil {
+		t.Fatal(err)
+	}
+	// Second turn: profile gone → resolves to default → base prompt. A new
+	// session under "default" is created (different key namespace).
+	srv.routeChannelEvent(context.Background(), ad, channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "again"})
+	defSess := waitSession(t, srv, "default")
+	if defSess == nil {
+		t.Fatal("default session not created after profile delete")
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		sys := defSess.Agent.System
+		if sys != "" && !strings.Contains(sys, "TEMP PROFILE PROMPT") && strings.Contains(sys, "SERVER BASE") {
+			return // passed
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("new turn did not use base prompt: %q", defSess.Agent.System)
+}
+
+// A profile with an unresolvable model must warn-and-fall-through to the
+// server default, not panic or start with the bogus unresolvable model.
+func TestBuildChannelAgent_UnresolvedModelFallsBack(t *testing.T) {
+	routingHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	got := srv.buildChannelAgent(&agentprofile.Profile{ID: "x", Description: "d", CapabilitySpec: agentprofile.CapabilitySpec{Model: "no-such-model"}})
+	if got == nil {
+		t.Fatal("buildChannelAgent returned nil")
+	}
+	// The bogus model must NOT be used — it falls back to the server default.
+	if got.Model == "no-such-model" {
+		t.Fatalf("unresolved profile model leaked into the agent: %q", got.Model)
 	}
 }

--- a/internal/server/agent_routing_test.go
+++ b/internal/server/agent_routing_test.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/open-octo/octo-agent/internal/channel"
+)
+
+// End-to-end IM routing (dev-docs/multi-agent-system-design.md §2-3): a
+// profile bound to a chat owns that chat's messages; multiple bindings with
+// no @-mention stay silent; an @-mention picks the agent explicitly.
+
+// writeAgentProfile drops a user-level profile into the test HOME.
+func writeAgentProfile(t *testing.T, id, content string) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HOME"), ".octo", "agents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, id+".md"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func routingHome(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+}
+
+// waitSession polls for the asynchronously spawned turn to create the
+// session (routeChannelEvent runs handleChannelMessage in a goroutine).
+func waitSession(t *testing.T, srv *Server, agentID string) *channel.Session {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if sess := srv.channelMgr.GetSession(evFor("x"), agentID); sess != nil {
+			return sess
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return nil
+}
+
+func TestRouteChannelEvent_RoutesToBoundExpertAgent(t *testing.T) {
+	routingHome(t)
+	writeAgentProfile(t, "reviewer", `---
+description: reviews code
+channel_bindings:
+  - {platform: fake, chat_id: c1}
+---
+You review code.
+`)
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("hello"))
+
+	sess := waitSession(t, srv, "reviewer")
+	if sess == nil {
+		t.Fatal("message to a bound chat did not create the expert's session")
+	}
+	if sess.AgentID != "reviewer" {
+		t.Fatalf("session AgentID = %q, want reviewer", sess.AgentID)
+	}
+	if sess.Store.EffectiveAgentID() != "reviewer" {
+		t.Fatalf("store agent_id = %q, want reviewer", sess.Store.AgentID)
+	}
+	// The default agent's namespace for the same chat stays empty.
+	if got := srv.channelMgr.GetSession(evFor("x"), "default"); got != nil {
+		t.Fatal("bound chat leaked a default-agent session")
+	}
+}
+
+func TestRouteChannelEvent_MultiBindingNoMentionDrops(t *testing.T) {
+	routingHome(t)
+	writeAgentProfile(t, "agent-a", `---
+description: a
+channel_bindings:
+  - {platform: fake, chat_id: c1}
+---
+A.
+`)
+	writeAgentProfile(t, "agent-b", `---
+description: b
+channel_bindings:
+  - {platform: fake, chat_id: c1}
+---
+B.
+`)
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("hello"))
+	time.Sleep(100 * time.Millisecond) // prove nothing async happens either
+
+	// Silence: no session under either agent, no reply sent.
+	if got := srv.channelMgr.GetSession(evFor("x"), "agent-a"); got != nil {
+		t.Fatal("multi-bound chat without @ created agent-a session")
+	}
+	if got := srv.channelMgr.GetSession(evFor("x"), "agent-b"); got != nil {
+		t.Fatal("multi-bound chat without @ created agent-b session")
+	}
+	if texts := ad.texts(); len(texts) != 0 {
+		t.Fatalf("expected silence, got replies: %v", texts)
+	}
+}
+
+func TestRouteChannelEvent_MentionSelectsAgent(t *testing.T) {
+	routingHome(t)
+	writeAgentProfile(t, "agent-a", `---
+description: a
+mention_as: ["@aa"]
+channel_bindings:
+  - {platform: fake, chat_id: c1}
+---
+A.
+`)
+	writeAgentProfile(t, "agent-b", `---
+description: b
+mention_as: ["@bb"]
+channel_bindings:
+  - {platform: fake, chat_id: c1}
+---
+B.
+`)
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("@bb hello"))
+
+	if got := waitSession(t, srv, "agent-b"); got == nil {
+		t.Fatal("@bb mention did not route to agent-b")
+	}
+	if got := srv.channelMgr.GetSession(evFor("x"), "agent-a"); got != nil {
+		t.Fatal("@bb mention leaked a session to agent-a")
+	}
+}
+
+func TestRouteChannelEvent_UnboundChatFallsBackToDefault(t *testing.T) {
+	routingHome(t)
+	writeAgentProfile(t, "reviewer", `---
+description: reviews code
+channel_bindings:
+  - {platform: fake, chat_id: other-chat}
+---
+You review code.
+`)
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("hello"))
+
+	sess := waitSession(t, srv, "default")
+	if sess == nil {
+		t.Fatal("unbound chat did not fall back to the default agent")
+	}
+	// chanServer uses BindByChat: the default agent's key must remain the
+	// legacy, un-prefixed shape.
+	if sess.Key != channel.SessionKey("fake:c1") {
+		t.Fatalf("default session key = %q, want legacy byte-identical key", sess.Key)
+	}
+}

--- a/internal/server/agent_routing_test.go
+++ b/internal/server/agent_routing_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/agentprofile"
@@ -36,37 +35,26 @@ func routingHome(t *testing.T) {
 	t.Setenv("USERPROFILE", tmp)
 }
 
-// waitSession polls for the asynchronously spawned turn to create the
-// session (routeChannelEvent runs handleChannelMessage in a goroutine).
-func waitSession(t *testing.T, srv *Server, agentID string) *channel.Session {
-	return waitSessionFor(t, srv, agentID, evFor("x"))
+// agentStoreDir returns the test HOME's profile dir.
+func agentStoreDir() string {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "agents")
 }
 
-// waitSessionFor polls for a session matching the routed event.
-func waitSessionFor(t *testing.T, srv *Server, agentID string, ev channel.InboundEvent) *channel.Session {
+// routeAndWait resolves the profile for ev, runs handleChannelMessage to
+// completion, and returns. Using the stub sender this is fast and avoids
+// racing with the async goroutine that routeChannelEvent would spawn.
+func routeAndWait(t *testing.T, srv *Server, ad *fullFakeAdapter, ev channel.InboundEvent, profile *agentprofile.Profile) {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if sess := srv.channelMgr.GetSession(ev, agentID); sess != nil {
-			return sess
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	return nil
-}
-
-// waitPrompt polls for the per-turn system prompt to be composed (the turn
-// that composes it runs in a goroutine).
-func waitPrompt(t *testing.T, sess *channel.Session, substring string) {
-	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.Contains(sess.Agent.System, substring) {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("prompt never contained %q; got %q", substring, sess.Agent.System)
+	turnDone := make(chan struct{})
+	go func() {
+		defer close(turnDone)
+		srv.handleChannelMessage(context.Background(), ad, ev, profile)
+	}()
+	<-turnDone
 }
 
 func TestRouteChannelEvent_RoutesToBoundExpertAgent(t *testing.T) {
@@ -80,10 +68,14 @@ You review code.
 `)
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
+	ev := evFor("hello")
+	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir(), nil)).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
+	if profile == nil {
+		t.Fatal("expected routing to reviewer, got nil")
+	}
+	routeAndWait(t, srv, ad, ev, profile)
 
-	srv.routeChannelEvent(context.Background(), ad, evFor("hello"))
-
-	sess := waitSession(t, srv, "reviewer")
+	sess := srv.channelMgr.GetSession(ev, "reviewer")
 	if sess == nil {
 		t.Fatal("message to a bound chat did not create the expert's session")
 	}
@@ -94,7 +86,7 @@ You review code.
 		t.Fatalf("store agent_id = %q, want reviewer", sess.Store.AgentID)
 	}
 	// The default agent's namespace for the same chat stays empty.
-	if got := srv.channelMgr.GetSession(evFor("x"), "default"); got != nil {
+	if got := srv.channelMgr.GetSession(ev, "default"); got != nil {
 		t.Fatal("bound chat leaked a default-agent session")
 	}
 }
@@ -117,15 +109,17 @@ B.
 `)
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
-
-	srv.routeChannelEvent(context.Background(), ad, evFor("hello"))
-	time.Sleep(100 * time.Millisecond) // prove nothing async happens either
-
-	// Silence: no session under either agent, no reply sent.
-	if got := srv.channelMgr.GetSession(evFor("x"), "agent-a"); got != nil {
+	ev := evFor("hello")
+	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir(), nil)).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
+	if profile != nil {
+		t.Fatalf("expected nil route (multi-binding, no @), got %q", profile.ID)
+	}
+	// No handleChannelMessage: routeChannelEvent would have dropped the event.
+	// Verify silence: no session under either agent, no reply sent.
+	if got := srv.channelMgr.GetSession(ev, "agent-a"); got != nil {
 		t.Fatal("multi-bound chat without @ created agent-a session")
 	}
-	if got := srv.channelMgr.GetSession(evFor("x"), "agent-b"); got != nil {
+	if got := srv.channelMgr.GetSession(ev, "agent-b"); got != nil {
 		t.Fatal("multi-bound chat without @ created agent-b session")
 	}
 	if texts := ad.texts(); len(texts) != 0 {
@@ -153,13 +147,17 @@ B.
 `)
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
+	ev := evFor("@bb hello")
+	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir(), nil)).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
+	if profile == nil || profile.ID != "agent-b" {
+		t.Fatalf("expected routing to agent-b, got %+v", profile)
+	}
+	routeAndWait(t, srv, ad, ev, profile)
 
-	srv.routeChannelEvent(context.Background(), ad, evFor("@bb hello"))
-
-	if got := waitSession(t, srv, "agent-b"); got == nil {
+	if got := srv.channelMgr.GetSession(ev, "agent-b"); got == nil {
 		t.Fatal("@bb mention did not route to agent-b")
 	}
-	if got := srv.channelMgr.GetSession(evFor("x"), "agent-a"); got != nil {
+	if got := srv.channelMgr.GetSession(ev, "agent-a"); got != nil {
 		t.Fatal("@bb mention leaked a session to agent-a")
 	}
 }
@@ -175,10 +173,14 @@ You review code.
 `)
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
+	ev := evFor("hello")
+	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir(), nil)).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
+	if profile == nil || !profile.IsDefault() {
+		t.Fatalf("expected default fallback, got %+v", profile)
+	}
+	routeAndWait(t, srv, ad, ev, profile)
 
-	srv.routeChannelEvent(context.Background(), ad, evFor("hello"))
-
-	sess := waitSession(t, srv, "default")
+	sess := srv.channelMgr.GetSession(ev, "default")
 	if sess == nil {
 		t.Fatal("unbound chat did not fall back to the default agent")
 	}
@@ -221,28 +223,27 @@ channel_bindings:
 	ad := &fullFakeAdapter{}
 
 	// Profile with system prompt → its prompt replaces base.
-	srv.routeChannelEvent(context.Background(), ad, channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "diag"})
-	opsSess := waitSession(t, srv, "ops")
+	evOps := channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "diag"}
+	router := agentprofile.NewRouter(store)
+	routeAndWait(t, srv, ad, evOps, router.Route(agentprofile.RouteInput{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "diag"}))
+	opsSess := srv.channelMgr.GetSession(evOps, "ops")
 	if opsSess == nil {
 		t.Fatal("ops session not created")
 	}
-	waitPrompt(t, opsSess, "OPS expert")
+	if !strings.Contains(opsSess.Agent.System, "OPS expert") {
+		t.Fatalf("profile system prompt not applied: %q", opsSess.Agent.System)
+	}
 
 	// Profile without system prompt → falls back to server base.
 	evBare := channel.InboundEvent{Platform: "fake", ChatID: "c2", UserID: "u2", Text: "diag"}
-	srv.routeChannelEvent(context.Background(), ad, evBare)
-	bareSess := waitSessionFor(t, srv, "bare", evBare)
+	routeAndWait(t, srv, ad, evBare, router.Route(agentprofile.RouteInput{Platform: "fake", ChatID: "c2", UserID: "u2", Text: "diag"}))
+	bareSess := srv.channelMgr.GetSession(evBare, "bare")
 	if bareSess == nil {
 		t.Fatal("bare session not created")
 	}
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.Contains(bareSess.Agent.System, "SERVER BASE SYSTEM") {
-			return // passed
-		}
-		time.Sleep(5 * time.Millisecond)
+	if !strings.Contains(bareSess.Agent.System, "SERVER BASE SYSTEM") {
+		t.Fatalf("bare profile did not fall back to base system: %q", bareSess.Agent.System)
 	}
-	t.Fatalf("bare profile did not fall back to base system: %q", bareSess.Agent.System)
 }
 
 // A profile deleted mid-session must fall back to the default system prompt
@@ -268,34 +269,35 @@ TEMP PROFILE PROMPT.
 		return agent.New(&stubSender{}, "stub-model")
 	}, channel.BindByChat)
 	ad := &fullFakeAdapter{}
+	router := agentprofile.NewRouter(store)
 
 	// First turn: profile exists → routes to "temp" → temp prompt applied.
-	srv.routeChannelEvent(context.Background(), ad, channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "hi"})
-	tempSess := waitSession(t, srv, "temp")
+	ev1 := channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "hi"}
+	routeAndWait(t, srv, ad, ev1, router.Route(agentprofile.RouteInput{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "hi"}))
+	tempSess := srv.channelMgr.GetSession(ev1, "temp")
 	if tempSess == nil {
 		t.Fatal("temp session not created")
 	}
-	waitPrompt(t, tempSess, "TEMP PROFILE PROMPT")
+	if !strings.Contains(tempSess.Agent.System, "TEMP PROFILE PROMPT") {
+		t.Fatalf("initial profile prompt not applied: %q", tempSess.Agent.System)
+	}
 	// Delete the profile file — read-through Store misses on next route.
 	if err := os.Remove(filepath.Join(dir, "temp.md")); err != nil {
 		t.Fatal(err)
 	}
-	// Second turn: profile gone → resolves to default → base prompt. A new
-	// session under "default" is created (different key namespace).
-	srv.routeChannelEvent(context.Background(), ad, channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "again"})
-	defSess := waitSession(t, srv, "default")
+	// Second turn: profile gone → resolves to default → base prompt.
+	ev2 := channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "again"}
+	routeAndWait(t, srv, ad, ev2, router.Route(agentprofile.RouteInput{Platform: "fake", ChatID: "c1", UserID: "u1", Text: "again"}))
+	defSess := srv.channelMgr.GetSession(ev2, "default")
 	if defSess == nil {
 		t.Fatal("default session not created after profile delete")
 	}
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		sys := defSess.Agent.System
-		if sys != "" && !strings.Contains(sys, "TEMP PROFILE PROMPT") && strings.Contains(sys, "SERVER BASE") {
-			return // passed
-		}
-		time.Sleep(5 * time.Millisecond)
+	if strings.Contains(defSess.Agent.System, "TEMP PROFILE PROMPT") {
+		t.Fatalf("deleted profile's prompt still applied: %q", defSess.Agent.System)
 	}
-	t.Fatalf("new turn did not use base prompt: %q", defSess.Agent.System)
+	if !strings.Contains(defSess.Agent.System, "SERVER BASE") {
+		t.Fatalf("did not fall back to base prompt: %q", defSess.Agent.System)
+	}
 }
 
 // A profile with an unresolvable model must warn-and-fall-through to the

--- a/internal/server/channel_model_test.go
+++ b/internal/server/channel_model_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/channel"
 	"github.com/open-octo/octo-agent/internal/config"
 )
@@ -32,10 +33,10 @@ func TestApplyChannelModel_HonorsStoreBinding(t *testing.T) {
 	}
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-	mgr := channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	mgr := channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(srv.getSender(), "stub-model")
 	}, channel.BindByChatUser)
-	sess := mgr.GetOrCreateSession(channel.InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"})
+	sess := mgr.GetOrCreateSession(channel.InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"}, nil)
 
 	// Unbound: default sender, model from the store.
 	srv.applyChannelModel(sess)

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/channel"
 	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/hooks"
@@ -77,7 +78,7 @@ func (a *fullFakeAdapter) typingCounts() (sendTyping, stopTyping int) {
 func chanServer(t *testing.T) *Server {
 	t.Helper()
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(&stubSender{}, "stub-model")
 	}, channel.BindByChat)
 	return srv
@@ -93,7 +94,7 @@ func TestRouteChannelEvent_PendingAskConsumesMessage(t *testing.T) {
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	replyCh, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatal(err)
@@ -118,7 +119,7 @@ func TestRouteChannelEvent_CommandBeatsPendingAsk(t *testing.T) {
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	replyCh, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatal(err)
@@ -178,13 +179,13 @@ func (panicSender) StreamMessagesWithTools(_ context.Context, _, _ string, _ []a
 // test panics the test binary instead of failing cleanly.
 func TestHandleChannelMessage_RecoversTurnPanic(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(panicSender{}, "stub-model")
 	}, channel.BindByChat)
 	ad := &fullFakeAdapter{}
 
 	// Runs the turn synchronously here; a recovered panic returns normally.
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"), nil)
 	// Reaching this line proves the turn panic was recovered, not propagated.
 }
 
@@ -204,13 +205,13 @@ func TestHandleChannelMessage_HonorsCompactAutoPct(t *testing.T) {
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	// The factory does not set it; only a turn resolves it from config.
 	if sess.Agent.CompactAutoFraction != 0 {
 		t.Fatalf("factory should not pre-set CompactAutoFraction, got %v", sess.Agent.CompactAutoFraction)
 	}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"), nil)
 
 	if want := float64(70) / 100.0; sess.Agent.CompactAutoFraction != want {
 		t.Errorf("after an IM turn CompactAutoFraction = %v, want %v (from compact_auto_pct: 70)", sess.Agent.CompactAutoFraction, want)
@@ -221,12 +222,12 @@ func TestHandleChannelMessage_SetsPerTurnGate(t *testing.T) {
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	if sess.Agent.Gate != nil {
 		t.Fatal("factory must not pre-set a gate anymore")
 	}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"), nil)
 
 	if sess.Agent.Gate == nil {
 		t.Error("handleChannelMessage must set a per-turn permission gate")
@@ -244,7 +245,7 @@ func TestHandleChannelMessage_TypingKeepaliveWired(t *testing.T) {
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"), nil)
 
 	sendTyping, stopTyping := ad.typingCounts()
 	if sendTyping == 0 {
@@ -262,7 +263,7 @@ func TestRouteChannelEvent_OtherUserCannotAnswer(t *testing.T) {
 	srv := chanServer(t) // BindByChat: one session per chat, shared by users
 	ad := &fullFakeAdapter{}
 
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	replyCh, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatal(err)
@@ -286,7 +287,7 @@ func TestRouteChannelEvent_EmptyTextNeverAnswers(t *testing.T) {
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	replyCh, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatal(err)
@@ -356,7 +357,7 @@ func (b *blockingSender) snapshot() (int, []string) {
 func TestRouteChannelEvent_MidTurnMessageSteers(t *testing.T) {
 	sender := &blockingSender{started: make(chan struct{}, 8), release: make(chan struct{})}
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		a := agent.New(sender, "stub-model")
 		// Run title generation on a separate lite sender: the turn spawns it
 		// concurrently, and on the primary sender it races the turn's own
@@ -372,7 +373,7 @@ func TestRouteChannelEvent_MidTurnMessageSteers(t *testing.T) {
 	<-sender.started // turn 1 is now blocked inside the sender
 
 	srv.routeChannelEvent(context.Background(), ad, evFor("steer me in"))
-	sess := srv.channelMgr.GetSession(evFor("x"))
+	sess := srv.channelMgr.GetSession(evFor("x"), "")
 	if !sess.Agent.Inbox.HasPending() {
 		t.Fatal("mid-turn message did not land in the running turn's Inbox")
 	}
@@ -402,12 +403,12 @@ func TestHandleChannelMessage_PersistsTurn(t *testing.T) {
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("please remember 42"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("please remember 42"), nil)
 
-	fresh := channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	fresh := channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(&stubSender{}, "stub-model")
 	}, channel.BindByChat)
-	restored := fresh.GetOrCreateSession(evFor("x"))
+	restored := fresh.GetOrCreateSession(evFor("x"), nil)
 	msgs := restored.Agent.History.Snapshot()
 	if len(msgs) < 2 {
 		t.Fatalf("restored history has %d messages, want >=2 (user+assistant)", len(msgs))
@@ -421,8 +422,8 @@ func TestHandleChannelMessage_RefreshesSystemPerTurn(t *testing.T) {
 	srv.memDir = t.TempDir()
 	ad := &fullFakeAdapter{}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("turn one"))
-	sess := srv.channelMgr.GetSession(evFor("x"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("turn one"), nil)
+	sess := srv.channelMgr.GetSession(evFor("x"), "")
 	if strings.Contains(sess.Agent.System, "fresh-fact-9000") {
 		t.Fatal("memory marker present before it was written")
 	}
@@ -430,7 +431,7 @@ func TestHandleChannelMessage_RefreshesSystemPerTurn(t *testing.T) {
 	if err := os.WriteFile(srv.memDir+"/MEMORY.md", []byte("- fresh-fact-9000"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	srv.handleChannelMessage(context.Background(), ad, evFor("turn two"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("turn two"), nil)
 	if !strings.Contains(sess.Agent.System, "fresh-fact-9000") {
 		t.Error("system prompt not recomposed: memory written mid-session is invisible to IM turns")
 	}
@@ -443,9 +444,9 @@ func TestHandleChannelMessage_WiresMemoryHooks(t *testing.T) {
 	srv.memDir = t.TempDir()
 	ad := &fullFakeAdapter{}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"), nil)
 
-	sess := srv.channelMgr.GetSession(evFor("x"))
+	sess := srv.channelMgr.GetSession(evFor("x"), "")
 	if !sess.Agent.Hooks.Configured(hooks.EventUserPromptSubmit) {
 		t.Error("IM agent missing UserPromptSubmit hook (keyword reminders)")
 	}
@@ -484,7 +485,7 @@ func TestHandleChannelMessage_RefreshesAutoRecallBeforeRegisteringHooks(t *testi
 		tools.SetMemoryBackendAutoRecall(false)
 	})
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"), nil)
 
 	// Drive a REAL Inject() call against this session's own engine and check
 	// for actual recalled content — not e.Configured(EventUserPromptSubmit)
@@ -496,7 +497,7 @@ func TestHandleChannelMessage_RefreshesAutoRecallBeforeRegisteringHooks(t *testi
 	// THIS turn's engine was built with the right value at registration
 	// time — see TestBuildAgent_RefreshesAutoRecallBeforeRegisteringHooks's
 	// doc comment for the experiment that found this).
-	sess := srv.channelMgr.GetSession(evFor("x"))
+	sess := srv.channelMgr.GetSession(evFor("x"), "")
 	if sess == nil || sess.Agent == nil || sess.Agent.Hooks == nil {
 		t.Fatal("expected a bound IM session with hooks wired after handleChannelMessage")
 	}
@@ -519,9 +520,9 @@ func TestHandleChannelMessage_WiresArchiveDir(t *testing.T) {
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"), nil)
 
-	sess := srv.channelMgr.GetSession(evFor("x"))
+	sess := srv.channelMgr.GetSession(evFor("x"), "")
 	if sess.Agent.ArchiveDir == "" {
 		t.Fatal("IM agent missing ArchiveDir — compaction would fold history without archiving it")
 	}
@@ -546,7 +547,7 @@ func TestHandleChannelMessage_RejectsTurnWhenBoundToOtherEntry(t *testing.T) {
 	ad := &fullFakeAdapter{}
 
 	// Pre-create the chat's deterministic store and mark it web-bound.
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	storeID := sess.Store.ID
 	path, err := sess.Store.SavePath()
 	if err != nil {
@@ -569,7 +570,7 @@ func TestHandleChannelMessage_RejectsTurnWhenBoundToOtherEntry(t *testing.T) {
 	}
 	sess.Store = loaded
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello again"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello again"), nil)
 
 	waitFor(t, func() bool {
 		for _, txt := range ad.texts() {
@@ -607,7 +608,7 @@ func TestHandleChannelMessage_RecoversWhenSessionFileDeletedExternally(t *testin
 
 	// Establish the chat's session and give it some history, exactly like an
 	// ordinary prior conversation.
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "old message"})
 	if err := sess.Persist(); err != nil {
 		t.Fatal(err)
@@ -623,7 +624,7 @@ func TestHandleChannelMessage_RecoversWhenSessionFileDeletedExternally(t *testin
 		t.Fatal(err)
 	}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello again"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello again"), nil)
 
 	waitFor(t, func() bool { return len(ad.texts()) > 0 })
 
@@ -653,12 +654,12 @@ func TestHandleChannelMessage_AdvertisesWorkflowToTopLevelTurn(t *testing.T) {
 
 	rec := &recordingSender{}
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(rec, "stub-model")
 	}, channel.BindByChat)
 
 	ad := &fullFakeAdapter{}
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"), nil)
 
 	waitFor(t, func() bool { return len(rec.lastTools) > 0 })
 
@@ -680,12 +681,12 @@ func TestHandleChannelMessage_AdvertisesWorkflowToTopLevelTurn(t *testing.T) {
 // model can react without waiting for the user's next message.
 func TestHandleChannelMessage_BackgroundCompletionTriggersIdleTurn(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(&stubSender{}, "stub-model")
 	}, channel.BindByChat)
 	ad := &fullFakeAdapter{}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"), nil)
 
 	// Wait for the user-initiated turn to finish.
 	waitFor(t, func() bool {
@@ -698,7 +699,7 @@ func TestHandleChannelMessage_BackgroundCompletionTriggersIdleTurn(t *testing.T)
 	})
 
 	// Simulate an async background process exiting after the turn went idle.
-	sess := srv.channelMgr.GetSession(evFor("x"))
+	sess := srv.channelMgr.GetSession(evFor("x"), "")
 	bgMgr := tools.SessionBackgroundManager("im:" + string(sess.Key))
 	bgMgr.FireExitHook(tools.BgExit{ID: "bg_1", Command: "make build", Status: "exited: 0", NewOutput: "done"})
 
@@ -731,7 +732,7 @@ func TestHandleChannelMessage_BackgroundCompletionTriggersIdleTurn(t *testing.T)
 // must not run.
 func TestRunChannelIdleTurn_SkipsWhenBoundToOtherEntry(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(&stubSender{}, "stub-model")
 	}, channel.BindByChat)
 	ad := &fullFakeAdapter{}
@@ -746,7 +747,7 @@ func TestRunChannelIdleTurn_SkipsWhenBoundToOtherEntry(t *testing.T) {
 	// authoritative binding and refuses to run.
 	// First create the channel session to learn its deterministic store ID,
 	// then overwrite the file with a web-bound meta record.
-	sess := srv.channelMgr.GetOrCreateSession(ev)
+	sess := srv.channelMgr.GetOrCreateSession(ev, nil)
 	storeID := sess.Store.ID
 	path, err := sess.Store.SavePath()
 	if err != nil {
@@ -790,7 +791,7 @@ func TestInjectorFor_SessionStickyAndDroppedOnUnbind(t *testing.T) {
 	ad := &fullFakeAdapter{}
 	ev := evFor("/unbind")
 
-	key := "im:" + string(srv.channelMgr.KeyFor(ev))
+	key := "im:" + string(srv.channelMgr.KeyFor(ev, ""))
 	first := srv.injectorFor(key)
 	if first == nil {
 		t.Fatal("injectorFor returned nil")
@@ -799,7 +800,7 @@ func TestInjectorFor_SessionStickyAndDroppedOnUnbind(t *testing.T) {
 		t.Error("injector must be sticky across turns in one session")
 	}
 
-	srv.handleChannelCommand(ad, ev)
+	srv.handleChannelCommand(ad, ev, agentprofile.DefaultProfile())
 	if srv.injectorFor(key) == first {
 		t.Error("/unbind must drop the session injector (fresh recall latch)")
 	}
@@ -813,13 +814,13 @@ func TestInjectorFor_DroppedOnNew(t *testing.T) {
 	ad := &fullFakeAdapter{}
 	ev := evFor("/new")
 
-	key := "im:" + string(srv.channelMgr.KeyFor(ev))
+	key := "im:" + string(srv.channelMgr.KeyFor(ev, ""))
 	first := srv.injectorFor(key)
 	if first == nil {
 		t.Fatal("injectorFor returned nil")
 	}
 
-	srv.handleChannelCommand(ad, ev)
+	srv.handleChannelCommand(ad, ev, agentprofile.DefaultProfile())
 	if srv.injectorFor(key) == first {
 		t.Error("/new must drop the session injector (fresh recall latch)")
 	}
@@ -833,7 +834,7 @@ func TestInjectorFor_DroppedOnNew(t *testing.T) {
 func TestChannelCommand_LoopPassesThroughToAgent(t *testing.T) {
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
-	if srv.handleChannelCommand(ad, evFor("/loop 5m check the build")) {
+	if srv.handleChannelCommand(ad, evFor("/loop 5m check the build"), agentprofile.DefaultProfile()) {
 		t.Fatal("/loop must not be intercepted as a command — it routes to the agent")
 	}
 }
@@ -852,13 +853,13 @@ func TestChannelCommand_UnbindKeepsLoopWakeup(t *testing.T) {
 	// those tests); arm one manually under the im: key the way imWaker does.
 	srv.wakeupTimers = map[string]*time.Timer{}
 	srv.wakeupStart = map[string]time.Time{}
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	key := "im:" + string(sess.Key)
 	srv.wakeupTimers[key] = time.AfterFunc(time.Hour, func() {})
 	srv.wakeupStart[key] = time.Now()
 
 	// /unbind must keep the wakeup armed — the loop continues silently.
-	if !srv.handleChannelCommand(ad, evFor("/unbind")) {
+	if !srv.handleChannelCommand(ad, evFor("/unbind"), agentprofile.DefaultProfile()) {
 		t.Fatal("/unbind should be handled as a command")
 	}
 	if _, ok := srv.wakeupTimers[key]; !ok {
@@ -866,7 +867,7 @@ func TestChannelCommand_UnbindKeepsLoopWakeup(t *testing.T) {
 	}
 
 	// /clear (a fresh-context command) DOES cancel the wakeup — contrast.
-	srv.handleChannelCommand(ad, evFor("/clear"))
+	srv.handleChannelCommand(ad, evFor("/clear"), agentprofile.DefaultProfile())
 	if _, ok := srv.wakeupTimers[key]; ok {
 		t.Fatal("/clear must cancel the armed loop wakeup (fresh context)")
 	}
@@ -880,19 +881,19 @@ func TestChannelCommand_UnbindThenStopCancelsWakeup(t *testing.T) {
 	ad := &fullFakeAdapter{}
 	srv.wakeupTimers = map[string]*time.Timer{}
 	srv.wakeupStart = map[string]time.Time{}
-	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
 	key := "im:" + string(sess.Key)
 	srv.wakeupTimers[key] = time.AfterFunc(time.Hour, func() {})
 	srv.wakeupStart[key] = time.Now()
 
 	// /unbind keeps the wakeup.
-	srv.handleChannelCommand(ad, evFor("/unbind"))
+	srv.handleChannelCommand(ad, evFor("/unbind"), agentprofile.DefaultProfile())
 	if _, ok := srv.wakeupTimers[key]; !ok {
 		t.Fatal("/unbind must keep an armed loop wakeup")
 	}
 
 	// /stop cancels it — the hard stop.
-	srv.handleChannelCommand(ad, evFor("/stop"))
+	srv.handleChannelCommand(ad, evFor("/stop"), agentprofile.DefaultProfile())
 	if _, ok := srv.wakeupTimers[key]; ok {
 		t.Fatal("/stop after /unbind must cancel the armed loop wakeup")
 	}

--- a/internal/server/channel_send_handlers_test.go
+++ b/internal/server/channel_send_handlers_test.go
@@ -56,7 +56,7 @@ func TestHandleChannelRecipients(t *testing.T) {
 	t.Setenv("USERPROFILE", tmp)
 
 	srv := chanServer(t)
-	srv.channelMgr.GetOrCreateSession(channel.InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"})
+	srv.channelMgr.GetOrCreateSession(channel.InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}, nil)
 
 	req := httptest.NewRequest("GET", "/api/channels/recipients", nil)
 	w := httptest.NewRecorder()

--- a/internal/server/channel_title_test.go
+++ b/internal/server/channel_title_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/channel"
 )
 
@@ -21,7 +22,7 @@ func TestHandleChannelMessage_GeneratesSessionTitle(t *testing.T) {
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	sender := &blockingTurnSender{entered: make(chan struct{}), release: make(chan struct{})}
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(sender, "stub-model")
 	}, channel.BindByChat)
 
@@ -35,14 +36,14 @@ func TestHandleChannelMessage_GeneratesSessionTitle(t *testing.T) {
 
 	ad := &fullFakeAdapter{}
 	ev := evFor("hello there")
-	sess := srv.channelMgr.GetOrCreateSession(ev) // pre-create to learn the store ID
+	sess := srv.channelMgr.GetOrCreateSession(ev, nil) // pre-create to learn the store ID
 	storeID := sess.Store.ID
 	if sess.Store.Title != "*Octo Agent" {
 		t.Fatalf("fresh IM session title = %q, want the placeholder", sess.Store.Title)
 	}
 
 	turnDone := make(chan struct{})
-	go func() { defer close(turnDone); srv.handleChannelMessage(context.Background(), ad, ev) }()
+	go func() { defer close(turnDone); srv.handleChannelMessage(context.Background(), ad, ev, nil) }()
 	<-sender.entered // main turn call is blocked; title generation runs concurrently
 
 	// Mid-turn the generated title is broadcast live...
@@ -81,7 +82,7 @@ func TestHandleChannelMessage_TitleFallsBackToSnippet(t *testing.T) {
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	sender := &blockingTitleFailSender{entered: make(chan struct{}), release: make(chan struct{})}
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(sender, "stub-model")
 	}, channel.BindByChat)
 
@@ -94,11 +95,11 @@ func TestHandleChannelMessage_TitleFallsBackToSnippet(t *testing.T) {
 
 	ad := &fullFakeAdapter{}
 	ev := evFor("hello there")
-	sess := srv.channelMgr.GetOrCreateSession(ev)
+	sess := srv.channelMgr.GetOrCreateSession(ev, nil)
 	storeID := sess.Store.ID
 
 	turnDone := make(chan struct{})
-	go func() { defer close(turnDone); srv.handleChannelMessage(context.Background(), ad, ev) }()
+	go func() { defer close(turnDone); srv.handleChannelMessage(context.Background(), ad, ev, nil) }()
 	<-sender.entered // main turn call is blocked; the snippet fallback lands mid-turn
 
 	if name := waitForRename(t, conn, storeID); name != "hello there" {
@@ -123,15 +124,15 @@ func TestHandleChannelMessage_SkipsTitleForEmptyFirstMessage(t *testing.T) {
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	spy := &titleSpySender{}
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(spy, "stub-model")
 	}, channel.BindByChat)
 
 	ad := &fullFakeAdapter{}
 	ev := evFor("") // text-free content, the attachments-only shape
-	sess := srv.channelMgr.GetOrCreateSession(ev)
+	sess := srv.channelMgr.GetOrCreateSession(ev, nil)
 
-	srv.handleChannelMessage(context.Background(), ad, ev)
+	srv.handleChannelMessage(context.Background(), ad, ev, nil)
 
 	if got := spy.titleCalls.Load(); got != 0 {
 		t.Errorf("title calls = %d, want 0 for a text-free first message", got)

--- a/internal/server/goal_test.go
+++ b/internal/server/goal_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/channel"
 )
 
@@ -321,12 +322,12 @@ func TestChannelTurn_GoalContinuationAndZeroProgressStop(t *testing.T) {
 	srv.goalsEnabled.Store(true)
 	ad := &fullFakeAdapter{}
 
-	sess := srv.channelMgr.GetOrCreateSession(evFor("x"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("x"), nil)
 	if _, err := sess.GoalStore().CreateGoal("keep going", 0); err != nil {
 		t.Fatal(err)
 	}
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("start"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("start"), nil)
 
 	msgs := sess.Agent.History.Snapshot()
 	cont := 0
@@ -363,19 +364,19 @@ func TestChannelTurn_BudgetCrossingSendsNotice(t *testing.T) {
 	srv := chanServer(t)
 	srv.goalsEnabled.Store(true)
 	// Replace the factory-made zero-usage agent with one that reports usage.
-	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
 		return agent.New(&usageStubSender{}, "stub-model")
 	}, channel.BindByChat)
 	ad := &fullFakeAdapter{}
 
-	sess := srv.channelMgr.GetOrCreateSession(evFor("x"))
+	sess := srv.channelMgr.GetOrCreateSession(evFor("x"), nil)
 	if _, err := sess.GoalStore().CreateGoal("small budget", 50); err != nil {
 		t.Fatal(err)
 	}
 	// Consume the mid-turn-creation skip so the first turn's usage bills.
 	sess.GoalStore().ResetGoalWallClock()
 
-	srv.handleChannelMessage(context.Background(), ad, evFor("start"))
+	srv.handleChannelMessage(context.Background(), ad, evFor("start"), nil)
 
 	if g, _ := sess.GoalStore().GoalSnapshot(); g.Status != agent.GoalBudgetLimited {
 		t.Fatalf("goal should be budget_limited, got %+v", g)

--- a/internal/server/remembered_test.go
+++ b/internal/server/remembered_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/permission"
 )
 
@@ -118,10 +119,10 @@ func TestChannelCommand_UnbindDropsRemembered(t *testing.T) {
 	ad := &fullFakeAdapter{}
 	ev := evFor("/unbind")
 
-	key := "im:" + string(srv.channelMgr.KeyFor(ev))
+	key := "im:" + string(srv.channelMgr.KeyFor(ev, ""))
 	before := srv.rememberedFor(key)
 
-	if !srv.handleChannelCommand(ad, ev) {
+	if !srv.handleChannelCommand(ad, ev, agentprofile.DefaultProfile()) {
 		t.Fatal("/unbind not handled as a command")
 	}
 	if srv.rememberedFor(key) == before {
@@ -136,10 +137,10 @@ func TestChannelCommand_NewDropsRemembered(t *testing.T) {
 	ad := &fullFakeAdapter{}
 	ev := evFor("/new")
 
-	key := "im:" + string(srv.channelMgr.KeyFor(ev))
+	key := "im:" + string(srv.channelMgr.KeyFor(ev, ""))
 	before := srv.rememberedFor(key)
 
-	if !srv.handleChannelCommand(ad, ev) {
+	if !srv.handleChannelCommand(ad, ev, agentprofile.DefaultProfile()) {
 		t.Fatal("/new not handled as a command")
 	}
 	if srv.rememberedFor(key) == before {

--- a/internal/server/restart_test.go
+++ b/internal/server/restart_test.go
@@ -286,7 +286,7 @@ func TestHandleChannelMessage_DrainingRepliesPolitely(t *testing.T) {
 	srv.drain.drain(0)
 
 	ad := &drainTestAdapter{}
-	srv.handleChannelMessage(context.Background(), ad, channel.InboundEvent{ChatID: "c1", Text: "hi"})
+	srv.handleChannelMessage(context.Background(), ad, channel.InboundEvent{ChatID: "c1", Text: "hi"}, nil)
 
 	if len(ad.texts()) != 1 {
 		t.Fatalf("SendText calls = %d, want 1", len(ad.texts()))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2170,22 +2170,38 @@ func (s *Server) buildChannelAgent(profile *agentprofile.Profile) *agent.Agent {
 
 // agentRouter lazily builds the profile store + router used by the IM routing
 // path. The store is read-through, so profile edits (API, Web UI, direct .md
-// edits) take effect on the next inbound event.
+// edits) take effect on the next inbound event. If the store/router have
+// already been set (e.g. by a test), the Once is a no-op.
 func (s *Server) agentRouter() *agentprofile.Router {
 	s.agentRouterOnce.Do(func() {
+		if s.agentStore != nil {
+			return
+		}
 		s.agentStore = agentprofile.New(agentUserDir(), agentProjectDir)
 		s.agentRouterVal = agentprofile.NewRouter(s.agentStore)
 	})
 	return s.agentRouterVal
 }
 
+// agentStoreIfReady returns the profile store if it has been initialized
+// (either by agentRouter or by a test), without triggering lazy init.
+func (s *Server) agentStoreIfReady() (*agentprofile.Store, bool) {
+	return s.agentStore, s.agentStore != nil
+}
+
 // profileForAgent resolves an agent ID to its profile, falling back to the
 // default profile on a miss (empty ID, or the profile was deleted while one
-// of its sessions is still live).
+// of its sessions is still live). It uses the already-initialized store if
+// present (respects a test-injected store) and only falls back to lazy init
+// if nothing has been set yet.
 func (s *Server) profileForAgent(agentID string) *agentprofile.Profile {
-	_ = s.agentRouter() // ensures agentStore is initialised
+	store, ok := s.agentStoreIfReady()
+	if !ok {
+		_ = s.agentRouter()
+		store = s.agentStore
+	}
 	if agentID != "" {
-		if p, ok := s.agentStore.Get(agentID); ok {
+		if p, ok := store.Get(agentID); ok {
 			return p
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/app"
 	"github.com/open-octo/octo-agent/internal/channel"
 	"github.com/open-octo/octo-agent/internal/hooks"
@@ -279,6 +280,13 @@ type Server struct {
 	channelMgr      *channel.Manager
 	channelCancel   context.CancelFunc
 	runningAdapters sync.Map // string -> channel.Adapter
+
+	// Agent profiles (multi-agent routing). agentStore/agentRouterVal are
+	// built lazily on first use via agentRouter() — tests that never touch
+	// the IM path never pay the directory scan.
+	agentStore      *agentprofile.Store
+	agentRouterVal  *agentprofile.Router
+	agentRouterOnce sync.Once
 
 	// channelMu guards channel (re)start bookkeeping — startChannels runs at
 	// boot, stopChannels at shutdown, and reloadChannel from an HTTP handler
@@ -2108,14 +2116,17 @@ func (s *Server) initChannels() {
 		// server restart needed.
 		return
 	}
-	s.channelMgr = channel.NewManager(chCfg, s.buildChannelFactory(), channel.BindByChatUser)
+	s.channelMgr = channel.NewManager(chCfg, s.buildChannelAgent, channel.BindByChatUser)
 	s.channelMgr.SetGoalsEnabled(s.goalsEnabled.Load())
 	s.channelMgr.SetModelOps(s.channelModelOps())
+	s.channelMgr.SetProfileLookup(func(id string) (*agentprofile.Profile, bool) {
+		return s.profileForAgent(id), true
+	})
 	slog.Info("channels enabled", "platforms", strings.Join(platforms, ", "))
 }
 
-// buildChannelFactory returns the agent factory the channel manager uses to
-// spin up a fresh agent per IM session. No gate is set here: handleChannelMessage
+// buildChannelAgent is the channel manager's agent factory, parameterized by
+// the routed profile. No gate is set here: handleChannelMessage
 // builds a fresh per-turn gate (configured mode + chat-interactive ask), the
 // same shape prepareToolTurn gives web turns. A factory-time gate would freeze
 // one policy snapshot for the session's whole life.
@@ -2126,22 +2137,82 @@ func (s *Server) initChannels() {
 // LiteSender/LiteModel resolved below have no such per-turn refresh anywhere
 // in the IM path, so they stay — this is genuinely the only place they're set
 // for the session's whole lifetime.
-func (s *Server) buildChannelFactory() func() *agent.Agent {
-	return func() *agent.Agent {
-		defaultSender, model := s.defaultSenderAndModel()
-		a := agent.New(defaultSender, model)
-		a.MaxTokens = s.cfg.MaxTokens
-		if cfg, err := config.Load(); err == nil {
-			a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
-			if a.LiteSender == nil {
-				if lm := app.ImplicitLiteModel(s.getProvider(), model, resolveBaseURL(s.getProvider(), cfg)); lm != "" {
-					a.LiteSender = defaultSender
-					a.LiteModel = lm
-				}
+//
+// A profile-pinned model swaps the session's starting sender+model; a user's
+// later /model binding still wins (applyChannelModel applies the persisted
+// binding over whatever the factory set).
+func (s *Server) buildChannelAgent(profile *agentprofile.Profile) *agent.Agent {
+	if profile == nil {
+		profile = agentprofile.DefaultProfile()
+	}
+	defaultSender, model := s.defaultSenderAndModel()
+	if profile.Model != "" {
+		if res, err := s.channelModelOps().Resolve(profile.Model); err == nil {
+			defaultSender, model = res.Sender, res.Model
+		} else {
+			slog.Warn("channel profile model unresolved, using server default",
+				"profile", profile.ID, "model", profile.Model, "err", err)
+		}
+	}
+	a := agent.New(defaultSender, model)
+	a.MaxTokens = s.cfg.MaxTokens
+	if cfg, err := config.Load(); err == nil {
+		a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
+		if a.LiteSender == nil {
+			if lm := app.ImplicitLiteModel(s.getProvider(), model, resolveBaseURL(s.getProvider(), cfg)); lm != "" {
+				a.LiteSender = defaultSender
+				a.LiteModel = lm
 			}
 		}
-		return a
 	}
+	return a
+}
+
+// agentRouter lazily builds the profile store + router used by the IM routing
+// path. The store is read-through, so profile edits (API, Web UI, direct .md
+// edits) take effect on the next inbound event.
+func (s *Server) agentRouter() *agentprofile.Router {
+	s.agentRouterOnce.Do(func() {
+		s.agentStore = agentprofile.New(agentUserDir(), agentProjectDir)
+		s.agentRouterVal = agentprofile.NewRouter(s.agentStore)
+	})
+	return s.agentRouterVal
+}
+
+// profileForAgent resolves an agent ID to its profile, falling back to the
+// default profile on a miss (empty ID, or the profile was deleted while one
+// of its sessions is still live).
+func (s *Server) profileForAgent(agentID string) *agentprofile.Profile {
+	_ = s.agentRouter() // ensures agentStore is initialised
+	if agentID != "" {
+		if p, ok := s.agentStore.Get(agentID); ok {
+			return p
+		}
+	}
+	return agentprofile.DefaultProfile()
+}
+
+// agentUserDir is the user-level profile directory (~/.octo/agents).
+func agentUserDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "agents")
+}
+
+// agentProjectDir is the delegation-only project-level profile directory
+// (<repo>/.octo/agents), resolved per call like the pre-existing loader.
+func agentProjectDir() string {
+	cwd, err := os.Getwd()
+	if err != nil || cwd == "" {
+		return ""
+	}
+	root := memory.ProjectRoot(cwd)
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, ".octo", "agents")
 }
 
 // channelModelOps builds the ModelOps the channel manager's /model command
@@ -2531,9 +2602,12 @@ func (s *Server) reloadChannel(platform string) {
 	defer s.channelMu.Unlock()
 	s.channelCfg = chCfg
 	if s.channelMgr == nil {
-		s.channelMgr = channel.NewManager(chCfg, s.buildChannelFactory(), channel.BindByChatUser)
+		s.channelMgr = channel.NewManager(chCfg, s.buildChannelAgent, channel.BindByChatUser)
 		s.channelMgr.SetGoalsEnabled(s.goalsEnabled.Load())
 		s.channelMgr.SetModelOps(s.channelModelOps())
+		s.channelMgr.SetProfileLookup(func(id string) (*agentprofile.Profile, bool) {
+			return s.profileForAgent(id), true
+		})
 	}
 
 	s.stopOneChannelLocked(platform)
@@ -2556,7 +2630,20 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 	// The adapter invokes this from its own inbound goroutine (not net/http), so
 	// a panic anywhere in the IM turn path would crash the whole serve process.
 	defer s.recoverBg("channel event (" + ev.Platform + ")")
-	if s.handleChannelCommand(ad, ev) {
+	// Resolve the routed agent once per event; every downstream path (commands,
+	// asks, steers, turns) works within its session-key namespace. A nil route
+	// means "stay silent": a group chat with multiple bound agents and no
+	// @-mention.
+	profile := s.agentRouter().Route(agentprofile.RouteInput{
+		Platform: ev.Platform,
+		ChatID:   ev.ChatID,
+		UserID:   ev.UserID,
+		Text:     ev.Text,
+	})
+	if profile == nil {
+		return
+	}
+	if s.handleChannelCommand(ad, ev, profile) {
 		return
 	}
 	// Button events (e.g. inline keyboard presses on Telegram, component
@@ -2564,7 +2651,7 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 	// bypassing the text-based DeliverAskReply path. Button events are routed
 	// before plain text so they work even when askButtonsOnly is set.
 	if ev.ButtonID != "" {
-		if sess := s.channelMgr.GetSession(ev); sess != nil {
+		if sess := s.channelMgr.GetSession(ev, profile.ID); sess != nil {
 			if sess.DeliverAskButton(ev.ChatID, ev.UserID, ev.ButtonID) {
 				return
 			}
@@ -2574,7 +2661,7 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 	// steer — an empty reply would consume the ask slot and deny for
 	// nothing, and an empty steer adds noise.
 	if strings.TrimSpace(ev.Text) != "" {
-		if sess := s.channelMgr.GetSession(ev); sess != nil {
+		if sess := s.channelMgr.GetSession(ev, profile.ID); sess != nil {
 			if sess.DeliverAskReply(ev.ChatID, ev.UserID, ev.Text) {
 				return
 			}
@@ -2594,13 +2681,14 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 			}
 		}
 	}
-	go s.handleChannelMessage(ctx, ad, ev)
+	go s.handleChannelMessage(ctx, ad, ev, profile)
 }
 
 // handleChannelCommand processes slash commands (e.g. /bind, /stop). Returns
 // true if the event was a command. Without the "/" guard, plain text like
 // "你好" would be parsed as an unknown command and never reach the agent.
-func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEvent) bool {
+// Commands operate within the routed agent's session-key namespace.
+func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEvent, profile *agentprofile.Profile) bool {
 	text := strings.TrimSpace(ev.Text)
 	if !strings.HasPrefix(text, "/") {
 		return false
@@ -2614,7 +2702,7 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 	cmd := strings.ToLower(strings.Fields(text)[0])
 	switch cmd {
 	case "/bind", "/clear", "/new":
-		imKey := "im:" + string(s.channelMgr.KeyFor(ev))
+		imKey := "im:" + string(s.channelMgr.KeyFor(ev, profile.ID))
 		s.rememberedMu.Lock()
 		delete(s.rememberedStores, imKey)
 		s.rememberedMu.Unlock()
@@ -2631,7 +2719,7 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 		// stops on an explicit /stop or schedule_wakeup(cancel=true). We still
 		// drop the per-key latches so the next non-loop message rebuilds a clean
 		// context under the chat's fresh session.
-		imKey := "im:" + string(s.channelMgr.KeyFor(ev))
+		imKey := "im:" + string(s.channelMgr.KeyFor(ev, profile.ID))
 		s.rememberedMu.Lock()
 		delete(s.rememberedStores, imKey)
 		s.rememberedMu.Unlock()
@@ -2640,12 +2728,12 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 		s.injectorMu.Unlock()
 	case "/stop":
 		// /stop is the IM interrupt — also the hard stop for an armed loop.
-		s.cancelWakeup("im:" + string(s.channelMgr.KeyFor(ev)))
+		s.cancelWakeup("im:" + string(s.channelMgr.KeyFor(ev, profile.ID)))
 	}
 	// /compact runs an LLM summarize, so it's handled out of the (synchronous,
 	// reply-string) CommandRouter: run it in a goroutine and report the result.
 	if cmd == "/compact" {
-		s.handleChannelCompact(ad, ev)
+		s.handleChannelCompact(ad, ev, profile.ID)
 		return true
 	}
 	// Reserved commands must not be intercepted by a skill (matching
@@ -2668,7 +2756,7 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 			return false
 		}
 	}
-	if reply := s.channelMgr.CommandRouter(ev); reply != "" {
+	if reply := s.channelMgr.CommandRouter(ev, profile.ID); reply != "" {
 		ad.SendText(ev.ChatID, reply, ev.MessageID)
 	}
 	return true
@@ -2677,8 +2765,8 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 // handleChannelCompact force-compacts an IM session's history and reports the
 // outcome. The summarize is an LLM call, so it runs in a goroutine; BeginRun
 // serialises it against any agent turn in the same session.
-func (s *Server) handleChannelCompact(ad channel.Adapter, ev channel.InboundEvent) {
-	sess := s.channelMgr.GetSession(ev)
+func (s *Server) handleChannelCompact(ad channel.Adapter, ev channel.InboundEvent, agentID string) {
+	sess := s.channelMgr.GetSession(ev, agentID)
 	if sess == nil {
 		ad.SendText(ev.ChatID, "No active session to compact.", ev.MessageID)
 		return
@@ -2722,7 +2810,7 @@ func (s *Server) handleChannelCompact(ad channel.Adapter, ev channel.InboundEven
 // handleChannelMessage runs an agent turn for a channel inbound event and
 // wires completion hooks so background processes / workflows can trigger
 // follow-up turns when the session goes idle (web kickIdleSteerTurn parity).
-func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, ev channel.InboundEvent) {
+func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, ev channel.InboundEvent, profile *agentprofile.Profile) {
 	// routeChannelEvent dispatches this in its own goroutine (go
 	// s.handleChannelMessage), so the whole IM turn runs outside any caller's
 	// recover — guard it here, at the goroutine's actual entry, or a panic mid
@@ -2737,7 +2825,7 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	}
 	defer s.drain.end()
 
-	sess := s.channelMgr.GetOrCreateSession(ev)
+	sess := s.channelMgr.GetOrCreateSession(ev, profile)
 	if sess == nil {
 		return
 	}
@@ -2957,7 +3045,14 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	if cfg.CompactAutoPct > 0 {
 		sess.Agent.CompactAutoFraction = float64(cfg.CompactAutoPct) / 100.0
 	}
-	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(sess.Agent.Model), memInjection, s.effectiveCoauthor(cfg))
+	// A profile with its own system prompt replaces the server's base prompt
+	// (default agent: unchanged, s.system). Resolved fresh per turn so profile
+	// edits land on the next message; a deleted profile falls back to default.
+	base := s.system
+	if p := s.profileForAgent(sess.AgentID); p.SystemPrompt != "" {
+		base = p.SystemPrompt
+	}
+	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(sess.Agent.Model), memInjection, s.effectiveCoauthor(cfg))
 
 	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,
 	// rebuilt per IM turn. The injector is session-sticky (recall latch) and


### PR DESCRIPTION
## Summary

PR2 of the [multi-agent system design](dev-docs/multi-agent-system-design.md) slicing — the wiring slice, landed **standalone** per the release plan. The single `channel.Manager` stays; session isolation is derived from the SessionKey itself (no MultiManager).

**Equivalence anchor: with no profiles present, every session key, store file ID, and IM behavior is byte-identical to before.** This is the PR's core review claim, verified by tests below.

### channel

- `sessionKeyFor` gains the routed agent: default agent (`""`/`"default"`) keeps legacy keys byte-for-byte; expert agents get `<agentID>#` prefixed keys — namespacing the sessions map, the `/bind` table, and the deterministic store file ID in one move
- `splitSessionKey` strips the prefix only when it matches a valid profile ID (`agentprofile.IsValidID`) — a chat ID containing `#` is not misparsed (edge found via existing `TestSessionStoreID_DeterministicAndSafe`)
- `GetOrCreateSession(ev, profile)`, `CommandRouter(ev, agentID)`, `GetSession`/`KeyFor(ev, agentID)`; `Session.AgentID` stamped at creation and mirrored to the persisted store's `agent_id`
- `/list` and `/bind` scoped to the routed agent; cross-agent binds rejected (design MVP rule)

### agent

- `Session.AgentID` (`agent_id`, empty = default = every legacy file, zero migration) + `EffectiveAgentID()`; meta record round-trips; `BranchFrom` copies

### server

- `routeChannelEvent` resolves the profile once per event via a lazily built router (read-through store over `~/.octo/agents` + project dir); nil route (multi-bound group, no @) drops the event
- `buildChannelFactory` → `buildChannelAgent(profile)`: profile-pinned model swaps the starting sender+model; a user's `/model` binding still wins
- `runChannelTurns` recomposes the system prompt from the session's profile **each turn** — profile edits land on the next message, deleted profile falls back to default

### Notes for reviewers

- Test call sites were updated mechanically (`GetOrCreateSession(ev, nil)`, `func(*agentprofile.Profile) *agent.Agent`, etc.) — no test logic changed
- One bug found & fixed during implementation: `cmdList`/`resolveBindTarget` normalize the agent ID, so direct calls with `""` and routed calls with `"default"` see the same sessions

## Test plan

- **New**: `channel/agent_namespace_test.go` (default byte-identity, per-agent store isolation, cross-agent bind rejection, `#`-in-chat-ID parsing, legacy store restore) and `server/agent_routing_test.go` (bound-agent routing, multi-binding silence, @-mention selection, default fallback)
- `go vet ./internal/...` clean; **full `go test ./...` green**

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
