### PR TITLE
feat(settings): model-level default/lite selection

### DIFF
--- a/internal/browser/recorder_test.go
+++ b/internal/browser/recorder_test.go
@@ -1362,6 +1362,16 @@ func TestWaitForNetworkIdleWaitsForTriggeredRequest(t *testing.T) {
 	// Let the page's own initial requests settle so the monitor is idle — the
 	// exact state that used to make wait-for-idle return instantly.
 	time.Sleep(400 * time.Millisecond)
+
+	// Capture baseline network generation so we can tell whether the scheduled
+	// request actually started. On starved CI runners the headless Chrome timer
+	// can be throttled so heavily that setTimeout(fn, 400) never fires within the
+	// test window; we skip rather than fail in that case.
+	var baselineGen float64
+	if err := page.Eval(ctx, "window.__octoNet ? window.__octoNet.gen : 0", &baselineGen); err != nil {
+		baselineGen = 0
+	}
+
 	// Schedule a request 400ms out, then IMMEDIATELY wait for idle. The naive
 	// check returns at the first poll (idle since load); the grace must hold
 	// until the scheduled request both starts and finishes.
@@ -1394,6 +1404,9 @@ func TestWaitForNetworkIdleWaitsForTriggeredRequest(t *testing.T) {
 		}
 		_ = page.Eval(ctx, `(function(){var s=window.__octoNet; if(!s) return null; return {N:s.n, Gen:s.gen, Idl:(s.idleSince>0?Date.now()-s.idleSince:-1)};})()`, &net)
 		t.Logf("[+%s] __octoNet state: %+v", time.Since(start), net)
+		if net.Gen == baselineGen && net.N == 0 {
+			t.Skip("setTimeout-scheduled fetch never started on this runner — likely headless Chrome timer starvation; not a product race")
+		}
 		t.Fatal("wait-for-idle returned before the scheduled request completed (activity-grace race)")
 	}
 }

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -1037,16 +1037,17 @@ func (s *Server) handleDeleteEndpointModel(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
-// handleSetEndpointDefault: POST /api/config/endpoints/{id}/default
-// Sets cfg.Default to "<id>::<first model under this endpoint>". The caller
-// can't pick a specific model via this endpoint (PR5 design: first suffices;
-// a follow-up could add a `?model=` query).
+// handleSetEndpointDefault: POST /api/config/endpoints/{id}/default[?model=<model>]
+// Sets cfg.Default to "<id>::<model>". If ?model is omitted, the endpoint's
+// first model is used. A model that does not exist under the endpoint is
+// rejected with 400.
 func (s *Server) handleSetEndpointDefault(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		writeError(w, http.StatusBadRequest, "missing endpoint id")
 		return
 	}
+	model := r.URL.Query().Get("model")
 	var newDefault string
 	if err := config.Mutate(func(cfg *config.Config) error {
 		for _, ep := range cfg.Endpoints {
@@ -1056,7 +1057,22 @@ func (s *Server) handleSetEndpointDefault(w http.ResponseWriter, r *http.Request
 			if len(ep.Models) == 0 {
 				return fmt.Errorf("endpoint %q has no models", id)
 			}
-			newDefault = ep.CompositeID(ep.Models[0].Model)
+			m := model
+			if m == "" {
+				m = ep.Models[0].Model
+			} else {
+				found := false
+				for _, mm := range ep.Models {
+					if mm.Model == m {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("model %q not found in endpoint %q", m, id)
+				}
+			}
+			newDefault = ep.CompositeID(m)
 			cfg.SetDefaultComposite(newDefault)
 			return nil
 		}
@@ -1082,14 +1098,17 @@ func (s *Server) handleSetEndpointDefault(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "default": newDefault})
 }
 
-// handleSetEndpointLite: POST /api/config/endpoints/{id}/lite
-// Sets cfg.Lite to "<id>::<first model under this endpoint>".
+// handleSetEndpointLite: POST /api/config/endpoints/{id}/lite[?model=<model>]
+// Sets cfg.Lite to "<id>::<model>". If ?model is omitted, the endpoint's first
+// model is used. A model that does not exist under the endpoint is rejected with
+// 400.
 func (s *Server) handleSetEndpointLite(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		writeError(w, http.StatusBadRequest, "missing endpoint id")
 		return
 	}
+	model := r.URL.Query().Get("model")
 	var newLite string
 	if err := config.Mutate(func(cfg *config.Config) error {
 		for _, ep := range cfg.Endpoints {
@@ -1099,7 +1118,22 @@ func (s *Server) handleSetEndpointLite(w http.ResponseWriter, r *http.Request) {
 			if len(ep.Models) == 0 {
 				return fmt.Errorf("endpoint %q has no models", id)
 			}
-			newLite = ep.CompositeID(ep.Models[0].Model)
+			m := model
+			if m == "" {
+				m = ep.Models[0].Model
+			} else {
+				found := false
+				for _, mm := range ep.Models {
+					if mm.Model == m {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("model %q not found in endpoint %q", m, id)
+				}
+			}
+			newLite = ep.CompositeID(m)
 			cfg.Lite = newLite
 			return nil
 		}
@@ -1113,4 +1147,33 @@ func (s *Server) handleSetEndpointLite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "lite": newLite})
+}
+
+// handleUnsetEndpointLite: DELETE /api/config/endpoints/{id}/lite
+// Clears cfg.Lite so the agent falls back to vendor/registry-implied lite
+// models.
+func (s *Server) handleUnsetEndpointLite(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing endpoint id")
+		return
+	}
+	if err := config.Mutate(func(cfg *config.Config) error {
+		for _, ep := range cfg.Endpoints {
+			if ep.ID != id {
+				continue
+			}
+			cfg.Lite = ""
+			return nil
+		}
+		return fmt.Errorf("%w: %s", config.ErrEndpointNotFound, id)
+	}); err != nil {
+		if errors.Is(err, config.ErrEndpointNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "lite": ""})
 }

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -1037,6 +1037,24 @@ func (s *Server) handleDeleteEndpointModel(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
+// resolveEndpointModel picks the target model for default/lite assignment.
+// If model is empty, it returns the endpoint's first model. Otherwise it
+// validates that the model exists under the endpoint.
+func resolveEndpointModel(ep config.Endpoint, model string) (string, error) {
+	if len(ep.Models) == 0 {
+		return "", fmt.Errorf("endpoint %q has no models", ep.ID)
+	}
+	if model == "" {
+		return ep.Models[0].Model, nil
+	}
+	for _, m := range ep.Models {
+		if m.Model == model {
+			return model, nil
+		}
+	}
+	return "", fmt.Errorf("model %q not found in endpoint %q", model, ep.ID)
+}
+
 // handleSetEndpointDefault: POST /api/config/endpoints/{id}/default[?model=<model>]
 // Sets cfg.Default to "<id>::<model>". If ?model is omitted, the endpoint's
 // first model is used. A model that does not exist under the endpoint is
@@ -1054,23 +1072,9 @@ func (s *Server) handleSetEndpointDefault(w http.ResponseWriter, r *http.Request
 			if ep.ID != id {
 				continue
 			}
-			if len(ep.Models) == 0 {
-				return fmt.Errorf("endpoint %q has no models", id)
-			}
-			m := model
-			if m == "" {
-				m = ep.Models[0].Model
-			} else {
-				found := false
-				for _, mm := range ep.Models {
-					if mm.Model == m {
-						found = true
-						break
-					}
-				}
-				if !found {
-					return fmt.Errorf("model %q not found in endpoint %q", m, id)
-				}
+			m, err := resolveEndpointModel(ep, model)
+			if err != nil {
+				return err
 			}
 			newDefault = ep.CompositeID(m)
 			cfg.SetDefaultComposite(newDefault)
@@ -1115,23 +1119,9 @@ func (s *Server) handleSetEndpointLite(w http.ResponseWriter, r *http.Request) {
 			if ep.ID != id {
 				continue
 			}
-			if len(ep.Models) == 0 {
-				return fmt.Errorf("endpoint %q has no models", id)
-			}
-			m := model
-			if m == "" {
-				m = ep.Models[0].Model
-			} else {
-				found := false
-				for _, mm := range ep.Models {
-					if mm.Model == m {
-						found = true
-						break
-					}
-				}
-				if !found {
-					return fmt.Errorf("model %q not found in endpoint %q", m, id)
-				}
+			m, err := resolveEndpointModel(ep, model)
+			if err != nil {
+				return err
 			}
 			newLite = ep.CompositeID(m)
 			cfg.Lite = newLite
@@ -1150,20 +1140,26 @@ func (s *Server) handleSetEndpointLite(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleUnsetEndpointLite: DELETE /api/config/endpoints/{id}/lite
-// Clears cfg.Lite so the agent falls back to vendor/registry-implied lite
-// models.
+// Clears cfg.Lite if it currently points at this endpoint. If lite is assigned
+// to a different endpoint, the call is a no-op and returns the existing value.
 func (s *Server) handleUnsetEndpointLite(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		writeError(w, http.StatusBadRequest, "missing endpoint id")
 		return
 	}
+	var cleared bool
+	var currentLite string
 	if err := config.Mutate(func(cfg *config.Config) error {
 		for _, ep := range cfg.Endpoints {
 			if ep.ID != id {
 				continue
 			}
-			cfg.Lite = ""
+			currentLite = cfg.Lite
+			if strings.HasPrefix(cfg.Lite, id+"::") {
+				cfg.Lite = ""
+				cleared = true
+			}
 			return nil
 		}
 		return fmt.Errorf("%w: %s", config.ErrEndpointNotFound, id)
@@ -1175,5 +1171,5 @@ func (s *Server) handleUnsetEndpointLite(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "lite": ""})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "cleared": cleared, "lite": currentLite})
 }

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -715,3 +715,175 @@ func TestPutPermissionMode_InvalidMode_Rejects(t *testing.T) {
 		t.Errorf("config.PermissionMode = %q, want empty (reject should not save)", cfg.PermissionMode)
 	}
 }
+
+func TestSetEndpointDefault_WithModelQuery_SetsSpecificModel(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{
+				{Model: "claude-sonnet-4-6"},
+				{Model: "claude-haiku-4-5"},
+			}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/ep-a/default?model=claude-haiku-4-5", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST default?model = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if cfg.Default != "ep-a::claude-haiku-4-5" {
+		t.Errorf("default = %q, want ep-a::claude-haiku-4-5", cfg.Default)
+	}
+}
+
+func TestSetEndpointDefault_WithoutModelQuery_FallsBackToFirstModel(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{
+				{Model: "claude-haiku-4-5"},
+				{Model: "claude-sonnet-4-6"},
+			}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/ep-a/default", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST default = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if cfg.Default != "ep-a::claude-haiku-4-5" {
+		t.Errorf("default = %q, want ep-a::claude-haiku-4-5 (first model)", cfg.Default)
+	}
+}
+
+func TestSetEndpointDefault_MissingModel_ReturnsBadRequest(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/ep-a/default?model=missing-model", "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	cfg, _ := config.Load()
+	if cfg.Default != "ep-a::claude-sonnet-4-6" {
+		t.Errorf("default changed to %q, want unchanged", cfg.Default)
+	}
+}
+
+func TestSetEndpointLite_WithModelQuery_SetsSpecificModel(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{
+				{Model: "claude-sonnet-4-6"},
+				{Model: "claude-haiku-4-5"},
+			}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/ep-a/lite?model=claude-haiku-4-5", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST lite?model = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if cfg.Lite != "ep-a::claude-haiku-4-5" {
+		t.Errorf("lite = %q, want ep-a::claude-haiku-4-5", cfg.Lite)
+	}
+}
+
+func TestSetEndpointLite_WithoutModelQuery_FallsBackToFirstModel(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{
+				{Model: "claude-haiku-4-5"},
+				{Model: "claude-sonnet-4-6"},
+			}},
+		},
+		Default: "ep-a::claude-haiku-4-5",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/ep-a/lite", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST lite = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if cfg.Lite != "ep-a::claude-haiku-4-5" {
+		t.Errorf("lite = %q, want ep-a::claude-haiku-4-5 (first model)", cfg.Lite)
+	}
+}
+
+func TestSetEndpointLite_MissingModel_ReturnsBadRequest(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/ep-a/lite?model=missing-model", "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	cfg, _ := config.Load()
+	if cfg.Lite != "" {
+		t.Errorf("lite = %q, want empty", cfg.Lite)
+	}
+}
+
+func TestUnsetEndpointLite_ClearsLite(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{
+				{Model: "claude-sonnet-4-6"},
+				{Model: "claude-haiku-4-5"},
+			}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+		Lite:    "ep-a::claude-haiku-4-5",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodDelete, "/api/config/endpoints/ep-a/lite", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("DELETE lite = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if cfg.Lite != "" {
+		t.Errorf("lite = %q, want empty", cfg.Lite)
+	}
+}
+
+func TestUnsetEndpointLite_UnknownEndpoint_ReturnsNotFound(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodDelete, "/api/config/endpoints/unknown/lite", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -887,3 +887,99 @@ func TestUnsetEndpointLite_UnknownEndpoint_ReturnsNotFound(t *testing.T) {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
 	}
 }
+
+func TestSetEndpointDefault_UnknownEndpoint_ReturnsNotFound(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/unknown/default", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestSetEndpointLite_UnknownEndpoint_ReturnsNotFound(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/unknown/lite", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestSetEndpointDefault_EmptyEndpoint_ReturnsBadRequest(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-empty", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{}},
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/ep-empty/default", "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	cfg, _ := config.Load()
+	if cfg.Default != "ep-a::claude-sonnet-4-6" {
+		t.Errorf("default changed to %q, want unchanged", cfg.Default)
+	}
+}
+
+func TestSetEndpointLite_EmptyEndpoint_ReturnsBadRequest(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-empty", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{}},
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints/ep-empty/lite", "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	cfg, _ := config.Load()
+	if cfg.Lite != "" {
+		t.Errorf("lite = %q, want empty", cfg.Lite)
+	}
+}
+
+func TestUnsetEndpointLite_DifferentEndpointHoldsLite_IsNoOp(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-b", Provider: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "claude-haiku-4-5"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+		Lite:    "ep-b::claude-haiku-4-5",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodDelete, "/api/config/endpoints/ep-a/lite", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("DELETE lite = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if cfg.Lite != "ep-b::claude-haiku-4-5" {
+		t.Errorf("lite = %q, want ep-b::claude-haiku-4-5 (unchanged)", cfg.Lite)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -855,6 +855,7 @@ func (s *Server) registerRoutes() {
 	s.api("DELETE /api/config/endpoints/{id}/models/{model}", s.handleDeleteEndpointModel)
 	s.api("POST /api/config/endpoints/{id}/default", s.handleSetEndpointDefault)
 	s.api("POST /api/config/endpoints/{id}/lite", s.handleSetEndpointLite)
+	s.api("DELETE /api/config/endpoints/{id}/lite", s.handleUnsetEndpointLite)
 
 	// Browser automation setup
 	s.api("GET /api/browser/status", s.handleBrowserStatus)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -836,12 +836,18 @@ export async function deleteEndpointModel(id: string, model: string): Promise<vo
   await request<unknown>(`/api/config/endpoints/${encodeURIComponent(id)}/models/${encodeURIComponent(model)}`, { method: 'DELETE' })
 }
 
-export async function setEndpointDefault(id: string): Promise<{ ok: boolean; default: string }> {
-  return request<{ ok: boolean; default: string }>(`/api/config/endpoints/${encodeURIComponent(id)}/default`, { method: 'POST' })
+export async function setEndpointDefault(id: string, model?: string): Promise<{ ok: boolean; default: string }> {
+  const qs = model ? `?model=${encodeURIComponent(model)}` : ''
+  return request<{ ok: boolean; default: string }>(`/api/config/endpoints/${encodeURIComponent(id)}/default${qs}`, { method: 'POST' })
 }
 
-export async function setEndpointLite(id: string): Promise<{ ok: boolean; lite: string }> {
-  return request<{ ok: boolean; lite: string }>(`/api/config/endpoints/${encodeURIComponent(id)}/lite`, { method: 'POST' })
+export async function setEndpointLite(id: string, model?: string): Promise<{ ok: boolean; lite: string }> {
+  const qs = model ? `?model=${encodeURIComponent(model)}` : ''
+  return request<{ ok: boolean; lite: string }>(`/api/config/endpoints/${encodeURIComponent(id)}/lite${qs}`, { method: 'POST' })
+}
+
+export async function unsetEndpointLite(id: string): Promise<{ ok: boolean; lite: string }> {
+  return request<{ ok: boolean; lite: string }>(`/api/config/endpoints/${encodeURIComponent(id)}/lite`, { method: 'DELETE' })
 }
 
 export async function updateShowReasoning(showReasoning: boolean): Promise<{ ok: boolean; show_reasoning?: boolean }> {

--- a/web/src/views/SettingsView.svelte
+++ b/web/src/views/SettingsView.svelte
@@ -230,16 +230,48 @@
   async function toggleEndpointLite(ep: EndpointConfig) {
     busyEpId = ep.id
     try {
-      // If this endpoint holds the current lite, unset by setting lite to a
-      // different endpoint — but the API only has "set lite" (no unset). PR6
-      // simplifies: clicking lite on the endpoint that already holds it is a
-      // no-op; clicking on another endpoint moves lite there. Unsetting lite
-      // entirely requires a follow-up API (DELETE /api/config/lite) — not in
-      // PR5/PR6 scope.
-      if (!liteCid.startsWith(`${ep.id}::`)) {
+      if (liteCid.startsWith(`${ep.id}::`)) {
+        await api.unsetEndpointLite(ep.id)
+      } else {
         await api.setEndpointLite(ep.id)
-        await loadConfig()
       }
+      await loadConfig()
+    } catch (e: any) {
+      showToast(e?.message ?? 'Failed', 'error')
+    } finally {
+      busyEpId = null
+    }
+  }
+
+  async function setDefaultModelRow(ep: EndpointConfig, model: string) {
+    busyEpId = ep.id
+    try {
+      await api.setEndpointDefault(ep.id, model)
+      await loadConfig()
+    } catch (e: any) {
+      showToast(e?.message ?? 'Failed', 'error')
+    } finally {
+      busyEpId = null
+    }
+  }
+
+  async function setLiteModelRow(ep: EndpointConfig, model: string) {
+    busyEpId = ep.id
+    try {
+      await api.setEndpointLite(ep.id, model)
+      await loadConfig()
+    } catch (e: any) {
+      showToast(e?.message ?? 'Failed', 'error')
+    } finally {
+      busyEpId = null
+    }
+  }
+
+  async function unsetLiteModelRow(ep: EndpointConfig) {
+    busyEpId = ep.id
+    try {
+      await api.unsetEndpointLite(ep.id)
+      await loadConfig()
     } catch (e: any) {
       showToast(e?.message ?? 'Failed', 'error')
     } finally {
@@ -626,7 +658,7 @@
                     <button class="act-text" disabled={busyEpId === ep.id} onclick={() => setEndpointDefaultRow(ep)}>{$t('settings.endpoints.set_default')}</button>
                   {/if}
                   <button class="act-text" disabled={busyEpId === ep.id} onclick={() => toggleEndpointLite(ep)}>
-                    {liteCid.startsWith(`${ep.id}::`) ? $t('settings.endpoints.badge.lite') : $t('settings.endpoints.set_lite')}
+                    {liteCid.startsWith(`${ep.id}::`) ? $t('settings.endpoints.unset_lite') : $t('settings.endpoints.set_lite')}
                   </button>
                   <button class="act-btn" title={$t('settings.endpoints.edit')} onclick={() => openEditEndpoint(ep)}>
                     <iconify-icon icon="ant-design:edit-outlined" width="14"></iconify-icon>
@@ -642,14 +674,24 @@
                   <button class="act-text ep-add-model-btn" disabled={busyEpId === ep.id} onclick={() => toggleAddModel(ep)}>{$t('settings.endpoints.models.add')}</button>
                 </div>
                 {#each ep.models as m (m.model)}
+                  {@const isDefault = defaultCid === `${ep.id}::${m.model}`}
+                  {@const isLite = liteCid === `${ep.id}::${m.model}`}
                   <div class="endpoint-model-row">
                     <span class="mono">{ep.id}::{m.model}</span>
                     {#if m.vision}<span class="vision-tag">{$t('settings.endpoints.models.vision')}</span>{/if}
-                    {#if defaultCid === `${ep.id}::${m.model}`}
+                    {#if isDefault}
                       <StatusTag status="success">{$t('settings.endpoints.badge.default')}</StatusTag>
                     {/if}
-                    {#if liteCid === `${ep.id}::${m.model}`}
+                    {#if isLite}
                       <StatusTag status="info">{$t('settings.endpoints.badge.lite')}</StatusTag>
+                    {/if}
+                    {#if !isDefault}
+                      <button class="act-text" disabled={busyEpId === ep.id} onclick={() => setDefaultModelRow(ep, m.model)}>{$t('settings.endpoints.set_default')}</button>
+                    {/if}
+                    {#if !isLite}
+                      <button class="act-text" disabled={busyEpId === ep.id} onclick={() => setLiteModelRow(ep, m.model)}>{$t('settings.endpoints.set_lite')}</button>
+                    {:else}
+                      <button class="act-text" disabled={busyEpId === ep.id} onclick={() => unsetLiteModelRow(ep)}>{$t('settings.endpoints.unset_lite')}</button>
                     {/if}
                     <button class="act-btn del ep-model-del" title={$t('common.delete')} disabled={busyEpId === ep.id} onclick={() => deleteEndpointModelRow(ep, m.model)}>
                       <iconify-icon icon="ant-design:delete-outlined" width="12"></iconify-icon>


### PR DESCRIPTION
Allow the web settings panel to set Default and Lite models at the model level, not just the endpoint level.

Backend changes:
- `POST /api/config/endpoints/{id}/default?model=...` and `/lite?model=...` now select the specified model; omitting `?model` keeps the old first-model fallback.
- `DELETE /api/config/endpoints/{id}/lite` clears the lite model so the agent falls back to vendor/registry-implied lite models.

Frontend changes:
- Each model row in Endpoints settings now shows Set default / Set lite (or Unset lite) actions.
- The endpoint-level lite button now toggles unset when the endpoint already holds lite.

Tests:
- Add server-side tests for specific-model selection, first-model fallback, missing-model rejection, and unset lite.