### PR TITLE
docs(skills): fix expert-agent-manager wechat binding description

### DIFF
--- a/internal/skills/defaults/expert-agent-manager/SKILL.md
+++ b/internal/skills/defaults/expert-agent-manager/SKILL.md
@@ -216,7 +216,13 @@ existing profile are preserved unless the user explicitly changes them.
 
 ### Binding to an IM chat
 
-1. **Collect platform + chat ID** (e.g. `weixin` + group ID).
+1. **Collect platform + chat ID.** The format depends on the platform:
+   - **WeChat (weixin):** only private chats are supported. The `chat_id` is the
+     user's private chat ID (e.g. `o9cq8...@im.wechat`). Group chats are not
+     available on this platform.
+   - **Other platforms** (Telegram, Discord, Feishu, DingTalk, WeCom): both
+     private and group chat IDs are supported.
+   When the user says "bind to a WeChat group", correct them — it isn't possible.
 2. **Call `POST /api/agents/:id/bind`** with `{"platform": "...", "chat_id": "..."}`.
 3. **Verify** with `GET /api/agents/:id`.
 


### PR DESCRIPTION
## 问题

`expert-agent-manager` skill 的「Binding to an IM chat」小节示例写的是 `weixin + group ID`，但**微信 channel 只支持私聊绑定**，群聊不可用。这会误导所有下载 octo 的用户。

## 修改

将单一的 `weixin + group ID` 示例替换为分平台的约束说明：

- **WeChat (weixin):** 仅支持私聊，`chat_id` 为单聊 ID（如 `o9cq8...@im.wechat`），不支持群聊
- **其他平台**（Telegram, Discord, Feishu, DingTalk, WeCom）：私聊和群聊均支持

并加了一句：当用户说"绑到微信群"时直接纠正。

## 影响范围

仅修改 SKILL.md 文档，无代码变更。