### PR TITLE
chore: remove debug code from QuestionOverlay

### DIFF
--- a/web/src/mobile/QuestionOverlay.svelte
+++ b/web/src/mobile/QuestionOverlay.svelte
@@ -39,7 +39,6 @@
 
   onMount(() => {
     cleanups.push(ws.on('request_user_question', (ev: any) => {
-      console.log('[octo-mobile] request_user_question received', ev.session_id, ev.question?.slice(0, 40))
       const sid = ev.session_id
       if (!sid) return
       questionModals.update(m => ({


### PR DESCRIPTION
Clean up the debug DOM element and ws.onAny handler that were added to verify mobile cross-client ask_user_question rendering. The feature works correctly — all debug instrumentation removed.