### PR TITLE
fix(glob): make TestLiteralPathPrefix platform-aware for Windows

### DIFF
--- a/internal/tools/glob_test.go
+++ b/internal/tools/glob_test.go
@@ -187,6 +187,11 @@ func TestGlob_FileRoot(t *testing.T) {
 }
 
 func TestLiteralPathPrefix(t *testing.T) {
+	// On Unix, paths starting with "/" are absolute; on Windows, they aren't.
+	absPrefixWant := "internal/tools"
+	if filepath.IsAbs("/internal/tools/*.go") {
+		absPrefixWant = "/internal/tools"
+	}
 	cases := []struct {
 		pattern string
 		want    string
@@ -197,9 +202,9 @@ func TestLiteralPathPrefix(t *testing.T) {
 		{"**/*.go", ""},
 		{"*.go", ""},
 		{"src/*/foo.go", "src"},
-		{"../sibling/*.go", ""},                     // ".." must never anchor outside the search root
-		{"foo/../bar/*.go", "foo"},                  // stops at ".." rather than treating it as literal
-		{"/internal/tools/*.go", "/internal/tools"}, // leading "/" preserved for absolute patterns
+		{"../sibling/*.go", ""},                 // ".." must never anchor outside the search root
+		{"foo/../bar/*.go", "foo"},              // stops at ".." rather than treating it as literal
+		{"/internal/tools/*.go", absPrefixWant}, // absolute on Unix, relative on Windows
 		{"./internal/tools/*.go", "internal/tools"},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

On Windows, paths starting with `/` (e.g. `/internal/tools/*.go`) are NOT absolute — `filepath.IsAbs` returns false. The `literalPathPrefix` function added in #1829 correctly handles this (only prepends `/` when `os.IsPathSeparator(pattern[0])` is true), but the test assertion hardcoded `"/internal/tools"` as the expected value, which fails on Windows.

**Fix:** Use `filepath.IsAbs` in the test to determine the expected `want` value at runtime — `"/internal/tools"` on Unix, `"internal/tools"` on Windows.

## Changes

- `internal/tools/glob_test.go`: 1 file, +5/-1 lines (test expectation only)