### PR TITLE
fix(build): suppress macOS linker version warnings for octo-desktop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,12 @@ build-full: build
 # WebView2). Embeds the web UI first (the in-process server go:embeds webdist).
 # Produces a bare binary; use `wails3 build` inside cmd/octo-desktop for a
 # packaged .app / installer.
+DESKTOP_MACOS_VERSION ?= $(shell sw_vers -productVersion 2>/dev/null | cut -d. -f1 || echo 11)
 desktop: web-build
-	cd cmd/octo-desktop && CGO_ENABLED=1 go build -ldflags='$(DESKTOP_LDFLAGS)' -o ../../octo-desktop .
+	cd cmd/octo-desktop && CGO_ENABLED=1 \
+		CGO_CFLAGS="-mmacosx-version-min=$(DESKTOP_MACOS_VERSION)" \
+		CGO_LDFLAGS="-Wl,-macos_version_min,$(DESKTOP_MACOS_VERSION) -Wl,-no_warn_duplicate_libraries" \
+		go build -ldflags='$(DESKTOP_LDFLAGS)' -o ../../octo-desktop .
 
 # Package the desktop shell into a double-clickable macOS Octo.app bundle
 # (embeds the web UI, ad-hoc signed for local use). Real Developer ID

--- a/scripts/package-desktop-macos.sh
+++ b/scripts/package-desktop-macos.sh
@@ -44,8 +44,11 @@ for arch in amd64 arm64; do
 
 	echo "==> building octo-desktop (darwin/$arch)"
 	out="$ROOT/octo-desktop-$arch"
+	macos_ver="$(sw_vers -productVersion | cut -d. -f1)"
 	( cd "$MOD_DIR" && \
 		GOOS=darwin GOARCH="$arch" CGO_ENABLED=1 CC="clang -arch $cc_arch" \
+		CGO_CFLAGS="-mmacosx-version-min=$macos_ver" \
+		CGO_LDFLAGS="-Wl,-macos_version_min,$macos_ver -Wl,-no_warn_duplicate_libraries" \
 		go build -tags embedrg -ldflags "$LDFLAGS" -o "$out" . )
 	slices+=("$out")
 done


### PR DESCRIPTION
### Background

`make desktop` 和 `scripts/package-desktop-macos.sh` 一直有 ~20 条 `ld: warning: object file was built for newer 'macOS' version (26.0) than being linked (11.0)` 和 `ld: warning: ignoring duplicate libraries: '-lobjc'` warning。

### Root cause

Go 的 internal linker 硬编码 `-macos_version_min 11.0`，但当前 macOS SDK 是 26.0，导致 CGO 生成的目标文件标记为 26.0，与 linker 的 11.0 冲突。

### Changes

通过 `CGO_CFLAGS` + `CGO_LDFLAGS` 显式传入当前 macOS 主版本号，消除版本 mismatch：

- **Makefile** `desktop` target: 动态取 `sw_vers -productVersion` 主版本号，设 `-mmacosx-version-min` 和 `-macos_version_min`
- **scripts/package-desktop-macos.sh**: 相同修复（universal binary 双架构编译）
- 加 `-Wl,-no_warn_duplicate_libraries` 消除 `-lobjc` 重复 warning
- 版本号通过 `DESKTOP_MACOS_VERSION` 变量可覆盖（`make desktop DESKTOP_MACOS_VERSION=14`）

### 对比

| 之前 | 之后 |
|---|---|
| 21 warnings | 1 warning（Go 内部 linker 11.0 vs 我们的 26.0，不可消除——Go 工具链行为）|

Closes #—