### PR TITLE
fix(web): reduce TasksView action buttons from 4 to 3

### DIFF
--- a/web/src/views/TasksView.svelte
+++ b/web/src/views/TasksView.svelte
@@ -88,17 +88,6 @@
     }
   }
 
-  async function handleToggle(t: api.TaskResponse) {
-    const next = !t.enabled
-    try {
-      await api.toggleTask(t.id, next)
-      rawTasks = rawTasks.map(r => r.id === t.id ? { ...r, enabled: next } : r)
-      showToast(next ? tr('tasks.resumed') : tr('tasks.paused_toast'))
-    } catch (e: any) {
-      showToast(e?.message ?? 'Failed to update task', 'error')
-    }
-  }
-
   async function handleDelete(t: api.TaskResponse) {
     if (!(await confirmDialog(tr('tasks.confirm_delete').replace('{name}', t.name)))) return
     try {
@@ -189,13 +178,6 @@
             <div class="row-actions">
               <button class="act-btn" title={$t('tasks.run_now')} onclick={() => handleRun(task)}>
                 <iconify-icon icon="ant-design:caret-right-outlined" width="15"></iconify-icon>
-              </button>
-              <button
-                class="act-btn"
-                title={task.enabled ? $t('tasks.pause') : $t('tasks.resume')}
-                onclick={() => handleToggle(task)}
-              >
-                <iconify-icon icon={task.enabled ? 'ant-design:pause-outlined' : 'ant-design:play-circle-outlined'} width="15"></iconify-icon>
               </button>
               <button class="act-btn" title={$t('common.edit')} onclick={() => openEdit(task)}>
                 <iconify-icon icon="ant-design:edit-outlined" width="14"></iconify-icon>


### PR DESCRIPTION
## Summary

Remove the per-row Pause/Resume button from TasksView, reducing action buttons from 4 to 3.

Before: ▶Run / ⏯Pause / ✎Edit / ✕Delete (4)
After:  ▶Run / ✎Edit / ✕Delete (3)

Pause/Resume is now handled through the Edit conversation flow (`cron-task-creator` skill). The `toggleTask` function is kept in `api.ts` since the mobile TasksTab still uses it.

Closes the >3 action buttons violation flagged in the Agent-First UI audit.