### PR TITLE
fix: remove footer and preview/code toggle from ArtifactModal

### DIFF
--- a/web/src/components/ArtifactModal.svelte
+++ b/web/src/components/ArtifactModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { artifacts, panelContent, artifactSel, artifactView, artifactModalOpen, showToast } from '../lib/stores'
+  import { artifacts, panelContent, artifactSel, artifactModalOpen, showToast } from '../lib/stores'
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact } from '../lib/artifact-actions'
 
@@ -34,7 +34,7 @@
 <div class="backdrop" role="presentation" onclick={close}>
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1" bind:this={modalEl}
        onkeydown={onKeydown} onclick={(e) => e.stopPropagation()}>
-    <!-- Topbar -->
+    <!-- Topbar — icon + filename + type + actions -->
     <div class="topbar">
       <iconify-icon icon={cur.icon} width="15" style="color:var(--blue-6);flex:0 0 auto"></iconify-icon>
       <div class="file-info">
@@ -51,38 +51,9 @@
       </button>
     </div>
 
-    <!-- Preview/Code toggle -->
-    <div class="toolbar">
-      <div class="seg">
-        <button class="seg-btn" class:active={$artifactView === 'preview'} onclick={() => artifactView.set('preview')}>{$t('artifacts.preview')}</button>
-        <button class="seg-btn" class:active={$artifactView === 'code'} onclick={() => artifactView.set('code')}>{$t('artifacts.code')}</button>
-      </div>
-      <span class="sandboxed-label">{$t('artifacts.sandboxed')}</span>
-    </div>
-
-    <!-- Body -->
+    <!-- Body — always preview, no toolbar / footer chrome -->
     <div class="body">
-      {#if $artifactView === 'preview'}
-        <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
-      {:else}
-        <pre class="code-view">{cur.code}</pre>
-      {/if}
-    </div>
-
-    <!-- Footer chip switcher -->
-    <div class="footer">
-      <span class="footer-lbl">{$t('chat.artifacts')}</span>
-      {#each $artifacts as a, i}
-      <button
-        class="chip"
-        class:active={i === $artifactSel}
-        title={a.path}
-        onclick={() => artifactSel.set(i)}
-      >
-        <iconify-icon icon={a.icon} width="13"></iconify-icon>
-        {a.short}
-      </button>
-      {/each}
+      <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
     </div>
   </div>
 </div>
@@ -129,33 +100,6 @@
   cursor: pointer; color: var(--text-tertiary);
 }
 .icon-btn:hover { background: var(--hover-neutral); color: var(--blue-6); }
-.toolbar {
-  flex: 0 0 auto; padding: 8px 14px; border-bottom: 1px solid var(--border-table);
-  display: flex; align-items: center; gap: 8px;
-}
-.seg { display: inline-flex; padding: 2px; background: var(--control-track); border-radius: 8px; gap: 2px; }
-.seg-btn {
-  height: 26px; padding: 0 14px; border: none; border-radius: 6px; font-size: 12px;
-  cursor: pointer; background: transparent; color: var(--text-secondary); font-family: inherit;
-}
-.seg-btn.active { background: var(--bg-container); color: var(--blue-6); }
-.sandboxed-label { margin-left: auto; font-size: 11px; color: var(--text-tertiary); }
 .body { flex: 1; min-height: 0; background: var(--bg-container); }
 iframe { border: 0; width: 100%; height: 100%; display: block; }
-.code-view {
-  margin: 0; height: 100%; box-sizing: border-box; overflow: auto;
-  padding: 14px 16px; background: var(--bg-sidebar); font-size: 12px; line-height: 1.7;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--text); white-space: pre;
-}
-.footer {
-  flex: 0 0 auto; border-top: 1px solid var(--border-secondary);
-  padding: 8px 14px; display: flex; align-items: center; gap: 6px; overflow-x: auto;
-}
-.footer-lbl { font-size: 11px; color: var(--text-tertiary); flex: 0 0 auto; margin-right: 2px; }
-.chip {
-  height: 30px; padding: 0 10px; border: 1px solid var(--border-secondary); background: var(--bg-container);
-  color: var(--text-secondary); border-radius: 6px; display: flex; align-items: center;
-  gap: 6px; font-size: 12px; cursor: pointer; flex: 0 0 auto; font-family: inherit;
-}
-.chip.active { border-color: var(--blue-6); background: var(--active-blue-bg); color: var(--blue-6); }
 </style>


### PR DESCRIPTION
Simplifies the maximized artifact view to show only the essential chrome:

- **Removed**: Preview/Code toggle toolbar, footer chip switcher
- **Kept**: Topbar (icon + filename + copy/download/restore/close), always-preview body

The sidebar ArtifactsPanel still has the full controls — only the modal popup is affected. Saves ~1.5 KB of CSS.
