### PR TITLE
refactor(agentprofile): remove project-level agent profiles, agents a…

### DIFF
--- a/cmd/octo/agent_flag_test.go
+++ b/cmd/octo/agent_flag_test.go
@@ -38,7 +38,7 @@ func TestRunChat_AgentFlagListsAvailableOnError(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	store := agentprofile.New(dir, func() string { return "" })
+	store := agentprofile.New(dir)
 	if err := store.Create(&agentprofile.Profile{
 		ID:             "my-agent",
 		Name:           "My Agent",
@@ -76,7 +76,7 @@ func TestRunChat_AgentFlagResolvesByID(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	store := agentprofile.New(dir, func() string { return "" })
+	store := agentprofile.New(dir)
 	if err := store.Create(&agentprofile.Profile{
 		ID:             "my-agent",
 		Name:           "My Agent",

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -522,7 +522,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	var agentProfile *agentprofile.Profile
 	var agentStore *agentprofile.Store
 	if *agentName != "" {
-		agentStore = agentprofile.New(agentUserDir(), agentProjectDir)
+		agentStore = agentprofile.New(agentUserDir())
 		profile, ok := agentStore.Get(*agentName)
 		if !ok {
 			ids := append([]string{"default"}, profileIDs(agentStore)...)
@@ -1270,20 +1270,6 @@ func agentUserDir() string {
 		return ""
 	}
 	return filepath.Join(home, ".octo", "agents")
-}
-
-// agentProjectDir is the delegation-only project-level profile directory
-// (<repo>/.octo/agents), resolved per call like the pre-existing loader.
-func agentProjectDir() string {
-	cwd, err := os.Getwd()
-	if err != nil || cwd == "" {
-		return ""
-	}
-	root := memory.ProjectRoot(cwd)
-	if root == "" {
-		return ""
-	}
-	return filepath.Join(root, ".octo", "agents")
 }
 
 // profileIDs returns the IDs of all non-builtin profiles in the store.

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -990,7 +990,7 @@ func (m *tuiModel) dispatchClear() (tea.Model, tea.Cmd) {
 func (m *tuiModel) dispatchAgent(rest string) (tea.Model, tea.Cmd) {
 	cfg := m.cfg
 	if rest == "list" {
-		store := agentprofile.New(agentUserDir(), agentProjectDir)
+		store := agentprofile.New(agentUserDir())
 		names := append([]string{"default"}, profileIDs(store)...)
 		m.println(noticeStyle.Render("Available agents: " + strings.Join(names, ", ")))
 		return m, nil
@@ -1001,7 +1001,7 @@ func (m *tuiModel) dispatchAgent(rest string) (tea.Model, tea.Cmd) {
 		m.println(noticeStyle.Render("Current agent: Default (full access)"))
 		return m, nil
 	}
-	store := agentprofile.New(agentUserDir(), agentProjectDir)
+	store := agentprofile.New(agentUserDir())
 	if p, ok := store.Get(agentID); ok {
 		m.println(noticeStyle.Render(fmt.Sprintf("Current agent: %s — %s", p.Name, p.Description)))
 	} else {

--- a/internal/agentprofile/profile.go
+++ b/internal/agentprofile/profile.go
@@ -3,11 +3,10 @@
 // skills) plus the platform slice (mention aliases, channel bindings) used
 // when a profile is addressed directly by users.
 //
-// Profiles come from three sources, in increasing precedence:
+// Profiles come from two sources, in increasing precedence:
 //
 //   - builtin: code-defined (default, explore, general, code-review)
 //   - user:    ~/.octo/agents/<id>.md       (conversation + delegation modes)
-//   - project: <repo>/.octo/agents/<id>.md  (delegation mode only)
 //
 // A profile is consumed in two modes:
 //
@@ -79,7 +78,7 @@ type Profile struct {
 	CapabilitySpec
 
 	WorkingDir      string
-	ChannelBindings []ChannelBinding // conversation mode only; user-level only
+	ChannelBindings []ChannelBinding // conversation mode only
 
 	Source Source
 

--- a/internal/agentprofile/profile.go
+++ b/internal/agentprofile/profile.go
@@ -30,8 +30,7 @@ import (
 	"unicode/utf8"
 )
 
-// Source marks where a profile comes from. It determines which run modes the
-// profile supports and its override precedence (project > user > builtin).
+// Source marks where a profile comes from.
 type Source string
 
 const (
@@ -41,10 +40,6 @@ const (
 	// SourceUser profiles live in ~/.octo/agents/*.md and support both
 	// conversation and delegation modes.
 	SourceUser Source = "user"
-	// SourceProject profiles live in <repo>/.octo/agents/*.md and are
-	// delegation-only: the platform slice (mention aliases, channel
-	// bindings) is ignored, so a project file can never hijack IM routing.
-	SourceProject Source = "project"
 )
 
 // DefaultID is the reserved ID of the code-defined default agent.

--- a/internal/agentprofile/router_test.go
+++ b/internal/agentprofile/router_test.go
@@ -5,7 +5,7 @@ import "testing"
 // routerStore builds a store with user profiles for channel-binding routing tests.
 func routerStore(t *testing.T) *Store {
 	t.Helper()
-	s, userDir, _ := newTestStore(t)
+	s, userDir := newTestStore(t)
 	writeMD(t, userDir, "code.md", "---\ndescription: dc\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
 	writeMD(t, userDir, "ops.md", "---\ndescription: do\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n  - {platform: weixin, chat_id: g2}\n---\nbody\n")
 	writeMD(t, userDir, "solo.md", "---\ndescription: ds\nchannel_bindings:\n  - {platform: feishu, chat_id: dm1}\n---\nbody\n")

--- a/internal/agentprofile/store.go
+++ b/internal/agentprofile/store.go
@@ -9,56 +9,38 @@ import (
 	"strings"
 )
 
-// Store loads profiles from the user-level and project-level agent
-// directories plus the code-defined builtins, and answers every query by
-// rescanning: it is deliberately read-through, so a change made through any
-// path (REST API, Web UI, direct .md edit) is visible on the next read. The
-// directories hold a handful of small files, so a rescan is cheap — this is
-// exactly how the pre-existing discoverAgents loader already behaved.
-//
-// Precedence is project > user > builtin: a user .md can shadow a builtin
-// (e.g. a personal "explore"), and a project .md can shadow both.
+// Store loads profiles from the user-level agent directory plus the
+// code-defined builtins, and answers every query by rescanning: it is
+// deliberately read-through, so a change made through any path (REST API,
+// Web UI, direct .md edit) is visible on the next read. The directory holds
+// a handful of small files, so a rescan is cheap.
 type Store struct {
-	userDir    string
-	projectDir func() string // resolved per scan (cwd-dependent); nil disables
+	userDir string
 }
 
-// New builds a Store over the user-level directory. projectDir, when non-nil,
-// is consulted on every scan for the delegation-only project-level directory.
-func New(userDir string, projectDir func() string) *Store {
-	return &Store{userDir: userDir, projectDir: projectDir}
+// New builds a Store over the user-level directory (~/.octo/agents).
+func New(userDir string) *Store {
+	return &Store{userDir: userDir}
 }
 
-// load scans all sources and returns the merged id → profile map. Files that
-// fail to parse are skipped (a broken profile must never take the others down
-// with it, and the next read self-heals once the file is fixed).
+// load scans user profiles and returns the id → profile map, with builtins as
+// the base layer. Files that fail to parse are skipped.
 func (s *Store) load() map[string]*Profile {
 	profiles := make(map[string]*Profile)
 	for _, p := range builtinProfiles() {
 		profiles[p.ID] = p
 	}
 	s.scanDir(s.userDir, SourceUser, profiles)
-	if s.projectDir != nil {
-		s.scanDir(s.projectDir(), SourceProject, profiles)
-	}
 	return profiles
 }
 
 // scanDir merges *.md profiles from dir into dst, overwriting same-named
-// entries of lower precedence. A missing or unreadable dir is a no-op.
-//
-// The read path accepts any .md basename as an ID (zero-migration
-// compatibility with the pre-existing agent loader); the slug rule is
-// enforced on writes instead. The reserved "default" ID is skipped so a
-// stray default.md can never shadow the code-defined default agent.
+// entries. A missing or unreadable dir is a no-op.
 func (s *Store) scanDir(dir string, src Source, dst map[string]*Profile) {
 	s.scanDirFiltered(dir, src, dst, nil)
 }
 
 // scanDirFiltered is scanDir with an optional ID filter (nil = accept all).
-// The IM-routing path passes IsValidID so a non-slug filename can never
-// become a routable profile; the delegation path passes nil to keep loading
-// legacy .md files written before the slug rule existed.
 func (s *Store) scanDirFiltered(dir string, src Source, dst map[string]*Profile, accept func(string) bool) {
 	if dir == "" {
 		return
@@ -81,30 +63,22 @@ func (s *Store) scanDirFiltered(dir string, src Source, dst map[string]*Profile,
 		p, err := parseFile(filepath.Join(dir, e.Name()))
 		if err != nil {
 			log.Printf("agentprofile: skipping %s: %v", filepath.Join(dir, e.Name()), err)
-			continue // broken file: skip, self-heal next read
+			continue
 		}
 		p.ID = id
 		p.Source = src
-		if src == SourceProject {
-			// Delegation-only: the platform slice from a project file must
-			// never influence IM routing.
-			p.ChannelBindings = nil
-		}
 		dst[id] = p
 	}
 }
 
-// Load performs a full scan. With the read-through design it has no cached
-// state to refresh and unreadable directories are tolerated as empty — it
-// exists to keep the documented API shape and as a scan smoke hook for tests.
+// Load performs a full scan.
 func (s *Store) Load() error {
 	s.load()
 	return nil
 }
 
-// Get returns the profile with the given id, honoring the project > user >
-// builtin precedence. The default profile is code-defined and always
-// available.
+// Get returns the profile with the given id. The default profile is
+// code-defined and always available.
 func (s *Store) Get(id string) (*Profile, bool) {
 	if id == DefaultID {
 		return DefaultProfile(), true
@@ -113,8 +87,7 @@ func (s *Store) Get(id string) (*Profile, bool) {
 	return p, ok
 }
 
-// List returns every non-builtin profile (user- and project-level), sorted by
-// ID for stable output.
+// List returns every user-level profile, sorted by ID for stable output.
 func (s *Store) List() []*Profile {
 	var out []*Profile
 	for _, p := range s.load() {
@@ -127,10 +100,7 @@ func (s *Store) List() []*Profile {
 	return out
 }
 
-// Create validates p and writes it as <userDir>/<id>.md. It refuses to
-// overwrite an existing file (including one shadowing a builtin — shadowing
-// stays a deliberate, hand-written affair), to use the reserved default ID,
-// or to claim a mention alias another profile already holds.
+// Create validates p and writes it as <userDir>/<id>.md.
 func (s *Store) Create(p *Profile) error {
 	if err := s.validateForStoreWrite(p); err != nil {
 		return err
@@ -142,21 +112,18 @@ func (s *Store) Create(p *Profile) error {
 	return s.writeFile(path, p)
 }
 
-// Update rewrites an existing user-level profile. Builtin and project-level
-// profiles are immutable through the Store: edit code or the project file.
+// Update rewrites an existing user-level profile.
 func (s *Store) Update(p *Profile) error {
 	if err := s.validateForStoreWrite(p); err != nil {
 		return err
 	}
 	path := filepath.Join(s.userDir, p.ID+".md")
 	if _, err := os.Stat(path); err != nil {
-		return fmt.Errorf("profile %q not found at user level (builtin/project profiles are read-only here)", p.ID)
+		return fmt.Errorf("profile %q not found", p.ID)
 	}
 	return s.writeFile(path, p)
 }
 
-// validateForStoreWrite is the write gate shared by Create and Update: schema
-// validation and the reserved default ID.
 func (s *Store) validateForStoreWrite(p *Profile) error {
 	if err := validateForWrite(p); err != nil {
 		return err
@@ -167,15 +134,15 @@ func (s *Store) validateForStoreWrite(p *Profile) error {
 	return nil
 }
 
-// Delete removes a user-level profile. A profile with channel bindings must
-// be unbound first, so an IM chat is never left routing to a ghost.
+// Delete removes a profile. Builtin profiles are protected. A profile with
+// channel bindings must be unbound first.
 func (s *Store) Delete(id string) error {
 	p, ok := s.Get(id)
 	if !ok {
 		return fmt.Errorf("profile %q not found", id)
 	}
-	if p.Source != SourceUser {
-		return fmt.Errorf("profile %q is %s-level and cannot be deleted through the Store", id, p.Source)
+	if p.Source == SourceBuiltin {
+		return fmt.Errorf("profile %q is builtin and cannot be deleted", id)
 	}
 	if len(p.ChannelBindings) > 0 {
 		return fmt.Errorf("profile %q still has %d channel binding(s): unbind them first", id, len(p.ChannelBindings))
@@ -183,8 +150,7 @@ func (s *Store) Delete(id string) error {
 	return os.Remove(filepath.Join(s.userDir, id+".md"))
 }
 
-// writeFile serializes p and writes it via temp-file + rename, so a
-// concurrent read-through scan never observes a partially written file.
+// writeFile serializes p and writes it via temp-file + rename.
 func (s *Store) writeFile(path string, p *Profile) error {
 	b, err := serialize(p)
 	if err != nil {
@@ -215,16 +181,7 @@ func (s *Store) writeFile(path string, p *Profile) error {
 	return os.Rename(tmpName, path)
 }
 
-// userProfiles scans only the user-level directory. IM routing queries
-// (ByChannel/ByMention) build on this — not on the merged map — so a
-// project-level file shadowing a user profile's ID (delegation override)
-// can never silence that profile's conversation-mode routing.
-//
-// IM routing only honors slug-shaped profile IDs (the same rule enforced on
-// writes): a hand-placed `a#b.md` would otherwise produce an ID whose '#'
-// defeats the session-key namespace splitter, so the router would misroute
-// messages to it. Delegation-mode lookups (sub_agent) keep the legacy lenient
-// loader via scanDir, which still accepts any basename.
+// userProfiles scans only the user-level directory for IM routing.
 func (s *Store) userProfiles() map[string]*Profile {
 	m := make(map[string]*Profile)
 	s.scanDirFiltered(s.userDir, SourceUser, m, IsValidID)
@@ -232,10 +189,6 @@ func (s *Store) userProfiles() map[string]*Profile {
 }
 
 // ByChannel returns the user-level profiles bound to the given IM chat.
-// When adapterID is non-empty, only bindings with a matching AdapterID
-// (or an empty AdapterID — legacy compatibility) are considered. When
-// adapterID is empty, the legacy two-dimensional (platform, chat_id)
-// match is used. The router treats >1 results as "ambiguous: stay silent".
 func (s *Store) ByChannel(platform, adapterID, chatID string) []*Profile {
 	var out []*Profile
 	for _, p := range s.userProfiles() {
@@ -243,8 +196,6 @@ func (s *Store) ByChannel(platform, adapterID, chatID string) []*Profile {
 			if b.Platform != platform || b.ChatID != chatID {
 				continue
 			}
-			// adapterID match: non-empty → exact match or legacy empty;
-			// empty adapterID in query → match any (legacy mode).
 			if adapterID != "" && b.AdapterID != "" && b.AdapterID != adapterID {
 				continue
 			}

--- a/internal/agentprofile/store_test.go
+++ b/internal/agentprofile/store_test.go
@@ -6,16 +6,15 @@ import (
 	"testing"
 )
 
-// newTestStore builds a Store over two temp dirs (user + project).
-func newTestStore(t *testing.T) (*Store, string, string) {
+// newTestStore builds a Store over a temp user dir.
+func newTestStore(t *testing.T) (*Store, string) {
 	t.Helper()
 	userDir := t.TempDir()
-	projectDir := t.TempDir()
-	return New(userDir, func() string { return projectDir }), userDir, projectDir
+	return New(userDir), userDir
 }
 
 func TestStoreBuiltinFallback(t *testing.T) {
-	s, _, _ := newTestStore(t)
+	s, _ := newTestStore(t)
 	for _, id := range []string{"explore", "general", "code-review"} {
 		p, ok := s.Get(id)
 		if !ok || p.Source != SourceBuiltin {
@@ -30,36 +29,21 @@ func TestStoreBuiltinFallback(t *testing.T) {
 	}
 }
 
-func TestStorePrecedence(t *testing.T) {
-	s, userDir, projectDir := newTestStore(t)
-	// User file shadows the builtin "explore".
+func TestStoreUserOverridesBuiltin(t *testing.T) {
+	s, userDir := newTestStore(t)
 	writeMD(t, userDir, "explore.md", "---\ndescription: user explore\n---\nuser persona\n")
-	// Project file shadows the user file.
-	writeMD(t, projectDir, "explore.md", "---\ndescription: project explore\n---\nproject persona\n")
 
 	p, ok := s.Get("explore")
 	if !ok {
 		t.Fatal("Get(explore) not found")
 	}
-	if p.Source != SourceProject || p.SystemPrompt != "project persona" {
-		t.Fatalf("precedence project > user > builtin broken: %+v", p)
-	}
-}
-
-func TestStoreProjectStripsPlatformSlice(t *testing.T) {
-	s, _, projectDir := newTestStore(t)
-	writeMD(t, projectDir, "ops.md", "---\ndescription: d\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
-
-	if p, _ := s.Get("ops"); p == nil || len(p.ChannelBindings) != 0 {
-		t.Fatalf("project profile kept platform slice: %+v", p)
-	}
-	if got := s.ByChannel("weixin", "", "g1"); len(got) != 0 {
-		t.Fatal("project-level binding must not be routable")
+	if p.Source != SourceUser || p.SystemPrompt != "user persona" {
+		t.Fatalf("user file should override builtin: %+v", p)
 	}
 }
 
 func TestStoreSkipsBrokenFilesAndReservedID(t *testing.T) {
-	s, userDir, _ := newTestStore(t)
+	s, userDir := newTestStore(t)
 	writeMD(t, userDir, "broken.md", "no frontmatter here\n")
 	writeMD(t, userDir, "default.md", "---\ndescription: impostor\n---\nbody\n") // reserved ID: skipped
 	writeMD(t, userDir, "good.md", "---\ndescription: d\n---\nbody\n")
@@ -75,12 +59,8 @@ func TestStoreSkipsBrokenFilesAndReservedID(t *testing.T) {
 	}
 }
 
-// Delegation lookups (sub_agent) and the profile API keep the zero-migration
-// lenient loader: any .md basename is a valid profile ID on the read path,
-// even names that fail the write-side slug rule. The write path still
-// enforces slug via validateForWrite.
 func TestStore_DelegationAcceptsNonSlugFilenames(t *testing.T) {
-	s, userDir, _ := newTestStore(t)
+	s, userDir := newTestStore(t)
 	writeMD(t, userDir, "Code_Review.md", "---\ndescription: legacy\n---\nbody\n")
 
 	p, ok := s.Get("Code_Review")
@@ -105,7 +85,7 @@ func TestStore_UserProfilesSkipsNonSlug(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "valid.md"), []byte("---\ndescription: d\n---\nbody\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	s := New(dir, nil)
+	s := New(dir)
 	// userProfiles() (IM-routing source) skips non-slug files.
 	if p := s.ByChannel("weixin", "", "g1"); len(p) > 0 {
 		t.Fatalf("non-slug profile is routable via IM: %+v", p)
@@ -120,7 +100,7 @@ func TestStore_UserProfilesSkipsNonSlug(t *testing.T) {
 }
 
 func TestStoreReadThrough(t *testing.T) {
-	s, userDir, _ := newTestStore(t)
+	s, userDir := newTestStore(t)
 	writeMD(t, userDir, "a.md", "---\ndescription: v1\n---\nbody v1\n")
 
 	p, _ := s.Get("a")
@@ -143,7 +123,7 @@ func TestStoreReadThrough(t *testing.T) {
 }
 
 func TestStoreCreateUpdateDelete(t *testing.T) {
-	s, userDir, _ := newTestStore(t)
+	s, userDir := newTestStore(t)
 
 	p := &Profile{ID: "reviewer", Name: "Reviewer", Description: "d",
 		CapabilitySpec: CapabilitySpec{SystemPrompt: "prompt", Tools: []string{"read_file"}}}
@@ -197,7 +177,7 @@ func TestStoreCreateUpdateDelete(t *testing.T) {
 }
 
 func TestStoreByChannelByMention(t *testing.T) {
-	s, userDir, _ := newTestStore(t)
+	s, userDir := newTestStore(t)
 	writeMD(t, userDir, "a.md", "---\ndescription: da\nmention_as: [\"@review\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nbody\n")
 	writeMD(t, userDir, "b.md", "---\ndescription: db\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n  - {platform: feishu, chat_id: g2}\n---\nbody\n")
 
@@ -212,23 +192,8 @@ func TestStoreByChannelByMention(t *testing.T) {
 	}
 }
 
-// A project-level file shadowing a user profile's ID overrides delegation
-// (Get) but must never silence the user profile's IM routing.
-func TestStoreProjectShadowKeepsUserRouting(t *testing.T) {
-	s, userDir, projectDir := newTestStore(t)
-	writeMD(t, userDir, "reviewer.md", "---\ndescription: user\nmention_as: [\"@review\"]\nchannel_bindings:\n  - {platform: weixin, chat_id: g1}\n---\nuser body\n")
-	writeMD(t, projectDir, "reviewer.md", "---\ndescription: project\n---\nproject body\n")
-
-	if p, _ := s.Get("reviewer"); p.Source != SourceProject {
-		t.Fatalf("delegation precedence broken: %+v", p)
-	}
-	if got := s.ByChannel("weixin", "", "g1"); len(got) != 1 || got[0].ID != "reviewer" {
-		t.Fatalf("project shadow silenced user routing: %+v", got)
-	}
-}
-
 func TestStoreDefaultReserved(t *testing.T) {
-	s, userDir, _ := newTestStore(t)
+	s, userDir := newTestStore(t)
 
 	if p, ok := s.Get(DefaultID); !ok || !p.IsDefault() {
 		t.Fatalf("Get(default) = %v, %v — the default profile must always resolve", p, ok)

--- a/internal/server/agent_routing_test.go
+++ b/internal/server/agent_routing_test.go
@@ -69,7 +69,7 @@ You review code.
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 	ev := evFor("hello")
-	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir(), nil)).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
+	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir())).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
 	if profile == nil {
 		t.Fatal("expected routing to reviewer, got nil")
 	}
@@ -110,7 +110,7 @@ B.
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 	ev := evFor("hello")
-	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir(), nil)).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
+	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir())).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
 	if profile != nil {
 		t.Fatalf("expected nil route (multi-binding), got %q", profile.ID)
 	}
@@ -139,7 +139,7 @@ You review code.
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 	ev := evFor("hello")
-	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir(), nil)).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
+	profile := agentprofile.NewRouter(agentprofile.New(agentStoreDir())).Route(agentprofile.RouteInput{Platform: ev.Platform, ChatID: ev.ChatID, UserID: ev.UserID, Text: ev.Text})
 	if profile == nil || !profile.IsDefault() {
 		t.Fatalf("expected default fallback, got %+v", profile)
 	}
@@ -177,7 +177,7 @@ channel_bindings:
 ---
 `)
 	dir := filepath.Join(os.Getenv("HOME"), ".octo", "agents")
-	store := agentprofile.New(dir, func() string { return "" })
+	store := agentprofile.New(dir)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	srv.system = "SERVER BASE SYSTEM"
 	srv.agentStore = store
@@ -225,7 +225,7 @@ channel_bindings:
 ---
 TEMP PROFILE PROMPT.
 `)
-	store := agentprofile.New(dir, func() string { return "" })
+	store := agentprofile.New(dir)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	srv.system = "SERVER BASE"
 	srv.agentStore = store

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2217,7 +2217,7 @@ func (s *Server) agentRouter() *agentprofile.Router {
 		if s.agentStore != nil {
 			return
 		}
-		s.agentStore = agentprofile.New(agentUserDir(), agentProjectDir)
+		s.agentStore = agentprofile.New(agentUserDir())
 		s.agentRouterVal = agentprofile.NewRouter(s.agentStore)
 	})
 	return s.agentRouterVal
@@ -2255,20 +2255,6 @@ func agentUserDir() string {
 		return ""
 	}
 	return filepath.Join(home, ".octo", "agents")
-}
-
-// agentProjectDir is the delegation-only project-level profile directory
-// (<repo>/.octo/agents), resolved per call like the pre-existing loader.
-func agentProjectDir() string {
-	cwd, err := os.Getwd()
-	if err != nil || cwd == "" {
-		return ""
-	}
-	root := memory.ProjectRoot(cwd)
-	if root == "" {
-		return ""
-	}
-	return filepath.Join(root, ".octo", "agents")
 }
 
 // channelModelOps builds the ModelOps the channel manager's /model command

--- a/internal/tools/agents.go
+++ b/internal/tools/agents.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/open-octo/octo-agent/internal/memory"
 	"gopkg.in/yaml.v3"
 )
 
@@ -31,22 +30,6 @@ var userAgentsRoot = func() string {
 	return filepath.Join(home, ".octo", "agents")
 }
 
-// projectAgentsRoot returns <project-root>/.octo/agents for the current working
-// directory's repository, or "" when it can't be resolved. Project-level agents
-// override user-level ones of the same name (matching .claude/agents semantics).
-// A var so tests can point it at a temp directory.
-var projectAgentsRoot = func() string {
-	cwd, err := os.Getwd()
-	if err != nil || cwd == "" {
-		return ""
-	}
-	root := memory.ProjectRoot(cwd)
-	if root == "" {
-		return ""
-	}
-	return filepath.Join(root, ".octo", "agents")
-}
-
 // discoveredAgents holds the last scanned user-defined agents.
 var (
 	discoveredAgentsMu sync.RWMutex
@@ -58,11 +41,7 @@ var (
 // the freshest set call it before lookupAgentPreset.
 func discoverAgents() {
 	fresh := make(map[string]agentPreset)
-	// User-level first, then project-level — project entries override
-	// user-level ones of the same name.
-	for _, root := range []string{userAgentsRoot(), projectAgentsRoot()} {
-		scanAgentsRoot(root, fresh)
-	}
+	scanAgentsRoot(userAgentsRoot(), fresh)
 	discoveredAgentsMu.Lock()
 	discoveredAgents = fresh
 	discoveredAgentsMu.Unlock()

--- a/internal/tools/agents_test.go
+++ b/internal/tools/agents_test.go
@@ -15,14 +15,6 @@ func useAgentsRoot(t *testing.T, dir string) {
 	t.Cleanup(func() { userAgentsRoot = orig })
 }
 
-// useProjectAgentsRoot points projectAgentsRoot at dir for the test's duration.
-func useProjectAgentsRoot(t *testing.T, dir string) {
-	t.Helper()
-	orig := projectAgentsRoot
-	projectAgentsRoot = func() string { return dir }
-	t.Cleanup(func() { projectAgentsRoot = orig })
-}
-
 func writeAgentFile(t *testing.T, root, name, content string) {
 	t.Helper()
 	if err := os.MkdirAll(root, 0o755); err != nil {
@@ -202,31 +194,6 @@ func TestParseAgentFile_ModelInheritIsEmpty(t *testing.T) {
 	}
 	if p.model != "" {
 		t.Errorf("model = %q, want empty (inherit)", p.model)
-	}
-}
-
-func TestDiscoverAgents_ProjectOverridesUser(t *testing.T) {
-	userRoot := t.TempDir()
-	projRoot := t.TempDir()
-	useAgentsRoot(t, userRoot)
-	useProjectAgentsRoot(t, projRoot)
-
-	writeAgentFile(t, userRoot, "helper.md", "---\ndescription: user helper\n---\nuser body")
-	writeAgentFile(t, userRoot, "useronly.md", "---\ndescription: user only\n---\nbody")
-	writeAgentFile(t, projRoot, "helper.md", "---\ndescription: project helper\n---\nproject body")
-
-	discoverAgents()
-
-	p, ok := lookupAgentPreset("helper")
-	if !ok {
-		t.Fatal("helper not discovered")
-	}
-	if p.description != "project helper" {
-		t.Errorf("description = %q, want project-level override", p.description)
-	}
-	// User-only agents are still visible.
-	if _, ok := lookupAgentPreset("useronly"); !ok {
-		t.Error("user-only agent should remain discoverable")
 	}
 }
 

--- a/internal/tools/profile_names_test.go
+++ b/internal/tools/profile_names_test.go
@@ -27,7 +27,7 @@ func (s *resultSpawnerSync) Continue(ctx context.Context, agentID, message strin
 // user-defined profiles), retiring the old agent_presets.go lookup.
 func TestAgentTool_SubagentTypeResolvesViaStore(t *testing.T) {
 	dir := t.TempDir()
-	store := agentprofile.New(dir, nil)
+	store := agentprofile.New(dir)
 
 	ctx := WithProfileStore(context.Background(), store)
 	mgr := NewSubAgentManager(&resultSpawnerSync{reply: "ok"})

--- a/internal/tools/profile_tools_test.go
+++ b/internal/tools/profile_tools_test.go
@@ -25,7 +25,7 @@ func TestDefaultToolsForProfile_NoProfileReturnsAll(t *testing.T) {
 
 func TestDefaultToolsForProfile_FiltersByAllowlist(t *testing.T) {
 	dir := t.TempDir()
-	store := agentprofile.New(dir, nil)
+	store := agentprofile.New(dir)
 	// Create a profile with a restricted tool allowlist.
 	// (Writing the file and relying on read-through scan.)
 	if err := store.Create(&agentprofile.Profile{
@@ -60,7 +60,7 @@ func TestDefaultToolsForProfile_FiltersByAllowlist(t *testing.T) {
 
 func TestDefaultToolsForProfile_BuiltinEmptyReturnsAll(t *testing.T) {
 	dir := t.TempDir()
-	store := agentprofile.New(dir, nil)
+	store := agentprofile.New(dir)
 	// All builtin agents (default, explore, general, code-review) have empty
 	// Tools and get the full toolbelt — they manage restrictions via ReadOnly
 	// and the system prompt.
@@ -84,7 +84,7 @@ func TestDefaultToolsForProfile_BuiltinEmptyReturnsAll(t *testing.T) {
 
 func TestDefaultToolsForProfile_ExpertEmptyReturnsNone(t *testing.T) {
 	dir := t.TempDir()
-	store := agentprofile.New(dir, nil)
+	store := agentprofile.New(dir)
 	// An expert agent without tools gets none.
 	if err := store.Create(&agentprofile.Profile{
 		ID:          "expert-no-tools",
@@ -104,7 +104,7 @@ func TestDefaultToolsForProfile_ExpertEmptyReturnsNone(t *testing.T) {
 
 func TestDefaultToolsForProfile_UnknownAgentFallsBack(t *testing.T) {
 	dir := t.TempDir()
-	store := agentprofile.New(dir, nil)
+	store := agentprofile.New(dir)
 	// No profile for "ghost" → store.Get misses → all tools.
 	ctx := WithSessionAgentID(WithProfileStore(context.Background(), store), "ghost")
 	all := DefaultToolsForProfile(ctx, "test-model")
@@ -117,7 +117,7 @@ func TestDefaultToolsForProfile_SubToolsFiltered(t *testing.T) {
 	// Verify that sub_agent tools (which require a SubAgentManager in ctx) are
 	// filtered out when the profile doesn't include them.
 	dir := t.TempDir()
-	store := agentprofile.New(dir, nil)
+	store := agentprofile.New(dir)
 	if err := store.Create(&agentprofile.Profile{
 		ID:          "no-sub",
 		Description: "no sub-agent",

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -580,8 +580,7 @@ func sessionAgentIDFromContext(ctx context.Context) string {
 //
 // Empty Tools means different things depending on the agent source:
 //   - builtin (default, explore, general, code-review): empty = all tools
-//     (backward compatible; their behavior is managed via ReadOnly/LeanContext)
-//   - user-created / project: empty = no tools (explicitly restricted)
+//   - user-created: empty = no tools (explicitly restricted)
 func DefaultToolsForProfile(ctx context.Context, model string) []agent.ToolDefinition {
 	all := defaultToolsFor(ctx, model)
 	store := profileStoreFromContext(ctx)

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -201,12 +201,8 @@ func MCPManifestFor(model string, profile *agentprofile.Profile) string {
 }
 
 // hasMCPBridgeAccess reports whether the profile can use the MCP bridge tools
-// (mcp_describe and mcp_call). Matches DefaultToolsForProfile's filter logic:
-// builtin agents with empty Tools get everything; user/project agents with
-// empty Tools get nothing; an explicit allowlist must include both bridge
-// tools (the manifest text instructs the model to call mcp_describe then
-// mcp_call — having only one creates a dead end). A nil profile means
-// "default agent, full access."
+// (mcp_describe and mcp_call). Builtin agents with empty Tools get everything;
+// user agents with empty Tools get nothing.
 func hasMCPBridgeAccess(profile *agentprofile.Profile) bool {
 	if profile == nil || profile.IsDefault() {
 		return true

--- a/internal/tools/tool_search_test.go
+++ b/internal/tools/tool_search_test.go
@@ -264,19 +264,6 @@ func TestHasMCPBridgeAccess_UserEmptyTools(t *testing.T) {
 	}
 }
 
-func TestHasMCPBridgeAccess_ProjectEmptyTools(t *testing.T) {
-	p := &agentprofile.Profile{
-		ID:     "proj-no-tools",
-		Source: agentprofile.SourceProject,
-		CapabilitySpec: agentprofile.CapabilitySpec{
-			Tools: []string{}, // empty = none for project
-		},
-	}
-	if hasMCPBridgeAccess(p) {
-		t.Error("project agent with empty Tools must NOT have MCP bridge access")
-	}
-}
-
 func TestHasMCPBridgeAccess_BothBridgeTools(t *testing.T) {
 	p := &agentprofile.Profile{
 		ID:     "mcp-enabled",


### PR DESCRIPTION
## Summary

Remove project-level agent profiles entirely. Agents now live exclusively in `~/.octo/agents/` — one place, one source of truth.

## Why

Project-level profiles (`<repo>/.octo/agents/*.md`) caused confusion:
- When `octo serve` starts from a project directory, project agents shadow user agents
- The web panel showed agents that couldn't be deleted (Store was read-only for project)
- The delegation-only vs conversation-mode distinction was invisible to users
- Three sources of truth (builtin, user, project) for what should be one concept

Simplifies to two sources: builtin (code-defined) and user (global `~/.octo/agents/`).

## Changes

| Package | Change |
|---|---|
| `agentprofile` | Remove `SourceProject`, simplify `Store.New()` to single-arg, drop project dir scanning |
| `agentprofile` | Simplify `Delete()` protection to only guard builtins |
| `server/chat/tui` | Remove `agentProjectDir()`, use single-arg `New()` |
| `tools/agents.go` | Remove legacy `projectAgentsRoot` var and project scanning from `discoverAgents` |
| Tests | Drop project-specific tests (precedence, shadow, strips platform slice) |

**Net: 17 files, +66 / -256 lines.**

## User-visible impact

- Project-level `.octo/agents/` directories are no longer scanned — team-shared agent configs must move to individual `~/.octo/agents/` or be distributed via other means.
- Web panel agent management is now fully functional (create/edit/delete all work).

## Self-review

- [x] Smallest possible diff for the need
- [x] No new configuration knobs
- [x] No new dependencies
- [x] Fits the existing design / naming / layering
- [x] All tests pass
- [x] Coverage does not drop