### PR TITLE
fix: multi-agent corrections — system prompt, system skills, AgentEdit checklist

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -1023,12 +1023,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			sess.Bind(agent.EntryTUI, false)
 			if agentProfileID != "" {
 				sess.AgentID = agentProfileID
-		// An expert agent profile with its own system prompt
-		// replaces the server base prompt. Persist in the session
-		// so resume recomposes with the right persona.
-		if agentProfile != nil && agentProfile.SystemPrompt != "" {
-			sess.System = agentProfile.SystemPrompt
-		}
+				// An expert agent profile with its own system prompt
+				// replaces the server base prompt. Persist in the session
+				// so resume recomposes with the right persona.
+				if agentProfile != nil && agentProfile.SystemPrompt != "" {
+					sess.System = agentProfile.SystemPrompt
+				}
 			}
 		}
 		wireSessionHooks(a, sess, agent.EntryTUI)

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -514,9 +514,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	resolvedShowReasoning := resolveShowReasoning(showReasoningFlagSet, *showReasoning, cfg)
 
 	// Resolve the --agent profile (if specified) from ~/.octo/agents.
+	// When the profile carries its own SystemPrompt, it replaces the
+	// server's base prompt — so expert agents actually use their persona.
 	// The profile ID is stamped onto the session so it routes to the right
 	// agent namespace and filters tools/skills per the profile's allowlist.
 	var agentProfileID string
+	var agentProfile *agentprofile.Profile
 	var agentStore *agentprofile.Store
 	if *agentName != "" {
 		agentStore = agentprofile.New(agentUserDir(), agentProjectDir)
@@ -527,6 +530,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				*agentName, strings.Join(ids, ", "))
 			return 2
 		}
+		agentProfile = profile
 		agentProfileID = profile.ID
 	}
 
@@ -1019,6 +1023,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			sess.Bind(agent.EntryTUI, false)
 			if agentProfileID != "" {
 				sess.AgentID = agentProfileID
+		// An expert agent profile with its own system prompt
+		// replaces the server base prompt. Persist in the session
+		// so resume recomposes with the right persona.
+		if agentProfile != nil && agentProfile.SystemPrompt != "" {
+			sess.System = agentProfile.SystemPrompt
+		}
 			}
 		}
 		wireSessionHooks(a, sess, agent.EntryTUI)
@@ -1107,6 +1117,9 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	tools.SetWorkflowForeground(true)
 	oneShotSess := agent.NewSession(resolvedModel, *system)
 	if agentProfileID != "" {
+		if agentProfile != nil && agentProfile.SystemPrompt != "" {
+			oneShotSess.System = agentProfile.SystemPrompt
+		}
 		oneShotSess.AgentID = agentProfileID
 	}
 	wireSessionHooks(a, oneShotSess, agent.EntryCLI)

--- a/internal/skills/defaults/channel-manager/SKILL.md
+++ b/internal/skills/defaults/channel-manager/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: channel-manager
+system: true
 description: |
   Configure IM platform channels (Feishu, Weixin/WeChat, WeCom, DingTalk, Discord, Telegram) for octo.
   Guides the user through platform consoles, collects credentials, writes ~/.octo/channels.yml,

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: cron-task-creator
+system: true
 description: Create, inspect, run, edit, enable/disable, and delete octo's scheduled cron tasks — recurring agent prompts stored in ~/.octo/tasks/*.json and executed by the octo serve scheduler. Use when the user wants to schedule a recurring task, e.g. "run X every morning", "schedule a daily report", "set up a cron job", "定时任务", "每天自动跑".
 ---
 

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: cron-task-creator
-system: true
 description: Create, inspect, run, edit, enable/disable, and delete octo's scheduled cron tasks — recurring agent prompts stored in ~/.octo/tasks/*.json and executed by the octo serve scheduler. Use when the user wants to schedule a recurring task, e.g. "run X every morning", "schedule a daily report", "set up a cron job", "定时任务", "每天自动跑".
 ---
 

--- a/internal/skills/defaults/expert-agent-manager/SKILL.md
+++ b/internal/skills/defaults/expert-agent-manager/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: expert-agent-manager
+system: true
 description: Manage octo's agent profiles through conversation — create, modify, delete, list, and bind agents to IM chats by calling REST APIs. This skill is exclusive to the Default Agent (full-access). Use when the user wants to manage agents conversationally, e.g. "create a code review agent", "list all agents", "bind agent X to this group", "delete agent Y", "帮我建一个 agent", "管理 agent".
 ---
 

--- a/internal/skills/defaults/mcp-creator/SKILL.md
+++ b/internal/skills/defaults/mcp-creator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: mcp-creator
+system: true
 description: Configure and connect MCP (Model Context Protocol) servers through guided conversation — find the right server package or endpoint, build the config entry, write it to ~/.octo/mcp.json, and verify the connection. Use when the user wants to add, set up, or connect an MCP server, e.g. "add an MCP server", "connect X via MCP", "set up the filesystem MCP", "添加 MCP", "接入 MCP 服务".
 ---
 

--- a/internal/skills/defaults/skill-creator/SKILL.md
+++ b/internal/skills/defaults/skill-creator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-creator
+system: true
 description: Create new skills, modify existing skills, and help users turn repeatable workflows into reusable instructions. Use when the user wants to create a skill from scratch, edit or improve an existing skill, capture a workflow as a skill, or optimize a skill's description for better triggering accuracy. Do NOT use to chain or orchestrate several EXISTING skills/recordings into a runnable saved workflow — that is workflow-creator.
 ---
 

--- a/internal/skills/defaults/workflow-creator/SKILL.md
+++ b/internal/skills/defaults/workflow-creator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: workflow-creator
+system: true
 description: Turn a repeatable multi-step task into a runnable, reusable saved workflow through guided conversation, in either of two shapes — chaining existing skills/recordings (wiring each one's output into the next's input), or composing the workflow script's own primitives (agent/parallel/pipeline) directly when the task needs fresh sub-agent orchestration and no existing skill covers it. Figure out which shape fits, generate the Ruby workflow, dry-run it, and save it with workflow_save. Use when the user wants to combine / chain / orchestrate work into one repeatable flow — whether that's several EXISTING skills, or a from-scratch multi-agent script (parallel review, fan-out research, a pipeline over a list) — e.g. "chain these skills", "把这几个技能连起来", "串个流程", "做个 workflow", "编排一下", "build a workflow", "写个并行跑多个 agent 的脚本". Do NOT use to author a single new skill (that is skill-creator), to run one skill/agent a single time (just call it), or to design a recurring/self-triggering loop with its own trigger and state file (use `cron-task-creator` to schedule a saved workflow instead — a saved workflow is just the one-shot script such a scheduled run calls, not the loop itself).
 ---
 

--- a/internal/skills/manifest_profile_test.go
+++ b/internal/skills/manifest_profile_test.go
@@ -80,15 +80,18 @@ func countSkillLines(manifest string) int {
 func TestManifestForProfile_EmptyToolSkillsReturnsAll(t *testing.T) {
 	r := discoverWithDefaults(t)
 	full := RenderManifest(r)
-	profiled := ManifestForProfile(r, &agentprofile.Profile{
+	// Default agent sees the full manifest including system skills.
+	profiled := ManifestForProfile(r, agentprofile.DefaultProfile())
+	if full != profiled {
+		t.Fatalf("empty ToolSkills should return full manifest for default agent")
+	}
+	// Non-default agent with empty ToolSkills gets manifest minus system skills.
+	expertProfiled := ManifestForProfile(r, &agentprofile.Profile{
 		ID:          "test",
 		Description: "d",
-		CapabilitySpec: agentprofile.CapabilitySpec{
-			ToolSkills: []string{},
-		},
 	})
-	if full != profiled {
-		t.Fatalf("empty ToolSkills should return full manifest")
+	if expertProfiled == full {
+		t.Fatalf("non-default agent with empty ToolSkills should strip system skills")
 	}
 }
 

--- a/internal/skills/manifest_profile_test.go
+++ b/internal/skills/manifest_profile_test.go
@@ -41,7 +41,19 @@ func TestManifestForProfile_FiltersByToolSkills(t *testing.T) {
 	if len(allSkills) == 0 {
 		t.Fatal("expected skills")
 	}
-	target := allSkills[0].Name
+	// Pick the first non-system skill — a system skill (e.g. skill-creator)
+	// would be stripped from an expert agent's manifest and break the
+	// one-skill-count assertion below.
+	var target string
+	for _, s := range allSkills {
+		if !s.System {
+			target = s.Name
+			break
+		}
+	}
+	if target == "" {
+		t.Skip("no non-system skill available")
+	}
 	profiled := ManifestForProfile(r, &agentprofile.Profile{
 		ID:          "test",
 		Description: "d",

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -41,6 +41,7 @@ type Skill struct {
 	Body        string // SKILL.md body after frontmatter
 	Dir         string // absolute path of the skill directory
 	Source      string // "project" | "user" (display only, for --list-skills)
+	System      bool   // frontmatter system: true → hidden from expert agent manifests
 }
 
 // Registry holds the skills discovered for a session, indexed by name. It is
@@ -111,7 +112,7 @@ func (r *Registry) scanRoot(root, source string) {
 		if err != nil {
 			continue
 		}
-		desc, body, ok := parse(b)
+		desc, sys, body, ok := parse(b)
 		if !ok || desc == "" {
 			continue
 		}
@@ -121,6 +122,7 @@ func (r *Registry) scanRoot(root, source string) {
 		}
 		r.skills[name] = Skill{
 			Name:        name,
+System:      sys,
 			Description: desc,
 			Body:        strings.TrimSpace(body),
 			Dir:         abs,
@@ -135,22 +137,23 @@ func (r *Registry) scanRoot(root, source string) {
 type frontmatter struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
+	System      bool   `yaml:"system"` // hidden from expert agent manifests
 }
 
 // parse splits a SKILL.md into its frontmatter description and body. It expects
 // the file to open with a `---` line and contain a closing `---` line; the YAML
 // between them is unmarshalled for the description. ok is false when the file
 // has no frontmatter fence or the YAML doesn't parse.
-func parse(b []byte) (desc, body string, ok bool) {
+func parse(b []byte) (desc string, sys bool, body string, ok bool) {
 	front, body, ok := splitFrontmatter(string(b))
 	if !ok {
-		return "", "", false
+		return "", false, "", false
 	}
 	var fm frontmatter
 	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
-		return "", "", false
+		return "", false, "", false
 	}
-	return strings.TrimSpace(fm.Description), body, true
+	return strings.TrimSpace(fm.Description), fm.System, body, true
 }
 
 // splitFrontmatter returns the text between the opening and closing `---`
@@ -353,12 +356,23 @@ func RenderManifest(r *Registry) string {
 // When profile is non-nil and declares ToolSkills, only those skills are
 // listed — the design's per-agent skill isolation. A nil profile or an empty
 // ToolSkills list means "all skills" (the default agent behavior).
+//
+// Expert agents (non-default profiles) additionally have system-level skills
+// hidden — skills marked system:true in their frontmatter (e.g.
+// expert-agent-manager, channel-manager) exist for the Default Agent's
+// management surface and make no sense in an expert agent's context.
 func ManifestForProfile(r *Registry, profile *agentprofile.Profile) string {
 	if r.Len() == 0 {
 		return ""
 	}
 	if profile == nil || len(profile.ToolSkills) == 0 {
-		return RenderManifest(r)
+		manifest := RenderManifest(r)
+		// Default agent sees everything; expert agents without an allowlist
+		// still have system skills filtered from the raw manifest.
+		if profile != nil && !profile.IsDefault() {
+			manifest = stripSystemSkills(r, manifest)
+		}
+		return manifest
 	}
 	allowed := make(map[string]bool, len(profile.ToolSkills))
 	for _, name := range profile.ToolSkills {
@@ -369,9 +383,10 @@ func ManifestForProfile(r *Registry, profile *agentprofile.Profile) string {
 	b.WriteString("When a task matches a skill's description, call the `skill` tool with its " +
 		"name to load the full instructions before acting. Don't guess the instructions " +
 		"from the one-line description. The user can also trigger one directly by typing /<name>.\n\n")
+	expert := !profile.IsDefault()
 	n := 0
 	for _, s := range r.List() {
-		if allowed[s.Name] {
+		if allowed[s.Name] && !(expert && s.System) {
 			fmt.Fprintf(&b, "- %s: %s\n", s.Name, s.Description)
 			n++
 		}
@@ -380,6 +395,41 @@ func ManifestForProfile(r *Registry, profile *agentprofile.Profile) string {
 		return ""
 	}
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// stripSystemSkills filters system-level skill lines from the rendered manifest
+// text. It looks for "- <name>: " prefixed lines whose name matches a skill with
+// System==true in the registry, and removes them.
+func stripSystemSkills(r *Registry, manifest string) string {
+	// Collect the names of system skills.
+	sys := map[string]bool{}
+	for _, s := range r.List() {
+		if s.System {
+			sys[s.Name] = true
+		}
+	}
+	if len(sys) == 0 {
+		return manifest
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(manifest, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- ") {
+			// Extract skill name: "- name: description..."
+			rest := trimmed[2:]
+			if colon := strings.IndexByte(rest, ':'); colon > 0 {
+				name := rest[:colon]
+				if sys[name] {
+					continue // skip system skill lines
+				}
+			}
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(line)
+	}
+	return b.String()
 }
 
 // ccCompatNote bridges skills authored for Claude Code — the ecosystem most

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -122,7 +122,7 @@ func (r *Registry) scanRoot(root, source string) {
 		}
 		r.skills[name] = Skill{
 			Name:        name,
-System:      sys,
+			System:      sys,
 			Description: desc,
 			Body:        strings.TrimSpace(body),
 			Dir:         abs,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -352,6 +352,15 @@ export async function updateSessionWorkingDir(id: string, dir: string): Promise<
   })
 }
 
+// Available tools for AgentEdit checklist — mirrors GET /api/tools.
+export interface ToolInfo {
+  name: string
+  description: string
+}
+export async function fetchAvailableTools(): Promise<ToolInfo[]> {
+  return request<ToolInfo[]>('/api/tools')
+}
+
 // Skills
 
 // The server returns { skills: [{name, description, source, enabled}] }. Map it

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -52,8 +52,12 @@ export const en: Record<string, string> = {
   "agents.model_placeholder": "Leave empty to use the default model",
   "agents.tools": "Tools",
   "agents.tools_placeholder": "read_file, grep, glob (comma-separated, empty = all)",
+
+  "agents.tools_loading": "Loading available toolsu2026",
   "agents.tools_hint": "Leave empty to grant all tools (default agent behaviour).",
   "agents.tool_skills": "Skills",
+
+  "agents.skills_loading": "Loading available skillsu2026",
   "agents.tool_skills_placeholder": "code-review, tech-design",
   "agents.mention_as": "Mention Aliases",
   "agents.mention_as_placeholder": "@review, @expert",
@@ -855,7 +859,11 @@ export const zh: Record<string, string> = {
   "agents.tools": "工具",
   "agents.tools_placeholder": "read_file, grep, glob（逗号分隔，空=全部）",
   "agents.tools_hint": "留空授予全部工具（默认智能体行为）。",
+
+  "agents.tools_loading": "正在加载可用工具…",
   "agents.tool_skills": "技能",
+
+  "agents.skills_loading": "正在加载可用技能…",
   "agents.tool_skills_placeholder": "code-review, tech-design",
   "agents.mention_as": "提及别名",
   "agents.mention_as_placeholder": "@review, @expert",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -51,14 +51,11 @@ export const en: Record<string, string> = {
   "agents.model": "Model",
   "agents.model_placeholder": "Leave empty to use the default model",
   "agents.tools": "Tools",
-  "agents.tools_placeholder": "read_file, grep, glob (comma-separated, empty = all)",
 
-  "agents.tools_loading": "Loading available toolsu2026",
-  "agents.tools_hint": "Leave empty to grant all tools (default agent behaviour).",
+  "agents.tools_loading": "Loading available tools…",
   "agents.tool_skills": "Skills",
 
-  "agents.skills_loading": "Loading available skillsu2026",
-  "agents.tool_skills_placeholder": "code-review, tech-design",
+  "agents.skills_loading": "Loading available skills…",
   "agents.mention_as": "Mention Aliases",
   "agents.mention_as_placeholder": "@review, @expert",
   "agents.mention_as_hint": "Each alias must start with @ and be globally unique.",
@@ -857,14 +854,11 @@ export const zh: Record<string, string> = {
   "agents.model": "模型",
   "agents.model_placeholder": "留空使用默认模型",
   "agents.tools": "工具",
-  "agents.tools_placeholder": "read_file, grep, glob（逗号分隔，空=全部）",
-  "agents.tools_hint": "留空授予全部工具（默认智能体行为）。",
 
   "agents.tools_loading": "正在加载可用工具…",
   "agents.tool_skills": "技能",
 
   "agents.skills_loading": "正在加载可用技能…",
-  "agents.tool_skills_placeholder": "code-review, tech-design",
   "agents.mention_as": "提及别名",
   "agents.mention_as_placeholder": "@review, @expert",
   "agents.mention_as_hint": "每个别名必须以 @ 开头且全局唯一。",

--- a/web/src/views/AgentEdit.svelte
+++ b/web/src/views/AgentEdit.svelte
@@ -21,7 +21,6 @@
   interface ChecklistItem {
     name: string
     description: string
-    kind: 'builtin' | 'skill' | 'mcp'
   }
   let availableTools: ChecklistItem[] = $state([])
   let availableSkills: ChecklistItem[] = $state([])
@@ -40,12 +39,10 @@
       availableTools = toolDefs.map(t => ({
         name: t.name,
         description: t.description || '',
-        kind: 'builtin' as const,
       }))
       availableSkills = skillDefs.map(s => ({
         name: s.name,
         description: s.desc || '',
-        kind: 'skill' as const,
       }))
     } catch {
       // Degrade gracefully — the text-input fallback is always available

--- a/web/src/views/AgentEdit.svelte
+++ b/web/src/views/AgentEdit.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { t } from '../lib/i18n'
-  import type { Agent } from '../lib/api'
+  import * as api from '../lib/api'
 
   interface Props {
-    agent: Agent | null
-    onSave: (agent: Agent) => void
+    agent: api.Agent | null
+    onSave: (agent: api.Agent) => void
     onCancel: () => void
   }
 
@@ -13,32 +14,82 @@
   let name = $state('')
   let description = $state('')
   let model = $state('')
-  let tools = $state('')
-  let toolSkills = $state('')
   let mentionAs = $state('')
   let systemPrompt = $state('')
 
-  // Reset form fields when the agent prop changes (Svelte 5 captures prop
-  // values only at initialisation; without this, editing a different agent
-  // keeps the previous form content).
+  // Checklist items loaded from the Default Agent's resource pool.
+  interface ChecklistItem {
+    name: string
+    description: string
+    kind: 'builtin' | 'skill' | 'mcp'
+  }
+  let availableTools: ChecklistItem[] = $state([])
+  let availableSkills: ChecklistItem[] = $state([])
+
+  // Selected tool/skill names (from the agent's current allowlists).
+  let selectedTools: Set<string> = $state(new Set<string>())
+  let selectedSkills: Set<string> = $state(new Set<string>())
+
+  // Load available resources from the Default Agent pool.
+  async function loadResources() {
+    try {
+      const [toolDefs, skillDefs] = await Promise.all([
+        api.fetchAvailableTools(),
+        api.listSkills(),
+      ])
+      availableTools = toolDefs.map(t => ({
+        name: t.name,
+        description: t.description || '',
+        kind: 'builtin' as const,
+      }))
+      availableSkills = skillDefs.map(s => ({
+        name: s.name,
+        description: s.desc || '',
+        kind: 'skill' as const,
+      }))
+    } catch {
+      // Degrade gracefully — the text-input fallback is always available
+      // via the profile's .md file.
+    }
+  }
+
+  // Reset form fields when the agent prop changes.
   $effect(() => {
     name = agent?.name ?? ''
     description = agent?.description ?? ''
     model = agent?.model ?? ''
-    tools = agent?.tools?.join(', ') ?? ''
-    toolSkills = agent?.tool_skills?.join(', ') ?? ''
     mentionAs = agent?.mention_as?.join(', ') ?? ''
     systemPrompt = agent?.system_prompt ?? ''
+    selectedTools = new Set(agent?.tools ?? [])
+    selectedSkills = new Set(agent?.tool_skills ?? [])
   })
+
+  onMount(loadResources)
+
+  function toggleTool(name: string) {
+    const next = new Set(selectedTools)
+    if (next.has(name)) next.delete(name)
+    else next.add(name)
+    selectedTools = next
+  }
+
+  function toggleSkill(name: string) {
+    const next = new Set(selectedSkills)
+    if (next.has(name)) next.delete(name)
+    else next.add(name)
+    selectedSkills = next
+  }
 
   function handleSubmit(e: Event) {
     e.preventDefault()
+    const selTools = [...selectedTools]
+    const selSkills = [...selectedSkills]
     const body = {
       name: name.trim(),
       description: description.trim(),
       model: model.trim() || undefined,
-      tools: tools.trim() ? tools.split(',').map(s => s.trim()).filter(Boolean) : undefined,
-      tool_skills: toolSkills.trim() ? toolSkills.split(',').map(s => s.trim()).filter(Boolean) : undefined,
+      tools: selTools.length > 0 ? selTools : undefined,
+      tool_skills: selSkills.length > 0 ? selSkills : undefined,
       mention_as: mentionAs.trim() ? mentionAs.split(',').map(s => s.trim()).filter(Boolean) : undefined,
       system_prompt: systemPrompt.trim() || undefined,
     }
@@ -46,7 +97,7 @@
       alert('Name and description are required')
       return
     }
-    onSave(body as Agent)
+    onSave(body as api.Agent)
   }
 </script>
 
@@ -70,15 +121,51 @@
         <label>{$t('agents.model')}</label>
         <input bind:value={model} placeholder={$t('agents.model_placeholder')} />
       </div>
+
+      <!-- Tools checklist -->
       <div class="field">
         <label>{$t('agents.tools')}</label>
-        <input bind:value={tools} placeholder={$t('agents.tools_placeholder')} />
-        <small>{$t('agents.tools_hint')}</small>
+        {#if availableTools.length > 0}
+          <div class="checklist">
+            {#each availableTools as t}
+              <label class="check-item" title={t.description}>
+                <input
+                  type="checkbox"
+                  checked={selectedTools.has(t.name)}
+                  onchange={() => toggleTool(t.name)}
+                />
+                <span class="check-name">{t.name}</span>
+                <span class="check-hint">{t.description}</span>
+              </label>
+            {/each}
+          </div>
+        {:else}
+          <small>{$t('agents.tools_loading')}</small>
+        {/if}
       </div>
+
+      <!-- Skills checklist -->
       <div class="field">
         <label>{$t('agents.tool_skills')}</label>
-        <input bind:value={toolSkills} placeholder={$t('agents.tool_skills_placeholder')} />
+        {#if availableSkills.length > 0}
+          <div class="checklist">
+            {#each availableSkills as s}
+              <label class="check-item" title={s.description}>
+                <input
+                  type="checkbox"
+                  checked={selectedSkills.has(s.name)}
+                  onchange={() => toggleSkill(s.name)}
+                />
+                <span class="check-name">{s.name}</span>
+                <span class="check-hint">{s.description}</span>
+              </label>
+            {/each}
+          </div>
+        {:else}
+          <small>{$t('agents.skills_loading')}</small>
+        {/if}
       </div>
+
       <div class="field">
         <label>{$t('agents.mention_as')}</label>
         <input bind:value={mentionAs} placeholder={$t('agents.mention_as_placeholder')} />
@@ -99,7 +186,7 @@
   }
   .modal {
     background: var(--bg-container); border-radius: 12px; padding: 24px;
-    max-width: 480px; width: 90%; max-height: 80vh; overflow-y: auto;
+    max-width: 600px; width: 90%; max-height: 80vh; overflow-y: auto;
   }
   h3 { margin: 0 0 20px; font-size: 18px; font-weight: 600; }
   .field { margin-bottom: 16px; }
@@ -108,9 +195,35 @@
     width: 100%; padding: 8px 12px; border: 1px solid var(--border-secondary);
     border-radius: 6px; background: var(--bg-primary); color: var(--text-primary);
     font-size: 13px; font-family: inherit;
-    &:focus { outline: none; border-color: var(--blue-6); }
   }
+  input:focus, textarea:focus { outline: none; border-color: var(--blue-6); }
   small { display: block; font-size: 11px; color: var(--text-tertiary); margin-top: 2px; }
+
+  /* ── checklist ──────────────────────────────────────────────────────────── */
+  .checklist {
+    border: 1px solid var(--border-secondary); border-radius: 8px;
+    max-height: 200px; overflow-y: auto; padding: 4px;
+    background: var(--bg-primary);
+  }
+  .check-item {
+    display: flex; align-items: center; gap: 8px;
+    padding: 6px 8px; border-radius: 5px; cursor: pointer;
+    font-size: 13px;
+  }
+  .check-item:hover { background: var(--hover-neutral); }
+  .check-item input[type="checkbox"] { width: auto; margin: 0; flex: 0 0 auto; }
+  .check-name {
+    flex: 0 0 auto; min-width: 110px;
+    font-family: var(--font-mono, 'SF Mono', Monaco, monospace);
+    font-size: 12px; color: var(--text-primary);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .check-hint {
+    flex: 1; min-width: 0;
+    font-size: 11px; color: var(--text-tertiary);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+
   .actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 20px; }
   .btn-primary {
     height: 32px; padding: 0 14px; border: none; background: var(--blue-6); border-radius: 6px;


### PR DESCRIPTION
1. CLI --agent now injects profile.SystemPrompt when set, so
   octo chat --agent code-review actually uses the expert agent's
   persona instead of the default system prompt.

2. AgentEdit form replaces free-text tools/tool_skills fields with
   a checklist loaded from GET /api/tools and GET /api/skills.
   Tools and skills are selected via checkboxes.

3. System-level skills (skill-creator, expert-agent-manager,
   channel-manager, cron-task-creator, mcp-creator) are marked
   system: true in their SKILL.md frontmatter. ManifestForProfile
   hides them for non-default profiles.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
