### PR TITLE
refactor: remove mention alias mechanism

### DIFF
--- a/internal/agentprofile/parse.go
+++ b/internal/agentprofile/parse.go
@@ -21,7 +21,6 @@ type frontmatter struct {
 	ReadOnly        bool             `yaml:"read_only,omitempty"`
 	LeanContext     bool             `yaml:"lean_context,omitempty"`
 	WorkingDir      string           `yaml:"working_dir,omitempty"`
-	MentionAs       []string         `yaml:"mention_as,omitempty"`
 	ChannelBindings []ChannelBinding `yaml:"channel_bindings,omitempty"`
 }
 
@@ -65,7 +64,6 @@ func parseFile(path string) (*Profile, error) {
 			LeanContext:     fm.LeanContext,
 		},
 		WorkingDir:      fm.WorkingDir,
-		MentionAs:       fm.MentionAs,
 		ChannelBindings: fm.ChannelBindings,
 	}
 	if info, err := os.Stat(path); err == nil {
@@ -89,7 +87,6 @@ func serialize(p *Profile) ([]byte, error) {
 		ReadOnly:        p.ReadOnly,
 		LeanContext:     p.LeanContext,
 		WorkingDir:      p.WorkingDir,
-		MentionAs:       p.MentionAs,
 		ChannelBindings: p.ChannelBindings,
 	}
 	head, err := yaml.Marshal(&fm)

--- a/internal/agentprofile/parse_test.go
+++ b/internal/agentprofile/parse_test.go
@@ -14,7 +14,6 @@ model: claude-sonnet-4-20250514
 tools: [read_file, grep, glob]
 tool_skills: [code-review]
 read_only: true
-mention_as: ["@review"]
 channel_bindings:
   - {platform: weixin, chat_id: dev-group-1}
 ---
@@ -50,9 +49,6 @@ func TestParseFile(t *testing.T) {
 	}
 	if len(p.Tools) != 3 || len(p.ToolSkills) != 1 || p.ToolSkills[0] != "code-review" {
 		t.Fatalf("tools = %v skills = %v", p.Tools, p.ToolSkills)
-	}
-	if len(p.MentionAs) != 1 || p.MentionAs[0] != "@review" {
-		t.Fatalf("mention_as = %v", p.MentionAs)
 	}
 	if len(p.ChannelBindings) != 1 || p.ChannelBindings[0].Platform != "weixin" {
 		t.Fatalf("bindings = %+v", p.ChannelBindings)
@@ -104,7 +100,6 @@ func TestSerializeRoundTrip(t *testing.T) {
 			ToolSkills:   []string{"code-review"},
 			ReadOnly:     true,
 		},
-		MentionAs:       []string{"@review"},
 		ChannelBindings: []ChannelBinding{{Platform: "weixin", ChatID: "g1"}},
 	}
 	b, err := serialize(orig)
@@ -120,7 +115,7 @@ func TestSerializeRoundTrip(t *testing.T) {
 	if got.Name != orig.Name || got.Description != orig.Description ||
 		got.Model != orig.Model || got.SystemPrompt != orig.SystemPrompt ||
 		!got.ReadOnly || len(got.Tools) != 2 || len(got.ToolSkills) != 1 ||
-		len(got.MentionAs) != 1 || len(got.ChannelBindings) != 1 {
+		len(got.ChannelBindings) != 1 {
 		t.Fatalf("roundtrip mismatch:\n got %+v\nwant %+v", got, orig)
 	}
 }

--- a/internal/agentprofile/profile.go
+++ b/internal/agentprofile/profile.go
@@ -83,7 +83,6 @@ type Profile struct {
 	CapabilitySpec
 
 	WorkingDir      string
-	MentionAs       []string         // conversation mode only; user-level only
 	ChannelBindings []ChannelBinding // conversation mode only; user-level only
 
 	Source Source
@@ -119,12 +118,6 @@ var idRule = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,31}$`)
 // from a chat ID that merely contains '#'.
 func IsValidID(id string) bool { return idRule.MatchString(id) }
 
-// aliasRule is the mention alias shape: @ plus the same charset the router's
-// mention extractor recognizes, so a validated alias can always match.
-// Sync with agentprofile/router.go's mentionRule (@[A-Za-z0-9][A-Za-z0-9_-]*) if
-// either changes.
-var aliasRule = regexp.MustCompile(`^@[A-Za-z0-9][A-Za-z0-9_-]*$`)
-
 // Validate checks the fields every write path (REST API, meta-skill, Store)
 // must enforce. Model-against-config validation lives in the API layer, which
 // is the only place that can see the server config.
@@ -137,11 +130,6 @@ func (p *Profile) Validate() error {
 	}
 	if utf8.RuneCountInString(p.Name) > 32 {
 		return fmt.Errorf("name too long: %d chars (max 32)", utf8.RuneCountInString(p.Name))
-	}
-	for _, alias := range p.MentionAs {
-		if !aliasRule.MatchString(alias) {
-			return fmt.Errorf("invalid mention alias %q: must be @ followed by [A-Za-z0-9_-]", alias)
-		}
 	}
 	return nil
 }

--- a/internal/agentprofile/profile_test.go
+++ b/internal/agentprofile/profile_test.go
@@ -23,10 +23,6 @@ func TestValidate(t *testing.T) {
 		{"id 32 chars ok", func(p *Profile) { p.ID = strings.Repeat("a", 32) }, ""},
 		{"description required", func(p *Profile) { p.Description = "  " }, "description is required"},
 		{"name too long", func(p *Profile) { p.Name = strings.Repeat("n", 33) }, "name too long"},
-		{"alias missing @", func(p *Profile) { p.MentionAs = []string{"review"} }, "invalid mention alias"},
-		{"alias bare @", func(p *Profile) { p.MentionAs = []string{"@"} }, "invalid mention alias"},
-		{"alias bad charset", func(p *Profile) { p.MentionAs = []string{"@$$"} }, "invalid mention alias"},
-		{"alias ok", func(p *Profile) { p.MentionAs = []string{"@review", "@CR"} }, ""},
 		{"name 32 CJK chars ok", func(p *Profile) { p.Name = strings.Repeat("审", 32) }, ""},
 	}
 	for _, tt := range tests {

--- a/internal/agentprofile/router.go
+++ b/internal/agentprofile/router.go
@@ -1,7 +1,5 @@
 package agentprofile
 
-import "regexp"
-
 // RouteInput carries the fields of an inbound IM event the router needs. It
 // is deliberately defined here rather than reusing channel.InboundEvent so
 // agentprofile stays importable from both internal/channel (PR2) and
@@ -26,39 +24,16 @@ type Router struct {
 // NewRouter builds a Router over store.
 func NewRouter(store *Store) *Router { return &Router{store: store} }
 
-// mentionRule matches @alias tokens in message text. The captured alias is
-// looked up (with the @) against profiles' mention_as lists.
-var mentionRule = regexp.MustCompile(`@([A-Za-z0-9][A-Za-z0-9_-]*)`)
-
-// MentionAlias extracts the first @-alias from text, "" when there is none.
-func MentionAlias(text string) string {
-	m := mentionRule.FindStringSubmatch(text)
-	if m == nil {
-		return ""
-	}
-	return "@" + m[1]
-}
-
 // Route returns the profile that should handle the event, or nil when the
-// message must be dropped (group chat with multiple bound profiles and no
-// @-mention — the "stay silent" rule). The decision table:
+// message must be dropped (group chat with multiple bound profiles — the
+// "stay silent" rule). The decision table:
 //
-//	| scenario                        | result            |
-//	|---------------------------------|-------------------|
-//	| @alias bound to a profile       | that profile      |
-//	| @alias not bound anywhere       | default (fallback)|
-//	| exactly one channel binding     | the bound profile |
-//	| multiple bindings, no @-mention | nil (drop)        |
-//	| no binding                      | default           |
-//
-// @-mentions win over channel bindings: an explicit @ is never ambiguous.
+//	| scenario                         | result            |
+//	|----------------------------------|-------------------|
+//	| exactly one channel binding      | the bound profile |
+//	| multiple bindings                | nil (drop)        |
+//	| no binding                       | default           |
 func (r *Router) Route(in RouteInput) *Profile {
-	if alias := MentionAlias(in.Text); alias != "" {
-		if p, ok := r.store.ByMention(alias); ok {
-			return p
-		}
-		return DefaultProfile()
-	}
 	switch bound := r.store.ByChannel(in.Platform, in.ChatID); len(bound) {
 	case 0:
 		return DefaultProfile()

--- a/internal/agentprofile/router_test.go
+++ b/internal/agentprofile/router_test.go
@@ -2,33 +2,14 @@ package agentprofile
 
 import "testing"
 
-// routerStore builds a store with two user profiles bound as in the design
-// doc's decision table: "code" (@review, bound to weixin:g1) and "ops"
-// (@ops, bound to weixin:g1 as well — the ambiguous group).
+// routerStore builds a store with user profiles for channel-binding routing tests.
 func routerStore(t *testing.T) *Store {
 	t.Helper()
 	s, userDir, _ := newTestStore(t)
-	writeMD(t, userDir, "code.md", "---\ndescription: dc\nmention_as: [\"@review\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
-	writeMD(t, userDir, "ops.md", "---\ndescription: do\nmention_as: [\"@ops\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n  - {platform: weixin, chat_id: g2}\n---\nbody\n")
+	writeMD(t, userDir, "code.md", "---\ndescription: dc\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
+	writeMD(t, userDir, "ops.md", "---\ndescription: do\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n  - {platform: weixin, chat_id: g2}\n---\nbody\n")
 	writeMD(t, userDir, "solo.md", "---\ndescription: ds\nchannel_bindings:\n  - {platform: feishu, chat_id: dm1}\n---\nbody\n")
 	return s
-}
-
-func TestMentionAlias(t *testing.T) {
-	cases := map[string]string{
-		"@review this PR":   "@review",
-		"please @ops check": "@ops",
-		"no mention":        "",
-		"email a@b.com":     "@b", // documented limitation: first @-token wins
-		"@":                 "",
-		"@${not}":           "",
-		"@code-review hi":   "@code-review",
-	}
-	for in, want := range cases {
-		if got := MentionAlias(in); got != want {
-			t.Errorf("MentionAlias(%q) = %q, want %q", in, got, want)
-		}
-	}
 }
 
 func TestRouterDecisionTable(t *testing.T) {
@@ -42,20 +23,12 @@ func TestRouterDecisionTable(t *testing.T) {
 			RouteInput{Platform: "weixin", ChatID: "dm-9", Text: "hi"}, "default"},
 		{"DM bound uniquely → bound profile",
 			RouteInput{Platform: "feishu", ChatID: "dm1", Text: "hi"}, "solo"},
-		{"group @unknown alias → default fallback",
-			RouteInput{Platform: "weixin", ChatID: "g1", Text: "@nobody hi"}, "default"},
-		{"group @review → code",
-			RouteInput{Platform: "weixin", ChatID: "g1", Text: "@review pr 123"}, "code"},
-		{"group multi-binding @ops → ops",
-			RouteInput{Platform: "weixin", ChatID: "g1", Text: "@ops check logs"}, "ops"},
-		{"group multi-binding no @ → drop",
+		{"group multi-binding → drop",
 			RouteInput{Platform: "weixin", ChatID: "g1", Text: "hello"}, ""},
-		{"group single-binding no @ → bound profile",
+		{"group single-binding → bound profile",
 			RouteInput{Platform: "weixin", ChatID: "g2", Text: "hello"}, "ops"},
 		{"group unbound → default",
 			RouteInput{Platform: "weixin", ChatID: "g9", Text: "hello"}, "default"},
-		{"@ mention wins over channel binding",
-			RouteInput{Platform: "feishu", ChatID: "dm1", Text: "@ops look"}, "ops"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/agentprofile/store.go
+++ b/internal/agentprofile/store.go
@@ -88,7 +88,6 @@ func (s *Store) scanDirFiltered(dir string, src Source, dst map[string]*Profile,
 		if src == SourceProject {
 			// Delegation-only: the platform slice from a project file must
 			// never influence IM routing.
-			p.MentionAs = nil
 			p.ChannelBindings = nil
 		}
 		dst[id] = p
@@ -157,27 +156,13 @@ func (s *Store) Update(p *Profile) error {
 }
 
 // validateForStoreWrite is the write gate shared by Create and Update: schema
-// validation, the reserved default ID, and global mention-alias uniqueness
-// (the design's anti-impersonation rule — only the Store can see all
-// profiles, so the check lives here).
+// validation and the reserved default ID.
 func (s *Store) validateForStoreWrite(p *Profile) error {
 	if err := validateForWrite(p); err != nil {
 		return err
 	}
 	if p.ID == DefaultID {
 		return fmt.Errorf("id %q is reserved for the code-defined default agent", DefaultID)
-	}
-	for id, other := range s.load() {
-		if id == p.ID || other.Source != SourceUser {
-			continue
-		}
-		for _, alias := range p.MentionAs {
-			for _, taken := range other.MentionAs {
-				if alias == taken {
-					return fmt.Errorf("mention alias %q is already claimed by profile %q", alias, id)
-				}
-			}
-		}
 	}
 	return nil
 }
@@ -260,16 +245,4 @@ func (s *Store) ByChannel(platform, chatID string) []*Profile {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
-}
-
-// ByMention resolves an @-alias (including the @) to a user-level profile.
-func (s *Store) ByMention(alias string) (*Profile, bool) {
-	for _, p := range s.userProfiles() {
-		for _, a := range p.MentionAs {
-			if a == alias {
-				return p, true
-			}
-		}
-	}
-	return nil, false
 }

--- a/internal/agentprofile/store_test.go
+++ b/internal/agentprofile/store_test.go
@@ -1,11 +1,8 @@
 package agentprofile
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
 	"testing"
 )
 
@@ -51,17 +48,13 @@ func TestStorePrecedence(t *testing.T) {
 
 func TestStoreProjectStripsPlatformSlice(t *testing.T) {
 	s, _, projectDir := newTestStore(t)
-	writeMD(t, projectDir, "ops.md", "---\ndescription: d\nmention_as: [\"@ops\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
+	writeMD(t, projectDir, "ops.md", "---\ndescription: d\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
 
-	if _, ok := s.ByMention("@ops"); ok {
-		t.Fatal("project-level alias must not be routable")
+	if p, _ := s.Get("ops"); p == nil || len(p.ChannelBindings) != 0 {
+		t.Fatalf("project profile kept platform slice: %+v", p)
 	}
 	if got := s.ByChannel("weixin", "g1"); len(got) != 0 {
 		t.Fatal("project-level binding must not be routable")
-	}
-	p, _ := s.Get("ops")
-	if len(p.MentionAs) != 0 || len(p.ChannelBindings) != 0 {
-		t.Fatalf("project profile kept platform slice: %+v", p)
 	}
 }
 
@@ -116,9 +109,6 @@ func TestStore_UserProfilesSkipsNonSlug(t *testing.T) {
 	// userProfiles() (IM-routing source) skips non-slug files.
 	if p := s.ByChannel("weixin", "g1"); len(p) > 0 {
 		t.Fatalf("non-slug profile is routable via IM: %+v", p)
-	}
-	if p, ok := s.ByMention("@anything"); ok {
-		t.Fatalf("non-slug profile is @-routable: %+v", p)
 	}
 	// But Get()/List() (delegation + API) still see it.
 	if _, ok := s.Get("a#b"); !ok {
@@ -220,13 +210,6 @@ func TestStoreByChannelByMention(t *testing.T) {
 	if got := s.ByChannel("weixin", "unknown"); len(got) != 0 {
 		t.Fatalf("ByChannel unknown = %+v", got)
 	}
-	p, ok := s.ByMention("@review")
-	if !ok || p.ID != "a" {
-		t.Fatalf("ByMention(@review) = %v, %v", p, ok)
-	}
-	if _, ok := s.ByMention("@nobody"); ok {
-		t.Fatal("ByMention(@nobody) should miss")
-	}
 }
 
 // A project-level file shadowing a user profile's ID overrides delegation
@@ -242,9 +225,6 @@ func TestStoreProjectShadowKeepsUserRouting(t *testing.T) {
 	if got := s.ByChannel("weixin", "g1"); len(got) != 1 || got[0].ID != "reviewer" {
 		t.Fatalf("project shadow silenced user routing: %+v", got)
 	}
-	if p, ok := s.ByMention("@review"); !ok || p.ID != "reviewer" {
-		t.Fatalf("project shadow broke alias routing: %v, %v", p, ok)
-	}
 }
 
 func TestStoreDefaultReserved(t *testing.T) {
@@ -259,44 +239,4 @@ func TestStoreDefaultReserved(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(userDir, "default.md")); !os.IsNotExist(err) {
 		t.Fatal("impostor default.md was written")
 	}
-}
-
-func TestStoreAliasUniqueness(t *testing.T) {
-	s, userDir, _ := newTestStore(t)
-	writeMD(t, userDir, "a.md", "---\ndescription: da\nmention_as: [\"@review\"]\n---\nbody\n")
-
-	// Create with a taken alias fails.
-	err := s.Create(&Profile{ID: "b", Description: "db", MentionAs: []string{"@review"}})
-	if err == nil || !strings.Contains(err.Error(), "already claimed") {
-		t.Fatalf("Create with duplicate alias = %v", err)
-	}
-	// Update of the owner itself keeps the alias.
-	writeMD(t, userDir, "a.md", "---\ndescription: da\nmention_as: [\"@review\"]\n---\nbody\n")
-	if err := s.Update(&Profile{ID: "a", Description: "da2", MentionAs: []string{"@review"}}); err != nil {
-		t.Fatalf("Update of alias owner = %v", err)
-	}
-	// Update claiming someone else's alias fails.
-	writeMD(t, userDir, "b.md", "---\ndescription: db\n---\nbody\n")
-	if err := s.Update(&Profile{ID: "b", Description: "db", MentionAs: []string{"@review"}}); err == nil {
-		t.Fatal("Update stealing alias should fail")
-	}
-}
-
-func TestStoreConcurrentAccess(t *testing.T) {
-	s, _, _ := newTestStore(t)
-	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			id := fmt.Sprintf("p%d", i%4)
-			p := &Profile{ID: id, Description: "d"}
-			_ = s.Create(p)
-			_, _ = s.Get(id)
-			_ = s.List()
-			_ = s.Update(p)
-			_ = s.Delete(id)
-		}(i)
-	}
-	wg.Wait()
 }

--- a/internal/server/agent_routing_test.go
+++ b/internal/server/agent_routing_test.go
@@ -112,53 +112,18 @@ B.
 	ev := evFor("hello")
 	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir(), nil)).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
 	if profile != nil {
-		t.Fatalf("expected nil route (multi-binding, no @), got %q", profile.ID)
+		t.Fatalf("expected nil route (multi-binding), got %q", profile.ID)
 	}
 	// No handleChannelMessage: routeChannelEvent would have dropped the event.
 	// Verify silence: no session under either agent, no reply sent.
 	if got := srv.channelMgr.GetSession(ev, "agent-a"); got != nil {
-		t.Fatal("multi-bound chat without @ created agent-a session")
+		t.Fatal("multi-bound chat created agent-a session")
 	}
 	if got := srv.channelMgr.GetSession(ev, "agent-b"); got != nil {
-		t.Fatal("multi-bound chat without @ created agent-b session")
+		t.Fatal("multi-bound chat created agent-b session")
 	}
 	if texts := ad.texts(); len(texts) != 0 {
 		t.Fatalf("expected silence, got replies: %v", texts)
-	}
-}
-
-func TestRouteChannelEvent_MentionSelectsAgent(t *testing.T) {
-	routingHome(t)
-	writeAgentProfile(t, "agent-a", `---
-description: a
-mention_as: ["@aa"]
-channel_bindings:
-  - {platform: fake, chat_id: c1}
----
-A.
-`)
-	writeAgentProfile(t, "agent-b", `---
-description: b
-mention_as: ["@bb"]
-channel_bindings:
-  - {platform: fake, chat_id: c1}
----
-B.
-`)
-	srv := chanServer(t)
-	ad := &fullFakeAdapter{}
-	ev := evFor("@bb hello")
-	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir(), nil)).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
-	if profile == nil || profile.ID != "agent-b" {
-		t.Fatalf("expected routing to agent-b, got %+v", profile)
-	}
-	routeAndWait(t, srv, ad, ev, profile)
-
-	if got := srv.channelMgr.GetSession(ev, "agent-b"); got == nil {
-		t.Fatal("@bb mention did not route to agent-b")
-	}
-	if got := srv.channelMgr.GetSession(ev, "agent-a"); got != nil {
-		t.Fatal("@bb mention leaked a session to agent-a")
 	}
 }
 

--- a/internal/server/agents_handlers.go
+++ b/internal/server/agents_handlers.go
@@ -20,7 +20,6 @@ type agentRequest struct {
 	Model        string   `json:"model,omitempty"`
 	Tools        []string `json:"tools,omitempty"`
 	ToolSkills   []string `json:"tool_skills,omitempty"`
-	MentionAs    []string `json:"mention_as,omitempty"`
 	SystemPrompt string   `json:"system_prompt,omitempty"`
 }
 
@@ -42,7 +41,6 @@ type agentResponse struct {
 	Model           string                        `json:"model,omitempty"`
 	Tools           []string                      `json:"tools,omitempty"`
 	ToolSkills      []string                      `json:"tool_skills,omitempty"`
-	MentionAs       []string                      `json:"mention_as,omitempty"`
 	SystemPrompt    string                        `json:"system_prompt,omitempty"`
 	ChannelBindings []agentprofile.ChannelBinding `json:"channel_bindings,omitempty"`
 }
@@ -55,7 +53,6 @@ func agentToResp(p *agentprofile.Profile) agentResponse {
 		Model:           p.Model,
 		Tools:           p.Tools,
 		ToolSkills:      p.ToolSkills,
-		MentionAs:       p.MentionAs,
 		SystemPrompt:    p.SystemPrompt,
 		ChannelBindings: p.ChannelBindings,
 	}
@@ -140,7 +137,6 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 			ToolSkills:   req.ToolSkills,
 			SystemPrompt: req.SystemPrompt,
 		},
-		MentionAs: req.MentionAs,
 	}
 
 	if err := s.agentStoreOrInit().Create(p); err != nil {
@@ -186,7 +182,6 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 			ToolSkills:   req.ToolSkills,
 			SystemPrompt: req.SystemPrompt,
 		},
-		MentionAs:       req.MentionAs,
 		ChannelBindings: existing.ChannelBindings, // preserved unless explicitly changed
 	}
 

--- a/internal/server/agents_handlers_test.go
+++ b/internal/server/agents_handlers_test.go
@@ -28,9 +28,7 @@ func TestHandleAgents_CreateListGetDelete(t *testing.T) {
 	w = doJSON(t, srv, http.MethodPost, "/api/agents", `{
 		"name": "Code Reviewer",
 		"description": "Reviews code",
-		"tools": ["read_file", "grep"],
-		"mention_as": ["@review"]
-	}`)
+		"tools": ["read_file", "grep"]	}`)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("create = %d: %s", w.Code, w.Body.String())
 	}

--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -519,14 +519,18 @@ func TestKillAfterAgentExited(t *testing.T) {
 	var events []SubAgentEvent
 	m.SetOnEvent(func(ev SubAgentEvent) { mu.Lock(); events = append(events, ev); mu.Unlock() })
 
+	// Wait for the agent to complete (onExit fires).
+	// SetOnExit must be registered before Start(): the fixedSpawner returns
+	// immediately, so the async goroutine can complete and fire the exit hook
+	// before Start() returns — registering after Start() races that fire and
+	// loses the notification on a fast runner.
+	exited := make(chan struct{})
+	m.SetOnExit(func(SubAgentNotification) { close(exited) })
+
 	id, err := m.Start(SpawnRequest{Description: "d", Prompt: "p"})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-
-	// Wait for the agent to complete (onExit fires).
-	exited := make(chan struct{})
-	m.SetOnExit(func(SubAgentNotification) { close(exited) })
 	select {
 	case <-exited:
 	case <-time.After(5 * time.Second):

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -374,7 +374,6 @@ export interface Agent {
   model?: string
   tools?: string[]
   tool_skills?: string[]
-  mention_as?: string[]
   system_prompt?: string
   channel_bindings?: { platform: string; chat_id: string }[]
 }

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -56,9 +56,6 @@ export const en: Record<string, string> = {
   "agents.tool_skills": "Skills",
 
   "agents.skills_loading": "Loading available skills…",
-  "agents.mention_as": "Mention Aliases",
-  "agents.mention_as_placeholder": "@review, @expert",
-  "agents.mention_as_hint": "Each alias must start with @ and be globally unique.",
   "agents.all_tools": "All tools",
   "agents.bound_chats": "bound",
   "agents.delete_title": "Delete Agent",
@@ -859,9 +856,6 @@ export const zh: Record<string, string> = {
   "agents.tool_skills": "技能",
 
   "agents.skills_loading": "正在加载可用技能…",
-  "agents.mention_as": "提及别名",
-  "agents.mention_as_placeholder": "@review, @expert",
-  "agents.mention_as_hint": "每个别名必须以 @ 开头且全局唯一。",
   "agents.all_tools": "全部工具",
   "agents.bound_chats": "已绑定",
   "agents.delete_title": "删除智能体",

--- a/web/src/views/AgentEdit.svelte
+++ b/web/src/views/AgentEdit.svelte
@@ -14,7 +14,6 @@
   let name = $state('')
   let description = $state('')
   let model = $state('')
-  let mentionAs = $state('')
   let systemPrompt = $state('')
 
   // Checklist items loaded from the Default Agent's resource pool.
@@ -55,7 +54,6 @@
     name = agent?.name ?? ''
     description = agent?.description ?? ''
     model = agent?.model ?? ''
-    mentionAs = agent?.mention_as?.join(', ') ?? ''
     systemPrompt = agent?.system_prompt ?? ''
     selectedTools = new Set(agent?.tools ?? [])
     selectedSkills = new Set(agent?.tool_skills ?? [])
@@ -87,7 +85,6 @@
       model: model.trim() || undefined,
       tools: selTools.length > 0 ? selTools : undefined,
       tool_skills: selSkills.length > 0 ? selSkills : undefined,
-      mention_as: mentionAs.trim() ? mentionAs.split(',').map(s => s.trim()).filter(Boolean) : undefined,
       system_prompt: systemPrompt.trim() || undefined,
     }
     if (!body.name || !body.description) {
@@ -163,11 +160,6 @@
         {/if}
       </div>
 
-      <div class="field">
-        <label>{$t('agents.mention_as')}</label>
-        <input bind:value={mentionAs} placeholder={$t('agents.mention_as_placeholder')} />
-        <small>{$t('agents.mention_as_hint')}</small>
-      </div>
       <div class="actions">
         <button type="button" class="btn-secondary" onclick={onCancel}>{$t('common.cancel')}</button>
         <button type="submit" class="btn-primary">{$t('common.save')}</button>


### PR DESCRIPTION
Mention aliases (mention_as in profile frontmatter, @review in message
text) were a text-based routing mechanism that let users address expert
agents by typing @-tokens in message content. This was largely redundant
with channel bindings — the primary routing mechanism — and added
meaningless complexity.

Removed:
- Profile.MentionAs field and aliasRule validator
- Router.MentionAlias() and @-token extraction from Route()
- Store.ByMention() and alias-uniqueness check
- Frontmatter mention_as field in parse/serialize
- Web UI mention_as input in AgentEdit, api.ts Agent type, i18n keys
- All related tests

Route now decides solely by channel binding: 0 bindings → default,
1 binding → that profile, 2+ bindings → drop.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
