### PR TITLE
fix(scheduler): correct agent field comment — no "coding" built-in agent

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -61,7 +61,7 @@ type Task struct {
 	Cron      string        `json:"cron"`
 	Prompt    string        `json:"prompt"`
 	Model     string        `json:"model,omitempty"`
-	Agent     string        `json:"agent,omitempty"` // deprecated: "general" | "coding"; use AgentID
+	Agent     string        `json:"agent,omitempty"` // deprecated: "general" | "explore" | "code-review"; use AgentID
 	AgentID   string        `json:"agent_id,omitempty"`
 	Directory string        `json:"directory,omitempty"`
 	Notify    NotifyTargets `json:"notify,omitempty"`


### PR DESCRIPTION
The struct tag comment said `"general" | "coding"` but the actual built-in presets are `"general"`, `"explore"`, and `"code-review"`. There has never been a `"coding"` built-in.