### PR TITLE
fix(server): honor channel_bindings in agent PUT update

### DIFF
--- a/internal/server/agents_handlers.go
+++ b/internal/server/agents_handlers.go
@@ -14,13 +14,14 @@ import (
 // ─── Request/Response types ─────────────────────────────────────────────────
 
 type agentRequest struct {
-	ID           string   `json:"id,omitempty"`
-	Name         string   `json:"name"`
-	Description  string   `json:"description"`
-	Model        string   `json:"model,omitempty"`
-	Tools        []string `json:"tools,omitempty"`
-	ToolSkills   []string `json:"tool_skills,omitempty"`
-	SystemPrompt string   `json:"system_prompt,omitempty"`
+	ID              string                        `json:"id,omitempty"`
+	Name            string                        `json:"name"`
+	Description     string                        `json:"description"`
+	Model           string                        `json:"model,omitempty"`
+	Tools           []string                      `json:"tools,omitempty"`
+	ToolSkills      []string                      `json:"tool_skills,omitempty"`
+	SystemPrompt    string                        `json:"system_prompt,omitempty"`
+	ChannelBindings []agentprofile.ChannelBinding `json:"channel_bindings,omitempty"`
 }
 
 type agentBindRequest struct {
@@ -138,6 +139,7 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 			ToolSkills:   req.ToolSkills,
 			SystemPrompt: req.SystemPrompt,
 		},
+		ChannelBindings: req.ChannelBindings,
 	}
 
 	if err := s.agentStoreOrInit().Create(p); err != nil {
@@ -173,6 +175,11 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	bindings := existing.ChannelBindings
+	if req.ChannelBindings != nil {
+		bindings = req.ChannelBindings
+	}
+
 	p := &agentprofile.Profile{
 		ID:          existing.ID,
 		Name:        req.Name,
@@ -183,7 +190,7 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 			ToolSkills:   req.ToolSkills,
 			SystemPrompt: req.SystemPrompt,
 		},
-		ChannelBindings: existing.ChannelBindings, // preserved unless explicitly changed
+		ChannelBindings: bindings,
 	}
 
 	if err := s.agentStoreOrInit().Update(p); err != nil {

--- a/internal/server/agents_handlers_test.go
+++ b/internal/server/agents_handlers_test.go
@@ -151,6 +151,68 @@ func TestHandleAgents_BindUnbind(t *testing.T) {
 	}
 }
 
+// TestHandleAgents_UpdateBindings verifies that PUT /api/agents/:id can both
+// preserve existing bindings when the field is omitted and clear them when an
+// empty array is sent (matching the AgentEdit "delete + save" flow).
+func TestHandleAgents_UpdateBindings(t *testing.T) {
+	srv := agentsTestServer(t)
+
+	w := doJSON(t, srv, http.MethodPost, "/api/agents", `{
+		"name": "Binding Agent",
+		"description": "d",
+		"channel_bindings": [{"platform": "weixin", "chat_id": "c1"}]
+	}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create = %d: %s", w.Code, w.Body.String())
+	}
+	var created agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if len(created.ChannelBindings) != 1 || created.ChannelBindings[0].ChatID != "c1" {
+		t.Fatalf("unexpected created bindings: %+v", created.ChannelBindings)
+	}
+
+	// Omitting channel_bindings in PUT should preserve existing ones.
+	w = doJSON(t, srv, http.MethodPut, "/api/agents/"+created.ID, `{
+		"name": "Binding Agent v2",
+		"description": "d2"
+	}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update without bindings = %d: %s", w.Code, w.Body.String())
+	}
+	var preserved agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &preserved); err != nil {
+		t.Fatal(err)
+	}
+	if len(preserved.ChannelBindings) != 1 || preserved.ChannelBindings[0].ChatID != "c1" {
+		t.Fatalf("expected bindings preserved, got %+v", preserved.ChannelBindings)
+	}
+
+	// Sending an empty array should clear them (the bug being fixed).
+	w = doJSON(t, srv, http.MethodPut, "/api/agents/"+created.ID, `{
+		"name": "Binding Agent v3",
+		"description": "d3",
+		"channel_bindings": []
+	}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update with empty bindings = %d: %s", w.Code, w.Body.String())
+	}
+	var cleared agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &cleared); err != nil {
+		t.Fatal(err)
+	}
+	if len(cleared.ChannelBindings) != 0 {
+		t.Fatalf("expected 0 bindings after clear, got %+v", cleared.ChannelBindings)
+	}
+
+	// Verify it persisted.
+	got := doAgent(t, srv, created.ID)
+	if len(got.ChannelBindings) != 0 {
+		t.Fatalf("expected 0 bindings on reload, got %+v", got.ChannelBindings)
+	}
+}
+
 // agentsTestServer returns a server with an isolated ~/.octo/agents dir.
 func agentsTestServer(t *testing.T) *Server {
 	t.Helper()


### PR DESCRIPTION
AgentEdit sends `channel_bindings` on save, but `handleUpdateAgent` decoded into an `agentRequest` that lacked the field, so the server always kept the existing bindings. This made deleting a binding in the UI and clicking Save appear to do nothing.

- Add `ChannelBindings` to `agentRequest`.
- Apply it on create and on update (`nil` means preserve, empty slice means clear).
- Add `TestHandleAgents_UpdateBindings` covering preserve and clear.

Fixes the binding delete + save flow in AgentEdit.