### PR TITLE
fix(web): AgentEdit channel dropdown shows undefined platform

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.13.0"
+var Version = "1.14.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -92,14 +92,13 @@ export interface McpServer {
 }
 
 export interface Channel {
-  name: string
+  platform: string
   adapter_id?: string
-  handle: string
-  activity: string
-  icon: string
-  tagStatus: TagStatus
-  tagLabel: string
   enabled: boolean
+  running?: boolean
+  has_config?: boolean
+  fields?: Record<string, string>
+  issue?: string
 }
 
 export interface Memory {

--- a/web/src/views/AgentEdit.svelte
+++ b/web/src/views/AgentEdit.svelte
@@ -56,9 +56,9 @@
       availableBots = channelList
         .filter(c => c.enabled)
         .map(c => ({
-          platform: c.name,
-          adapter_id: c.adapter_id || c.name,
-          label: c.adapter_id && c.adapter_id !== c.name ? `${c.name} / ${c.adapter_id}` : c.name,
+          platform: c.platform,
+          adapter_id: c.adapter_id || c.platform,
+          label: c.adapter_id && c.adapter_id !== c.platform ? `${c.platform} / ${c.adapter_id}` : c.platform,
         }))
     } catch { /* degrade gracefully */ }
   }


### PR DESCRIPTION
Fixes the channel binding dropdown in the agent edit modal rendering `undefined / weixin` instead of the platform name.

### Changes
- `web/src/lib/types.ts`: update `Channel` interface to match the server shape returned by `GET /api/channels` (`platform`, `adapter_id`, `enabled`, plus optional `running`/`has_config`/`fields`/`issue`).
- `web/src/views/AgentEdit.svelte`: read `c.platform` instead of the non-existent `c.name` when building the binding bot list.
- `internal/version/version.go`: bump version to `1.14.0`.

### Verification
- `cd web && npx svelte-check` passes with 0 errors.
- `go test ./internal/version/...` passes.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>