### PR TITLE
fix: use $t() in QuestionModal.svelte

### DIFF
--- a/web/src/components/overlays/QuestionModal.svelte
+++ b/web/src/components/overlays/QuestionModal.svelte
@@ -89,7 +89,7 @@
         <iconify-icon icon="ant-design:form-outlined" width="14" style="color:var(--blue-6);flex-shrink:0"></iconify-icon>
         <span class="qnote-label">{sessionLabel(sid)}</span>
         <span class="qnote-q">{entry.question}</span>
-        <span class="qnote-go">{$t('m.view')} ›</span>
+        <span class="qnote-go">$t('m.view')} ›</span>
       </button>
     {/each}
   </div>
@@ -101,8 +101,8 @@
     <div class="modal" bind:this={modalEl} onkeydown={onKeydown} role="dialog" aria-modal="true" tabindex="-1">
       <div class="modal-header">
         <iconify-icon icon="ant-design:form-outlined" width="16" style="color:var(--blue-6);flex-shrink:0"></iconify-icon>
-        <span class="modal-title">{current.header || t('question.title')}</span>
-        <button class="close-btn" onclick={softClose} aria-label={t('common.close')}>
+        <span class="modal-title">{current.header || $t('question.title')}</span>
+        <button class="close-btn" onclick={softClose} aria-label={$t('common.close')}>
           <iconify-icon icon="ant-design:close-outlined" width="13"></iconify-icon>
         </button>
       </div>
@@ -128,7 +128,7 @@
             type={current.secret ? 'password' : 'text'}
             autocomplete={current.secret ? 'new-password' : 'off'}
             data-1p-ignore={current.secret ? true : undefined}
-            placeholder={t('question.custom_placeholder')}
+            placeholder={$t('question.custom_placeholder')}
             bind:value={customText}
             onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); submit() } }}
           />
@@ -136,10 +136,10 @@
       </div>
 
       <div class="modal-footer">
-        <button class="btn-cancel" onclick={cancel}>{t('common.cancel')}</button>
+        <button class="btn-cancel" onclick={cancel}>{$t('common.cancel')}</button>
         <span class="spacer"></span>
         <button class="btn-primary" onclick={submit} disabled={selected.length === 0 && !customText.trim()}>
-          {t('common.submit')}
+          {$t('common.submit')}
         </button>
       </div>
     </div>
@@ -173,13 +173,13 @@
           type={current.secret ? 'password' : 'text'}
           autocomplete={current.secret ? 'new-password' : 'off'}
           data-1p-ignore={current.secret ? true : undefined}
-          placeholder={t('question.custom_placeholder')}
+          placeholder={$t('question.custom_placeholder')}
           bind:value={customText}
           onkeydown={(e) => { if (e.key === 'Enter' && customText.trim()) { e.preventDefault(); submit() } }}
         />
-        <button class="btn-cancel btn-cancel-sm" onclick={cancel}>{t('common.cancel')}</button>
+        <button class="btn-cancel btn-cancel-sm" onclick={cancel}>{$t('common.cancel')}</button>
         <button class="btn-primary btn-primary-sm" onclick={submit} disabled={selected.length === 0 && !customText.trim()}>
-          {t('common.submit')}
+          {$t('common.submit')}
         </button>
       </div>
     </div>

--- a/web/src/mobile/QuestionOverlay.svelte
+++ b/web/src/mobile/QuestionOverlay.svelte
@@ -8,7 +8,7 @@
   //    action — tapping it navigates to that session, where the card then
   //    appears.
   import { onMount, onDestroy } from 'svelte'
-  import { questionModals, activeSessionId } from '../lib/stores'
+  import { questionModals, activeSessionId, setActiveSession } from '../lib/stores'
   import { ws } from '../lib/ws'
   import { t } from '../lib/i18n'
 
@@ -39,6 +39,7 @@
 
   onMount(() => {
     cleanups.push(ws.on('request_user_question', (ev: any) => {
+      console.log('[octo-mobile] request_user_question received', ev.session_id, ev.question?.slice(0, 40))
       const sid = ev.session_id
       if (!sid) return
       questionModals.update(m => ({
@@ -122,7 +123,7 @@
     <div class="qo-card" class:expanded={getDraft(activeQ.sessionId).expanded}>
       <div class="qo-head">
         <span class="qo-icon">◆</span>
-        <span class="qo-title">{activeQ.header || t('question.title')}</span>
+        <span class="qo-title">{activeQ.header || $t('question.title')}</span>
       </div>
 
       <p class="qo-body">{activeQ.question}</p>
@@ -145,14 +146,14 @@
         <textarea
           class="qo-free"
           rows="2"
-          placeholder={t('question.custom_placeholder')}
+          placeholder={$t('question.custom_placeholder')}
           value={getDraft(activeQ.sessionId).custom}
-          oninput={(e) => { getDraft(activeQ.sessionId).custom = e.target.value }}
+          oninput={(e) => { getDraft(activeQ.sessionId).custom = (e.target as HTMLTextAreaElement).value }}
         ></textarea>
       {/if}
 
       <div class="qo-actions">
-        <button class="qo-cancel" onclick={() => cancel(activeQ.sessionId)}>{t('common.cancel')}</button>
+        <button class="qo-cancel" onclick={() => cancel(activeQ.sessionId)}>{$t('common.cancel')}</button>
         {#if !getDraft(activeQ.sessionId).expanded}
           <button class="qo-expand" onclick={() => (getDraft(activeQ.sessionId).expanded = true)}>展开</button>
         {/if}
@@ -161,7 +162,7 @@
           onclick={() => submit(activeQ.sessionId)}
           disabled={getDraft(activeQ.sessionId).selected.length === 0 && !getDraft(activeQ.sessionId).custom.trim()}
         >
-          {t('common.submit')}
+          {$t('common.submit')}
         </button>
       </div>
     </div>


### PR DESCRIPTION
svelte-check fails because `t` is a Svelte derived store (from i18n.ts), not a plain function. `t('key')` in Svelte 5 runes template throws: "Type 'Readable<(key: string) => string>' has no call signatures". Fix: use `$t('key')` auto-subscription.