### PR TITLE
docs: add Expert Agents user guide (en + zh)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -75,6 +75,7 @@ export default defineConfig({
 						{ label: 'Give it memory', slug: 'guides/memory', translations: { 'zh-CN': '让它拥有记忆' } },
 						{ label: 'Connect a memory backend', slug: 'guides/memory-backends', translations: { 'zh-CN': '接入记忆后端' } },
 						{ label: 'Sub-agents', slug: 'guides/sub-agents', translations: { 'zh-CN': '子代理' } },
+						{ label: 'Expert agents', slug: 'guides/expert-agents', translations: { 'zh-CN': '专家智能体' } },
 						{ label: 'Workflows', slug: 'guides/workflows', translations: { 'zh-CN': '工作流' } },
 						{ label: 'Automate with hooks', slug: 'guides/hooks', translations: { 'zh-CN': '用 Hooks 自动化' } },
 						{ label: 'Bridge to chat apps', slug: 'guides/channels', translations: { 'zh-CN': '接入聊天应用' } },

--- a/docs/src/content/docs/guides/expert-agents.md
+++ b/docs/src/content/docs/guides/expert-agents.md
@@ -1,0 +1,175 @@
+---
+title: Expert Agents
+description: Create and use specialised agents — each with their own persona, tool set, and skills — for different kinds of work.
+---
+
+Expert agents let you partition work across specialised personas. Instead of one
+agent that juggles code review, debugging, research, and writing all at once, you
+create one agent per role — each with its own system prompt, tool allowlist, and
+skill set.
+
+## Quick start
+
+Create a code-review agent through the Web UI or conversation:
+
+```bash
+# Via the CLI
+octo chat --agent code-review "review the diff"
+```
+
+The Web UI also has an **Agents** panel (`/agents`) where you can create, edit,
+and delete expert agents — plus bind them to IM channels.
+
+## Creating an agent
+
+### From the Web UI
+
+1. Open the **Agents** panel (sidebar → Agents, or press `Cmd+K` → "Agents").
+2. Click **New Agent**.
+3. Fill in:
+   - **Name** — how it appears in the sidebar and agent picker.
+   - **Description** — shown in the agent list. Required.
+   - **System Prompt** — the persona. Write what the agent is, what it does, and
+     how it should behave. This replaces the Default Agent's identity layers
+     (soul.md, user.md).
+   - **Model** — leave empty to use the default model, or pick a specific one.
+   - **Tools** — check the tools the agent may use. Leave all unchecked to
+     grant full tool access (Default Agent behaviour).
+   - **Skills** — check the skills the agent may load on demand.
+4. Click **Save**.
+
+### From conversation
+
+Ask the Default Agent:
+
+> Create a code-review agent with read-only file access. Give it the
+> code-review skill.
+
+The Default Agent uses the `expert-agent-manager` skill to create and configure
+the agent through the same underlying API.
+
+## How expert agents differ from the Default Agent
+
+| Aspect | Default Agent | Expert Agent |
+|--------|:---:|:---:|
+| Persona | `~/.octo/soul.md` + `~/.octo/user.md` | Profile's system prompt (standalone) |
+| User rules | `~/.octo/octorules.md` + `.octorules` | ❌ Skipped |
+| Tools | Full toolbelt | Per-profile allowlist |
+| Skills | All available skills | Per-profile allowlist; system skills hidden |
+| MCP servers | All connected | Per-profile allowlist |
+| Session pool | Own pool | Own pool, isolated by `<agentID>#` key prefix |
+| Management | Creates/edits/deletes expert agents | Cannot modify profiles or install skills |
+
+The key principle: an expert agent's system prompt **stands alone**. It does not
+inherit the Default Agent's persona (soul.md), user profile (user.md), or user
+conventions (octorules.md). If you want your expert agent to follow those rules,
+include them directly in its system prompt.
+
+## Using expert agents
+
+### Web — new session picker
+
+The sidebar's "New Session" button has a caret (▼) on the right side. Click it to
+pick which agent handles the new session. Sessions, once created, are permanently
+bound to the chosen agent — switch agents by opening a new session.
+
+Each session in the sidebar is tagged with its agent name.
+
+### IM channels — @-mentions and bindings
+
+Bind an expert agent to a channel so messages route to it automatically:
+
+```
+/bind code-review
+```
+
+In group chats with multiple bound agents, use `@review` to address a specific
+one:
+
+```
+@review can you check this diff?
+```
+
+An agent without a channel binding can still be reached via `@mention` in any chat
+where the bot is present.
+
+### CLI
+
+```bash
+# Start an interactive session
+octo --agent code-review
+
+# One-shot
+octo --agent code-review -p "review the latest commit"
+
+# List available agents
+octo --agent
+# → agent "code-review" not found (available: default, code-review, ops-helper)
+```
+
+### TUI
+
+Use `/agent` inside an interactive session to list or switch agents:
+
+```
+/agent                # list available agents
+/agent code-review    # switch to code-review (creates a new session)
+```
+
+## Per-agent tool and skill filtering
+
+When you create an expert agent, you pick which tools and skills it can use. At
+runtime:
+
+- **Tools** are filtered on every turn — an expert agent only sees the tools in
+  its allowlist. An empty allowlist means "all tools" (like the Default Agent).
+- **Skills** are filtered in the system prompt manifest. System-level skills
+  (`skill-creator`, `expert-agent-manager`, `channel-manager`, etc.) are
+  automatically hidden from expert agents — they only make sense for the
+  Default Agent.
+- **Browser-recorded skills** are hidden unless the `browser` tool is in the
+  agent's allowlist.
+
+## Per-agent session isolation
+
+Each agent has its own session pool, separated by an `<agentID>#` prefix on the
+session key. This means:
+
+- A chat bound to `code-review` has its own history, `/bind`, `/list`, and `/stop`
+  — independent of the Default Agent's sessions in the same chat.
+- Existing sessions are never migrated; they stay with whichever agent created
+  them.
+- Old sessions from before the multi-agent upgrade belong to the Default Agent.
+
+## Sub-agents can use expert profiles
+
+The `sub_agent` tool accepts `subagent_type` to dispatch a child agent with a
+specific profile's capability set:
+
+```
+sub_agent(subagent_type: "code-review", prompt: "review the diff")
+```
+
+This runs a fresh, ephemeral sub-agent with the code-review profile's tools and
+system prompt — it never enters that agent's session pool.
+
+## Cron tasks and agent ownership
+
+Cron tasks are owned by the agent that created them. In the Web UI's Tasks panel:
+
+- The **Agent** column shows which agent owns each cron task.
+- Default Agent users see a **Transfer** action to reassign a task to another agent.
+- Filter by `?agent_id=` to see one agent's tasks.
+
+## Best practices
+
+- **One agent, one job**: "code-review", not "dev-ops-review-writer". Narrow
+  personas make prompts shorter and results better.
+- **Start with a clear system prompt**: two or three sentences about what the
+  agent is and isn't. You can always refine it later.
+- **Restrict tools**: only check the tools the agent genuinely needs. An agent
+  that only reviews code doesn't need `terminal` or `write_file`.
+- **Give it exactly one or two skills**: the skill description is the model's
+  trigger cue — don't drown the signal.
+- **Test with a one-shot**: before binding an agent to a channel, try `octo
+  --agent new-agent -p "test prompt"` to see how it responds.

--- a/docs/src/content/docs/zh/guides/expert-agents.md
+++ b/docs/src/content/docs/zh/guides/expert-agents.md
@@ -1,0 +1,160 @@
+---
+title: 专家智能体
+description: 创建和使用专精智能体——每个拥有独立的角色、工具集和技能——应对不同类型的工作。
+---
+
+专家智能体让你把工作划分到不同专精角色上。与其让一个智能体同时处理代码审查、调试、
+调研和文档撰写，不如为每种角色各创建一个——每个智能体有自己的 system prompt、
+工具白名单和技能集合。
+
+## 快速上手
+
+通过 Web UI 或对话创建代码审查智能体：
+
+```bash
+# CLI 方式
+octo chat --agent code-review "review the diff"
+```
+
+Web UI 也有 **Agents** 面板（`/agents`）用于创建、编辑和删除专家智能体，
+还可以把它们绑定到 IM 频道。
+
+## 创建智能体
+
+### Web UI
+
+1. 打开 **Agents** 面板（侧边栏 → Agents，或按 `Cmd+K` → "Agents"）。
+2. 点击 **New Agent**。
+3. 填写：
+   - **Name** — 在侧边栏和智能体选择器中显示的名称。
+   - **Description** — 在列表中显示的描述，必填。
+   - **System Prompt** — 角色定义。描述这个智能体是什么、做什么、怎么做。
+     这会**替换** Default Agent 的身份层（soul.md、user.md）。
+   - **Model** — 留空使用默认模型，或指定特定模型。
+   - **Tools** — 勾选此智能体可以使用的工具。全部不勾选 = 授予全部工具
+     （Default Agent 行为）。
+   - **Skills** — 勾选此智能体可加载的技能。
+4. 点击 **Save**。
+
+### 对话中创建
+
+直接对 Default Agent 说：
+
+> 帮我创建一个代码审查智能体，只需要只读文件权限，加上 code-review 技能。
+
+Default Agent 会通过 `expert-agent-manager` 技能调用 REST API 完成创建。
+
+## 专家智能体与 Default Agent 的区别
+
+| 维度 | Default Agent | Expert Agent |
+|------|:---:|:---:|
+| 角色 | `~/.octo/soul.md` + `~/.octo/user.md` | profile 的 system prompt（独立） |
+| 用户规则 | `~/.octo/octorules.md` + `.octorules` | ❌ 不注入 |
+| 工具 | 完整工具集 | profile 白名单 |
+| 技能 | 全部可用技能 | profile 白名单；系统技能自动隐藏 |
+| MCP 服务 | 全部连接 | profile 白名单 |
+| 会话池 | 独立池 | 独立池，通过 `<agentID>#` key 前缀隔离 |
+| 管理权限 | 创建/编辑/删除专家智能体 | 不能修改 profile 或安装技能 |
+
+核心原则：**专家智能体的 system prompt 是独立的**。它不会继承 Default Agent
+的角色（soul.md）、用户档案（user.md）或用户规则（octorules.md）。如果你希望
+专家智能体也遵循这些规则，需要直接写进它的 system prompt 中。
+
+## 使用专家智能体
+
+### Web — 新建会话时选择
+
+侧边栏"新会话"按钮右侧有一个下拉箭头（▼），点击可选择由哪个智能体处理新会话。
+会话创建后**永久绑定**给选定的智能体——要切换智能体，开一个新会话即可。
+
+侧边栏中每条会话都标记了所属智能体的标签。
+
+### IM 频道 — @ 提及与频道绑定
+
+把专家智能体绑定到频道后，消息会自动路由到它：
+
+```
+/bind code-review
+```
+
+在绑定了多个智能体的群聊中，用 `@review` 指定目标：
+
+```
+@review 帮我看看这个 diff
+```
+
+没有频道绑定的智能体可以通过 `@mention` 在任何 bot 所在的聊天中被呼叫。
+
+### CLI
+
+```bash
+# 启动交互会话
+octo --agent code-review
+
+# 一次性任务
+octo --agent code-review -p "review the latest commit"
+
+# 列出可用智能体
+octo --agent
+# → agent "code-review" not found (available: default, code-review, ops-helper)
+```
+
+### TUI
+
+在交互会话中使用 `/agent` 命令：
+
+```
+/agent                # 列出可用智能体
+/agent code-review    # 切换到 code-review（创建新会话）
+```
+
+## 单智能体工具与技能过滤
+
+创建专家智能体时，你可以选择它能使用哪些工具和技能。运行时：
+
+- **工具**每轮自动过滤——专家智能体只看得到 allowlist 中的工具。
+  空 allowlist = 全部工具可用（同 Default Agent）。
+- **技能**在 system prompt manifest 中按 profile 过滤。系统级技能
+  （`skill-creator`、`expert-agent-manager`、`channel-manager` 等）自动对
+  专家智能体隐藏——它们只对 Default Agent 有意义。
+- **浏览器录制的技能**在智能体的 allowlist 不含 `browser` 工具时自动隐藏。
+
+## 智能体会话隔离
+
+每个智能体有独立的会话池，通过 `<agentID>#` 前缀区分。这意味着：
+
+- 绑定到 `code-review` 的聊天有自己独立的 history、`/bind`、`/list`、`/stop`
+  ——与同聊天中 Default Agent 的会话互不干扰。
+- 已有会话不会迁移，始终归属于创建它的智能体。
+- 多智能体升级前的旧会话归属于 Default Agent。
+
+## 子智能体可使用专家 profile
+
+`sub_agent` 工具接受 `subagent_type` 参数来启动具有特定 profile 能力集的子智能体：
+
+```
+sub_agent(subagent_type: "code-review", prompt: "review the diff")
+```
+
+它会启动一个全新的、临时的子智能体，使用 code-review profile 的 tool 和 system
+prompt——不会进入该智能体的会话池。
+
+## Cron 任务的智能体归属
+
+cron 任务归属于创建它的智能体。在 Web UI 的 Tasks 面板中：
+
+- **Agent** 列显示每个 cron 任务归属于哪个智能体。
+- Default Agent 用户可看到 **Transfer** 操作，可将任务转移给其他智能体。
+- 通过 `?agent_id=` 参数过滤特定智能体的任务。
+
+## 最佳实践
+
+- **一个智能体、一件事**：叫"code-review"而不是"dev-ops-review-writer"。
+  窄角色的 prompt 更短、效果更好。
+- **system prompt 先写清晰**：两三句话描述这个智能体是什么、不是什么。
+  后续随时可以优化。
+- **限制工具**：只勾选智能体真正需要的工具。只做代码审查的智能体不需要
+  `terminal` 或 `write_file`。
+- **只给一两个技能**：技能描述是模型的触发信号——不要淹没它。
+- **先用 one-shot 测试**：绑定到频道前，先 `octo --agent new-agent -p "测试提示"`
+  看看响应是否符合预期。


### PR DESCRIPTION
User-facing guide covering:
- Creating expert agents via Web UI or conversation
- How expert agents differ from Default Agent (identity layers,
  tool/skill filtering, session isolation)
- Using expert agents across Web, IM, CLI, and TUI
- Sub-agents with expert profiles, cron ownership, best practices

Also registered in the Guides sidebar navigation.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
