### PR TITLE
fix: prevent infinite loading loop in Light Apps panel

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -46,6 +46,7 @@
 
   // ── Light Apps (new) ──────────────────────────────────────────────────────
   let laLoading = $state(false)
+  let laAttempted = $state(false)
 
   async function loadLightApps() {
     if ($lightapps.length > 0) return
@@ -54,7 +55,10 @@
       const list = await api.listLightApps()
       lightapps.set(list)
     } catch { /* empty list */ }
-    finally { laLoading = false }
+    finally {
+      laLoading = false
+      laAttempted = true
+    }
   }
 
   async function selectLightApp(slug: string) {
@@ -70,7 +74,8 @@
 
   // Load light apps list once when the panel opens in lightapps mode.
   $effect(() => {
-    if ($panelContent === 'lightapps' && $lightapps.length === 0) loadLightApps()
+    if ($panelContent === 'lightapps' && $lightapps.length === 0 && !laAttempted) loadLightApps()
+    if ($panelContent !== 'lightapps') laAttempted = false
   })
 
   function closePanel() { panelContent.set(null) }


### PR DESCRIPTION
When the Light Apps API call fails (e.g. no Light Apps directory exists yet), `$lightapps` remains `[]`. The `$effect` would see `length === 0` is still true and call `loadLightApps()` again — creating an infinite loop of failing API calls and loading spinners.

Fix: add `laAttempted` guard flag that ensures the load runs at most once per panel open. Reset on panel close so re-opening re-triggers.

Fixes the infinite loading spinner when opening the sidebar on a non-chat page.
