### PR TITLE
fix(skills,web): include system_prompt in expert-agent-manager skill and unify AgentEdit buttons

### DIFF
--- a/internal/skills/defaults/expert-agent-manager/SKILL.md
+++ b/internal/skills/defaults/expert-agent-manager/SKILL.md
@@ -37,6 +37,7 @@ Use the `web_fetch` tool to call them. All requests return JSON.
   "id": "code-review",
   "name": "Code Reviewer",
   "description": "Reviews code for bugs and style",
+  "system_prompt": "You are a thorough code reviewer. Be concise but precise.",
   "model": "claude-sonnet-4-20250514",
   "tools": ["read_file", "grep", "glob"],
   "tool_skills": ["code-review"],
@@ -47,6 +48,7 @@ Use the `web_fetch` tool to call them. All requests return JSON.
 - `id`: filename slug (lowercase, `[a-z0-9-]`); immutable after creation.
 - `name`: display name.
 - `description`: required; shown in listings.
+- `system_prompt`: the agent's system prompt (the Markdown body of `~/.octo/agents/<id>.md`); required for the agent to behave differently from the default agent.
 - `model`: optional model override (must be in `~/.octo/config.yml`'s models).
 - `tools`: tool allowlist; empty = all tools (default agent behavior).
 - `tool_skills`: skills exposed as tools.
@@ -67,8 +69,9 @@ Use the `web_fetch` tool to call them. All requests return JSON.
 2. **Confirm before creating.** Show the user the profile you're about to
    create and confirm.
 
-3. **Call `POST /api/agents`.** Body is the profile JSON. The server derives
-   the `id` from the name (slug). On success (201), echo back the created
+3. **Call `POST /api/agents`.** Body is the profile JSON. Include `system_prompt`
+   in the JSON body (it becomes the Markdown body of the `.md` file). The server
+   derives the `id` from the name (slug). On success (201), echo back the created
    profile.
 
 4. **Verify.** Call `GET /api/agents/:id` to confirm it was written.

--- a/web/src/views/AgentEdit.svelte
+++ b/web/src/views/AgentEdit.svelte
@@ -85,8 +85,8 @@
         <small>{$t('agents.mention_as_hint')}</small>
       </div>
       <div class="actions">
-        <button type="button" class="secondary" onclick={onCancel}>{$t('common.cancel')}</button>
-        <button type="submit" class="primary">{$t('common.save')}</button>
+        <button type="button" class="btn-secondary" onclick={onCancel}>{$t('common.cancel')}</button>
+        <button type="submit" class="btn-primary">{$t('common.save')}</button>
       </div>
     </form>
   </div>
@@ -108,16 +108,20 @@
     width: 100%; padding: 8px 12px; border: 1px solid var(--border-secondary);
     border-radius: 6px; background: var(--bg-primary); color: var(--text-primary);
     font-size: 13px; font-family: inherit;
-    &:focus { outline: none; border-color: var(--primary); }
+    &:focus { outline: none; border-color: var(--blue-6); }
   }
   small { display: block; font-size: 11px; color: var(--text-tertiary); margin-top: 2px; }
   .actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 20px; }
-  .secondary {
-    padding: 8px 16px; background: var(--bg-hover); color: var(--text-primary);
-    border: none; border-radius: 6px; font-size: 13px; cursor: pointer;
+  .btn-primary {
+    height: 32px; padding: 0 14px; border: none; background: var(--blue-6); border-radius: 6px;
+    font-size: 14px; color: #fff; cursor: pointer; font-family: inherit;
   }
-  .primary {
-    padding: 8px 16px; background: var(--primary); color: white; border: none;
-    border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer;
+  .btn-primary:hover:not(:disabled) { background: var(--blue-5); }
+  .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-secondary {
+    height: 32px; padding: 0 14px; border: 1px solid var(--border); background: var(--bg-container);
+    border-radius: 6px; font-size: 13px; color: var(--text-secondary); cursor: pointer; font-family: inherit;
   }
+  .btn-secondary:hover:not(:disabled) { border-color: var(--blue-5); color: var(--blue-5); }
+  .btn-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
 </style>


### PR DESCRIPTION
## Problem

1. The default `expert-agent-manager` skill documented the `POST /api/agents` profile JSON without the `system_prompt` field. Agents created through this skill were persisted with an empty Markdown body and behaved like the default agent instead of following their intended persona.
2. `web/src/views/AgentEdit.svelte` used custom `.primary` / `.secondary` button classes that referenced `var(--primary)`, a CSS variable that is not defined anywhere in the project. The Save button therefore had no usable background color and was hard to see.

## Fix

- Update the skill documentation to include `system_prompt` in the example profile JSON, add a field description, and remind the caller to send it in the `POST /api/agents` body.
- Switch `AgentEdit` to the standard `btn-primary` / `btn-secondary` classes used by `AgentsView`, `McpView`, and other panels, and change the input focus ring from `var(--primary)` to `var(--blue-6)`.

## Verification

- [x] Diff reviewed.
- [x] The same skill content was applied to the live `~/.octo/agents/weixiaozhe.md` profile and verified via `GET /api/agents/weixiaozhe`.
- [x] `Svelte Check` passes for the changed `.svelte` file.

---

Co-authored-by: octo-agent <no-reply@octo-agent.dev>