### PR TITLE
fix(agent): send title instruction as system prompt to avoid model confusion

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -1419,7 +1420,8 @@ func (a *Agent) GenerateTitle(ctx context.Context) (string, error) {
 // retry would double the latency of a call bounded by TitleGenerationTimeout.
 func (a *Agent) GenerateTitleFrom(ctx context.Context, snap []Message) (string, error) {
 	sender, model := a.GetSender(), a.Model
-	if a.LiteSender != nil && a.LiteModel != "" {
+	isLite := a.LiteSender != nil && a.LiteModel != ""
+	if isLite {
 		sender, model = a.LiteSender, a.LiteModel
 	}
 	if sender == nil || model == "" {
@@ -1427,12 +1429,13 @@ func (a *Agent) GenerateTitleFrom(ctx context.Context, snap []Message) (string, 
 	}
 	text := firstUserText(snap)
 	if text == "" {
+		slog.Info("title generation skipped: no user text in snapshot")
 		return "", nil
 	}
 	if r := []rune(text); len(r) > titleContextMaxRunes {
 		text = string(r[:titleContextMaxRunes])
 	}
-	msgs := []Message{NewUserMessage(text), NewUserMessage(titleInstruction)}
+	msgs := []Message{NewUserMessage(text)}
 
 	if nr, ok := sender.(NoReasoningSender); ok {
 		sender = nr.NoReasoning()
@@ -1440,11 +1443,15 @@ func (a *Agent) GenerateTitleFrom(ctx context.Context, snap []Message) (string, 
 		sender = le.LowEffort()
 	}
 
-	reply, err := sender.SendMessages(ctx, model, "", msgs, titleMaxTokens)
+	slog.Info("title generation request", "model", model, "is_lite", isLite)
+	reply, err := sender.SendMessages(ctx, model, titleInstruction, msgs, titleMaxTokens)
 	if err != nil {
+		slog.Info("title generation provider error", "model", model, "err", err)
 		return "", err
 	}
-	return cleanTitle(reply.Content), nil
+	cleaned := cleanTitle(reply.Content)
+	slog.Info("title generation response", "model", model, "raw_len", len(reply.Content), "raw", reply.Content, "cleaned", cleaned)
+	return cleaned, nil
 }
 
 // GenerateTitleOrSnippet is GenerateTitleFrom with a guaranteed result: on
@@ -1458,8 +1465,12 @@ func (a *Agent) GenerateTitleOrSnippet(ctx context.Context, snap []Message) (str
 	t, err := a.GenerateTitleFrom(ctx, snap)
 	if err == nil {
 		if t = strings.TrimSpace(t); t != "" {
+			slog.Info("title generation succeeded", "title", t)
 			return t, nil
 		}
+		slog.Info("title generation returned empty, falling back to snippet")
+	} else {
+		slog.Info("title generation errored, falling back to snippet", "err", err)
 	}
 	return FirstUserSnippet(snap), err
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1915,19 +1915,16 @@ func TestAgent_GenerateTitle(t *testing.T) {
 		t.Errorf("history len = %d, want 2 (GenerateTitle must not append)", a.History.Len())
 	}
 	// The title call is deliberately minimal: ONLY the first user message's
-	// text plus the instruction, with no system prompt — the rest of the
-	// history ("found it") and a.System must not leak into the request.
-	if n := len(send.gotMessages); n != 2 {
-		t.Fatalf("sent %d messages, want 2 (first user message + instruction)", n)
+	// text, with the title instruction sent as the system prompt — the rest
+	// of the history ("found it") and a.System must not leak into the request.
+	if n := len(send.gotMessages); n != 1 {
+		t.Fatalf("sent %d messages, want 1 (first user message only)", n)
 	}
 	if send.gotMessages[0].Content != "the login page redirects in a loop" {
 		t.Errorf("first sent message = %q, want the first user message only", send.gotMessages[0].Content)
 	}
-	if send.gotMessages[1].Content != titleInstruction {
-		t.Errorf("last sent message = %q, want the title instruction", send.gotMessages[1].Content)
-	}
-	if send.gotSystem != "" {
-		t.Errorf("system = %q, want empty (title call sends no system prompt)", send.gotSystem)
+	if send.gotSystem != titleInstruction {
+		t.Errorf("system = %q, want the title instruction", send.gotSystem)
 	}
 	if send.gotMaxToks != titleMaxTokens {
 		t.Errorf("maxTokens = %d, want %d", send.gotMaxToks, titleMaxTokens)

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -180,14 +180,11 @@ func TestListSessionsBrief_ReflectsGeneratedTitle(t *testing.T) {
 	}
 }
 
-// isTitlePrompt reports whether msgs is GenerateTitle's throwaway call
-// (identified by its trailing instruction, not by any dedicated flag — the
-// provider itself only ever sees an ordinary message list).
-func isTitlePrompt(msgs []agent.Message) bool {
-	if len(msgs) == 0 {
-		return false
-	}
-	return strings.Contains(msgs[len(msgs)-1].Content, "Generate a very short title")
+// isTitlePrompt reports whether this is GenerateTitle's throwaway call
+// (identified by its system prompt carrying the title instruction, not by any
+// dedicated flag — the provider itself only ever sees an ordinary user message).
+func isTitlePrompt(system string, msgs []agent.Message) bool {
+	return strings.Contains(system, "Generate a very short title")
 }
 
 // titleSpySender counts title-generation calls while letting the main turn
@@ -198,8 +195,8 @@ type titleSpySender struct {
 	titleCalls atomic.Int32
 }
 
-func (s *titleSpySender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
-	if isTitlePrompt(msgs) {
+func (s *titleSpySender) SendMessages(_ context.Context, _, system string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	if isTitlePrompt(system, msgs) {
 		s.titleCalls.Add(1)
 	}
 	return agent.Reply{Content: "stub reply"}, nil
@@ -249,8 +246,8 @@ type blockingTurnSender struct {
 	release chan struct{} // the main call returns once this is closed
 }
 
-func (s *blockingTurnSender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
-	if isTitlePrompt(msgs) {
+func (s *blockingTurnSender) SendMessages(_ context.Context, _, system string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	if isTitlePrompt(system, msgs) {
 		return agent.Reply{Content: "early title"}, nil
 	}
 	return agent.Reply{Content: "stub reply"}, nil
@@ -271,8 +268,8 @@ type blockingTitleFailSender struct {
 	release chan struct{}
 }
 
-func (s *blockingTitleFailSender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
-	if isTitlePrompt(msgs) {
+func (s *blockingTitleFailSender) SendMessages(_ context.Context, _, system string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	if isTitlePrompt(system, msgs) {
 		return agent.Reply{}, fmt.Errorf("stub: title provider error")
 	}
 	return agent.Reply{Content: "stub reply"}, nil


### PR DESCRIPTION
## Problem

Session title generation for some models (observed with Kimi k2.7-code) always fell back to the first-message snippet. The model was actually returning the literal placeholder string `"Title Request"` instead of a generated title.

## Root cause

The title instruction was sent as a second consecutive user message after the first user message. The model treated the combined messages as a request *about* a title rather than a command to generate one.

## Fix

Send the title instruction as the `system` prompt and only the first user message as the single user message. This makes the task unambiguous and matches the intent of title generation as a throwaway task instruction.

Also adds INFO-level logging to `GenerateTitleFrom` / `GenerateTitleOrSnippet` so future title regressions are observable: model name, whether the lite sender is used, raw response, cleaned result, and snippet fallback are all logged.

## Verification

- `go test ./internal/agent ./internal/server ./cmd/octo ./internal/app ./internal/provider/...` passes.
- Manual run with k2.7-code now emits a real title instead of `"Title Request"`.