### PR TITLE
fix(web): adapt markdown/code/image preview colors to light/dark theme

### DIFF
--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -105,10 +105,12 @@ export async function observeArtifact(
   let code = ''
   let preview = ''
   try {
+    const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
     if (kind === 'image') {
       // The sandboxed iframe loads the image from the same-host endpoint.
       code = url
-      preview = `<body style="margin:0;display:flex;align-items:center;justify-content:center;background:#1e1e1e;height:100vh"><img style="max-width:100%;max-height:100vh" src="${url}"></body>`
+      const imgBg = isDark ? '#1e1e1e' : '#f5f5f5'
+      preview = `<body style="margin:0;display:flex;align-items:center;justify-content:center;background:${imgBg};height:100vh"><img style="max-width:100%;max-height:100vh" src="${url}"></body>`
     } else {
       const res = await fetch(url)
       if (!res.ok) return
@@ -118,11 +120,18 @@ export async function observeArtifact(
           // External scripts/stylesheets can't load inside a sandboxed srcdoc
           // iframe without same-origin access. Show a warning + the raw source.
           const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-          preview = `<body style="margin:0;padding:16px;font:13px/1.5 system-ui,sans-serif;color:#555;background:#fafafa">
-<div style="padding:10px 14px;background:#fff8e1;border:1px solid #f0c040;border-radius:6px;margin-bottom:14px;font-size:13px;color:#7a5c00">
+          const warnBodyBg = isDark ? '#0d1117' : '#fafafa'
+          const warnBodyColor = isDark ? '#8b949e' : '#555'
+          const warnCardBg = isDark ? '#2b2111' : '#fff8e1'
+          const warnCardBorder = isDark ? '#594214' : '#f0c040'
+          const warnCardColor = isDark ? '#e8b339' : '#7a5c00'
+          const warnPreBg = isDark ? '#161b22' : '#f5f5f5'
+          const warnPreColor = isDark ? '#c9d1d9' : '#333'
+          preview = `<body style="margin:0;padding:16px;font:13px/1.5 system-ui,sans-serif;color:${warnBodyColor};background:${warnBodyBg}">
+<div style="padding:10px 14px;background:${warnCardBg};border:1px solid ${warnCardBorder};border-radius:6px;margin-bottom:14px;font-size:13px;color:${warnCardColor}">
 ⚠️ This file references external resources and cannot be previewed here. Use <b>Open in new tab</b> or switch to <b>Code</b> view.
 </div>
-<pre style="margin:0;padding:12px;background:#f5f5f5;border-radius:6px;overflow:auto;font:12px/1.6 'SFMono-Regular',Menlo,monospace;color:#333;white-space:pre-wrap">${escaped}</pre>
+<pre style="margin:0;padding:12px;background:${warnPreBg};border-radius:6px;overflow:auto;font:12px/1.6 'SFMono-Regular',Menlo,monospace;color:${warnPreColor};white-space:pre-wrap">${escaped}</pre>
 </body>`
         } else {
           preview = code
@@ -132,47 +141,27 @@ export async function observeArtifact(
         // access to the host app's CSS or JS.  Inline the highlight.js theme
         // CSS, code-block layout, and a copy-button handler so syntax
         // highlighting and the "Copy" button actually work in preview mode.
-        const MD_STYLES = [
-          // code-block layout (mirrors ChatView.svelte :global rules)
-          `.code-block{border:1px solid #30363d;border-radius:8px;overflow:hidden;background:#1e1e1e;margin:10px 0}`,
-          `.code-header{display:flex;align-items:center;gap:8px;padding:6px 8px 6px 12px;background:#2d2d2d;border-bottom:1px solid #30363d}`,
-          `.code-lang{font-size:11px;color:#888;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}`,
-          `.copy-btn{margin-left:auto;height:24px;padding:0 8px;border:none;background:transparent;border-radius:5px;font-size:11px;color:#888;cursor:pointer;font-family:inherit}`,
-          `.copy-btn:hover{background:#3d3d3d;color:#58a6ff}`,
-          `pre{margin:0;padding:12px 14px;overflow-x:auto;font-size:13px;line-height:1.6;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#d4d4d4}`,
-          `code.hljs{background:transparent;padding:0}`,
-          // highlight.js GitHub Dark theme (simplified — 1:1 with upstream)
-          `.hljs{color:#c9d1d9;background:#0d1117}`,
-          `.hljs-keyword,.hljs-doctag,.hljs-meta\\ .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable\\.language_{color:#ff7b72}`,
-          `.hljs-title,.hljs-title\\.class_,.hljs-title\\.class_\\.inherited__,.hljs-title\\.function_{color:#d2a8ff}`,
-          `.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-variable,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id{color:#79c0ff}`,
-          `.hljs-regexp,.hljs-string,.hljs-meta\\ .hljs-string{color:#a5d6ff}`,
-          `.hljs-built_in,.hljs-symbol{color:#ffa657}`,
-          `.hljs-comment,.hljs-code,.hljs-formula{color:#8b949e}`,
-          `.hljs-name,.hljs-quote,.hljs-selector-tag,.hljs-selector-pseudo,.hljs-tag{color:#7ee787}`,
-          `.hljs-subst{color:#c9d1d9}`,
-          `.hljs-section{color:#1f6feb;font-weight:700}`,
-          `.hljs-bullet{color:#f2cc60}`,
-          `.hljs-emphasis{font-style:italic}`,
-          `.hljs-strong{font-weight:700}`,
-          `.hljs-addition{color:#aff5b4;background:#033a16}`,
-          `.hljs-deletion{color:#ffdcd7;background:#67060c}`,
-        ].join('')
+        const MD_STYLES = isDark ? darkMDStyles() : lightMDStyles()
+        const bodyStyle = isDark
+          ? 'margin:0;padding:16px;font:14px/1.6 system-ui,-apple-system,sans-serif;color:#d4d4d4;background:#1e1e1e'
+          : 'margin:0;padding:16px;font:14px/1.6 system-ui,-apple-system,sans-serif;color:rgba(0,0,0,0.88);background:#ffffff'
         const COPY_SCRIPT = `<script>
-document.querySelector('.body').addEventListener('click',function(e){
-  var b=e.target.closest('.copy-btn');if(!b)return;
-  var c=b.closest('.code-block').querySelector('pre code');
-  navigator.clipboard.writeText(c?c.textContent:'').then(function(){
-    var o=b.textContent;b.textContent='Copied!';
-    setTimeout(function(){b.textContent=o},1500);
-  })
-});
-<\/script>`
-        preview = `<style>${MD_STYLES}</style><body style="margin:0;padding:16px;font:14px/1.6 system-ui,-apple-system,sans-serif;color:#d4d4d4;background:#1e1e1e">${renderMarkdown(code)}${COPY_SCRIPT}</body>`
+	document.querySelector('.body').addEventListener('click',function(e){
+	  var b=e.target.closest('.copy-btn');if(!b)return;
+	  var c=b.closest('.code-block').querySelector('pre code');
+	  navigator.clipboard.writeText(c?c.textContent:'').then(function(){
+	    var o=b.textContent;b.textContent='Copied!';
+	    setTimeout(function(){b.textContent=o},1500);
+	  })
+	});
+	<\/script>`
+        preview = `<style>${MD_STYLES}</style><body style="${bodyStyle}">${renderMarkdown(code)}${COPY_SCRIPT}</body>`
       } else {
-        // code kind: show with a dark monospace style
+        // code kind: show with theme-aware monospace style
         const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-        preview = `<body style="margin:0;background:#1e1e1e"><pre style="margin:0;padding:16px;color:#d4d4d4;font:13px/1.6 'SFMono-Regular',Menlo,monospace;white-space:pre-wrap;word-break:break-all">${escaped}</pre></body>`
+        const codeBg = isDark ? '#1e1e1e' : '#ffffff'
+        const codeColor = isDark ? '#d4d4d4' : 'rgba(0,0,0,0.88)'
+        preview = `<body style="margin:0;background:${codeBg}"><pre style="margin:0;padding:16px;color:${codeColor};font:13px/1.6 'SFMono-Regular',Menlo,monospace;white-space:pre-wrap;word-break:break-all">${escaped}</pre></body>`
       }
     }
   } catch {
@@ -205,4 +194,63 @@ document.querySelector('.body').addEventListener('click',function(e){
     autoOpened = true
     panelContent.set('session')
   }
+}
+
+// darkMDStyles returns inline CSS for code blocks and syntax highlighting
+// in dark mode — mirrors highlight.js github-dark.css.
+function darkMDStyles(): string {
+  return [
+    `.code-block{border:1px solid #30363d;border-radius:8px;overflow:hidden;background:#1e1e1e;margin:10px 0}`,
+    `.code-header{display:flex;align-items:center;gap:8px;padding:6px 8px 6px 12px;background:#2d2d2d;border-bottom:1px solid #30363d}`,
+    `.code-lang{font-size:11px;color:#888;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}`,
+    `.copy-btn{margin-left:auto;height:24px;padding:0 8px;border:none;background:transparent;border-radius:5px;font-size:11px;color:#888;cursor:pointer;font-family:inherit}`,
+    `.copy-btn:hover{background:#3d3d3d;color:#58a6ff}`,
+    `pre{margin:0;padding:12px 14px;overflow-x:auto;font-size:13px;line-height:1.6;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#d4d4d4}`,
+    `code.hljs{background:transparent;padding:0}`,
+    `.hljs{color:#c9d1d9;background:#0d1117}`,
+    `.hljs-keyword,.hljs-doctag,.hljs-meta\\ .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable\\.language_{color:#ff7b72}`,
+    `.hljs-title,.hljs-title\\.class_,.hljs-title\\.class_\\.inherited__,.hljs-title\\.function_{color:#d2a8ff}`,
+    `.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-variable,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id{color:#79c0ff}`,
+    `.hljs-regexp,.hljs-string,.hljs-meta\\ .hljs-string{color:#a5d6ff}`,
+    `.hljs-built_in,.hljs-symbol{color:#ffa657}`,
+    `.hljs-comment,.hljs-code,.hljs-formula{color:#8b949e}`,
+    `.hljs-name,.hljs-quote,.hljs-selector-tag,.hljs-selector-pseudo,.hljs-tag{color:#7ee787}`,
+    `.hljs-subst{color:#c9d1d9}`,
+    `.hljs-section{color:#1f6feb;font-weight:700}`,
+    `.hljs-bullet{color:#f2cc60}`,
+    `.hljs-emphasis{font-style:italic}`,
+    `.hljs-strong{font-weight:700}`,
+    `.hljs-addition{color:#aff5b4;background:#033a16}`,
+    `.hljs-deletion{color:#ffdcd7;background:#67060c}`,
+  ].join('')
+}
+
+// lightMDStyles returns inline CSS for code blocks and syntax highlighting
+// in light mode — mirrors the main app's light theme and GitHub light syntax.
+function lightMDStyles(): string {
+  return [
+    `.code-block{border:1px solid #d0d7de;border-radius:8px;overflow:hidden;background:#f6f8fa;margin:10px 0}`,
+    `.code-header{display:flex;align-items:center;gap:8px;padding:6px 8px 6px 12px;background:#eaeef2;border-bottom:1px solid #d0d7de}`,
+    `.code-lang{font-size:11px;color:#57606a;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}`,
+    `.copy-btn{margin-left:auto;height:24px;padding:0 8px;border:none;background:transparent;border-radius:5px;font-size:11px;color:#57606a;cursor:pointer;font-family:inherit}`,
+    `.copy-btn:hover{background:#d0d7de;color:#0969da}`,
+    `pre{margin:0;padding:12px 14px;overflow-x:auto;font-size:13px;line-height:1.6;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#24292f}`,
+    `code.hljs{background:transparent;padding:0}`,
+    // highlight.js GitHub (light) theme — simplified
+    `.hljs{color:#24292f;background:#fff}`,
+    `.hljs-keyword,.hljs-doctag,.hljs-meta\\ .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable\\.language_{color:#cf222e}`,
+    `.hljs-title,.hljs-title\\.class_,.hljs-title\\.class_\\.inherited__,.hljs-title\\.function_{color:#8250df}`,
+    `.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-variable,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id{color:#0550ae}`,
+    `.hljs-regexp,.hljs-string,.hljs-meta\\ .hljs-string{color:#0a3069}`,
+    `.hljs-built_in,.hljs-symbol{color:#953800}`,
+    `.hljs-comment,.hljs-code,.hljs-formula{color:#6e7781}`,
+    `.hljs-name,.hljs-quote,.hljs-selector-tag,.hljs-selector-pseudo,.hljs-tag{color:#116329}`,
+    `.hljs-subst{color:#24292f}`,
+    `.hljs-section{color:#0550ae;font-weight:700}`,
+    `.hljs-bullet{color:#953800}`,
+    `.hljs-emphasis{font-style:italic}`,
+    `.hljs-strong{font-weight:700}`,
+    `.hljs-addition{color:#1a7f37;background:#dafbe1}`,
+    `.hljs-deletion{color:#cf222e;background:#ffebe9}`,
+  ].join('')
 }

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -2377,7 +2377,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 /* ── Rich answer (markdown) ──────────────────────────────────────────────── */
 .rich-answer { font-size: 14px; line-height: 1.6; color: var(--text); display: flex; flex-direction: column; gap: 12px; }
 :global(.rich-answer p) { margin: 0; }
-:global(.rich-answer code), :global(.think-body code) {
+:global(.rich-answer :not(pre) > code), :global(.think-body :not(pre) > code) {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; font-style: normal;
   background: var(--bg-table-header); border: 1px solid var(--border-table); border-radius: 4px; padding: 1px 5px;
 }


### PR DESCRIPTION
## Problem

Two related CSS issues make the web UI's light mode hard to use:

1. **Plaintext code blocks nearly invisible in light mode** — `:global(.rich-answer code)` applies `background: var(--bg-table-header)` (near-white) to code-block `<code class="hljs">` elements, overriding github-dark.css's dark background, while `.hljs` keeps its `color: #c9d1d9` (light gray). Result: light-gray text on white background.

2. **Artifacts panel previews always render in dark theme** — the srcdoc iframe for Markdown, image, and code previews hardcodes `background:#1e1e1e` and dark syntax colors, clashing with the app's light theme.

## Fix

### ChatView.svelte
- Change `:global(.rich-answer code)` → `:global(.rich-answer :not(pre) > code)`
- Inline-code styles (bg, border, padding) now only apply to `<pre>`-external `<code>` elements, letting `.hljs` dark background show through in code blocks

### artifacts.ts
- Detect `data-theme` on `<html>` at render time (`isDark`)
- **Markdown preview**: uses dark/light `MD_STYLES` function pair — dark keeps existing github-dark colors, light gets full GitHub Light syntax palette + light code-block chrome
- **Image preview**: `#1e1e1e` bg in dark, `#f5f5f5` bg in light
- **Code preview**: `#1e1e1e`/`#d4d4d4` in dark, `#ffffff`/`rgba(0,0,0,0.88)` in light
- **HTML external-refs warning page**: all three color groups (body, warning card, code block) now adapt to theme

## Files changed
- `web/src/views/ChatView.svelte` — 1 selector change
- `web/src/lib/artifacts.ts` — extract `darkMDStyles()` / `lightMDStyles()` functions, theme-aware body/code/image previews