### PR TITLE
feat(profile-tools): filter tools/skills per profile; presets merge into Store (PR3)

### DIFF
--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -54,6 +54,15 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 		ctx = tools.WithGoalStore(ctx, sess)
 	}
 
+	// Resolve the routed agent's profile for per-turn tool/skill filtering.
+	// The store is read-through, so profile edits land on the next message.
+	// Stamped into ctx so DefaultToolsForCtx auto-filters via
+	// DefaultToolsForProfile.
+	if sess != nil {
+		ctx = tools.WithProfileStore(ctx, s.agentStore)
+		ctx = tools.WithSessionAgentID(ctx, sess.EffectiveAgentID())
+	}
+
 	// Gate image-handing tools (browser, read_file) on the active model's vision
 	// capability. Unlike the CLI (which goes through app.WireTools), the server
 	// wires tools here, so this is the only place serve learns whether the model

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1263,7 +1263,15 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	if g := tools.MemoryBackendGuidance(); g != "" {
 		memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
 	}
-	a.System, a.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(model), memInjection, s.effectiveCoauthor(cfg))
+	// A profile with its own system prompt replaces the server's base prompt
+	// (default agent: unchanged, s.system). Resolved fresh per turn so profile
+	// edits land on the next message; a deleted profile falls back to default.
+	profile := s.profileForAgent(sess.EffectiveAgentID())
+	base := s.system
+	if profile.SystemPrompt != "" {
+		base = profile.SystemPrompt
+	}
+	a.System, a.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(model), memInjection, s.effectiveCoauthor(cfg))
 
 	// L2: attention-layer rules (triggered keywords) + save-nudge on milestone
 	// tool results, plus any shell hooks (env/hooks.yml), unified on the agent's
@@ -1610,6 +1618,18 @@ func (s *Server) curSkillsManifest() string {
 	s.skillsMu.RLock()
 	defer s.skillsMu.RUnlock()
 	return s.skillsManifest
+}
+
+// curSkillsManifestForProfile is curSkillsManifest filtered to the profile's
+// ToolSkills. When profile is nil or declares no ToolSkills, the full manifest
+// is returned (default agent behavior). Resolved fresh per turn so profile
+// edits land on the next message.
+func (s *Server) curSkillsManifestForProfile(profile *agentprofile.Profile) string {
+	raw := s.curSkillsManifest()
+	if profile == nil || len(profile.ToolSkills) == 0 {
+		return raw
+	}
+	return skills.ManifestForProfile(s.skillReg, profile)
 }
 
 // setSkillsManifest replaces the skills manifest under a write lock. Called by
@@ -3038,6 +3058,14 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// prompt compose just below keys the MCP manifest off it.
 	s.applyChannelModel(sess)
 
+	// Resolve the routed agent's profile for per-turn behavior (system prompt,
+	// tool allowlist, skill allowlist). The store is read-through, so profile
+	// edits land on the next message. Stamped into ctx so DefaultToolsForCtx
+	// auto-filters via DefaultToolsForProfile.
+	profile := s.profileForAgent(sess.AgentID)
+	ctx = tools.WithProfileStore(ctx, s.agentStore)
+	ctx = tools.WithSessionAgentID(ctx, sess.AgentID)
+
 	// Recompose the system prompt every turn so memory written and skills
 	// imported/toggled since server start are visible — web turns get this
 	// for free from buildAgent; the IM factory's compose-once snapshot went
@@ -3065,10 +3093,10 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// (default agent: unchanged, s.system). Resolved fresh per turn so profile
 	// edits land on the next message; a deleted profile falls back to default.
 	base := s.system
-	if p := s.profileForAgent(sess.AgentID); p.SystemPrompt != "" {
-		base = p.SystemPrompt
+	if profile.SystemPrompt != "" {
+		base = profile.SystemPrompt
 	}
-	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(sess.Agent.Model), memInjection, s.effectiveCoauthor(cfg))
+	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(sess.Agent.Model), memInjection, s.effectiveCoauthor(cfg))
 
 	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,
 	// rebuilt per IM turn. The injector is session-sticky (recall latch) and

--- a/internal/skills/manifest_profile_test.go
+++ b/internal/skills/manifest_profile_test.go
@@ -1,0 +1,99 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agentprofile"
+)
+
+func TestManifestForProfile_NoProfileReturnsAll(t *testing.T) {
+	r := Discover(t.TempDir())
+	if r.Len() == 0 {
+		t.Fatal("expected at least one skill from defaults")
+	}
+	full := RenderManifest(r)
+	profiled := ManifestForProfile(r, nil)
+	if full != profiled {
+		t.Fatalf("nil profile should return full manifest.\nfull:\n%s\nprofiled:\n%s", full, profiled)
+	}
+}
+
+func TestManifestForProfile_FiltersByToolSkills(t *testing.T) {
+	r := Discover(t.TempDir())
+	full := RenderManifest(r)
+	if full == "" {
+		t.Fatal("expected non-empty manifest")
+	}
+	allSkills := r.List()
+	if len(allSkills) == 0 {
+		t.Fatal("expected skills")
+	}
+	target := allSkills[0].Name
+	profiled := ManifestForProfile(r, &agentprofile.Profile{
+		ID:         "test",
+		Description: "d",
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			ToolSkills: []string{target},
+		},
+	})
+	if profiled == "" {
+		t.Fatal("expected non-empty manifest")
+	}
+	// The profiled manifest should contain the target skill.
+	if !containsSkill(profiled, target) {
+		t.Fatalf("manifest missing target skill %q:\n%s", target, profiled)
+	}
+	// Count skill entries: profiled should have exactly 1, full should have all.
+	fullLines := countSkillLines(full)
+	profiledLines := countSkillLines(profiled)
+	if profiledLines != 1 {
+		t.Fatalf("expected exactly 1 skill in profiled manifest, got %d:\n%s", profiledLines, profiled)
+	}
+	if fullLines != len(allSkills) {
+		t.Fatalf("expected %d skills in full manifest, got %d", len(allSkills), fullLines)
+	}
+}
+
+func countSkillLines(manifest string) int {
+	n := 0
+	for _, line := range strings.Split(manifest, "\n") {
+		if strings.HasPrefix(line, "- ") {
+			n++
+		}
+	}
+	return n
+}
+
+func TestManifestForProfile_EmptyToolSkillsReturnsAll(t *testing.T) {
+	r := Discover(t.TempDir())
+	full := RenderManifest(r)
+	profiled := ManifestForProfile(r, &agentprofile.Profile{
+		ID:          "test",
+		Description: "d",
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			ToolSkills: []string{},
+		},
+	})
+	if full != profiled {
+		t.Fatalf("empty ToolSkills should return full manifest")
+	}
+}
+
+func TestManifestForProfile_NoMatchReturnsEmpty(t *testing.T) {
+	r := Discover(t.TempDir())
+	profiled := ManifestForProfile(r, &agentprofile.Profile{
+		ID:          "test",
+		Description: "d",
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			ToolSkills: []string{"nonexistent-skill-xyz"},
+		},
+	})
+	if profiled != "" {
+		t.Fatalf("expected empty manifest for non-matching ToolSkills, got:\n%s", profiled)
+	}
+}
+
+func containsSkill(manifest, name string) bool {
+	return len(name) > 0 && strings.Contains(manifest, name)
+}

--- a/internal/skills/manifest_profile_test.go
+++ b/internal/skills/manifest_profile_test.go
@@ -31,7 +31,7 @@ func TestManifestForProfile_FiltersByToolSkills(t *testing.T) {
 	}
 	target := allSkills[0].Name
 	profiled := ManifestForProfile(r, &agentprofile.Profile{
-		ID:         "test",
+		ID:          "test",
 		Description: "d",
 		CapabilitySpec: agentprofile.CapabilitySpec{
 			ToolSkills: []string{target},

--- a/internal/skills/manifest_profile_test.go
+++ b/internal/skills/manifest_profile_test.go
@@ -1,26 +1,50 @@
 package skills
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agentprofile"
 )
 
-func TestManifestForProfile_NoProfileReturnsAll(t *testing.T) {
-	r := Discover(t.TempDir())
-	if r.Len() == 0 {
-		t.Fatal("expected at least one skill from defaults")
+// discoverWithDefaults materializes the embedded default skills into a temp
+// directory and returns a Registry that has them loaded. Required because
+// TestMain redirects defaultSkillsRoot to an empty temp dir; tests that need
+// the real defaults must opt in.
+func discoverWithDefaults(t *testing.T) *Registry {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "skills-default")
+	useDefaultRoot(t, root)
+	if err := MaterializeDefaults("test"); err != nil {
+		t.Fatal(err)
 	}
+	return Discover(t.TempDir())
+}
+
+func TestManifestForProfile_NoProfileReturnsAll(t *testing.T) {
+	r := discoverWithDefaults(t)
 	full := RenderManifest(r)
 	profiled := ManifestForProfile(r, nil)
-	if full != profiled {
-		t.Fatalf("nil profile should return full manifest.\nfull:\n%s\nprofiled:\n%s", full, profiled)
+	// Don't compare strings directly — List() sort is non-deterministic
+	// (pre-existing bug). Verify the profiled manifest contains every skill.
+	for _, s := range r.List() {
+		if !strings.Contains(profiled, s.Name) {
+			t.Fatalf("nil profile manifest missing skill %q", s.Name)
+		}
+	}
+	// Both should be non-empty and have the same number of skill entries.
+	if full == "" || profiled == "" {
+		t.Fatal("expected non-empty manifests")
+	}
+	if countSkillLines(full) != countSkillLines(profiled) {
+		t.Fatalf("full and profiled manifests have different skill counts: %d vs %d",
+			countSkillLines(full), countSkillLines(profiled))
 	}
 }
 
 func TestManifestForProfile_FiltersByToolSkills(t *testing.T) {
-	r := Discover(t.TempDir())
+	r := discoverWithDefaults(t)
 	full := RenderManifest(r)
 	if full == "" {
 		t.Fatal("expected non-empty manifest")
@@ -66,7 +90,7 @@ func countSkillLines(manifest string) int {
 }
 
 func TestManifestForProfile_EmptyToolSkillsReturnsAll(t *testing.T) {
-	r := Discover(t.TempDir())
+	r := discoverWithDefaults(t)
 	full := RenderManifest(r)
 	profiled := ManifestForProfile(r, &agentprofile.Profile{
 		ID:          "test",
@@ -75,13 +99,21 @@ func TestManifestForProfile_EmptyToolSkillsReturnsAll(t *testing.T) {
 			ToolSkills: []string{},
 		},
 	})
-	if full != profiled {
-		t.Fatalf("empty ToolSkills should return full manifest")
+	// Don't compare strings directly — List() sort is non-deterministic
+	// (pre-existing bug). Verify the profiled manifest contains every skill.
+	for _, s := range r.List() {
+		if !strings.Contains(profiled, s.Name) {
+			t.Fatalf("empty ToolSkills manifest missing skill %q", s.Name)
+		}
+	}
+	if countSkillLines(full) != countSkillLines(profiled) {
+		t.Fatalf("full and profiled manifests have different skill counts: %d vs %d",
+			countSkillLines(full), countSkillLines(profiled))
 	}
 }
 
 func TestManifestForProfile_NoMatchReturnsEmpty(t *testing.T) {
-	r := Discover(t.TempDir())
+	r := discoverWithDefaults(t)
 	profiled := ManifestForProfile(r, &agentprofile.Profile{
 		ID:          "test",
 		Description: "d",

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/pathutil"
 	"github.com/open-octo/octo-agent/internal/trash"
 	"gopkg.in/yaml.v3"
@@ -335,6 +336,39 @@ func RenderManifest(r *Registry) string {
 		"from the one-line description. The user can also trigger one directly by typing /<name>.\n\n")
 	for _, s := range r.List() {
 		fmt.Fprintf(&b, "- %s: %s\n", s.Name, s.Description)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// ManifestForProfile is RenderManifest filtered to the profile's ToolSkills.
+// When profile is non-nil and declares ToolSkills, only those skills are
+// listed — the design's per-agent skill isolation. A nil profile or an empty
+// ToolSkills list means "all skills" (the default agent behavior).
+func ManifestForProfile(r *Registry, profile *agentprofile.Profile) string {
+	if r.Len() == 0 {
+		return ""
+	}
+	if profile == nil || len(profile.ToolSkills) == 0 {
+		return RenderManifest(r)
+	}
+	allowed := make(map[string]bool, len(profile.ToolSkills))
+	for _, name := range profile.ToolSkills {
+		allowed[name] = true
+	}
+	var b strings.Builder
+	b.WriteString("# Available skills\n\n")
+	b.WriteString("When a task matches a skill's description, call the `skill` tool with its " +
+		"name to load the full instructions before acting. Don't guess the instructions " +
+		"from the one-line description. The user can also trigger one directly by typing /<name>.\n\n")
+	n := 0
+	for _, s := range r.List() {
+		if allowed[s.Name] {
+			fmt.Fprintf(&b, "- %s: %s\n", s.Name, s.Description)
+			n++
+		}
+	}
+	if n == 0 {
+		return ""
 	}
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -32,12 +32,11 @@ func profileStoreFromContext(ctx context.Context) *agentprofile.Store {
 // profileNames returns a comma-separated list of available profile names
 // (built-ins + user-defined) for error messages.
 func profileNames(store *agentprofile.Store) string {
-	if store == nil {
-		return "default, explore, general, code-review"
-	}
-	names := []string{"default"}
-	for _, p := range store.List() {
-		names = append(names, p.ID)
+	names := []string{"default", "code-review", "explore", "general"}
+	if store != nil {
+		for _, p := range store.List() {
+			names = append(names, p.ID)
+		}
 	}
 	sort.Strings(names[1:]) // keep "default" first
 	return strings.Join(names, ", ")

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -3,10 +3,45 @@ package tools
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 )
+
+// ctxKeyProfileStore is the context key for the per-turn agentprofile.Store.
+type ctxKeyProfileStore struct{}
+
+// WithProfileStore attaches an agentprofile.Store to the context so the
+// sub_agent tool can resolve subagent_type names against profiles. The store
+// is read-through, so profile edits (API, Web UI, direct .md edits) take
+// effect on the next resolution without any reload call.
+func WithProfileStore(ctx context.Context, store *agentprofile.Store) context.Context {
+	return context.WithValue(ctx, ctxKeyProfileStore{}, store)
+}
+
+// profileStoreFromContext returns the context's profile store, or nil.
+func profileStoreFromContext(ctx context.Context) *agentprofile.Store {
+	if s, ok := ctx.Value(ctxKeyProfileStore{}).(*agentprofile.Store); ok {
+		return s
+	}
+	return nil
+}
+
+// profileNames returns a comma-separated list of available profile names
+// (built-ins + user-defined) for error messages.
+func profileNames(store *agentprofile.Store) string {
+	if store == nil {
+		return "default, explore, general, code-review"
+	}
+	names := []string{"default"}
+	for _, p := range store.List() {
+		names = append(names, p.ID)
+	}
+	sort.Strings(names[1:]) // keep "default" first
+	return strings.Join(names, ", ")
+}
 
 // AgentTool is the unified sub-agent tool. It replaces the previous
 // explore_agent / plan_agent / general_agent /
@@ -105,15 +140,38 @@ func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (a
 	// sub-agent the user can't talk to.
 	subagentType := strings.TrimSpace(stringArg(input, "subagent_type"))
 	if subagentType == "" {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("sub_agent: subagent_type is required. Available: %s", listPresetNames())
+		return agent.ToolResult{Text: ""}, fmt.Errorf("sub_agent: subagent_type is required. Available: %s", profileNames(profileStoreFromContext(ctx)))
 	}
-	p, ok := lookupAgentPreset(subagentType)
-	if !ok {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("sub_agent: unknown subagent_type %q. Available: %s", subagentType, listPresetNames())
+	store := profileStoreFromContext(ctx)
+	var profile *agentprofile.Profile
+	if store != nil {
+		if p, ok := store.Get(subagentType); ok {
+			profile = p
+		}
+	} else {
+		// Fallback for callers that haven't wired a store (e.g. legacy CLI):
+		// resolve via the deprecated preset loader.
+		if p, ok := lookupAgentPreset(subagentType); ok {
+			profile = &agentprofile.Profile{
+				ID:          p.name,
+				Description: p.description,
+				CapabilitySpec: agentprofile.CapabilitySpec{
+					SystemPrompt:    p.persona,
+					ReadOnly:        p.readOnly,
+					LeanContext:     p.leanSystem,
+					Tools:           p.tools,
+					DisallowedTools: p.disallowedTools,
+					Model:           p.model,
+				},
+			}
+		}
+	}
+	if profile == nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("sub_agent: unknown subagent_type %q. Available: %s", subagentType, profileNames(store))
 	}
 
-	// Build the spawn request. Call-level tools/model win over the preset's
-	// frontmatter defaults; the preset fills in what the call left unset.
+	// Build the spawn request. Call-level tools/model win over the profile's
+	// frontmatter defaults; the profile fills in what the call left unset.
 	callTools := stringSliceArg(input, "tools")
 	callModel := strings.TrimSpace(stringArg(input, "model"))
 	req := SpawnRequest{
@@ -123,15 +181,15 @@ func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (a
 		Tools:       callTools,
 		Model:       callModel,
 	}
-	req.SystemSuffix = p.persona
-	req.ReadOnly = p.readOnly
-	req.LeanSystem = p.leanSystem
-	req.DisallowedTools = p.disallowedTools
+	req.SystemSuffix = profile.SystemPrompt
+	req.ReadOnly = profile.ReadOnly
+	req.LeanSystem = profile.LeanContext
+	req.DisallowedTools = profile.DisallowedTools
 	if len(callTools) == 0 {
-		req.Tools = p.tools
+		req.Tools = profile.Tools
 	}
 	if callModel == "" {
-		req.Model = p.model
+		req.Model = profile.Model
 	}
 
 	// Determine sync vs async

--- a/internal/tools/profile_names_test.go
+++ b/internal/tools/profile_names_test.go
@@ -1,0 +1,84 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agentprofile"
+)
+
+// Minimal resultSpawner that returns a fixed reply.
+type resultSpawnerSync struct {
+	reply string
+}
+
+func (s *resultSpawnerSync) Spawn(ctx context.Context, req SpawnRequest) (SpawnResult, error) {
+	return SpawnResult{Reply: s.reply}, nil
+}
+
+func (s *resultSpawnerSync) Continue(ctx context.Context, agentID, message string) (SpawnResult, error) {
+	return SpawnResult{}, fmt.Errorf("continue not supported")
+}
+
+// TestAgentTool_SubagentTypeResolvesViaStore verifies that the sub_agent tool
+// resolves subagent_type names against the agentprofile.Store (built-in +
+// user-defined profiles), retiring the old agent_presets.go lookup.
+func TestAgentTool_SubagentTypeResolvesViaStore(t *testing.T) {
+	dir := t.TempDir()
+	store := agentprofile.New(dir, nil)
+
+	ctx := WithProfileStore(context.Background(), store)
+	mgr := NewSubAgentManager(&resultSpawnerSync{reply: "ok"})
+	ctx = WithSubAgentManager(ctx, mgr)
+
+	// Built-in profile resolves without any file.
+	res, err := (AgentTool{}).Execute(ctx, "sub_agent", map[string]any{
+		"description":   "d",
+		"prompt":        "p",
+		"subagent_type": "explore",
+	})
+	if err != nil {
+		t.Fatalf("built-in 'explore' should resolve: %v", err)
+	}
+	if res.Text == "" {
+		t.Fatal("expected non-empty result")
+	}
+
+	// User-defined profile (on disk) resolves too.
+	if err := store.Create(&agentprofile.Profile{
+		ID:          "my-reviewer",
+		Description: "custom",
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			SystemPrompt: "You review things.",
+			ReadOnly:     true,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	res, err = (AgentTool{}).Execute(ctx, "sub_agent", map[string]any{
+		"description":   "d",
+		"prompt":        "p",
+		"subagent_type": "my-reviewer",
+	})
+	if err != nil {
+		t.Fatalf("user-defined 'my-reviewer' should resolve: %v", err)
+	}
+	if res.Text == "" {
+		t.Fatal("expected non-empty result")
+	}
+
+	// Unknown type errors with available names.
+	_, err = (AgentTool{}).Execute(ctx, "sub_agent", map[string]any{
+		"description":   "d",
+		"prompt":        "p",
+		"subagent_type": "nonexistent",
+	})
+	if err == nil {
+		t.Fatal("unknown subagent_type should error")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Fatalf("error should mention the unknown type, got: %v", err)
+	}
+}

--- a/internal/tools/profile_names_test.go
+++ b/internal/tools/profile_names_test.go
@@ -81,4 +81,7 @@ func TestAgentTool_SubagentTypeResolvesViaStore(t *testing.T) {
 	if !strings.Contains(err.Error(), "nonexistent") {
 		t.Fatalf("error should mention the unknown type, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "explore") {
+		t.Errorf("error should list built-in profile 'explore' even when Store is wired, got: %v", err)
+	}
 }

--- a/internal/tools/profile_tools_test.go
+++ b/internal/tools/profile_tools_test.go
@@ -39,13 +39,22 @@ func TestDefaultToolsForProfile_FiltersByAllowlist(t *testing.T) {
 	}
 	ctx := WithSessionAgentID(WithProfileStore(context.Background(), store), "restricted")
 	filtered := DefaultToolsForProfile(ctx, "test-model")
-	if len(filtered) != 2 {
-		t.Fatalf("expected 2 tools, got %d: %+v", len(filtered), toolNames(filtered))
-	}
+	// Don't assert exact count — defaultToolsFor gates tools on process-global
+	// flags, which test order can affect. Verify presence instead.
+	haveReadFile, haveGrep := false, false
 	for _, d := range filtered {
+		if d.Name == "read_file" {
+			haveReadFile = true
+		}
+		if d.Name == "grep" {
+			haveGrep = true
+		}
 		if d.Name != "read_file" && d.Name != "grep" {
 			t.Errorf("unexpected tool %q in filtered list", d.Name)
 		}
+	}
+	if !haveReadFile || !haveGrep {
+		t.Fatalf("filtered tools missing expected tools (have read_file=%v grep=%v): %+v", haveReadFile, haveGrep, toolNames(filtered))
 	}
 }
 

--- a/internal/tools/profile_tools_test.go
+++ b/internal/tools/profile_tools_test.go
@@ -1,0 +1,111 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
+)
+
+// ctxKeyProfileStore and ctxKeySessionAgentID are defined in registry.go.
+
+func TestDefaultToolsForProfile_NoProfileReturnsAll(t *testing.T) {
+	ctx := context.Background()
+	all := DefaultToolsForProfile(ctx, "test-model")
+	if len(all) == 0 {
+		t.Fatal("expected non-empty tool list")
+	}
+	// No store/agentID in context → all tools returned.
+	before := len(all)
+	if before < 5 {
+		t.Fatalf("expected several tools, got %d", before)
+	}
+}
+
+func TestDefaultToolsForProfile_FiltersByAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	store := agentprofile.New(dir, nil)
+	// Create a profile with a restricted tool allowlist.
+	// (Writing the file and relying on read-through scan.)
+	if err := store.Create(&agentprofile.Profile{
+		ID:          "restricted",
+		Description: "only read_file and grep",
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{"read_file", "grep"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ctx := WithSessionAgentID(WithProfileStore(context.Background(), store), "restricted")
+	filtered := DefaultToolsForProfile(ctx, "test-model")
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 tools, got %d: %+v", len(filtered), toolNames(filtered))
+	}
+	for _, d := range filtered {
+		if d.Name != "read_file" && d.Name != "grep" {
+			t.Errorf("unexpected tool %q in filtered list", d.Name)
+		}
+	}
+}
+
+func TestDefaultToolsForProfile_EmptyToolsReturnsAll(t *testing.T) {
+	dir := t.TempDir()
+	store := agentprofile.New(dir, nil)
+	if err := store.Create(&agentprofile.Profile{
+		ID:          "full",
+		Description: "all tools",
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{}, // empty = all
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ctx := WithSessionAgentID(WithProfileStore(context.Background(), store), "full")
+	all := DefaultToolsForProfile(ctx, "test-model")
+	if len(all) < 5 {
+		t.Fatalf("expected several tools with empty allowlist, got %d", len(all))
+	}
+}
+
+func TestDefaultToolsForProfile_UnknownAgentFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	store := agentprofile.New(dir, nil)
+	// No profile for "ghost" → store.Get misses → all tools.
+	ctx := WithSessionAgentID(WithProfileStore(context.Background(), store), "ghost")
+	all := DefaultToolsForProfile(ctx, "test-model")
+	if len(all) < 5 {
+		t.Fatalf("expected all tools for unknown agent, got %d", len(all))
+	}
+}
+
+func TestDefaultToolsForProfile_SubToolsFiltered(t *testing.T) {
+	// Verify that sub_agent tools (which require a SubAgentManager in ctx) are
+	// filtered out when the profile doesn't include them.
+	dir := t.TempDir()
+	store := agentprofile.New(dir, nil)
+	if err := store.Create(&agentprofile.Profile{
+		ID:          "no-sub",
+		Description: "no sub-agent",
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{"read_file", "grep", "terminal"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ctx := WithSessionAgentID(WithProfileStore(context.Background(), store), "no-sub")
+	filtered := DefaultToolsForProfile(ctx, "test-model")
+	for _, d := range filtered {
+		if d.Name == "sub_agent" || d.Name == "sub_agent_status" {
+			t.Errorf("sub-agent tool %q should be filtered out", d.Name)
+		}
+	}
+}
+
+func toolNames(defs []agent.ToolDefinition) []string {
+	var out []string
+	for _, d := range defs {
+		out = append(out, d.Name)
+	}
+	return out
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -544,8 +544,60 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 // that used to be required, which mutated process-global state on every turn
 // of an inherently multi-session process (#1133). CLI/TUI callers, which have
 // no ctx-scoped manager, see identical behavior to DefaultToolsFor.
+//
+// When the context also carries a profile store (WithProfileStore) and session
+// agent ID (WithSessionAgentID), tools are filtered to the profile's allowlist
+// — see DefaultToolsForProfile.
 func DefaultToolsForCtx(ctx context.Context, model string) []agent.ToolDefinition {
-	return defaultToolsFor(ctx, model)
+	return DefaultToolsForProfile(ctx, model)
+}
+
+// ctxKeySessionAgentID is the context key for the per-turn session AgentID.
+type ctxKeySessionAgentID struct{}
+
+// WithSessionAgentID attaches a session's agent ID to the context so
+// DefaultToolsForProfile can resolve the profile for tool filtering. Stamped
+// per turn by the server's IM/web/cron handlers.
+func WithSessionAgentID(ctx context.Context, agentID string) context.Context {
+	return context.WithValue(ctx, ctxKeySessionAgentID{}, agentID)
+}
+
+// sessionAgentIDFromContext returns the context's session AgentID, or "".
+func sessionAgentIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(ctxKeySessionAgentID{}).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// DefaultToolsForProfile is DefaultToolsForCtx with a per-profile allowlist.
+// When the context carries a profile store (WithProfileStore) and a session
+// agent ID (WithSessionAgentID), it resolves the profile and filters tools to
+// its allowlist. Otherwise it behaves like DefaultToolsForCtx — so callers
+// that don't wire a store see unchanged behavior. Resolved fresh per turn so
+// profile edits land on the next message without rebuilding anything.
+func DefaultToolsForProfile(ctx context.Context, model string) []agent.ToolDefinition {
+	all := defaultToolsFor(ctx, model)
+	store := profileStoreFromContext(ctx)
+	agentID := sessionAgentIDFromContext(ctx)
+	if store == nil || agentID == "" {
+		return all
+	}
+	profile, ok := store.Get(agentID)
+	if !ok || len(profile.Tools) == 0 {
+		return all
+	}
+	allowed := make(map[string]bool, len(profile.Tools))
+	for _, t := range profile.Tools {
+		allowed[t] = true
+	}
+	filtered := make([]agent.ToolDefinition, 0, len(all))
+	for _, t := range all {
+		if allowed[t.Name] {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
 }
 
 func defaultToolsFor(ctx context.Context, model string) []agent.ToolDefinition {


### PR DESCRIPTION
## Summary

PR3 of the [multi-agent system design](dev-docs/multi-agent-system-design.md) slicing — per-turn tool/skill filtering by profile and preset merge into the Store. Merges cleanly on top of merged PR2.

- **`tools.DefaultToolsForProfile(ctx, model)`** — filters the tool allowlist to `profile.Tools`. Context-driven: `WithProfileStore` + `WithSessionAgentID` stamp the store + agent ID, so **all existing `DefaultToolsForCtx` call sites auto-filter when a store is wired**; unchanged behavior otherwise. `DefaultToolsForCtx` now delegates to it.
- **`skills.ManifestForProfile(reg, profile)`** — filters the skill manifest to `profile.ToolSkills`. Per-turn composition so profile edits land on the next message.
- **`sub_agent` subagent_type resolves via `agentprofile.Store.Get`** (built-in + user-defined profiles), with a legacy fallback to the old preset loader for paths that don't wire a store yet (CLI/TUI). Adds `WithProfileStore` context accessor + `profileNames` helper.
- **Server wiring** — `runChannelTurns` / `buildAgent` / `prepareToolTurn` stamp the context with the profile store + session AgentID and compose the system prompt from the resolved profile (profile.SystemPrompt replaces base; profile-curated manifest replaces full).
- **agentprofile housekeeping** — `IsValidID` export (channel dependency), `RouteInput.UserID` comment, `aliasRule` sync note, `CreatedAt` mcomment, `SetProfileLookup` comment.

## Design deviations flagged for review

1. `DefaultToolsForCtx` now delegates to `DefaultToolsForProfile` — all existing call sites gain profile filtering automatically. This is opt-in (no filtering when no store/agentID in context) but reviewers should confirm this is the intended shape rather than a separate explicit function call at each call site.

2. The `sub_agent` tool retains a legacy fallback to `lookupAgentPreset` when the store is nil (CLI/TUI haven't wired it yet in PR4). This is a temporary bridge — PR4 removes it.

## Test plan

- `tools/profile_tools_test.go` — filter by allowlist, empty allowlist = all, unknown agent = all, sub-tools filtered, no profile = all
- `tools/profile_names_test.go` — `sub_agent` resolves built-in + user-defined profiles via Store; error message lists available names
- `skills/manifest_profile_test.go` — filter by ToolSkills, empty = all, no match = empty, nil = all
- `go vet ./...` clean; **full `go test ./... -race` green**

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
