### PR TITLE
fix(skills): make List() and All() sort deterministic via sourceOrder map

### DIFF
--- a/internal/skills/manifest_profile_test.go
+++ b/internal/skills/manifest_profile_test.go
@@ -26,20 +26,8 @@ func TestManifestForProfile_NoProfileReturnsAll(t *testing.T) {
 	r := discoverWithDefaults(t)
 	full := RenderManifest(r)
 	profiled := ManifestForProfile(r, nil)
-	// Don't compare strings directly — List() sort is non-deterministic
-	// (pre-existing bug). Verify the profiled manifest contains every skill.
-	for _, s := range r.List() {
-		if !strings.Contains(profiled, s.Name) {
-			t.Fatalf("nil profile manifest missing skill %q", s.Name)
-		}
-	}
-	// Both should be non-empty and have the same number of skill entries.
-	if full == "" || profiled == "" {
-		t.Fatal("expected non-empty manifests")
-	}
-	if countSkillLines(full) != countSkillLines(profiled) {
-		t.Fatalf("full and profiled manifests have different skill counts: %d vs %d",
-			countSkillLines(full), countSkillLines(profiled))
+	if full != profiled {
+		t.Fatalf("nil profile should return full manifest.\nfull:\n%s\nprofiled:\n%s", full, profiled)
 	}
 }
 
@@ -99,16 +87,8 @@ func TestManifestForProfile_EmptyToolSkillsReturnsAll(t *testing.T) {
 			ToolSkills: []string{},
 		},
 	})
-	// Don't compare strings directly — List() sort is non-deterministic
-	// (pre-existing bug). Verify the profiled manifest contains every skill.
-	for _, s := range r.List() {
-		if !strings.Contains(profiled, s.Name) {
-			t.Fatalf("empty ToolSkills manifest missing skill %q", s.Name)
-		}
-	}
-	if countSkillLines(full) != countSkillLines(profiled) {
-		t.Fatalf("full and profiled manifests have different skill counts: %d vs %d",
-			countSkillLines(full), countSkillLines(profiled))
+	if full != profiled {
+		t.Fatalf("empty ToolSkills should return full manifest")
 	}
 }
 

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -232,9 +232,16 @@ func (r *Registry) List() []Skill {
 		}
 	}
 	r.mu.RUnlock()
+	// Source priority: project overrides user, user overrides default.
+	// Must use a total order (strict weak ordering) — the old
+	// out[i].Source == "project" shortcut was not antisymmetric
+	// (e.g. "user" vs "default" returned false for both directions),
+	// which made sort.Slice non-deterministic.
+	sourceOrder := map[string]int{"project": 0, "user": 1, "default": 2}
 	sort.Slice(out, func(i, j int) bool {
-		if out[i].Source != out[j].Source {
-			return out[i].Source == "project" // project before user
+		si, sj := sourceOrder[out[i].Source], sourceOrder[out[j].Source]
+		if si != sj {
+			return si < sj
 		}
 		return out[i].Name < out[j].Name
 	})
@@ -254,9 +261,11 @@ func (r *Registry) All() []Skill {
 		out = append(out, s)
 	}
 	r.mu.RUnlock()
+	sourceOrder := map[string]int{"project": 0, "user": 1, "default": 2}
 	sort.Slice(out, func(i, j int) bool {
-		if out[i].Source != out[j].Source {
-			return out[i].Source == "project" // project before user
+		si, sj := sourceOrder[out[i].Source], sourceOrder[out[j].Source]
+		if si != sj {
+			return si < sj
 		}
 		return out[i].Name < out[j].Name
 	})


### PR DESCRIPTION
## Summary

Replaces the broken sort comparison in `skills.List()` and `skills.All()` that
caused non-deterministic output across consecutive calls.

## Root cause

The old comparison was:

```go
if out[i].Source != out[j].Source {
    return out[i].Source == project
}
```

This is not a strict weak ordering — when sources are "user" and "default",
both `comp(A,B)` and `comp(B,A)` return false, violating antisymmetry.
`sort.Slice` behavior is undefined in this case, producing different
sort orders across calls.

## Fix

Use a `sourceOrder` map that assigns a unique integer to each source value
(project=0, user=1, default=2), making integer comparison properly
transitive and antisymmetric.

## Impact

- **Prompt cache stability**: `ManifestForProfile` calls `List()` on every turn
  for profiles with filtered skills. With non-deterministic ordering, the
  manifest string changed each turn, invalidating the LLM's prompt cache.
  This fix eliminates that cache churn.

## Changes

| File | Change |
|------|--------|
| `internal/skills/skills.go` | `List()` and `All()` use `sourceOrder` map instead of broken shortcut |
| `internal/skills/manifest_profile_test.go` | Revert workaround (content-based assertions) to direct string comparison now that sort is stable |

## Test plan

- Existing `TestManifestForProfile_*` and `TestList_ProjectBeforeUserThenByName` all pass
- `go vet ./...` clean
- `go test -race ./internal/skills/ ./internal/tools/` green