### PR TITLE
docs: clarify web has no global agent switcher; per-session binding only

### DIFF
--- a/dev-docs/multi-agent-system-design.md
+++ b/dev-docs/multi-agent-system-design.md
@@ -831,12 +831,13 @@ octo 已有的用户 agent 定义机制（`~/.octo/agents/*.md`，供 `subagent_
 | GET | `/api/cron?agent_id=:id` | 按 agent 过滤 cron 列表 |
 | PUT | `/api/cron/:id/transfer` | 转移 cron 归属（仅 default） |
 
-### 切换
+### Web 端 Agent 选择
+
+Web 端不维护全局 active agent 状态——agent 绑定在 session 上，会话创建时选定、创建后不可切换。用户在侧边栏新建会话时通过 Agent Picker 下拉选择目标 agent，会话列表每条会话标记所属 agent 的彩色 tag。
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| GET | `/api/agent-current` | 获取当前 web 端的 active agent（存 cookie 或返回 default） |
-| GET | `/api/agents` | 列出所有 profiles（新建会话时选择） |
+| GET | `/api/agents` | 列出所有 profiles（新建会话时选择 agent） |
 
 ---
 
@@ -850,8 +851,7 @@ octo 已有的用户 agent 定义机制（`~/.octo/agents/*.md`，供 `subagent_
 | `internal/agentprofile/store.go` | Store（三来源加载/保存/索引） |
 | `internal/agentprofile/router.go` | AgentRouter（按事件路由到 profile） |
 | `web/src/views/AgentsView.svelte` | Agent 管理主面板 |
-| `web/src/views/AgentEditView.svelte` | Agent 编辑表单 |
-| `web/src/components/agents/AgentList.svelte` | 下拉 agent 列表 |
+| `web/src/views/AgentEditView.svelte` | Agent 编辑表单，含 tools/skills/MCP checklist |
 | `skills/expert-agent-manager/SKILL.md` | Expert Agent Manager 元技能（Default Agent 专用） |
 
 ### 修改文件
@@ -874,11 +874,11 @@ octo 已有的用户 agent 定义机制（`~/.octo/agents/*.md`，供 `subagent_
 | `cmd/octo-desktop/main.go` | desktop 启动传 `agentName` 给 server |
 | `web/src/lib/stores.ts` | 新增 `agentList`, `cronOwnership` stores |
 | `web/src/lib/api.ts` | 新增 agents API 调用；cron transfer API |
-| `web/src/components/layout/Header.svelte` | 集成 AgentAvatar 下拉 |
-| `web/src/views/SkillsView.svelte` | 技能列表根据 active agent 过滤；不在 default 时隐藏新增和系统级 skill |
-| `web/src/views/McpView.svelte` | MCP 列表根据 active agent 过滤 |
+| `web/src/views/SkillsView.svelte` | 全局技能管理面板，始终以 Default Agent 身份访问；不做 per-agent 过滤 |
+| `web/src/views/McpView.svelte` | 全局 MCP 管理面板，始终以 Default Agent 身份访问；不做 per-agent 过滤 |
 | `web/src/views/WorkflowsView.svelte` | workflow 面板展示全部 workflow；不做按 agent 过滤 |
-| `web/src/views/ChatView.svelte` | 会话列表根据 active agent 拉取 |
+| `web/src/views/ChatView.svelte` | 会话列表每条会话标记所属 agent tag；会话内不显示 agent 切换入口 |
+| `web/src/views/AgentEditView.svelte` | Agent 编辑表单内展示 tools/skills/MCP checklist，允许从 Default Agent 资源池中勾选启用 |
 | `web/src/views/TasksView.svelte` | cron 列表按 agent 过滤；default 视图显示"归属"列和"转移"操作 |
 
 ---
@@ -952,7 +952,7 @@ octo 已有的用户 agent 定义机制（`~/.octo/agents/*.md`，供 `subagent_
 | 3 | tools/skills 按 profile 过滤（`DefaultToolsForProfile`、`ManifestForProfile`、`system:true`、browser skill 隐藏）+ `subagent_type` 解析改走 Store、`discoverAgents` 合并进 Store、代码内 "preset" 标识符统一更名为 profile | 只依赖 PR1，可与 PR2 并行 |
 | 4 | CLI/TUI `--agent` + `/agent` 命令 | 第一个端到端验证切片：profile 创建 → 路由 → 工具过滤全链路 |
 | 5 | REST API `/api/agents/*` + cron `agent_id`/transfer + `expert-agent-manager` 元技能 | 对话式管理入口可用 |
-| 6 | Web UI（Agents 面板、Header 切换、各 View 过滤） | 纯前端，API 已就绪 |
+| 6 | Web UI（Agents 面板、会话列表 agent tag、AgentEdit 表单 checklist） | 纯前端，API 已就绪 |
 
 要点：
 
@@ -963,7 +963,7 @@ octo 已有的用户 agent 定义机制（`~/.octo/agents/*.md`，供 `subagent_
 
 - [ ] 无 profile 文件时行为与改造前完全一致（向后兼容）
 - [ ] 创建 profile → 绑定频道 → IM 发消息 → 正确路由
-- [ ] Web 新建会话选 agent → 会话正确归属；skill/MCP 面板不按 agent 过滤
+- [ ] Web 新建会话选 agent → 会话正确归属
 - [ ] API 变更与直接编辑 .md 均在下一次读取生效（无需重启、无 reload API）
 - [ ] Default Agent 的 system prompt 不可通过 profile 编辑器修改（只读显示"由 onboard 管理"）
 - [ ] `octo --agent code-review` 正常启动
@@ -1000,7 +1000,7 @@ octo 已有的用户 agent 定义机制（`~/.octo/agents/*.md`，供 `subagent_
 - `internal/agentprofile/` — 全新包，可整体删除
 - `internal/server/` — 改动集中在 `handleChannelMessage` 路由步骤 + 新增 handlers，撤销路由步骤即可
 - `internal/channel/manager.go` — key 命名空间与签名扩展向后兼容（default agent key 不变），无需回滚数据
-- `web/src/views/AgentsView.svelte` + `AgentEditView.svelte` + `AgentAvatar.svelte` — 全新文件，可删除
+- `web/src/views/AgentsView.svelte` + `AgentEditView.svelte` — 全新文件，可删除
 
 回滚步骤：
 1. 删除新增文件


### PR DESCRIPTION
Remove residual references to a global active-agent toggle from the
multi-agent design doc: no /api/agent-current, no Header AgentAvatar,
no SkillsView/McpView per-agent filtering. The design is: agent is
bound at session creation via the sidebar Agent Picker, and SkillsView/
McpView are always Default Agent's management surface.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
