### PR TITLE
feat(tools): filter MCP manifest by profile bridge access + expert prompt banner

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -931,7 +931,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// (mcpBoot below), so this still evaluates to "" at first paint for TUI —
 	// cfg.recomposeMCPManifest (wired below) redoes this once mcpReadyMsg
 	// fires and the registry is actually live.
-	mcpManifest := tools.MCPManifestFor(resolvedModel)
+	mcpManifest := tools.MCPManifestFor(resolvedModel, agentProfile)
 
 	// Inject the project's MEMORY.md (plus the manage-it-yourself instruction)
 	// into the system prompt. The agent reads/writes the rest of the memory
@@ -1017,7 +1017,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			// MCP manifest against a.Model (may differ from resolvedModel — a
 			// saved session can override it above) so the Tool Search
 			// activation gate matches the model actually in use.
-			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, agentProfile != nil && agentProfile.SystemPrompt != "")
+			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model, agentProfile), memInjection, coauthor, agentProfile != nil && agentProfile.SystemPrompt != "")
 		} else {
 			sess = agent.NewSession(resolvedModel, *system)
 			sess.Bind(agent.EntryTUI, false)
@@ -1033,7 +1033,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 					// prompt (line ~946). Re-compose with the expert
 					// prompt and skip identity layers so the expert's
 					// persona isn't polluted by soul.md/user.md.
-					a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, true)
+					a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model, agentProfile), memInjection, coauthor, true)
 				}
 			}
 		}
@@ -1089,7 +1089,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// for both a fresh session (NewSession stores *system into it) and a
 		// resumed one (loaded from disk), so it's correct in either case.
 		cfg.recomposeMCPManifest = func() {
-			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, agentProfile != nil && agentProfile.SystemPrompt != "")
+			a.System, a.LeanSystem = prompt.ComposePair(sess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model, agentProfile), memInjection, coauthor, agentProfile != nil && agentProfile.SystemPrompt != "")
 		}
 		if toolsOn {
 			// Built-ins only at first paint — the MCP registry is still nil
@@ -1127,7 +1127,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			oneShotSess.System = agentProfile.SystemPrompt
 			// Re-compose a.System with the expert prompt and skip
 			// identity layers (soul.md/user.md don't belong here).
-			a.System, a.LeanSystem = prompt.ComposePair(oneShotSess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model), memInjection, coauthor, true)
+			a.System, a.LeanSystem = prompt.ComposePair(oneShotSess.System, cwd, env, skillsManifest, tools.MCPManifestFor(a.Model, agentProfile), memInjection, coauthor, true)
 		}
 		oneShotSess.AgentID = agentProfileID
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -33,6 +33,20 @@ When you run ` + "`git commit`" + ` (via the terminal tool or any other path), a
 
 The trailer must be placed at the very end of the commit message, separated from the body by a blank line, following standard Git trailer format. Do not add this trailer if the user explicitly tells you not to.`
 
+// expertOverrideBanner is prepended to the profile's SystemPrompt when
+// expertMode is true. It makes explicit that the expert agent's configured
+// persona and rules take priority over the base prompt's generic guidance —
+// without it, detailed base-prompt instructions (tool-use norms, phase
+// boundaries, output style) can drown out the shorter custom prompt.
+const expertOverrideBanner = `# Expert Agent Configuration
+
+The system prompt below is **authoritative** and **overrides any conflicting
+instructions** in the sections above. Follow this persona, constraints, and
+rules even when they contradict earlier guidance.
+
+---
+`
+
 // ProjectContextFile is the per-repo conventions file Compose looks for in
 // the working directory. It carries project-specific rules the agent should
 // follow (the human-facing counterpart to CLAUDE.md).
@@ -59,16 +73,26 @@ var userRulesPath = func() string {
 // when expertMode is true), in order of increasing specificity:
 //
 //  1. base     — embedded octo foundation (always present)
+//
 //  2. soul     — ~/.octo/soul.md, if present (agent identity & behavior)
+//
 //  3. env      — environment snapshot (cwd, git, date, OS) the caller renders
+//
 //  4. skills   — the available-skills manifest the caller renders, if any
+//
 //  5. mcpTools — the available-MCP-tools manifest the caller renders, if any (see tools.MCPManifestFor)
+//
 //  6. memory   — cross-session memory the caller renders, if any (C9; includes inherited home-dir memories)
+//
 //  7. profile  — ~/.octo/user.md, if present (who the user is)
+//
 //  8. user     — ~/.octo/octorules.md, if present (cross-project user rules)
+//
 //  9. project  — ProjectContextFile in cwd, if present (repo conventions)
 //
-// 10. system   — the --system value, if any (highest-priority override, last)
+//  10. system   — the --system value, if any (highest-priority override, last).
+//     In expertMode, prefixed with an authoritative banner so the
+//     expert agent's persona overrides base-prompt instructions.
 //
 // Empty layers are skipped. Later layers appear later in the text, which is
 // the conventional way to let more specific instructions take precedence —
@@ -129,7 +153,11 @@ func Compose(userSystem, cwd, env, skills, mcpTools, memory string, coauthor, ex
 		}
 	}
 	if u := strings.TrimSpace(userSystem); u != "" {
-		layers = append(layers, u)
+		if expertMode {
+			layers = append(layers, expertOverrideBanner+u)
+		} else {
+			layers = append(layers, u)
+		}
 	}
 
 	return strings.Join(layers, "\n\n---\n\n")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -593,7 +593,7 @@ func (s *Server) enableSubAgentTools() {
 	}
 	cwd, envCtx := s.curCwdEnv()
 	cfg, _ := config.Load() // zero value on error still resolves correctly via EffectiveCoauthor
-	template.System, template.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(model), memInjection, s.effectiveCoauthor(cfg), false)
+	template.System, template.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(model, nil), memInjection, s.effectiveCoauthor(cfg), false)
 	executor := tools.NewDefaultRegistry()
 	spawner := app.NewSpawner(template, executor, func(ctx context.Context) []agent.ToolDefinition {
 		return tools.DefaultToolsForCtx(ctx, s.model)
@@ -1284,7 +1284,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 		base = profile.SystemPrompt
 		expertMode = true
 	}
-	a.System, a.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(model), memInjection, s.effectiveCoauthor(cfg), expertMode)
+	a.System, a.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
 
 	// L2: attention-layer rules (triggered keywords) + save-nudge on milestone
 	// tool results, plus any shell hooks (env/hooks.yml), unified on the agent's
@@ -3118,7 +3118,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		base = profile.SystemPrompt
 		expertMode = true
 	}
-	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(sess.Agent.Model), memInjection, s.effectiveCoauthor(cfg), expertMode)
+	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(sess.Agent.Model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
 
 	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,
 	// rebuilt per IM turn. The injector is session-sticky (recall latch) and

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 )
 
 // Tool Search defers MCP tool schemas behind two bridge tools instead of
@@ -183,14 +184,47 @@ func toolSearchBridgeDefs() []agent.ToolDefinition {
 //
 // Returns "" when the bridge isn't active for model (the full per-tool
 // definitions, schema included, are already inline in the tools array, so
-// repeating the names in the prompt would just duplicate them) or when there
-// are no MCP tools connected.
-func MCPManifestFor(model string) string {
+// repeating the names in the prompt would just duplicate them), when there
+// are no MCP tools connected, or when profile is a non-default agent that
+// lacks the MCP bridge tools (mcp_describe and mcp_call) — listing
+// tools the agent can't invoke is misleading. A nil profile means "default
+// agent, full access" and never suppresses the manifest.
+func MCPManifestFor(model string, profile *agentprofile.Profile) string {
 	catalog := mcpCatalog()
 	if !toolSearchActive(model, catalog) {
 		return ""
 	}
+	if !hasMCPBridgeAccess(profile) {
+		return ""
+	}
 	return renderMCPManifest(catalog)
+}
+
+// hasMCPBridgeAccess reports whether the profile can use the MCP bridge tools
+// (mcp_describe and mcp_call). Matches DefaultToolsForProfile's filter logic:
+// builtin agents with empty Tools get everything; user/project agents with
+// empty Tools get nothing; an explicit allowlist must include both bridge
+// tools (the manifest text instructs the model to call mcp_describe then
+// mcp_call — having only one creates a dead end). A nil profile means
+// "default agent, full access."
+func hasMCPBridgeAccess(profile *agentprofile.Profile) bool {
+	if profile == nil || profile.IsDefault() {
+		return true
+	}
+	if len(profile.Tools) == 0 {
+		return profile.Source == agentprofile.SourceBuiltin
+	}
+	hasDescribe := false
+	hasCall := false
+	for _, t := range profile.Tools {
+		if t == toolDescribeName {
+			hasDescribe = true
+		}
+		if t == toolCallName {
+			hasCall = true
+		}
+	}
+	return hasDescribe && hasCall
 }
 
 // renderMCPManifest builds the manifest text for a given catalog. Split out

--- a/internal/tools/tool_search_test.go
+++ b/internal/tools/tool_search_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
 )
 
 // fakeCatalog installs a fixed MCP catalog for the duration of a test, so the
@@ -168,7 +169,7 @@ func TestMCPManifestFor_ActiveListsNamesNotSchema(t *testing.T) {
 	fakeCatalog(t, sampleCatalog())
 	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOn})
 
-	manifest := MCPManifestFor("claude-opus-4-8")
+	manifest := MCPManifestFor("claude-opus-4-8", nil)
 	for _, want := range []string{"mcp__github__create_issue", "mcp__github__list_pulls", "mcp__slack__post_message", "# Available MCP tools"} {
 		if !strings.Contains(manifest, want) {
 			t.Errorf("manifest missing %q:\n%s", want, manifest)
@@ -185,7 +186,7 @@ func TestMCPManifestFor_InactiveReturnsEmpty(t *testing.T) {
 	fakeCatalog(t, sampleCatalog())
 	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOff})
 
-	if got := MCPManifestFor("claude-opus-4-8"); got != "" {
+	if got := MCPManifestFor("claude-opus-4-8", nil); got != "" {
 		t.Errorf("bridge inactive should yield no manifest, got:\n%s", got)
 	}
 }
@@ -195,7 +196,7 @@ func TestMCPManifestFor_EmptyCatalogReturnsEmpty(t *testing.T) {
 	fakeCatalog(t, nil)
 	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOn})
 
-	if got := MCPManifestFor("claude-opus-4-8"); got != "" {
+	if got := MCPManifestFor("claude-opus-4-8", nil); got != "" {
 		t.Errorf("empty catalog should yield no manifest, got:\n%s", got)
 	}
 }
@@ -216,9 +217,154 @@ func TestMCPManifestFor_NoCap(t *testing.T) {
 	fakeCatalog(t, big)
 	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOn})
 
-	manifest := MCPManifestFor("claude-opus-4-8")
+	manifest := MCPManifestFor("claude-opus-4-8", nil)
 	got := strings.Count(manifest, "\n- mcp__srv__tool_")
 	if got != len(big) {
 		t.Errorf("manifest listed %d of %d tools, want all of them uncapped", got, len(big))
+	}
+}
+
+// ── hasMCPBridgeAccess boundary tests ──────────────────────────────────────
+
+func TestHasMCPBridgeAccess_NilProfile(t *testing.T) {
+	if !hasMCPBridgeAccess(nil) {
+		t.Error("nil profile must have MCP bridge access (template path)")
+	}
+}
+
+func TestHasMCPBridgeAccess_DefaultProfile(t *testing.T) {
+	if !hasMCPBridgeAccess(agentprofile.DefaultProfile()) {
+		t.Error("default agent must have MCP bridge access")
+	}
+}
+
+func TestHasMCPBridgeAccess_BuiltinEmptyTools(t *testing.T) {
+	p := &agentprofile.Profile{
+		ID:     "explore",
+		Source: agentprofile.SourceBuiltin,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{}, // empty = all for builtin
+		},
+	}
+	if !hasMCPBridgeAccess(p) {
+		t.Error("builtin agent with empty Tools must have MCP bridge access")
+	}
+}
+
+func TestHasMCPBridgeAccess_UserEmptyTools(t *testing.T) {
+	p := &agentprofile.Profile{
+		ID:     "expert-no-tools",
+		Source: agentprofile.SourceUser,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{}, // empty = none for user-created
+		},
+	}
+	if hasMCPBridgeAccess(p) {
+		t.Error("user-created agent with empty Tools must NOT have MCP bridge access")
+	}
+}
+
+func TestHasMCPBridgeAccess_ProjectEmptyTools(t *testing.T) {
+	p := &agentprofile.Profile{
+		ID:     "proj-no-tools",
+		Source: agentprofile.SourceProject,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{}, // empty = none for project
+		},
+	}
+	if hasMCPBridgeAccess(p) {
+		t.Error("project agent with empty Tools must NOT have MCP bridge access")
+	}
+}
+
+func TestHasMCPBridgeAccess_BothBridgeTools(t *testing.T) {
+	p := &agentprofile.Profile{
+		ID:     "mcp-enabled",
+		Source: agentprofile.SourceUser,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{"read_file", "mcp_describe", "mcp_call"},
+		},
+	}
+	if !hasMCPBridgeAccess(p) {
+		t.Error("profile with both mcp_describe and mcp_call must have access")
+	}
+}
+
+func TestHasMCPBridgeAccess_OnlyDescribe(t *testing.T) {
+	p := &agentprofile.Profile{
+		ID:     "describe-only",
+		Source: agentprofile.SourceUser,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{"mcp_describe"},
+		},
+	}
+	if hasMCPBridgeAccess(p) {
+		t.Error("profile with only mcp_describe (no mcp_call) must NOT have access")
+	}
+}
+
+func TestHasMCPBridgeAccess_OnlyCall(t *testing.T) {
+	p := &agentprofile.Profile{
+		ID:     "call-only",
+		Source: agentprofile.SourceUser,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{"mcp_call"},
+		},
+	}
+	if hasMCPBridgeAccess(p) {
+		t.Error("profile with only mcp_call (no mcp_describe) must NOT have access")
+	}
+}
+
+func TestHasMCPBridgeAccess_NoMCPTools(t *testing.T) {
+	p := &agentprofile.Profile{
+		ID:     "no-mcp",
+		Source: agentprofile.SourceUser,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{"read_file", "grep", "terminal"},
+		},
+	}
+	if hasMCPBridgeAccess(p) {
+		t.Error("profile without any MCP bridge tools must NOT have access")
+	}
+}
+
+// ── MCPManifestFor end-to-end with profile ─────────────────────────────────
+
+func TestMCPManifestFor_ExpertWithoutBridgeReturnsEmpty(t *testing.T) {
+	resetToolSearchConfig(t)
+	fakeCatalog(t, sampleCatalog())
+	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOn})
+
+	p := &agentprofile.Profile{
+		ID:     "expert-no-mcp",
+		Source: agentprofile.SourceUser,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{"read_file", "grep"},
+		},
+	}
+	if got := MCPManifestFor("claude-opus-4-8", p); got != "" {
+		t.Errorf("expert agent without MCP bridge tools must see no manifest, got:\n%s", got)
+	}
+}
+
+func TestMCPManifestFor_ExpertWithBridgeReturnsManifest(t *testing.T) {
+	resetToolSearchConfig(t)
+	fakeCatalog(t, sampleCatalog())
+	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOn})
+
+	p := &agentprofile.Profile{
+		ID:     "expert-mcp",
+		Source: agentprofile.SourceUser,
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: []string{"mcp_describe", "mcp_call"},
+		},
+	}
+	manifest := MCPManifestFor("claude-opus-4-8", p)
+	if manifest == "" {
+		t.Error("expert agent with both MCP bridge tools must see the manifest")
+	}
+	if !strings.Contains(manifest, "# Available MCP tools") {
+		t.Errorf("manifest missing header:\n%s", manifest)
 	}
 }


### PR DESCRIPTION
## Summary

Two related changes for expert agent prompt correctness:

### 1. MCPManifestFor gets profile-aware filtering

`MCPManifestFor(model, profile)` now accepts a `*Profile` and suppresses the MCP tools manifest when the profile can't invoke them — an expert agent without both `mcp_describe` AND `mcp_call` in its tool allowlist no longer sees a misleading "# Available MCP tools" list.

New `hasMCPBridgeAccess` helper mirrors `DefaultToolsForProfile`'s three-branch logic:
- nil/default → always allow
- builtin + empty Tools → allow (get everything)  
- user/project + empty Tools → block (get nothing)
- explicit allowlist → require BOTH mcp_describe and mcp_call

### 2. Expert agent prompt gets authoritative banner

`prompt.Compose` in `expertMode` now prefixes the profile's SystemPrompt with:

```
# Expert Agent Configuration

The system prompt below is authoritative and overrides any conflicting 
instructions in the sections above.
```

This prevents the detailed base-prompt instructions (tool norms, phase boundaries, output style) from drowning out the shorter custom persona.

## Files changed

| File | Change |
|------|--------|
| `internal/tools/tool_search.go` | `MCPManifestFor` takes `*Profile`; `hasMCPBridgeAccess` helper |
| `internal/tools/tool_search_test.go` | 11 new tests covering all boundary cases |
| `internal/prompt/prompt.go` | `expertOverrideBanner` prefix in expertMode |
| `internal/server/server.go` | 3 call sites pass profile |
| `cmd/octo/chat.go` | 5 call sites pass agentProfile |

## Testing

- 4 existing MCPManifestFor tests pass (nil profile = unchanged)
- 9 hasMCPBridgeAccess boundary tests: nil, default, builtin, user, project, both, describe-only, call-only, none
- 2 MCPManifestFor end-to-end tests: expert without bridge → empty, expert with bridge → manifest
- All prompt.Compose tests pass including TestCompose_ExpertModeSkipsIdentityLayers