### PR TITLE
fix(server): default session agent_profile to code-defined default agent

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/permission"
@@ -398,14 +399,15 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 	out := make([]sessionItem, 0, len(sessions))
 	cronCount := 0
 	for _, sess := range sessions {
-		// agent_profile is not persisted on the session; default to "general"
-		// so the UI renders. Sessions from before source was persisted load
-		// with an empty Source and fall back to "manual".
+		// agent_profile is not persisted on the session; default to the
+		// code-defined default agent so the UI renders in the Default pool.
+		// Sessions from before source was persisted load with an empty Source
+		// and fall back to "manual".
 		source := sess.Source
 		if source == "" {
 			source = "manual"
 		}
-		item := s.toSessionItem(sess, source, "general")
+		item := s.toSessionItem(sess, source, agentprofile.DefaultID)
 		out = append(out, item)
 		if item.Source == "cron" {
 			cronCount++
@@ -456,7 +458,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 
 	agentProfile := req.AgentProfile
 	if agentProfile == "" {
-		agentProfile = "general"
+		agentProfile = agentprofile.DefaultID
 	}
 	source := req.Source
 	if source == "" {
@@ -1160,7 +1162,7 @@ func (s *Server) handleUpdateSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("set title: %v", err))
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"session": s.toSessionItem(sess, "manual", "general")})
+	writeJSON(w, http.StatusOK, map[string]any{"session": s.toSessionItem(sess, "manual", agentprofile.DefaultID)})
 }
 
 // ─── PATCH /api/sessions/{id}/model ─────────────────────────────────────────

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
@@ -120,6 +121,7 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 			Status:              s.sessionStatus(sess.ID),
 			CreatedAt:           sess.CreatedAt.UnixMilli(),
 			Source:              source,
+			AgentProfile:        agentprofile.DefaultID,
 			Model:               sess.Model,
 			TotalTurns:          sess.TurnCount(),
 			WorkingDir:          s.sessionCwd(sess),

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -110,6 +110,7 @@ type wsSessionInfo struct {
 	Status              string `json:"status,omitempty"` // "idle" | "working"
 	CreatedAt           int64  `json:"created_at"`       // unix ms
 	Source              string `json:"source,omitempty"` // "manual" | "cron" | "channel" | "setup"
+	AgentProfile        string `json:"agent_profile,omitempty"`
 	Model               string `json:"model,omitempty"`
 	TotalTurns          int    `json:"total_turns,omitempty"`
 	WorkingDir          string `json:"working_dir,omitempty"`


### PR DESCRIPTION
Unspecified-agent sessions were defaulting to "general" in REST list/create/update responses and missing the field entirely in the initial WS session_list. The web UI's activeAgent defaults to "default", so Sidebar filtered those sessions out and the list appeared empty on fresh page loads.

Use agentprofile.DefaultID ("default") consistently for sessions without a persisted expert agent, and add agent_profile to wsSessionInfo so WS and REST agree.

Fixes session list loading after main build.