### PR TITLE
feat(provider): add k3-256k model to kimi-coding-plan

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -115,6 +115,8 @@ func contextWindow(model string) int {
 	// ── Moonshot Kimi ──
 	case strings.Contains(m, "kimi-for-coding-highspeed"):
 		return 256_000
+	case strings.Contains(m, "k3-256k"):
+		return 256_000
 	case strings.Contains(m, "k3"):
 		return 1_000_000
 	case strings.Contains(m, "kimi-k2.7") || strings.Contains(m, "kimik2.7") || strings.Contains(m, "k2.7"):

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -93,6 +93,9 @@ func TestContextWindow(t *testing.T) {
 	if got := contextWindow("k3"); got != 1_000_000 {
 		t.Errorf("k3 window = %d, want 1000000", got)
 	}
+	if got := contextWindow("k3-256k"); got != 256_000 {
+		t.Errorf("k3-256k window = %d, want 256000", got)
+	}
 	if got := contextWindow("deepseek-v4-pro"); got != 1_000_000 {
 		t.Errorf("deepseek-v4-pro window = %d, want 1000000", got)
 	}

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -206,6 +206,7 @@ var Registry = []Vendor{
 			{ID: "kimi-for-coding", Vision: true},
 			{ID: "kimi-for-coding-highspeed", Vision: true},
 			{ID: "k3", Vision: true},
+			{ID: "k3-256k", Vision: true},
 			{ID: "kimi-k2.6", Vision: true},
 			{ID: "kimi-k2.7-code", Vision: true},
 		},


### PR DESCRIPTION
Register `k3-256k` under the `kimi-coding-plan` vendor.

- Add `k3-256k` to the Kimi Coding Plan model list.
- Map `k3-256k` to a 256k context window so compaction uses the correct budget (otherwise it would fall through to the generic `k3` rule and incorrectly use 1M).
- Add context-window test coverage.