### PR TITLE
fix(server): validate tool names in agent profile CRUD

### DIFF
--- a/internal/server/agents_handlers.go
+++ b/internal/server/agents_handlers.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/agentprofile"
+	"github.com/open-octo/octo-agent/internal/skills"
+	"github.com/open-octo/octo-agent/internal/tools"
 )
 
 // ─── Request/Response types ─────────────────────────────────────────────────
@@ -121,6 +123,13 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate tool and skill names against the canonical registries so users
+	// get immediate feedback instead of silent filtering at runtime.
+	if unknown := unknownToolNames(req.Tools, s.skillReg); len(unknown) > 0 {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown tools: %s", strings.Join(unknown, ", ")))
+		return
+	}
+
 	p := &agentprofile.Profile{
 		ID:          id,
 		Name:        req.Name,
@@ -158,6 +167,12 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 	existing, ok := s.agentStoreOrInit().Get(id)
 	if !ok {
 		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+
+	// Validate tool and skill names against the canonical registries.
+	if unknown := unknownToolNames(req.Tools, s.skillReg); len(unknown) > 0 {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown tools: %s", strings.Join(unknown, ", ")))
 		return
 	}
 
@@ -286,4 +301,27 @@ func slugify(name string) string {
 	}
 	s := strings.Trim(b.String(), "-")
 	return s
+}
+
+// unknownToolNames returns tools in names that are neither a known built-in
+// tool nor a known skill. When names is empty it returns nil (not validated,
+// meaning "all tools" in the profile's allowlist).
+func unknownToolNames(names []string, reg *skills.Registry) []string {
+	if len(names) == 0 {
+		return nil
+	}
+	known := make(map[string]bool, len(tools.KnownToolNames())+reg.Len())
+	for _, n := range tools.KnownToolNames() {
+		known[n] = true
+	}
+	for _, sk := range reg.List() {
+		known[sk.Name] = true
+	}
+	var unknown []string
+	for _, n := range names {
+		if !known[n] {
+			unknown = append(unknown, n)
+		}
+	}
+	return unknown
 }

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -600,6 +600,16 @@ func DefaultToolsForProfile(ctx context.Context, model string) []agent.ToolDefin
 	return filtered
 }
 
+// KnownToolNames returns the names of all built-in tools. Used by the server
+// to validate profile tool allowlists against the canonical tool set.
+func KnownToolNames() []string {
+	names := make([]string, len(allTools))
+	for i, t := range allTools {
+		names[i] = t.Definition().Name
+	}
+	return names
+}
+
 func defaultToolsFor(ctx context.Context, model string) []agent.ToolDefinition {
 	skillsOn := skillsEnabled()
 	mgrOn := subAgentManagerEnabled()


### PR DESCRIPTION
## Summary

The REST API for creating/updating agent profiles accepted any string in the
`tools` field. Unknown tool names were silently ignored at runtime when the
profile's tool allowlist was evaluated — no feedback to the user.

## Changes

1. **internal/tools/registry.go**: Export `KnownToolNames()` returning all
   built-in tool names from the canonical `allTools` list.
2. **internal/server/agents_handlers.go**: Add `unknownToolNames()` helper
   that checks names against known tools + known skills. Call it in both
   `handleCreateAgent` and `handleUpdateAgent` before writing the profile.

## Test plan

- Existing `TestHandleAgents_*` all pass (none provide unknown tools).
- `go vet ./...` clean.
- Manual: POST `{"tools":["nonexistent_tool"], ...}` returns 400.
