### PR TITLE
fix(prompt): skip identity layers (soul.md/user.md) for expert agents

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -1017,7 +1017,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			// MCP manifest against a.Model (may differ from resolvedModel — a
 			// saved session can override it above) so the Tool Search
 			// activation gate matches the model actually in use.
-			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, sess.EffectiveAgentID() != "default")
+			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, agentProfile != nil && agentProfile.SystemPrompt != "")
 		} else {
 			sess = agent.NewSession(resolvedModel, *system)
 			sess.Bind(agent.EntryTUI, false)
@@ -1031,8 +1031,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 					// a.System was set at startup from the server base
 					// prompt (line ~946). Re-compose with the expert
-					// prompt and skip identity layers so the expert.s
-					// persona isn.t polluted by soul.md/user.md.
+					// prompt and skip identity layers so the expert's
+					// persona isn't polluted by soul.md/user.md.
 					a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, true)
 				}
 			}
@@ -1089,7 +1089,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// for both a fresh session (NewSession stores *system into it) and a
 		// resumed one (loaded from disk), so it's correct in either case.
 		cfg.recomposeMCPManifest = func() {
-			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, sess.EffectiveAgentID() != "default")
+			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, agentProfile != nil && agentProfile.SystemPrompt != "")
 		}
 		if toolsOn {
 			// Built-ins only at first paint — the MCP registry is still nil

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -943,7 +943,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if g := tools.MemoryBackendGuidance(); g != "" {
 		memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
 	}
-	a.System, a.LeanSystem = prompt.ComposePair(*system, cwd, env, skillsManifest, mcpManifest, memInjection, coauthor)
+	a.System, a.LeanSystem = prompt.ComposePair(*system, cwd, env, skillsManifest, mcpManifest, memInjection, coauthor, false)
 
 	// Attention layer: re-surface MEMORY.md's structured rules (## 必须遵守 /
 	// ## 触发提醒) on the message stream at the point of action. This rides each
@@ -1017,7 +1017,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			// MCP manifest against a.Model (may differ from resolvedModel — a
 			// saved session can override it above) so the Tool Search
 			// activation gate matches the model actually in use.
-			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor)
+			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, sess.EffectiveAgentID() != "default")
 		} else {
 			sess = agent.NewSession(resolvedModel, *system)
 			sess.Bind(agent.EntryTUI, false)
@@ -1028,6 +1028,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				// so resume recomposes with the right persona.
 				if agentProfile != nil && agentProfile.SystemPrompt != "" {
 					sess.System = agentProfile.SystemPrompt
+
+					// a.System was set at startup from the server base
+					// prompt (line ~946). Re-compose with the expert
+					// prompt and skip identity layers so the expert.s
+					// persona isn.t polluted by soul.md/user.md.
+					a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, true)
 				}
 			}
 		}
@@ -1083,7 +1089,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// for both a fresh session (NewSession stores *system into it) and a
 		// resumed one (loaded from disk), so it's correct in either case.
 		cfg.recomposeMCPManifest = func() {
-			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor)
+			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, sess.EffectiveAgentID() != "default")
 		}
 		if toolsOn {
 			// Built-ins only at first paint — the MCP registry is still nil
@@ -1119,6 +1125,9 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if agentProfileID != "" {
 		if agentProfile != nil && agentProfile.SystemPrompt != "" {
 			oneShotSess.System = agentProfile.SystemPrompt
+			// Re-compose a.System with the expert prompt and skip
+			// identity layers (soul.md/user.md don't belong here).
+			a.System, a.LeanSystem = prompt.ComposePair(oneShotSess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, true)
 		}
 		oneShotSess.AgentID = agentProfileID
 	}

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -81,7 +81,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	a := agent.New(llmSender, resolvedModel)
-	a.System = prompt.Compose("", cwd, env, "", "", "", true) // init is a one-shot task; no skills/mcp/memory
+	a.System = prompt.Compose("", cwd, env, "", "", "", true, false) // init is a one-shot task; no skills/mcp/memory
 
 	// init's whole job is writing/updating .octorules at cwd's root, and it
 	// defaults to strict (no one is watching an ask prompt for a one-shot

--- a/internal/prompt/identity_test.go
+++ b/internal/prompt/identity_test.go
@@ -34,7 +34,7 @@ func useIdentityFiles(t *testing.T, soul, profile string) {
 
 func TestCompose_IdentityLayers(t *testing.T) {
 	useIdentityFiles(t, "SOUL_PERSONA", "USER_PROFILE_X")
-	out := Compose("", t.TempDir(), "ENV_Z", "SKILLS_M", "", "", true)
+	out := Compose("", t.TempDir(), "ENV_Z", "SKILLS_M", "", "", true, false)
 
 	baseIdx := strings.Index(out, "octo")
 	soulIdx := strings.Index(out, "SOUL_PERSONA")
@@ -58,7 +58,7 @@ func TestCompose_IdentityLayers(t *testing.T) {
 
 func TestCompose_IdentityAbsentSkipped(t *testing.T) {
 	useIdentityFiles(t, "", "") // neither file present
-	out := Compose("", t.TempDir(), "", "", "", "", false)
+	out := Compose("", t.TempDir(), "", "", "", "", false, false)
 	if strings.Contains(out, "soul.md") || strings.Contains(out, "user.md") {
 		t.Errorf("absent identity files should add no layer:\n%s", out)
 	}
@@ -73,7 +73,7 @@ func TestCompose_ProfileBeforeRules(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out := Compose("", dir, "", "", "", "", false)
+	out := Compose("", dir, "", "", "", "", false, false)
 	profileIdx := strings.Index(out, "USER_PROFILE_X")
 	projIdx := strings.Index(out, "PROJECT_RULE")
 	if profileIdx == -1 || projIdx == -1 || profileIdx >= projIdx {

--- a/internal/prompt/memory_test.go
+++ b/internal/prompt/memory_test.go
@@ -33,7 +33,7 @@ func TestCompose_UserLayerBetweenEnvAndProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out := Compose("SYSTEM_OVERRIDE", dir, "ENV_BLOCK", "", "", "", true)
+	out := Compose("SYSTEM_OVERRIDE", dir, "ENV_BLOCK", "", "", "", true, false)
 
 	envIdx := strings.Index(out, "ENV_BLOCK")
 	userIdx := strings.Index(out, "USER_GLOBAL_RULE")
@@ -58,7 +58,7 @@ func TestCompose_NoUserFile_NoUserLayer(t *testing.T) {
 	// path), so this isolates the test from real ~/.octo/{soul,user,octorules}.
 	useIdentityFiles(t, "", "")
 
-	out := Compose("", t.TempDir(), "", "", "", "", false)
+	out := Compose("", t.TempDir(), "", "", "", "", false, false)
 	if strings.Contains(out, "octorules.md") {
 		t.Errorf("absent user file should add no layer:\n%s", out)
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -55,8 +55,8 @@ var userRulesPath = func() string {
 	return filepath.Join(home, ".octo", "octorules.md")
 }
 
-// Compose assembles the session system prompt from up to ten layers, in
-// order of increasing specificity:
+// Compose assembles the session system prompt from up to ten layers (six
+// when expertMode is true), in order of increasing specificity:
 //
 //  1. base     — embedded octo foundation (always present)
 //  2. soul     — ~/.octo/soul.md, if present (agent identity & behavior)
@@ -139,7 +139,7 @@ func Compose(userSystem, cwd, env, skills, mcpTools, memory string, coauthor, ex
 // drops the skills manifest, MCP tools manifest, and memory injection (the
 // heaviest, most optional layers). The lean variant seeds cheap read-only
 // sub-agents (explore) that don't need the full harness context. Other
-// layers — soul, env, user/project conventions — are kept in both.
+// layers — soul, env, user/project conventions — are kept in both (except in expertMode, where soul/user/project are dropped from both).
 func ComposePair(userSystem, cwd, env, skills, mcpTools, memory string, coauthor, expertMode bool) (full, lean string) {
 	full = Compose(userSystem, cwd, env, skills, mcpTools, memory, coauthor, expertMode)
 	lean = Compose(userSystem, cwd, env, "", "", "", coauthor, expertMode)

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -89,15 +89,21 @@ var userRulesPath = func() string {
 //
 // coauthor, when true, injects a rule into the system prompt instructing the
 // agent to append a Co-authored-by trailer to every git commit message it writes.
-func Compose(userSystem, cwd, env, skills, mcpTools, memory string, coauthor bool) string {
+//
+// expertMode, when true, skips identity/persona layers (soul.md, user.md,
+// octorules.md, and project conventions) — these belong to the Default Agent
+// and would collide with an Expert Agent's custom system prompt.
+func Compose(userSystem, cwd, env, skills, mcpTools, memory string, coauthor, expertMode bool) string {
 	layers := []string{strings.TrimSpace(base)}
 
 	if coauthor {
 		layers = append(layers, coauthorRule)
 	}
 
-	if s := readSoul(); s != "" {
-		layers = append(layers, "# Agent identity (~/.octo/soul.md)\n\n"+s)
+	if !expertMode {
+		if s := readSoul(); s != "" {
+			layers = append(layers, "# Agent identity (~/.octo/soul.md)\n\n"+s)
+		}
 	}
 	if e := strings.TrimSpace(env); e != "" {
 		layers = append(layers, e)
@@ -111,14 +117,16 @@ func Compose(userSystem, cwd, env, skills, mcpTools, memory string, coauthor boo
 	if m := strings.TrimSpace(memory); m != "" {
 		layers = append(layers, m)
 	}
-	if p := readUserProfile(); p != "" {
-		layers = append(layers, "# User profile (~/.octo/user.md)\n\n"+p)
-	}
-	if u := readUserContext(); u != "" {
-		layers = append(layers, "# User conventions (~/.octo/octorules.md)\n\n"+u)
-	}
-	if proj := readProjectContext(cwd); proj != "" {
-		layers = append(layers, "# Project conventions ("+ProjectContextFile+")\n\n"+proj)
+	if !expertMode {
+		if p := readUserProfile(); p != "" {
+			layers = append(layers, "# User profile (~/.octo/user.md)\n\n"+p)
+		}
+		if u := readUserContext(); u != "" {
+			layers = append(layers, "# User conventions (~/.octo/octorules.md)\n\n"+u)
+		}
+		if proj := readProjectContext(cwd); proj != "" {
+			layers = append(layers, "# Project conventions ("+ProjectContextFile+")\n\n"+proj)
+		}
 	}
 	if u := strings.TrimSpace(userSystem); u != "" {
 		layers = append(layers, u)
@@ -132,9 +140,9 @@ func Compose(userSystem, cwd, env, skills, mcpTools, memory string, coauthor boo
 // heaviest, most optional layers). The lean variant seeds cheap read-only
 // sub-agents (explore) that don't need the full harness context. Other
 // layers — soul, env, user/project conventions — are kept in both.
-func ComposePair(userSystem, cwd, env, skills, mcpTools, memory string, coauthor bool) (full, lean string) {
-	full = Compose(userSystem, cwd, env, skills, mcpTools, memory, coauthor)
-	lean = Compose(userSystem, cwd, env, "", "", "", coauthor)
+func ComposePair(userSystem, cwd, env, skills, mcpTools, memory string, coauthor, expertMode bool) (full, lean string) {
+	full = Compose(userSystem, cwd, env, skills, mcpTools, memory, coauthor, expertMode)
+	lean = Compose(userSystem, cwd, env, "", "", "", coauthor, expertMode)
 	return full, lean
 }
 

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -82,3 +82,18 @@ func TestReadProjectContext_MissingFileIsEmpty(t *testing.T) {
 		t.Errorf("empty cwd should yield empty, got %q", got)
 	}
 }
+
+func TestCompose_ExpertModeSkipsIdentityLayers(t *testing.T) {
+	useIdentityFiles(t, "SOUL CONTENT", "USER CONTENT")
+	out := Compose("EXPERT_SYSTEM", t.TempDir(), "ENV", "SKILLS", "", "", true, true)
+	for _, forbidden := range []string{"soul.md", "user.md", "octorules.md", "Agent identity", "User profile"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("expertMode should skip %q", forbidden)
+		}
+	}
+	for _, want := range []string{"ENV", "SKILLS", "EXPERT_SYSTEM"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expertMode should keep %q", want)
+		}
+	}
+}

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCompose_BaseAlwaysPresent(t *testing.T) {
-	out := Compose("", t.TempDir(), "", "", "", "", false) // empty user/env/skills/mcp, no .octorules
+	out := Compose("", t.TempDir(), "", "", "", "", false, false) // empty user/env/skills/mcp, no .octorules
 	if !strings.Contains(out, "octo") {
 		t.Errorf("composed prompt should contain the base identity:\n%s", out)
 	}
@@ -19,7 +19,7 @@ func TestCompose_BaseAlwaysPresent(t *testing.T) {
 
 func TestComposePair_LeanDropsSkillsMCPAndMemory(t *testing.T) {
 	dir := t.TempDir()
-	full, lean := ComposePair("USER_RULE", dir, "ENV_BLOCK", "SKILLS_MANIFEST", "MCP_MANIFEST", "MEMORY_BLOCK", true)
+	full, lean := ComposePair("USER_RULE", dir, "ENV_BLOCK", "SKILLS_MANIFEST", "MCP_MANIFEST", "MEMORY_BLOCK", true, false)
 
 	// Full keeps everything; lean drops skills + mcp tools + memory but keeps env + user.
 	for _, want := range []string{"SKILLS_MANIFEST", "MCP_MANIFEST", "MEMORY_BLOCK", "ENV_BLOCK", "USER_RULE"} {
@@ -42,7 +42,7 @@ func TestCompose_LayersInOrder(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE_X"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out := Compose("USER_RULE_Y", dir, "ENV_BLOCK_Z", "SKILLS_MANIFEST_W", "MCP_MANIFEST_V", "", true)
+	out := Compose("USER_RULE_Y", dir, "ENV_BLOCK_Z", "SKILLS_MANIFEST_W", "MCP_MANIFEST_V", "", true, false)
 
 	baseIdx := strings.Index(out, "octo")
 	envIdx := strings.Index(out, "ENV_BLOCK_Z")
@@ -68,7 +68,7 @@ func TestCompose_SkipsAbsentLayers(t *testing.T) {
 	// same on a developer machine and on a fresh CI runner.
 	useIdentityFiles(t, "", "")
 	// No env, no skills, no mcp tools, no .octorules, no user prompt → just the base, no separators.
-	out := Compose("", t.TempDir(), "", "", "", "", false)
+	out := Compose("", t.TempDir(), "", "", "", "", false, false)
 	if strings.Contains(out, "---") {
 		t.Errorf("single-layer prompt should have no separator:\n%s", out)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -593,7 +593,7 @@ func (s *Server) enableSubAgentTools() {
 	}
 	cwd, envCtx := s.curCwdEnv()
 	cfg, _ := config.Load() // zero value on error still resolves correctly via EffectiveCoauthor
-	template.System, template.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(model), memInjection, s.effectiveCoauthor(cfg))
+	template.System, template.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(model), memInjection, s.effectiveCoauthor(cfg), false)
 	executor := tools.NewDefaultRegistry()
 	spawner := app.NewSpawner(template, executor, func(ctx context.Context) []agent.ToolDefinition {
 		return tools.DefaultToolsForCtx(ctx, s.model)
@@ -1279,10 +1279,12 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	// edits land on the next message; a deleted profile falls back to default.
 	profile := s.profileForAgent(sess.EffectiveAgentID())
 	base := s.system
+	expertMode := false
 	if profile.SystemPrompt != "" {
 		base = profile.SystemPrompt
+		expertMode = true
 	}
-	a.System, a.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(model), memInjection, s.effectiveCoauthor(cfg))
+	a.System, a.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(model), memInjection, s.effectiveCoauthor(cfg), expertMode)
 
 	// L2: attention-layer rules (triggered keywords) + save-nudge on milestone
 	// tool results, plus any shell hooks (env/hooks.yml), unified on the agent's
@@ -3111,10 +3113,12 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// (default agent: unchanged, s.system). Resolved fresh per turn so profile
 	// edits land on the next message; a deleted profile falls back to default.
 	base := s.system
+	expertMode := false
 	if profile.SystemPrompt != "" {
 		base = profile.SystemPrompt
+		expertMode = true
 	}
-	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(sess.Agent.Model), memInjection, s.effectiveCoauthor(cfg))
+	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(sess.Agent.Model), memInjection, s.effectiveCoauthor(cfg), expertMode)
 
 	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,
 	// rebuilt per IM turn. The injector is session-sticky (recall latch) and


### PR DESCRIPTION
Expert agents carry their own system prompt in the profile; injecting
the Default Agent's identity layers (soul.md, user.md, octorules.md,
and project conventions) on top of it creates persona collisions.

prompt.Compose/ComposePair gain an expertMode bool parameter.
expertMode=true skips the four identity/persona layers.

- server: buildAgentTemplate always false; per-turn compose passes
  true when profile.SystemPrompt != ""
- CLI: init.go always false; TUI fresh session with --agent +
  SystemPrompt passes true; resume uses EffectiveAgentID();
  one-shot also passes true for expert profiles

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
