### PR TITLE
docs: remove mention alias content from expert agents guide

### DIFF
--- a/docs/src/content/docs/guides/expert-agents.md
+++ b/docs/src/content/docs/guides/expert-agents.md
@@ -75,7 +75,7 @@ bound to the chosen agent — switch agents by opening a new session.
 
 Each session in the sidebar is tagged with its agent name.
 
-### IM channels — @-mentions and bindings
+### IM channels — channel bindings
 
 Bind an expert agent to a channel so messages route to it automatically:
 
@@ -83,15 +83,8 @@ Bind an expert agent to a channel so messages route to it automatically:
 /bind code-review
 ```
 
-In group chats with multiple bound agents, use `@review` to address a specific
-one:
-
-```
-@review can you check this diff?
-```
-
-An agent without a channel binding can still be reached via `@mention` in any chat
-where the bot is present.
+A group chat with multiple bound agents stays silent — bind only one
+agent per group, or keep the Default Agent for general use.
 
 ### CLI
 

--- a/docs/src/content/docs/zh/guides/expert-agents.md
+++ b/docs/src/content/docs/zh/guides/expert-agents.md
@@ -69,7 +69,7 @@ Default Agent 会通过 `expert-agent-manager` 技能调用 REST API 完成创�
 
 侧边栏中每条会话都标记了所属智能体的标签。
 
-### IM 频道 — @ 提及与频道绑定
+### IM 频道 — 频道绑定
 
 把专家智能体绑定到频道后，消息会自动路由到它：
 
@@ -77,13 +77,8 @@ Default Agent 会通过 `expert-agent-manager` 技能调用 REST API 完成创�
 /bind code-review
 ```
 
-在绑定了多个智能体的群聊中，用 `@review` 指定目标：
-
-```
-@review 帮我看看这个 diff
-```
-
-没有频道绑定的智能体可以通过 `@mention` 在任何 bot 所在的聊天中被呼叫。
+绑定多个智能体的群聊会保持静默——每个群只绑定一个智能体，
+或者保留 Default Agent 处理日常对话。
 
 ### CLI
 


### PR DESCRIPTION
After removing the mention_alias mechanism from the codebase, update
the user guide to reflect that routing is channel-binding only.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
