### PR TITLE
chore: bump version to 1.14.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.14.0"
+var Version = "1.14.1"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump version from 1.14.0 to 1.14.1.

Includes all Light Apps features:
- Light Apps panel + API (#1814, #1815)
- Artifacts panel sidebar (#1819)
- Save to Light Apps button (#1820)
