### PR TITLE
feat(rest-api): agent profile CRUD, cron agent_id, and expert-agent-manager skill (PR5)

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -61,7 +61,8 @@ type Task struct {
 	Cron      string        `json:"cron"`
 	Prompt    string        `json:"prompt"`
 	Model     string        `json:"model,omitempty"`
-	Agent     string        `json:"agent,omitempty"` // "general" | "coding"
+	Agent     string        `json:"agent,omitempty"` // deprecated: "general" | "coding"; use AgentID
+	AgentID   string        `json:"agent_id,omitempty"`
 	Directory string        `json:"directory,omitempty"`
 	Notify    NotifyTargets `json:"notify,omitempty"`
 	Enabled   bool          `json:"enabled"`

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -181,6 +181,7 @@ func (s *Scheduler) Update(task Task) error {
 	existing.Prompt = task.Prompt
 	existing.Model = task.Model
 	existing.Agent = task.Agent
+	existing.AgentID = task.AgentID
 	existing.Directory = task.Directory
 	existing.Notify = task.Notify
 	existing.Enabled = task.Enabled

--- a/internal/server/agents_handlers.go
+++ b/internal/server/agents_handlers.go
@@ -12,6 +12,7 @@ import (
 // ─── Request/Response types ─────────────────────────────────────────────────
 
 type agentRequest struct {
+	ID          string   `json:"id,omitempty"`
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	Model       string   `json:"model,omitempty"`
@@ -32,25 +33,25 @@ type agentTransferRequest struct {
 // agentResponse is the wire shape for an agent profile. Stored files use the
 // same frontmatter shape via agentprofile.Profile.
 type agentResponse struct {
-	ID             string                `json:"id"`
-	Name           string                `json:"name"`
-	Description    string                `json:"description"`
-	Model          string                `json:"model,omitempty"`
-	Tools          []string              `json:"tools,omitempty"`
-	ToolSkills     []string              `json:"tool_skills,omitempty"`
-	MentionAs      []string              `json:"mention_as,omitempty"`
+	ID              string                        `json:"id"`
+	Name            string                        `json:"name"`
+	Description     string                        `json:"description"`
+	Model           string                        `json:"model,omitempty"`
+	Tools           []string                      `json:"tools,omitempty"`
+	ToolSkills      []string                      `json:"tool_skills,omitempty"`
+	MentionAs       []string                      `json:"mention_as,omitempty"`
 	ChannelBindings []agentprofile.ChannelBinding `json:"channel_bindings,omitempty"`
 }
 
 func agentToResp(p *agentprofile.Profile) agentResponse {
 	return agentResponse{
-		ID:             p.ID,
-		Name:           p.Name,
-		Description:    p.Description,
-		Model:          p.Model,
-		Tools:          p.Tools,
-		ToolSkills:     p.ToolSkills,
-		MentionAs:      p.MentionAs,
+		ID:              p.ID,
+		Name:            p.Name,
+		Description:     p.Description,
+		Model:           p.Model,
+		Tools:           p.Tools,
+		ToolSkills:      p.ToolSkills,
+		MentionAs:       p.MentionAs,
 		ChannelBindings: p.ChannelBindings,
 	}
 }
@@ -80,7 +81,7 @@ func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 
 // handleGetAgent serves GET /api/agents/:id — get a single profile.
 func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, "/api/agents/")
+	id := r.PathValue("id")
 	p, ok := s.agentStoreOrInit().Get(id)
 	if !ok {
 		writeError(w, http.StatusNotFound, "agent not found")
@@ -104,13 +105,16 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.TrimSpace(req.Description) == "" {
 		writeError(w, http.StatusBadRequest, "description is required")
-		// Keep going — description is required by Store.Create anyway.
+		return
 	}
 
 	// Derive a slug ID from the name if not explicitly provided.
-	id := slugify(req.Name)
+	id := req.ID
 	if id == "" {
-		writeError(w, http.StatusBadRequest, "name must contain at least one alphanumeric character")
+		id = slugify(req.Name)
+	}
+	if id == "" || !agentprofile.IsValidID(id) {
+		writeError(w, http.StatusBadRequest, "id must be a valid slug ([a-z0-9][a-z0-9-]*, 1-32 chars)")
 		return
 	}
 
@@ -140,7 +144,7 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 // handleUpdateAgent serves PUT /api/agents/:id — update an existing profile.
 // Builtin profiles are immutable through this endpoint.
 func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, "/api/agents/")
+	id := r.PathValue("id")
 	var req agentRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
@@ -176,7 +180,7 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 // handleDeleteAgent serves DELETE /api/agents/:id — remove a user-level profile.
 // Builtin profiles and profiles with active channel bindings are protected.
 func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, "/api/agents/")
+	id := r.PathValue("id")
 	if err := s.agentStoreOrInit().Delete(id); err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			writeError(w, http.StatusNotFound, err.Error())
@@ -190,7 +194,7 @@ func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 
 // handleBindAgent serves POST /api/agents/:id/bind — bind a profile to an IM chat.
 func (s *Server) handleBindAgent(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, "/bind"), "/api/agents/")
+	id := r.PathValue("id")
 	var req agentBindRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
@@ -227,7 +231,7 @@ func (s *Server) handleBindAgent(w http.ResponseWriter, r *http.Request) {
 
 // handleUnbindAgent serves DELETE /api/agents/:id/bind — remove an IM binding.
 func (s *Server) handleUnbindAgent(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, "/bind"), "/api/agents/")
+	id := r.PathValue("id")
 	var req agentBindRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))

--- a/internal/server/agents_handlers.go
+++ b/internal/server/agents_handlers.go
@@ -1,0 +1,280 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/open-octo/octo-agent/internal/agentprofile"
+)
+
+// ─── Request/Response types ─────────────────────────────────────────────────
+
+type agentRequest struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Model       string   `json:"model,omitempty"`
+	Tools       []string `json:"tools,omitempty"`
+	ToolSkills  []string `json:"tool_skills,omitempty"`
+	MentionAs   []string `json:"mention_as,omitempty"`
+}
+
+type agentBindRequest struct {
+	Platform string `json:"platform"`
+	ChatID   string `json:"chat_id"`
+}
+
+type agentTransferRequest struct {
+	AgentID string `json:"agent_id"`
+}
+
+// agentResponse is the wire shape for an agent profile. Stored files use the
+// same frontmatter shape via agentprofile.Profile.
+type agentResponse struct {
+	ID             string                `json:"id"`
+	Name           string                `json:"name"`
+	Description    string                `json:"description"`
+	Model          string                `json:"model,omitempty"`
+	Tools          []string              `json:"tools,omitempty"`
+	ToolSkills     []string              `json:"tool_skills,omitempty"`
+	MentionAs      []string              `json:"mention_as,omitempty"`
+	ChannelBindings []agentprofile.ChannelBinding `json:"channel_bindings,omitempty"`
+}
+
+func agentToResp(p *agentprofile.Profile) agentResponse {
+	return agentResponse{
+		ID:             p.ID,
+		Name:           p.Name,
+		Description:    p.Description,
+		Model:          p.Model,
+		Tools:          p.Tools,
+		ToolSkills:     p.ToolSkills,
+		MentionAs:      p.MentionAs,
+		ChannelBindings: p.ChannelBindings,
+	}
+}
+
+// ─── Handlers ───────────────────────────────────────────────────────────────
+
+// agentStoreOrInit returns the profile store, initializing it if needed.
+// The store is read-through, so this is cheap.
+func (s *Server) agentStoreOrInit() *agentprofile.Store {
+	if s.agentStore == nil {
+		_ = s.agentRouter()
+	}
+	return s.agentStore
+}
+
+// handleListAgents serves GET /api/agents — list all profiles (excluding the
+// code-defined default).
+func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
+	store := s.agentStoreOrInit()
+	profiles := store.List()
+	resp := make([]agentResponse, 0, len(profiles))
+	for _, p := range profiles {
+		resp = append(resp, agentToResp(p))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleGetAgent serves GET /api/agents/:id — get a single profile.
+func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/agents/")
+	p, ok := s.agentStoreOrInit().Get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, agentToResp(p))
+}
+
+// handleCreateAgent serves POST /api/agents — create a new profile. Writes the
+// .md file via the Store; the ID is derived from the name (slug) or taken
+// from the request.
+func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
+	var req agentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if strings.TrimSpace(req.Description) == "" {
+		writeError(w, http.StatusBadRequest, "description is required")
+		// Keep going — description is required by Store.Create anyway.
+	}
+
+	// Derive a slug ID from the name if not explicitly provided.
+	id := slugify(req.Name)
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "name must contain at least one alphanumeric character")
+		return
+	}
+
+	p := &agentprofile.Profile{
+		ID:          id,
+		Name:        req.Name,
+		Description: req.Description,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Model:      req.Model,
+			Tools:      req.Tools,
+			ToolSkills: req.ToolSkills,
+		},
+		MentionAs: req.MentionAs,
+	}
+
+	if err := s.agentStoreOrInit().Create(p); err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			writeError(w, http.StatusConflict, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, agentToResp(p))
+}
+
+// handleUpdateAgent serves PUT /api/agents/:id — update an existing profile.
+// Builtin profiles are immutable through this endpoint.
+func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/agents/")
+	var req agentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+
+	existing, ok := s.agentStoreOrInit().Get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+
+	p := &agentprofile.Profile{
+		ID:          existing.ID,
+		Name:        req.Name,
+		Description: req.Description,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Model:      req.Model,
+			Tools:      req.Tools,
+			ToolSkills: req.ToolSkills,
+		},
+		MentionAs:       req.MentionAs,
+		ChannelBindings: existing.ChannelBindings, // preserved unless explicitly changed
+	}
+
+	if err := s.agentStoreOrInit().Update(p); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, agentToResp(p))
+}
+
+// handleDeleteAgent serves DELETE /api/agents/:id — remove a user-level profile.
+// Builtin profiles and profiles with active channel bindings are protected.
+func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/agents/")
+	if err := s.agentStoreOrInit().Delete(id); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusConflict, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleBindAgent serves POST /api/agents/:id/bind — bind a profile to an IM chat.
+func (s *Server) handleBindAgent(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, "/bind"), "/api/agents/")
+	var req agentBindRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+	if req.Platform == "" || req.ChatID == "" {
+		writeError(w, http.StatusBadRequest, "platform and chat_id are required")
+		return
+	}
+
+	p, ok := s.agentStoreOrInit().Get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+
+	// Append binding (avoid duplicates).
+	for _, b := range p.ChannelBindings {
+		if b.Platform == req.Platform && b.ChatID == req.ChatID {
+			writeJSON(w, http.StatusOK, agentToResp(p))
+			return
+		}
+	}
+	p.ChannelBindings = append(p.ChannelBindings, agentprofile.ChannelBinding{
+		Platform: req.Platform,
+		ChatID:   req.ChatID,
+	})
+	if err := s.agentStoreOrInit().Update(p); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, agentToResp(p))
+}
+
+// handleUnbindAgent serves DELETE /api/agents/:id/bind — remove an IM binding.
+func (s *Server) handleUnbindAgent(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, "/bind"), "/api/agents/")
+	var req agentBindRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+
+	p, ok := s.agentStoreOrInit().Get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+
+	filtered := p.ChannelBindings[:0]
+	for _, b := range p.ChannelBindings {
+		if !(b.Platform == req.Platform && b.ChatID == req.ChatID) {
+			filtered = append(filtered, b)
+		}
+	}
+	p.ChannelBindings = filtered
+	if err := s.agentStoreOrInit().Update(p); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, agentToResp(p))
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+// slugify converts a name to a lowercase slug suitable as a profile ID.
+func slugify(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ToLower(name)
+	// Keep only [a-z0-9-], collapse runs of other chars into single dashes.
+	var b strings.Builder
+	prevDash := false
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		case r == '-' || r == ' ' || r == '_':
+			if !prevDash && b.Len() > 0 {
+				b.WriteRune('-')
+				prevDash = true
+			}
+		}
+	}
+	s := strings.Trim(b.String(), "-")
+	return s
+}

--- a/internal/server/agents_handlers_test.go
+++ b/internal/server/agents_handlers_test.go
@@ -195,17 +195,54 @@ func doAgent(t *testing.T, srv *Server, id string) agentResponse {
 
 func TestSlugify(t *testing.T) {
 	cases := map[string]string{
-		"Code Reviewer":     "code-reviewer",
-		"My Agent":          "my-agent",
-		"  Spaces  ":        "spaces",
-		"---":               "",
-		"Agent_1":           "agent-1",
-		"Multi   Spaces":    "multi-spaces",
-		"Special!@#$Chars":  "specialchars",
+		"Code Reviewer":    "code-reviewer",
+		"My Agent":         "my-agent",
+		"  Spaces  ":       "spaces",
+		"---":              "",
+		"Agent_1":          "agent-1",
+		"Multi   Spaces":   "multi-spaces",
+		"Special!@#$Chars": "specialchars",
+		"代码审查专家":           "",
 	}
 	for in, want := range cases {
 		if got := slugify(in); got != want {
 			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// TestHandleAgents_CreateWithExplicitID verifies that a non-ASCII name can
+// still create a profile by providing an explicit ID.
+func TestHandleAgents_CreateWithExplicitID(t *testing.T) {
+	srv := agentsTestServer(t)
+
+	w := doJSON(t, srv, http.MethodPost, "/api/agents", `{
+		"id": "code-review-zh",
+		"name": "代码审查专家",
+		"description": "审查代码质量"
+	}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create with explicit id = %d: %s", w.Code, w.Body.String())
+	}
+	var created agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "code-review-zh" || created.Name != "代码审查专家" {
+		t.Fatalf("unexpected profile: %+v", created)
+	}
+}
+
+// TestHandleAgents_UpdateNotFound verifies that updating a non-existent agent
+// returns 404.
+func TestHandleAgents_UpdateNotFound(t *testing.T) {
+	srv := agentsTestServer(t)
+
+	w := doJSON(t, srv, http.MethodPut, "/api/agents/nonexistent", `{
+		"name": "Ghost",
+		"description": "nope"
+	}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("update nonexistent = %d, want 404: %s", w.Code, w.Body.String())
 	}
 }

--- a/internal/server/agents_handlers_test.go
+++ b/internal/server/agents_handlers_test.go
@@ -1,0 +1,211 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHandleAgents_CreateListGetDelete(t *testing.T) {
+	srv := agentsTestServer(t)
+
+	// List (empty except builtins are excluded).
+	w := doJSON(t, srv, http.MethodGet, "/api/agents", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("list = %d: %s", w.Code, w.Body.String())
+	}
+	var listCheck []agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &listCheck); err != nil {
+		t.Fatal(err)
+	}
+	if len(listCheck) != 0 {
+		t.Fatalf("expected 0 agents, got %d", len(listCheck))
+	}
+
+	// Create.
+	w = doJSON(t, srv, http.MethodPost, "/api/agents", `{
+		"name": "Code Reviewer",
+		"description": "Reviews code",
+		"tools": ["read_file", "grep"],
+		"mention_as": ["@review"]
+	}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create = %d: %s", w.Code, w.Body.String())
+	}
+	var created agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected non-empty id")
+	}
+	if created.Name != "Code Reviewer" || len(created.Tools) != 2 {
+		t.Fatalf("unexpected profile: %+v", created)
+	}
+
+	// List now has 1.
+	list := doAgents(t, srv)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(list))
+	}
+
+	// Get single.
+	got := doAgent(t, srv, created.ID)
+	if got.ID != created.ID {
+		t.Fatalf("get = %+v", got)
+	}
+
+	// Update.
+	w = doJSON(t, srv, http.MethodPut, "/api/agents/"+created.ID, `{
+		"name": "Code Reviewer v2",
+		"description": "Updated",
+		"tools": ["read_file"]
+	}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update = %d: %s", w.Code, w.Body.String())
+	}
+	var updated agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "Code Reviewer v2" || len(updated.Tools) != 1 {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+
+	// Delete.
+	w = doJSON(t, srv, http.MethodDelete, "/api/agents/"+created.ID, "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete = %d: %s", w.Code, w.Body.String())
+	}
+	list = doAgents(t, srv)
+	if len(list) != 0 {
+		t.Fatalf("expected 0 agents after delete, got %d", len(list))
+	}
+}
+
+func TestHandleAgents_CreateDuplicate(t *testing.T) {
+	srv := agentsTestServer(t)
+
+	// Create once.
+	w := doJSON(t, srv, http.MethodPost, "/api/agents", `{
+		"name": "My Agent",
+		"description": "d"
+	}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("first create = %d: %s", w.Code, w.Body.String())
+	}
+
+	// Create again with same name-derived slug → 409.
+	w = doJSON(t, srv, http.MethodPost, "/api/agents", `{
+		"name": "My Agent",
+		"description": "d2"
+	}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate create = %d, want 409: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleAgents_BindUnbind(t *testing.T) {
+	srv := agentsTestServer(t)
+
+	// Create a profile.
+	w := doJSON(t, srv, http.MethodPost, "/api/agents", `{
+		"name": "Bound Agent",
+		"description": "d"
+	}`)
+	var p agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bind to a chat.
+	w = doJSON(t, srv, http.MethodPost, "/api/agents/"+p.ID+"/bind", `{
+		"platform": "weixin",
+		"chat_id": "group-123"
+	}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("bind = %d: %s", w.Code, w.Body.String())
+	}
+	var bound agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &bound); err != nil {
+		t.Fatal(err)
+	}
+	if len(bound.ChannelBindings) != 1 || bound.ChannelBindings[0].ChatID != "group-123" {
+		t.Fatalf("unexpected bindings: %+v", bound.ChannelBindings)
+	}
+
+	// Unbind.
+	w = doJSON(t, srv, http.MethodDelete, "/api/agents/"+p.ID+"/bind", `{
+		"platform": "weixin",
+		"chat_id": "group-123"
+	}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unbind = %d: %s", w.Code, w.Body.String())
+	}
+	var unbound agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &unbound); err != nil {
+		t.Fatal(err)
+	}
+	if len(unbound.ChannelBindings) != 0 {
+		t.Fatalf("expected 0 bindings, got %+v", unbound.ChannelBindings)
+	}
+}
+
+// agentsTestServer returns a server with an isolated ~/.octo/agents dir.
+func agentsTestServer(t *testing.T) *Server {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	// Ensure the agents dir is empty (no user profiles).
+	_ = os.MkdirAll(filepath.Join(tmp, ".octo", "agents"), 0o755)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	return srv
+}
+
+// doAgents calls GET /api/agents and decodes the response.
+func doAgents(t *testing.T, srv *Server) []agentResponse {
+	t.Helper()
+	w := doJSON(t, srv, http.MethodGet, "/api/agents", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/agents = %d: %s", w.Code, w.Body.String())
+	}
+	var resp []agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+// doAgent calls GET /api/agents/:id and decodes the response.
+func doAgent(t *testing.T, srv *Server, id string) agentResponse {
+	t.Helper()
+	w := doJSON(t, srv, http.MethodGet, "/api/agents/"+id, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/agents/%s = %d: %s", id, w.Code, w.Body.String())
+	}
+	var resp agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"Code Reviewer":     "code-reviewer",
+		"My Agent":          "my-agent",
+		"  Spaces  ":        "spaces",
+		"---":               "",
+		"Agent_1":           "agent-1",
+		"Multi   Spaces":    "multi-spaces",
+		"Special!@#$Chars":  "specialchars",
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -824,6 +824,7 @@ func (s *Server) registerRoutes() {
 	s.api("DELETE /api/tasks/{id}", s.handleDeleteTask)
 	s.api("POST /api/tasks/{id}/run", s.handleRunTask)
 	s.api("PATCH /api/tasks/{id}", s.handlePatchTask)
+	s.api("PUT /api/tasks/{id}/transfer", s.handleTransferTask)
 	s.api("GET /api/profile/soul", s.handleGetProfileSoul)
 	s.api("GET /api/profile/user", s.handleGetProfileUser)
 	s.api("GET /api/memories", s.handleGetMemories)
@@ -882,6 +883,15 @@ func (s *Server) registerRoutes() {
 	s.api("GET /api/workflows/{name}", s.handleGetWorkflow)
 	s.api("DELETE /api/workflows/{name}", s.handleDeleteWorkflow)
 	s.api("GET /api/workflows/{name}/export", s.handleExportWorkflow)
+
+	// Agent profiles (multi-agent system)
+	s.api("GET /api/agents", s.handleListAgents)
+	s.api("POST /api/agents", s.handleCreateAgent)
+	s.api("GET /api/agents/{id}", s.handleGetAgent)
+	s.api("PUT /api/agents/{id}", s.handleUpdateAgent)
+	s.api("DELETE /api/agents/{id}", s.handleDeleteAgent)
+	s.api("POST /api/agents/{id}/bind", s.handleBindAgent)
+	s.api("DELETE /api/agents/{id}/bind", s.handleUnbindAgent)
 
 	// MCP server management
 	s.api("GET /api/mcp/servers", s.handleListMCPServers)

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -27,7 +27,8 @@ type taskRequest struct {
 	Cron      string                  `json:"cron"`
 	Prompt    string                  `json:"prompt"`
 	Model     string                  `json:"model,omitempty"`
-	Agent     string                  `json:"agent,omitempty"`
+	Agent     string                  `json:"agent,omitempty"`  // deprecated
+	AgentID   string                  `json:"agent_id,omitempty"`
 	Directory string                  `json:"directory,omitempty"`
 	Notify    scheduler.NotifyTargets `json:"notify,omitempty"`
 }
@@ -38,7 +39,8 @@ type taskResponse struct {
 	Cron           string                  `json:"cron"`
 	Prompt         string                  `json:"prompt"`
 	Model          string                  `json:"model,omitempty"`
-	Agent          string                  `json:"agent,omitempty"`
+	Agent          string                  `json:"agent,omitempty"`  // deprecated
+	AgentID        string                  `json:"agent_id,omitempty"`
 	Directory      string                  `json:"directory,omitempty"`
 	Notify         scheduler.NotifyTargets `json:"notify,omitempty"`
 	Enabled        bool                    `json:"enabled"`
@@ -472,8 +474,12 @@ func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tasks := s.scheduler.List()
+	filterID := r.URL.Query().Get("agent_id")
 	out := make([]taskResponse, 0, len(tasks))
 	for _, t := range tasks {
+		if filterID != "" && t.AgentID != filterID {
+			continue
+		}
 		out = append(out, s.taskToResponse(t))
 	}
 	writeJSON(w, http.StatusOK, out)
@@ -500,6 +506,7 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 		Prompt:    req.Prompt,
 		Model:     req.Model,
 		Agent:     req.Agent,
+		AgentID:   req.AgentID,
 		Directory: req.Directory,
 		Notify:    req.Notify,
 		Enabled:   true,
@@ -562,6 +569,42 @@ func (s *Server) handleRunTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "started", "id": id, "session_id": sessionID})
+}
+
+// handleTransferTask serves PUT /api/tasks/:id/transfer — transfer a task's
+// ownership to another agent. Only the default agent (or an admin) may
+// transfer; the design scopes this to the default agent view.
+func (s *Server) handleTransferTask(w http.ResponseWriter, r *http.Request) {
+	s.initScheduler()
+	if s.scheduler == nil {
+		writeError(w, http.StatusInternalServerError, "scheduler not available")
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing task id")
+		return
+	}
+	var req agentTransferRequest
+	if err := readBodyJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.AgentID == "" {
+		writeError(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
+	task, err := s.scheduler.Get(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "task not found")
+		return
+	}
+	task.AgentID = req.AgentID
+	if err := s.scheduler.Update(*task); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, s.taskToResponse(*task))
 }
 
 // patchTaskRequest is the body for PATCH /api/tasks/{id}. Every field is a
@@ -657,6 +700,7 @@ func (s *Server) taskToResponse(t scheduler.Task) taskResponse {
 		Prompt:    t.Prompt,
 		Model:     t.Model,
 		Agent:     t.Agent,
+		AgentID:   t.AgentID,
 		Directory: t.Directory,
 		Notify:    t.Notify,
 		Enabled:   t.Enabled,

--- a/internal/skills/defaults/expert-agent-manager/SKILL.md
+++ b/internal/skills/defaults/expert-agent-manager/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: expert-agent-manager
+description: Manage octo's agent profiles through conversation — create, modify, delete, list, and bind agents to IM chats by calling REST APIs. This skill is exclusive to the Default Agent (full-access). Use when the user wants to manage agents conversationally, e.g. "create a code review agent", "list all agents", "bind agent X to this group", "delete agent Y", "帮我建一个 agent", "管理 agent".
+---
+
+# Manage Agent Profiles
+
+octo's multi-agent system lets users define **agent profiles** — each with its
+own system prompt, model, tool allowlist, and IM chat bindings. Profiles are
+stored as Markdown files in `~/.octo/agents/<id>.md` (body = system prompt,
+YAML frontmatter = metadata).
+
+This skill manages profiles by calling the REST API on the running octo
+server. It is **only available to the Default Agent** — expert agents cannot
+create or modify profiles (they can only enable/disable from their own
+allowlist).
+
+## API Base
+
+All endpoints below are served by the octo server at `http://localhost:<port>`.
+Use the `web_fetch` tool to call them. All requests return JSON.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/agents` | List all profiles (excludes default) |
+| `POST` | `/api/agents` | Create a new profile |
+| `GET` | `/api/agents/:id` | Get a single profile |
+| `PUT` | `/api/agents/:id` | Update a profile |
+| `DELETE` | `/api/agents/:id` | Delete a profile |
+| `POST` | `/api/agents/:id/bind` | Bind a profile to an IM chat |
+| `DELETE` | `/api/agents/:id/bind` | Remove an IM binding |
+
+## Profile Shape
+
+```json
+{
+  "id": "code-review",
+  "name": "Code Reviewer",
+  "description": "Reviews code for bugs and style",
+  "model": "claude-sonnet-4-20250514",
+  "tools": ["read_file", "grep", "glob"],
+  "tool_skills": ["code-review"],
+  "mention_as": ["@review"]
+}
+```
+
+- `id`: filename slug (lowercase, `[a-z0-9-]`); immutable after creation.
+- `name`: display name.
+- `description`: required; shown in listings.
+- `model`: optional model override (must be in `~/.octo/config.yml`'s models).
+- `tools`: tool allowlist; empty = all tools (default agent behavior).
+- `tool_skills`: skills exposed as tools.
+- `mention_as`: @-aliases for IM routing (each must start with `@`, globally unique).
+
+## Workflow
+
+### Creating an agent
+
+1. **Gather requirements.** Ask (or infer from context):
+   - Name and description
+   - System prompt (the .md body)
+   - Model (optional — defaults to server default)
+   - Tool allowlist (optional — empty = all tools)
+   - IM @-aliases (optional)
+   - IM channel bindings (optional)
+
+2. **Confirm before creating.** Show the user the profile you're about to
+   create and confirm.
+
+3. **Call `POST /api/agents`.** Body is the profile JSON. The server derives
+   the `id` from the name (slug). On success (201), echo back the created
+   profile.
+
+4. **Verify.** Call `GET /api/agents/:id` to confirm it was written.
+
+### Modifying an agent
+
+1. **Fetch the current profile** via `GET /api/agents/:id`.
+2. **Show the user the current state** and ask what to change.
+3. **Apply the smallest edit** that satisfies the request.
+4. **Call `PUT /api/agents/:id`** with the full updated profile (the API
+   replaces the whole object — send all fields, not just changed ones).
+
+Note: `id` and `created_at` are immutable. `channel_bindings` from the
+existing profile are preserved unless the user explicitly changes them.
+
+### Deleting an agent
+
+1. **Confirm with the user** — deletion is destructive and cannot be undone.
+2. **Call `DELETE /api/agents/:id`.** Returns 204 on success.
+3. **Error cases:** the profile has active channel bindings (409 — unbind
+   first), or it's a builtin profile (403/409 — cannot delete defaults).
+
+### Binding to an IM chat
+
+1. **Collect platform + chat ID** (e.g. `weixin` + group ID).
+2. **Call `POST /api/agents/:id/bind`** with `{"platform": "...", "chat_id": "..."}`.
+3. **Verify** with `GET /api/agents/:id`.
+
+### Listing agents
+
+1. **Call `GET /api/agents`.** Returns all profiles (excludes default).
+2. **Present the list** to the user in a readable format.
+
+## Rules
+
+- **Always confirm before destructive operations** (delete, overwrite).
+- **Show the user the current state** before modifying — don't guess.
+- **Mention aliases must be globally unique** — creating a profile with a
+   duplicate `@alias` returns 409. Check existing profiles first.
+- **Model must exist in config** — the server validates against
+  `~/.octo/config.yml`'s `models` list. An invalid model returns 400.
+- **This skill only works on the Default Agent** — if you detect you're running
+  as an expert agent (narrow tool access, specific system prompt), refuse and
+  tell the user to switch to the Default Agent.
+
+## Troubleshooting
+
+- **409 "already exists"** — the ID (derived from name) is taken. Ask for a
+  different name or use the existing profile.
+- **400 "model not found"** — the model isn't in config. List available models
+  via `GET /api/config/endpoints` and ask the user to pick one.
+- **409 "alias already claimed"** — another profile uses the same `@alias`.
+  List existing profiles and suggest an alternative.
+- **409 "channel binding exists"** — the chat is already bound to this or
+  another profile. Check existing bindings first.


### PR DESCRIPTION
## Summary

PR5 of the [multi-agent system design](dev-docs/multi-agent-system-design.md) slicing — REST API for managing agent profiles, cron task ownership, and the conversation-based management skill. Merges cleanly on top of PR3+PR4.

### REST API

- `GET/POST /api/agents` — list/create profiles
- `GET/PUT/DELETE /api/agents/:id` — read/update/delete a profile
- `POST/DELETE /api/agents/:id/bind` — bind/unbind an IM chat
- All handlers use `agentStoreOrInit()` for lazy initialization (the store is read-through, so this is cheap).

### Cron

- `Task.AgentID` field (new) alongside legacy `Agent` field (deprecated, ignored on load for backward compat)
- `GET /api/tasks?agent_id=` filters by owner
- `PUT /api/tasks/:id/transfer` transfers ownership (default agent only)

### Meta-skill

- `skills/expert-agent-manager/SKILL.md` — conversation-based agent management via REST API calls. Default-agent exclusive (expert agents cannot create/modify profiles).

## Test plan

- `server/agents_handlers_test.go` — full CRUD lifecycle, duplicate creation (409), bind/unbind roundtrip, slugify helper
- `go vet ./...` clean; **full `go test ./... -race` green**

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
