### PR TITLE
fix(web): show agent_id in Tasks panel

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -8,6 +8,7 @@ export interface TaskResponse {
   prompt: string
   model: string
   agent: string
+  agent_id?: string
   notify: string
   enabled: boolean
   created_at: string

--- a/web/src/views/TasksView.svelte
+++ b/web/src/views/TasksView.svelte
@@ -43,7 +43,7 @@
       // Sync into shared store (ScheduledTask display shape) for other consumers
       tasks.set(rawTasks.map(t => ({
         name: t.name,
-        target: t.agent || t.model || '',
+        target: t.agent_id || t.agent || t.model || '',
         cron: t.cron,
         nextRun: t.enabled ? fmtDate(t.next_run) : '—',
         tagStatus: t.enabled ? 'success' : 'default',
@@ -153,8 +153,8 @@
             <!-- Name + agent/model target -->
             <div class="task-name-cell">
               <span class="task-name">{task.name}</span>
-              {#if task.agent || task.model}
-                <span class="task-target">{task.agent || task.model}</span>
+              {#if task.agent_id || task.agent || task.model}
+                <span class="task-target">{task.agent_id || task.agent || task.model}</span>
               {/if}
             </div>
 


### PR DESCRIPTION
## Problem

The Tasks panel showed `task.agent` (deprecated) or `task.model` as the subtitle, but never `task.agent_id` — even though the server already returns it. Tasks assigned to expert agents were visually indistinguishable from those using the default agent.

## Fix

1. **`api.ts`** — `TaskResponse` now includes `agent_id?: string`
2. **`TasksView.svelte`** — display chain: `agent_id || agent || model`, and the `{#if}` guard includes `agent_id`

## Testing

- `go build ./...` ✅
- `npm run build` ✅
