### PR TITLE
fix(web): eliminate build warnings — $state runes + chunkSizeWarningLimit

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -7,9 +7,9 @@
   import VersionBadge from './VersionBadge.svelte'
 
   // Agent list for the new-session picker dropdown.
-  let agents: api.Agent[] = []
-  let agentPickerOpen = false
-  let agentPickerEl: HTMLElement
+  let agents: api.Agent[] = $state([])
+  let agentPickerOpen = $state(false)
+  let agentPickerEl = $state<HTMLElement>()
 
   function dismissPicker(e: MouseEvent) {
     if (!agentPickerOpen || !agentPickerEl) return

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     // left behind are inert: index.html only references the fresh ones.
     emptyOutDir: false,
     // The UI ships as one embedded bundle served from localhost; code-splitting buys nothing here.
-    chunkSizeWarningLimit: 600,
+    chunkSizeWarningLimit: 1000,
   },
   server: {
     port: 5173,


### PR DESCRIPTION
### Changes

1. **Sidebar.svelte** — Add `$state()` runes to `agents`, `agentPickerOpen`, `agentPickerEl` to fix Svelte 5 non-reactive-update warnings
2. **vite.config.ts** — Raise `chunkSizeWarningLimit` from 600 to 1000 to suppress the main JS bundle (~634 kB) chunk-size warning

### Verification

`npm run build` passes with zero warnings.