### PR TITLE
fix(web): handle 204 No Content in api request helper

### DIFF
--- a/internal/server/agents_handlers.go
+++ b/internal/server/agents_handlers.go
@@ -205,7 +205,7 @@ func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, err.Error())
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": id})
 }
 
 // handleBindAgent serves POST /api/agents/:id/bind — bind a profile to an IM chat.

--- a/internal/server/agents_handlers_test.go
+++ b/internal/server/agents_handlers_test.go
@@ -74,7 +74,7 @@ func TestHandleAgents_CreateListGetDelete(t *testing.T) {
 
 	// Delete.
 	w = doJSON(t, srv, http.MethodDelete, "/api/agents/"+created.ID, "")
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusOK {
 		t.Fatalf("delete = %d: %s", w.Code, w.Body.String())
 	}
 	list = doAgents(t, srv)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -43,10 +43,6 @@ export async function request<T>(path: string, init?: RequestInit): Promise<T> {
   if (!res.ok) {
     throw new Error(await readErrorMessage(res, `${res.status} ${res.statusText}`))
   }
-  // 204 No Content has no body — skip JSON parsing.
-  if (res.status === 204) {
-    return undefined as unknown as T
-  }
   return res.json() as Promise<T>
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -43,6 +43,10 @@ export async function request<T>(path: string, init?: RequestInit): Promise<T> {
   if (!res.ok) {
     throw new Error(await readErrorMessage(res, `${res.status} ${res.statusText}`))
   }
+  // 204 No Content has no body — skip JSON parsing.
+  if (res.status === 204) {
+    return undefined as unknown as T
+  }
   return res.json() as Promise<T>
 }
 


### PR DESCRIPTION
## Summary

The `handleDeleteAgent` endpoint was the only DELETE endpoint returning 204 No Content, while all 16 other DELETE endpoints return 200 + JSON body. This inconsistency broke the frontend's `request()` helper which unconditionally calls `res.json()`.

## Fix

Align `handleDeleteAgent` with every other DELETE endpoint: return 200 OK + `{"deleted": "<id>"}`.

```diff
- w.WriteHeader(http.StatusNoContent)
+ writeJSON(w, http.StatusOK, map[string]any{"deleted": id})
```

No frontend changes needed — the existing `request()` helper already handles 200+JSON correctly for all other DELETE endpoints.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>