### PR TITLE
docs: add Light Apps guide, update product_help skill

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -83,6 +83,7 @@ export default defineConfig({
 						{ label: 'Run long-horizon goals', slug: 'guides/goals', translations: { 'zh-CN': '运行长周期目标' } },
 						{ label: 'Repeat a task with /loop', slug: 'guides/loop', translations: { 'zh-CN': '用 /loop 重复任务' } },
 						{ label: 'Schedule cron tasks', slug: 'guides/cron-tasks', translations: { 'zh-CN': '定时任务' } },
+						{ label: 'Light Apps', slug: 'guides/light-apps', translations: { 'zh-CN': '轻应用' } },
 						{ label: 'Self-host octo serve', slug: 'guides/self-host', translations: { 'zh-CN': '自托管 octo serve' } },
 					],
 				},

--- a/docs/src/content/docs/guides/light-apps.mdx
+++ b/docs/src/content/docs/guides/light-apps.mdx
@@ -1,0 +1,73 @@
+---
+title: Light Apps
+description: Save agent-generated HTML pages as reusable mini-apps. Open anytime — zero token cost.
+---
+
+import { Badge } from '@astrojs/starlight/components';
+
+<Badge text="New" variant="tip" /><br /><br />
+
+When you ask the agent to generate an HTML page — a data reconciliation tool, format converter,
+daily report template — and the task is **repeatable**, the agent will proactively suggest
+saving it as a **Light App**. Once saved, you can open it anytime from the Web UI without
+consuming LLM tokens.
+
+## What it is
+
+A Light App is a self-contained HTML page written by the agent using pure frontend technologies
+(HTML + CSS + JS). It lives under `~/.octo/light-apps/` with two files per app:
+
+```
+~/.octo/light-apps/<slug>/
+├── manifest.json   # metadata: name, description, icon, created_at
+└── index.html      # self-contained page (no CDN, no external requests)
+```
+
+Light Apps run in a sandboxed iframe and only have access to browser-side capabilities —
+`FileReader`, `<input type="file">`, `localStorage`. No backend needed, no backend access.
+
+## When to use
+
+✅ **Good candidates for Light Apps**:
+- Repeatable tools: data reconciliation, format conversion, CSV merging
+- Template generators: daily report templates, checklist generators
+- Tasks with fixed input → output rules: validators, calculators, formatters
+- Tools you want available offline
+
+❌ **Not suitable for Light Apps**:
+- One-off analysis or research
+- Tasks that genuinely need LLM reasoning each time
+- Workflows requiring backend APIs / databases (use [Skills](/docs/guides/use-skills/) or [Workflows](/docs/guides/workflows/))
+
+## How to create one
+
+The agent automatically evaluates whether an HTML page is worth saving as a Light App. The flow:
+
+1. You ask the agent to generate an HTML tool page in conversation
+2. The agent generates and previews it, then proactively asks: "Save as Light App? Open anytime from the Light Apps panel with zero tokens."
+3. On your confirmation, the agent writes both files to `~/.octo/light-apps/<slug>/` using `write_file`
+4. The slug is derived from the app name — lowercase letters, digits, and hyphens only
+
+You **don't need to touch the filesystem** — the agent handles everything.
+
+## Managing Light Apps
+
+Click "Light Apps" in the Web UI navigation bar to see a card grid of all saved apps:
+
+- **Open**: renders the app in the Artifacts sidebar panel in preview mode — fully interactive
+- **Edit**: opens an agent conversation with the current content inline, so the agent can update it
+- **Delete**: removes the app after confirmation
+
+Agent-generated HTML artifacts can also be saved to Light Apps with one click from the Artifacts panel.
+
+## Technical constraints
+
+Since Light Apps run in a sandboxed iframe, the agent follows these rules when generating them:
+
+- Fully self-contained: no CDN links, no external images, no cross-origin fetch
+- All CSS and JS inline (`<style>` + `<script>`)
+- File processing via `FileReader` + `<input type="file">`
+- Icons via emoji or inline SVG
+- Layout and color conventions from the `artifact-design` and `dataviz` skills
+
+The agent already knows these constraints — just describe what you want, and it handles the rest.

--- a/docs/src/content/docs/zh/guides/light-apps.mdx
+++ b/docs/src/content/docs/zh/guides/light-apps.mdx
@@ -1,0 +1,71 @@
+---
+title: 轻应用
+description: 把 Agent 生成的 HTML 页面保存为可复用的轻应用，随时打开，零 token 消耗。
+---
+
+import { Badge } from '@astrojs/starlight/components';
+
+<Badge text="New" variant="tip" /><br /><br />
+
+当你让 Agent 生成一个 HTML 页面——比如数据对账工具、格式转换器、日报模板——如果这个任务是**可重复**的，
+Agent 会主动提醒你把它保存为一个**轻应用**。保存后，你可以随时在 Web 界面里打开使用，不需要再消耗 LLM token。
+
+## 它是什么
+
+轻应用是 Agent 用纯前端技术（HTML + CSS + JS）写的自包含页面，存储在本机 `~/.octo/light-apps/`
+目录下。每个轻应用由两个文件组成：
+
+```
+~/.octo/light-apps/<slug>/
+├── manifest.json   # 元数据：名称、描述、图标、创建时间
+└── index.html      # 自包含页面（不依赖 CDN、不请求外部资源）
+```
+
+轻应用运行在浏览器的 sandboxed iframe 里，只能使用浏览器端能力——`FileReader`、`<input type="file">`、
+`localStorage` 等。它不能访问后端服务，也不需要后端。
+
+## 适用场景
+
+✅ **适合做成轻应用的任务**：
+- 重复性工具：数据对账、格式转换、CSV 合并
+- 模板生成器：日报模板、周报模板、清单生成
+- 输入→输出逻辑固定的任务：校验器、计算器、格式化工具
+- 需要离线可用的工具
+
+❌ **不适合做成轻应用**：
+- 一次性的分析或调研
+- 必须依赖 LLM 推理的任务
+- 需要后端 API / 数据库的工作流（用 [Skills](/docs/zh/guides/use-skills/) 或 [Workflows](/docs/zh/guides/workflows/) 代替）
+
+## 如何创建
+
+Agent 会自动判断一个 HTML 页面是否适合保存为轻应用。流程如下：
+
+1. 你在对话中让 Agent 生成一个 HTML 工具页面
+2. Agent 生成并预览后，如果判断任务可重复，会主动问：「保存为轻应用？以后随时在轻应用面板打开，不消耗 token。」
+3. 你确认后，Agent 用 `write_file` 直接把文件写入 `~/.octo/light-apps/<slug>/`
+4. slug 由小写字母、数字和连字符组成，从应用名称自动推导
+
+你也**不需要手动操作文件系统**——Agent 会自动完成一切。
+
+## 管理与使用
+
+在 Web 界面的导航栏点击「轻应用」，你会看到一个卡片网格，列出所有已保存的轻应用：
+
+- **打开**：在侧边栏的 Artifacts 面板中以 preview 模式渲染，可以直接交互使用
+- **编辑**：跳转到 Agent 对话，告诉 Agent 当前内容和修改需求，让它帮你更新
+- **删除**：确认后删除该轻应用
+
+Agent 生成的 HTML artifact 也可以在 Artifacts 面板中一键「保存到轻应用」。
+
+## 技术约束
+
+因为轻应用跑在 sandboxed iframe 里，Agent 在生成时必须遵守以下规则：
+
+- 完全自包含：不能引用 CDN、不能请求外部图片、不能跨域 fetch
+- CSS 和 JS 都内联（`<style>` + `<script>`）
+- 文件处理用 `FileReader` + `<input type="file">`
+- 图标用 emoji 或内联 SVG
+- 遵循 `artifact-design` 和 `dataviz` skill 的布局与配色规范
+
+这些约束 Agent 都清楚——你只需要告诉它要做什么，它会自动处理技术细节。

--- a/internal/skills/defaults/product_help/README.md
+++ b/internal/skills/defaults/product_help/README.md
@@ -17,8 +17,9 @@ data staying on the user's own machine. No Node / Python / Ruby runtime.
 - **Go SDK** (`pkg/octoagent`) — embed the agent loop in your own programs
 
 The eighth, a mobile app, is next. On top of the agent loop: skills, MCP clients,
-OS-level sandboxing, persistent memory, sub-agents, background workflows, and a
-task graph for autonomous multi-step goals.
+OS-level sandboxing, persistent memory, sub-agents, expert agents, background workflows,
+Light Apps (reusable agent-generated HTML tools), and a task graph for autonomous
+multi-step goals.
 
 ## Install
 

--- a/internal/skills/defaults/product_help/SKILL.md
+++ b/internal/skills/defaults/product_help/SKILL.md
@@ -26,9 +26,9 @@ You have access to octo's product documentation. Use it to answer user questions
    Read the relevant file(s) with `read_file` before answering.
 
 2. **Online docs** (fallback, and the source of truth for anything the bundled summaries don't cover) — the public docs site at `https://octo-agent.dev/docs/`, fetched with `web_fetch`:
-   - `guides/<topic>/` for narrative how-tos — e.g. `guides/goals/`, `guides/workflows/`, `guides/loop/`, `guides/cron-tasks/`, `guides/browser-automation/`, `guides/sub-agents/`, `guides/sandbox-the-agent/`, `guides/self-host/`, `guides/channels/`, `guides/hooks/`, `guides/use-skills/`, `guides/connect-mcp-servers/`, `guides/memory/`, `guides/memory-backends/`
+   - `guides/<topic>/` for narrative how-tos — e.g. `guides/goals/`, `guides/workflows/`, `guides/loop/`, `guides/cron-tasks/`, `guides/browser-automation/`, `guides/sub-agents/`, `guides/expert-agents/`, `guides/light-apps/`, `guides/sandbox-the-agent/`, `guides/self-host/`, `guides/channels/`, `guides/hooks/`, `guides/use-skills/`, `guides/connect-mcp-servers/`, `guides/memory/`, `guides/memory-backends/`
    - `reference/<topic>/` for exhaustive lookups — `reference/cli/`, `reference/config-file/`, `reference/permissions/`, `reference/slash-commands/`, `reference/tools/`, `reference/http-api/`, `reference/security/`, `reference/compatibility/`
-   - Some topics (`sub-agents`, `sandbox-the-agent`, `self-host`) have a full guide online but no bundled summary file at all — go straight to `web_fetch` for those.
+   - Some topics (`sub-agents`, `expert-agents`, `light-apps`, `sandbox-the-agent`, `self-host`) have a full guide online but no bundled summary file at all — go straight to `web_fetch` for those.
    - For anything neither the bundled docs nor the docs site cover (e.g. an internal design doc under `dev-docs/`), fall back to `https://github.com/open-octo/octo-agent/blob/main/<path>` via `web_fetch`.
 
 ## How to answer


### PR DESCRIPTION
## Summary

Documentation and skill updates for two features that were missing from the docs:

### Light Apps guide
- New user-facing guide (English + Chinese) covering: what Light Apps are, when to use them, how the agent creates them, the Web UI management flow, and sandboxed iframe constraints
- Added sidebar entry under Guides

### product_help skill
- Added `guides/expert-agents/` and `guides/light-apps/` to the online docs guide list
- Updated the "no bundled summary" list to include these two topics
- Updated the feature overview in README.md with expert agents and Light Apps

### Files changed
- `docs/src/content/docs/guides/light-apps.mdx` — new English guide
- `docs/src/content/docs/zh/guides/light-apps.mdx` — new Chinese guide
- `docs/astro.config.mjs` — sidebar entry
- `internal/skills/defaults/product_help/SKILL.md` — guide list + fallback list update
- `internal/skills/defaults/product_help/README.md` — feature overview update