### PR TITLE
fix: expert agents with empty Tools now get zero tools in conversation mode

### DIFF
--- a/internal/agentprofile/profile.go
+++ b/internal/agentprofile/profile.go
@@ -56,7 +56,7 @@ const DefaultID = "default"
 type CapabilitySpec struct {
 	Model        string   // frontmatter model; empty = inherit the caller's
 	SystemPrompt string   // .md body (never carried in frontmatter)
-	Tools        []string // frontmatter tools allowlist; empty = all tools
+	Tools        []string // frontmatter tools allowlist; empty → builtin: all, user: none
 	ToolSkills   []string // frontmatter tool_skills: skills exposed as tools
 
 	// Delegation refinements, parsed for zero-migration compatibility with

--- a/internal/tools/profile_tools_test.go
+++ b/internal/tools/profile_tools_test.go
@@ -58,22 +58,47 @@ func TestDefaultToolsForProfile_FiltersByAllowlist(t *testing.T) {
 	}
 }
 
-func TestDefaultToolsForProfile_EmptyToolsReturnsAll(t *testing.T) {
+func TestDefaultToolsForProfile_BuiltinEmptyReturnsAll(t *testing.T) {
 	dir := t.TempDir()
 	store := agentprofile.New(dir, nil)
+	// All builtin agents (default, explore, general, code-review) have empty
+	// Tools and get the full toolbelt — they manage restrictions via ReadOnly
+	// and the system prompt.
+	for _, id := range []string{"default", "explore", "general", "code-review"} {
+		t.Run(id, func(t *testing.T) {
+			p, ok := store.Get(id)
+			if !ok {
+				t.Fatalf("builtin %q not found", id)
+			}
+			if p.Source != agentprofile.SourceBuiltin {
+				t.Fatalf("%q source = %s, want builtin", id, p.Source)
+			}
+			ctx := WithSessionAgentID(WithProfileStore(context.Background(), store), id)
+			all := DefaultToolsForProfile(ctx, "test-model")
+			if len(all) < 5 {
+				t.Fatalf("expected several tools for builtin %q with empty allowlist, got %d", id, len(all))
+			}
+		})
+	}
+}
+
+func TestDefaultToolsForProfile_ExpertEmptyReturnsNone(t *testing.T) {
+	dir := t.TempDir()
+	store := agentprofile.New(dir, nil)
+	// An expert agent without tools gets none.
 	if err := store.Create(&agentprofile.Profile{
-		ID:          "full",
-		Description: "all tools",
+		ID:          "expert-no-tools",
+		Description: "expert with no tools",
 		CapabilitySpec: agentprofile.CapabilitySpec{
-			Tools: []string{}, // empty = all
+			Tools: []string{}, // empty = no tools for user-created expert
 		},
 	}); err != nil {
 		t.Fatal(err)
 	}
-	ctx := WithSessionAgentID(WithProfileStore(context.Background(), store), "full")
-	all := DefaultToolsForProfile(ctx, "test-model")
-	if len(all) < 5 {
-		t.Fatalf("expected several tools with empty allowlist, got %d", len(all))
+	ctx := WithSessionAgentID(WithProfileStore(context.Background(), store), "expert-no-tools")
+	filtered := DefaultToolsForProfile(ctx, "test-model")
+	if len(filtered) != 0 {
+		t.Fatalf("expected zero tools for expert agent with empty allowlist, got %d: %v", len(filtered), toolNames(filtered))
 	}
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 )
 
 // tool is the internal interface every built-in tool implements — both a
@@ -576,6 +577,11 @@ func sessionAgentIDFromContext(ctx context.Context) string {
 // its allowlist. Otherwise it behaves like DefaultToolsForCtx — so callers
 // that don't wire a store see unchanged behavior. Resolved fresh per turn so
 // profile edits land on the next message without rebuilding anything.
+//
+// Empty Tools means different things depending on the agent source:
+//   - builtin (default, explore, general, code-review): empty = all tools
+//     (backward compatible; their behavior is managed via ReadOnly/LeanContext)
+//   - user-created / project: empty = no tools (explicitly restricted)
 func DefaultToolsForProfile(ctx context.Context, model string) []agent.ToolDefinition {
 	all := defaultToolsFor(ctx, model)
 	store := profileStoreFromContext(ctx)
@@ -584,8 +590,14 @@ func DefaultToolsForProfile(ctx context.Context, model string) []agent.ToolDefin
 		return all
 	}
 	profile, ok := store.Get(agentID)
-	if !ok || len(profile.Tools) == 0 {
+	if !ok {
 		return all
+	}
+	if len(profile.Tools) == 0 {
+		if profile.Source == agentprofile.SourceBuiltin {
+			return all
+		}
+		return nil
 	}
 	allowed := make(map[string]bool, len(profile.Tools))
 	for _, t := range profile.Tools {


### PR DESCRIPTION
## Problem

When an expert agent is created without tools (empty `Tools` field), it gets the full toolbelt in conversation mode (IM/Web). Expected: zero tools.

## Root Cause

`DefaultToolsForProfile` (registry.go:579) treated `len(profile.Tools) == 0` as "all tools" for every agent. The comment in profile.go said `empty = all tools` — correct for the builtin default agent, wrong for user-created expert agents.

## Fix

Empty `Tools` now means different things depending on `Source`:
- **builtin** (default, explore, general, code-review): all tools — backward compatible; their behavior is managed via ReadOnly / LeanContext
- **user-created / project**: no tools — explicitly restricted

The semantics for sub\_agent delegation (spawner.go filterChildTools) are unchanged: nil/empty allowed there means "inherit from parent," regardless of profile source. Only the conversation-mode path is affected.

## Changes

| File | Change |
|------|--------|
| `internal/tools/registry.go` | Add `agentprofile` import; split the empty-Tools branch by `profile.Source` |
| `internal/tools/profile_tools_test.go` | Replace `EmptyToolsReturnsAll` with `BuiltinEmptyReturnsAll` (4 sub-tests) + `ExpertEmptyReturnsNone` |
| `internal/agentprofile/profile.go` | Update comment on `Tools` field |