### PR TITLE
fix(web): AgentEdit save hits /api/agents/undefined

### DIFF
--- a/web/src/views/AgentsView.svelte
+++ b/web/src/views/AgentsView.svelte
@@ -28,8 +28,8 @@
       if (creating) {
         await api.createAgent(agent)
         showToast('Agent created', 'success')
-      } else {
-        await api.updateAgent(agent.id, agent)
+      } else if (editing) {
+        await api.updateAgent(editing.id, agent)
         showToast('Agent updated', 'success')
       }
       editing = null


### PR DESCRIPTION
When editing an existing agent, clicking Save produced a request to `/api/agents/undefined` and failed.

### Root cause
- `AgentEdit` constructs a new request body in `handleSubmit` and passes it to `onSave`.
- That new body does not include the agent `id`.
- `AgentsView.handleSave` used `agent.id` from the passed body when calling `updateAgent`, resulting in `undefined` in the URL.

### Fix
- `AgentsView.handleSave` now uses the stable `editing.id` from the parent view for updates instead of expecting the child form to echo the id back.

### Verification
- `cd web && npm install && npx svelte-check` passes with 0 errors.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>