### PR TITLE
fix(tasks): wire task AgentID into cron session so expert agents work

### DIFF
--- a/internal/server/cron_consolidation_test.go
+++ b/internal/server/cron_consolidation_test.go
@@ -73,7 +73,7 @@ func TestPatchTask_UpdatesFields(t *testing.T) {
 
 	id := createTaskForTest(t, srv, `{"name":"edit-me","cron":"0 0 9 * * *","prompt":"old"}`)
 
-	patch := `{"prompt":"new prompt","directory":"/w","enabled":false}`
+	patch := `{"prompt":"new prompt","directory":"/w","enabled":false,"agent_id":"code-review"}`
 	req := httptest.NewRequest(http.MethodPatch, "/api/tasks/"+id, strings.NewReader(patch))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -93,6 +93,9 @@ func TestPatchTask_UpdatesFields(t *testing.T) {
 	}
 	if got.Enabled {
 		t.Errorf("enabled = true, want false (toggle via PATCH)")
+	}
+	if got.AgentID != "code-review" {
+		t.Errorf("agent_id = %q, want %q", got.AgentID, "code-review")
 	}
 	// Cron was not in the patch — it must be left untouched.
 	if got.Cron != "0 0 9 * * *" {

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -134,6 +134,7 @@ func (s *Server) newSession(task scheduler.Task) (string, error) {
 	sess := agent.NewSession(model, s.system)
 	sess.Source = "cron"
 	sess.Title = time.Now().Format("2006-01-02 15:04")
+	sess.AgentID = task.AgentID
 	// Cron ticks have no human to answer an ask prompt, unlike the web/IM
 	// default this mirrors — see ResolveUnattendedDefaultMode's doc comment.
 	_ = sess.SetPermissionMode(string(permission.ResolveUnattendedDefaultMode()))
@@ -615,7 +616,8 @@ type patchTaskRequest struct {
 	Cron      *string                  `json:"cron,omitempty"`
 	Prompt    *string                  `json:"prompt,omitempty"`
 	Model     *string                  `json:"model,omitempty"`
-	Agent     *string                  `json:"agent,omitempty"`
+	Agent     *string                  `json:"agent,omitempty"` // deprecated
+	AgentID   *string                  `json:"agent_id,omitempty"`
 	Directory *string                  `json:"directory,omitempty"`
 	Notify    *scheduler.NotifyTargets `json:"notify,omitempty"`
 	Name      *string                  `json:"name,omitempty"`
@@ -670,6 +672,9 @@ func (s *Server) handlePatchTask(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Agent != nil {
 		task.Agent = *req.Agent
+	}
+	if req.AgentID != nil {
+		task.AgentID = *req.AgentID
 	}
 	if req.Directory != nil {
 		task.Directory = *req.Directory

--- a/internal/server/tasks_handlers_test.go
+++ b/internal/server/tasks_handlers_test.go
@@ -260,3 +260,45 @@ func TestCreateSession_LazilyCreatesGroupForOldTask(t *testing.T) {
 		t.Fatalf("no lazily-created group holds session %q; groups=%+v", sessionID, groups)
 	}
 }
+
+func TestCreateSession_PersistsAgentID(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	sessionID, err := srv.CreateSession(scheduler.Task{Name: "t", AgentID: "code-review"})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	sess, err := agent.LoadSession(sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if sess.AgentID != "code-review" {
+		t.Errorf("sess.AgentID = %q, want %q", sess.AgentID, "code-review")
+	}
+	if got := sess.EffectiveAgentID(); got != "code-review" {
+		t.Errorf("EffectiveAgentID() = %q, want %q", got, "code-review")
+	}
+}
+
+func TestCreateSession_EmptyAgentID_DefaultsToDefault(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	sessionID, err := srv.CreateSession(scheduler.Task{Name: "t"})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	sess, err := agent.LoadSession(sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if sess.AgentID != "" {
+		t.Errorf("sess.AgentID = %q, want empty", sess.AgentID)
+	}
+	if got := sess.EffectiveAgentID(); got != "default" {
+		t.Errorf("EffectiveAgentID() = %q, want %q", got, "default")
+	}
+}


### PR DESCRIPTION
## Problem

Cron tasks accepted `agent_id` at creation and transfer, but the value was never wired into the session — `newSession()` didn't set `sess.AgentID`, so `buildAgent()` always resolved the default agent's system prompt.

Additionally, `PATCH /api/tasks/:id` had no `agent_id` field, making it impossible to change the assigned agent without deleting and recreating the task.

## Fix

1. **`newSession()`** — seeds `sess.AgentID` from `task.AgentID` (after `model` and `Source`, before directory & save).
2. **`patchTaskRequest`** — adds `AgentID *string` with `json:"agent_id,omitempty"`, and `handlePatchTask` wires it to `task.AgentID`.

## Testing

- `go build ./...` ✅
- `go vet ./internal/server/` ✅
- `go test -race ./internal/server/ -run Task` ✅ (17 tests)
- `go test -race ./internal/scheduler/` ✅ (14 tests)
