### PR TITLE
feat(web): real-time agent list refresh via WebSocket

### DIFF
--- a/internal/server/agents_handlers.go
+++ b/internal/server/agents_handlers.go
@@ -151,6 +151,7 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, agentToResp(p))
+	s.broadcastGlobal(map[string]any{"type": "agents_changed"})
 }
 
 // handleUpdateAgent serves PUT /api/agents/:id — update an existing profile.
@@ -198,6 +199,7 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, agentToResp(p))
+	s.broadcastGlobal(map[string]any{"type": "agents_changed"})
 }
 
 // handleDeleteAgent serves DELETE /api/agents/:id — remove a user-level profile.
@@ -213,6 +215,7 @@ func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": id})
+	s.broadcastGlobal(map[string]any{"type": "agents_changed"})
 }
 
 // handleBindAgent serves POST /api/agents/:id/bind — bind a profile to an IM chat.
@@ -251,6 +254,7 @@ func (s *Server) handleBindAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, agentToResp(p))
+	s.broadcastGlobal(map[string]any{"type": "agents_changed"})
 }
 
 // handleUnbindAgent serves DELETE /api/agents/:id/bind — remove an IM binding.
@@ -280,6 +284,7 @@ func (s *Server) handleUnbindAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, agentToResp(p))
+	s.broadcastGlobal(map[string]any{"type": "agents_changed"})
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, onDestroy } from 'svelte'
   import { view, sidebar, sessions, sessionGroups, pinnedSessions, groupMenuFor, editGroupId, editGroupDraft, activeSessionId, selMode, sel, menuFor, editId, editDraft, showToast, mcpServers, createNewSession } from '../../lib/stores'
   import * as api from '../../lib/api'
   import { t, tr } from '../../lib/i18n'
   import { confirmDialog } from '../../lib/confirm'
+  import { ws } from '../../lib/ws'
   import VersionBadge from './VersionBadge.svelte'
 
   // Agent list for the new-session picker dropdown.
@@ -35,6 +36,16 @@
       agents = await api.listAgents()
     } catch { /* agents list is optional */ }
   })
+
+  // Reload agent list when an agent is created/updated/deleted via the API
+  // (e.g. through expert-agent-manager skill in conversation).
+  const unsubAgents = ws.on('agents_changed', async () => {
+    try {
+      agents = await api.listAgents()
+    } catch { /* ignore */ }
+  })
+
+  onDestroy(() => { unsubAgents() })
 
   // The session list split into its groups (registry order) plus the leftover
   // "ungrouped" ones. Membership lives in the group registry; member IDs that


### PR DESCRIPTION
## Summary

After creating an agent through conversation (`expert-agent-manager` skill), the Sidebar's "New Session" agent picker dropdown did not pick up the new agent without a page refresh. `listAgents()` only ran once on mount.

## Changes

**Backend** (`agents_handlers.go`): Broadcast `{"type": "agents_changed"}` via `broadcastGlobal` after:
- `handleCreateAgent` (POST)
- `handleUpdateAgent` (PUT)
- `handleDeleteAgent` (DELETE)
- `handleBindAgent` (POST /bind)
- `handleUnbindAgent` (DELETE /bind)

**Frontend** (`Sidebar.svelte`): Listen for `agents_changed` WebSocket event and reload the agents list.