### PR TITLE
fix(tasks): validate agent_id exists at create/patch/transfer time

### DIFF
--- a/internal/server/cron_consolidation_test.go
+++ b/internal/server/cron_consolidation_test.go
@@ -271,3 +271,81 @@ func TestRetiredCronEndpoints_NotRouted(t *testing.T) {
 		}
 	}
 }
+
+// TestCreateTask_RejectsInvalidAgentID: creating a task with a non-existent
+// agent_id must return 400 immediately rather than silently falling back to
+// default at run time.
+func TestCreateTask_RejectsInvalidAgentID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	body := `{"name":"bad","cron":"0 0 9 * * *","prompt":"go","agent_id":"nonexistent"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("create with invalid agent_id status = %d, want 400: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateTask_AcceptsValidAgentID: creating a task with an existing agent_id
+// (built-in) must succeed.
+func TestCreateTask_AcceptsValidAgentID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	id := createTaskForTest(t, srv, `{"name":"ok","cron":"0 0 9 * * *","prompt":"go","agent_id":"code-review"}`)
+	tasks := listTasksForTest(t, srv)
+	if len(tasks) != 1 {
+		t.Fatalf("want 1 task, got %d", len(tasks))
+	}
+	if tasks[0].AgentID != "code-review" {
+		t.Errorf("agent_id = %q, want %q", tasks[0].AgentID, "code-review")
+	}
+	_ = id
+}
+
+// TestTransferTask_RejectsInvalidAgentID verifies the transfer endpoint rejects
+// a non-existent agent_id.
+func TestTransferTask_RejectsInvalidAgentID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	id := createTaskForTest(t, srv, `{"name":"t","cron":"0 0 9 * * *","prompt":"go"}`)
+
+	body := `{"agent_id":"nonexistent"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/tasks/"+id+"/transfer", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("transfer invalid agent_id status = %d, want 400: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestPatchTask_RejectsInvalidAgentID: PATCH with an invalid agent_id must
+// return 400.
+func TestPatchTask_RejectsInvalidAgentID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	id := createTaskForTest(t, srv, `{"name":"p","cron":"0 0 9 * * *","prompt":"go"}`)
+
+	body := `{"agent_id":"nonexistent"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/tasks/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("patch invalid agent_id status = %d, want 400: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2252,6 +2252,25 @@ func (s *Server) profileForAgent(agentID string) *agentprofile.Profile {
 	return agentprofile.DefaultProfile()
 }
 
+// validateAgentID checks that agentID (if non-empty) maps to an existing
+// profile in the store, returning an error when it doesn't — so the caller
+// can reject a bad agent_id at input time instead of silently falling back
+// to default at run time. An empty agentID is always valid (means default).
+func (s *Server) validateAgentID(agentID string) error {
+	if agentID == "" {
+		return nil
+	}
+	store, ok := s.agentStoreIfReady()
+	if !ok {
+		_ = s.agentRouter()
+		store = s.agentStore
+	}
+	if _, ok := store.Get(agentID); ok {
+		return nil
+	}
+	return fmt.Errorf("agent %q not found", agentID)
+}
+
 // agentUserDir is the user-level profile directory (~/.octo/agents).
 func agentUserDir() string {
 	home, err := os.UserHomeDir()

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -501,6 +501,10 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name, cron, and prompt are required")
 		return
 	}
+	if err := s.validateAgentID(req.AgentID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	task := scheduler.Task{
 		Name:      req.Name,
 		Cron:      req.Cron,
@@ -595,6 +599,10 @@ func (s *Server) handleTransferTask(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "agent_id is required")
 		return
 	}
+	if err := s.validateAgentID(req.AgentID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	task, err := s.scheduler.Get(id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "task not found")
@@ -681,6 +689,10 @@ func (s *Server) handlePatchTask(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Notify != nil {
 		task.Notify = *req.Notify
+	}
+	if err := s.validateAgentID(task.AgentID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 	if err := s.scheduler.Update(*task); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())


### PR DESCRIPTION
## Problem

Follow-up to #1831: creating/patching/transferring a task with a non-existent `agent_id` was silently accepted — the task would fall back to default agent at run time with zero user feedback.

## Fix

- New `validateAgentID(agentID string) error` helper on `Server` — checks the profile store, returns a clear error when the agent doesn't exist. Empty agentID is always valid (means default).
- Wired into `handleCreateTask`, `handlePatchTask`, and `handleTransferTask`.

### Reviewer finding resolved

The code review flagged an apparent inconsistency: `runChannelTurns` uses bare `sess.AgentID` while `buildAgent` uses `sess.EffectiveAgentID()`. On inspection, `channel.Session.AgentID` is already normalized via `normalizeAgentID()` (never empty — always the real ID or `"default"`), so the two paths are equivalent. No change needed.
