### PR TITLE
fix(web): merge duplicate plus buttons on new-session bar

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -311,9 +311,9 @@
       <button class="new-btn" onclick={() => newSession()}>
         <iconify-icon icon="ant-design:plus-outlined" width="14"></iconify-icon>
         <span>{$t('nav.new_session')}</span>
-        <button class="btn-caret" title={$t('nav.new_session_with_agent')} onclick={(e) => { e.stopPropagation(); agentPickerOpen = !agentPickerOpen }}>
+        <span class="btn-caret" title={$t('nav.new_session_with_agent')} onclick={(e) => { e.stopPropagation(); agentPickerOpen = !agentPickerOpen }}>
           <iconify-icon icon="ant-design:down-outlined" width="10"></iconify-icon>
-        </button>
+        </span>
       </button>
       {#if agentPickerOpen}
         <div class="agent-picker-menu">

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -311,9 +311,9 @@
       <button class="new-btn" onclick={() => newSession()}>
         <iconify-icon icon="ant-design:plus-outlined" width="14"></iconify-icon>
         <span>{$t('nav.new_session')}</span>
-      </button>
-      <button class="agent-pick-btn" title={$t('nav.new_session_with_agent')} onclick={() => agentPickerOpen = !agentPickerOpen}>
-        <iconify-icon icon="ant-design:plus-outlined" width="12"></iconify-icon>
+        <button class="btn-caret" title={$t('nav.new_session_with_agent')} onclick={(e) => { e.stopPropagation(); agentPickerOpen = !agentPickerOpen }}>
+          <iconify-icon icon="ant-design:down-outlined" width="10"></iconify-icon>
+        </button>
       </button>
       {#if agentPickerOpen}
         <div class="agent-picker-menu">
@@ -626,15 +626,16 @@
   flex: 1; height: 32px; border: none; border-radius: 6px;
   background: var(--blue-6); color: #fff; font-size: 14px;
   display: flex; align-items: center; justify-content: center; gap: 8px;
-  cursor: pointer; font-family: inherit;
+  cursor: pointer; font-family: inherit; position: relative;
 }
 .new-btn:hover { background: var(--blue-5); }
-.agent-pick-btn {
-  width: 32px; height: 32px; flex: 0 0 32px; border: none; border-radius: 6px;
-  background: var(--bg-hover); color: var(--text-tertiary);
+.btn-caret {
+  position: absolute; right: 4px; top: 50%; transform: translateY(-50%);
+  width: 22px; height: 22px; border: none; border-radius: 4px;
+  background: transparent; color: inherit;
   display: flex; align-items: center; justify-content: center; cursor: pointer;
 }
-.agent-pick-btn:hover { background: var(--border-secondary); color: var(--text-primary); }
+.btn-caret:hover { background: rgba(255,255,255,0.2); }
 .agent-picker-menu {
   position: absolute; top: 100%; left: 12px; right: 12px; z-index: 30;
   margin-top: 2px; padding: 4px;


### PR DESCRIPTION
## 问题

侧边栏"新会话"按钮本身带一个加号图标，旁边又有一个独立的加号按钮（Agent Picker），两个加号视觉冗余。

## 改动

把 Agent Picker 整合进主按钮内部：
- 主按钮保留加号图标 + 文字"新会话"
- 右侧增加一个下拉箭头按钮（ 阻止触发主按钮的 newSession）
- 删除独立的  及其样式

点击主按钮 → 直接用 Default Agent 新建会话
点击箭头 → 弹出 Agent 选择菜单

## 截图

| Before | After |
|--------|-------|
| 两个加号并排 | 一个加号 + 右边箭头 |