### PR TITLE
docs(skills): clarify global default vs per-session model switching

### DIFF
--- a/internal/skills/defaults/config-setup/SKILL.md
+++ b/internal/skills/defaults/config-setup/SKILL.md
@@ -228,6 +228,38 @@ DELETE /api/config/endpoints/{id}/lite   // clear lite designation
 The model is passed as a **query parameter** (`?model=…`), not in the request body.
 Omit `?model` to use the endpoint's first model as a fallback.
 
+**Important**: This changes the **server-wide default** that seeds new sessions.
+It does **not** switch the model of any session that is already running or already
+bound to a specific model. For those, see [Switching the Current Session's Model](#switching-the-current-sessions-model).
+
+### Switching the Current Session's Model
+
+A session is bound to the global default model only at creation time. Once it has
+a turn, it keeps that model until you explicitly switch it. This applies to
+Web, TUI, CLI one-shot, and IM sessions.
+
+- **Web UI**: Click the model chip in the Composer status bar (the row showing the
+current model name, e.g. `K3`), then pick the desired model from the dropdown.
+- **IM (Weixin/Feishu/DingTalk/WeCom/Discord/Telegram)**: Send `/model` to list
+configured models and see the current one, then `/model <endpoint>::<model>` to
+bind the session to that endpoint's model, or `/model default` to make it follow
+the server-wide default again. You cannot switch while a turn is running.
+- **REST API**:
+
+```
+PATCH /api/sessions/{id}/model
+{"model_id": "Kimi::k3-256k"}
+```
+
+Use `default` as the `model_id` to unbind the session from a specific endpoint
+and make it follow the global default on subsequent turns. Unknown or bare model
+strings are treated as raw model names on the default sender.
+
+**Restart behavior**: You do **not** need to restart `octo serve` after changing
+the global default or a session's model. Both take effect on the next turn. The
+only exception is a session that was already bound to a model before the change —
+it will not switch unless you use one of the methods above.
+
 ---
 
 ## Workflow
@@ -265,8 +297,8 @@ Keep it brief: one question at a time, one change per response.
 6. **Verify** via `GET /api/config/endpoints` — confirm the new endpoint
    appears with the right models.
 
-7. **Tell the user** the endpoint is ready. The agent will use it immediately
-   for new turns.
+7. **Tell the user** the endpoint is ready. New sessions will use it immediately.
+   Existing sessions keep their current model binding unless manually switched.
 
 ### Editing an existing endpoint
 
@@ -274,14 +306,23 @@ Keep it brief: one question at a time, one change per response.
 2. **Show the user** the endpoint's current config.
 3. **Apply the smallest change** via `PATCH /api/config/endpoints/{id}`.
 4. **Verify** the change took effect.
+5. **Point out** that updating an endpoint (key, URL, provider, protocol) does not
+   automatically switch any bound session to a different model; it only changes
+   how the already-bound model is reached. If the user wants a running session to
+   use a different model, use the per-session switch.
 
 ### Setting default / lite model
 
 1. **List endpoints** to show the user what's available.
 2. **Confirm** which model should be default (normal turns) and which lite
    (lightweight tasks).
-3. **Call** `PUT /api/config/endpoints/{id}/default` etc.
+3. **Call** `POST /api/config/endpoints/{id}/default` etc.
 4. **Confirm** the assignment.
+5. **Clarify the scope**: this only affects **new** sessions and any session that
+   is currently unbound. Sessions already in progress or already switched to a
+   specific model continue on that model. Tell the user how to switch the current
+   session if they expected it to change immediately (Web UI model chip, IM `/model`,
+   or `PATCH /api/sessions/{id}/model`).
 
 ---
 

--- a/internal/skills/defaults/product_help/CONFIG.md
+++ b/internal/skills/defaults/product_help/CONFIG.md
@@ -7,7 +7,7 @@ Path: `~/.octo/config.yml`. Every field is optional — a missing file or field 
 | Key | Type | Description |
 |---|---|---|
 | `endpoints` | list | Configured providers. Each bundles connection params (`id`, `name`, `provider` (`anthropic`\|`openai`\|`custom`), `base_url`, `api_key`, `protocol` (custom vendor only), optional `lite_model`) and a `models` list whose entries are `{ model, vision }` |
-| `default` | string | Composite id `<endpoint-id>::<model>` used when nothing else selects one; empty → first endpoint's first model |
+| `default` | string | Composite id `<endpoint-id>::<model>` used when nothing else selects one; empty → first endpoint's first model. **Only seeds new sessions** — a session that already has turns keeps the model it was bound to until you switch it explicitly (TUI/web chip/IM `/model`/`/api/sessions/{id}/model`). |
 | `lite` | string | Composite id `<endpoint-id>::<model>` for cheap internal calls (compaction summaries, session titles) |
 | `permission_mode` | string | `interactive` (default) \| `strict` \| `auto` |
 | `coauthor` | bool | Append `Co-authored-by` to git commits (default true) |

--- a/internal/skills/defaults/product_help/IM.md
+++ b/internal/skills/defaults/product_help/IM.md
@@ -4,6 +4,8 @@ octo can run as a chat bot on WeChat (iLink), Feishu, DingTalk, WeCom, Discord, 
 
 Each chat is a session like any other — per-user history and permission context, slash commands (a different set than the TUI/web; see the reference below), attachments bridge both ways, and a session goal works the same as elsewhere.
 
+IM-specific slash commands include `/model` (list models), `/model <endpoint>::<model>` to switch the current chat session to a specific model, and `/model default` to make it follow the server-wide default. Switching only affects this chat session; it does not change the global default in `~/.octo/config.yml`.
+
 ## Proactive messaging (`send_message` / `send_file`)
 
 A normal reply only reaches the chat the current turn is already talking to. To reach a **different** chat — e.g. the user is on the web UI and asks octo to message their WeChat — the model uses `send_message`/`send_file`, addressed by `platform` + `chat_id`. Calling with just a platform (or no arguments) returns the list of chats it can currently reach; a chat only appears once it has messaged the bot at least once. These tools only appear when a messenger is active (`octo serve` running with channels enabled).

--- a/internal/skills/defaults/product_help/TROUBLESHOOTING.md
+++ b/internal/skills/defaults/product_help/TROUBLESHOOTING.md
@@ -35,6 +35,8 @@ Precedence (highest first): CLI flag > env var > config file > built-in default.
 - `OCTO_PROVIDER` / `ANTHROPIC_MODEL` env vars override the config file
 - The config file's model is only honored when the resolved provider matches
 
+Also remember that a session is **bound to a model at creation time**. Changing the global default (`octo config`, the web UI Settings panel, or `POST /api/config/endpoints/{id}/default`) only affects **new** sessions. Existing sessions keep their current model until you explicitly switch them via the TUI `/model` command, the web UI Composer's model chip, the IM `/model` command, or `PATCH /api/sessions/{id}/model`.
+
 ## TUI
 
 ### TUI doesn't start (falls back to plain REPL)

--- a/internal/skills/defaults/product_help/TUI.md
+++ b/internal/skills/defaults/product_help/TUI.md
@@ -6,6 +6,8 @@ octo's TUI is a bubbletea-based interactive interface launched by `octo` with no
 
 Type `/` to open the completion menu (↑/↓ to navigate, Enter to run, Tab to fill in for arguments). Commands: `/help`, `/model`, `/thinking`, `/compact`, `/transcript`, `/goal` (create/edit/pause/resume/clear/replace a standing session objective — see below), `/clear`, `/skills` (trigger one directly with `/<name>`), `/mcp`, `/workflows`, `/memory`, `/init`, `/save`, `/sessions`, `/exit`/`/quit`.
 
+`/model` lists the configured models; `/model <endpoint>::<model>` switches the current TUI session to that model, and `/model default` makes it follow the server-wide default again. Switching only affects this session — the global default in `~/.octo/config.yml` is not changed. You cannot switch while a turn is running.
+
 `/goal <objective>` sets a goal; once set, octo auto-continues turns on its own until it completes, is paused, or hits its token/turn budget. `/goal edit` here is **prefill-only** (fills the input box with the current objective to revise) — unlike the web UI/IM where `/goal edit <text>` edits inline in one step.
 
 The Web UI and IM channels each recognize a **different** command set than the TUI (e.g. IM has `/bind`/`/unbind`/`/new` for re-binding a chat to a session; the TUI's `/skills`/`/mcp`/`/init`/etc. don't exist there). Full per-surface command tables and an availability matrix: **https://octo-agent.dev/docs/reference/slash-commands/** (`web_fetch`). The `/goal` feature in depth: **https://octo-agent.dev/docs/guides/goals/**.


### PR DESCRIPTION
## Summary

Clarifies in both `config-setup` and `product-help` skills that changing the **global default model** only affects **new sessions**, while existing sessions keep the model they were bound to at creation time.

## What changed

- **`config-setup` SKILL.md**:
  - Added explicit note that `POST /api/config/endpoints/{id}/default` is server-wide and only seeds new sessions.
  - Added a new "Switching the Current Session's Model" section covering Web UI chip, IM `/model`, REST API `PATCH /api/sessions/{id}/model`, and the fact that **no restart** is required.
  - Updated workflows (add endpoint, edit endpoint, set default/lite) to mention per-session binding behavior.

- **`product-help` bundled docs**:
  - `CONFIG.md`: noted `default` only seeds new sessions.
  - `TUI.md`: explained `/model` usage and scope.
  - `IM.md`: added IM-specific `/model` command notes.
  - `TROUBLESHOOTING.md`: expanded "Provider/model not what I expected" with the session-binding caveat and explicit switching options.

This prevents future answers from incorrectly implying that a global default change also switches the current conversation, or that a restart is needed.