### PR TITLE
fix(web): AgentEdit channel platform select not reflecting selection

### DIFF
--- a/web/src/views/AgentEdit.svelte
+++ b/web/src/views/AgentEdit.svelte
@@ -197,12 +197,15 @@
         <label>{$t('agents.channel_bindings')}</label>
         {#each bindings as b, i}
           <div class="bind-row">
-            <select bind:value={bindings[i].platform} class="bind-select" onchange={(e) => {
-              const val = (e.target as HTMLSelectElement).value
-              const parts = val.split('|')
-              bindings[i].platform = parts[0]
-              bindings[i].adapter_id = parts[1] || ''
-            }}>
+            <select
+              class="bind-select"
+              value={`${b.platform}|${b.adapter_id || b.platform}`}
+              onchange={(e) => {
+                const val = (e.target as HTMLSelectElement).value
+                const parts = val.split('|')
+                bindings[i] = { ...bindings[i], platform: parts[0], adapter_id: parts[1] || '' }
+              }}
+            >
               <option value="">{$t('agents.select_platform')}</option>
               {#each availableBots as bot}
                 <option value={`${bot.platform}|${bot.adapter_id}`}>{bot.label}</option>


### PR DESCRIPTION
After fixing the `undefined` label, the platform dropdown still did not reflect the user's selection because the bound value and option values mismatched.

### Problem
- The `<select>` used `bind:value={bindings[i].platform}`.
- Each `<option>` had a composite value `${platform}|${adapter_id}` (e.g. `weixin|weixin`).
- After picking an option, `platform` became `"weixin"`, which did not match any option value, so the browser kept showing the empty "Select platform" option. The chat_id input appeared not to show up/activate.

### Fix
- Replace `bind:value` with an explicit `value` computed from `${b.platform}|${b.adapter_id || b.platform}`.
- On change, update the binding entry as a new object so Svelte 5 reactivity detects the change.

### Verification
- `cd web && npm install && npx svelte-check` passes with 0 errors.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>