### PR TITLE
fix(skill): use curl instead of web_fetch for localhost API calls

### DIFF
--- a/internal/skills/defaults/config-setup/SKILL.md
+++ b/internal/skills/defaults/config-setup/SKILL.md
@@ -29,7 +29,7 @@ workspace_dir                     default / lite model
 ```
 
 All of these live in `~/.octo/config.yml` and are editable through the REST API
-on the running octo server at `http://localhost:<port>` (use `web_fetch`).
+on the running octo server at `http://localhost:<port>` (use `curl` via the `terminal` tool — do NOT use `web_fetch`, localhost is blocked by SSRF).
 
 ## Finding the server port
 

--- a/internal/skills/defaults/expert-agent-manager/SKILL.md
+++ b/internal/skills/defaults/expert-agent-manager/SKILL.md
@@ -19,7 +19,8 @@ allowlist).
 ## API Base
 
 All endpoints below are served by the octo server at `http://localhost:<port>`.
-Use the `web_fetch` tool to call them. All requests return JSON.
+Use `curl` via the `terminal` tool to call them. (Do NOT use `web_fetch` —
+localhost is blocked by SSRF protection.) All requests return JSON.
 
 | Method | Path | Description |
 |--------|------|-------------|


### PR DESCRIPTION
## Summary

`web_fetch` has SSRF protection that blocks localhost/127.0.0.1. When a skill tells the agent to call the octo REST API via `web_fetch`, the call is denied:

```
permission_denied: web_fetch matched deny rule (hostname: ... localhost ...)
```

Fix: switch the instructions to use `curl` via the `terminal` tool instead.

## Changes

- `expert-agent-manager/SKILL.md` — change "Use the `web_fetch` tool" → "Use `curl` via the `terminal` tool (do NOT use `web_fetch` — localhost is blocked by SSRF)"
- `config-setup/SKILL.md` — same fix

Note: `cron-task-creator` already uses `curl` verbatim, no change needed.