### PR TITLE
fix(serve): accept `octo serve stop|status` subcommands + fix misleading positional-arg hint

### DIFF
--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -142,6 +142,9 @@ Examples:
   octo serve --addr 127.0.0.1:3000     Bind to a specific address
   octo serve --no-channel              Skip IM platform bridges
   octo serve --no-tools                Disable the agentic tool loop
+  octo serve -d                        Run in the background (daemon)
+  octo serve status                    Show daemon status
+  octo serve stop                      Stop the background daemon
 
 Common flags:
   --addr <host:port>       Bind address (default :8088)

--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -56,12 +56,31 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	// Reject any positional argument: serve takes flags only, and a bare
-	// value like ":19099" silently falls into fs.Args() (defaulting --addr to
-	// 127.0.0.1:8088) — see issue #1614. Point the user at the flag form
-	// explicitly instead of letting the wrong port start quietly.
+	// Daemon-control subcommands: `octo serve stop|status` is what users
+	// reach for first (issue #1842), so accept it alongside --stop/--status.
+	// Any other positional argument is rejected: serve takes flags only, and
+	// a bare value like ":19099" silently falls into fs.Args() (defaulting
+	// --addr to 127.0.0.1:8088) — see issue #1614.
 	if rest := fs.Args(); len(rest) > 0 {
-		fmt.Fprintf(stderr, "octo serve: unexpected positional argument(s) %q — use flags for every option (e.g. `octo serve -addr %s -d`)\n", rest, rest[0])
+		switch rest[0] {
+		case "stop", "status":
+			if len(rest) > 1 {
+				fmt.Fprintf(stderr, "octo serve %s: unexpected extra argument(s) %q\n", rest[0], rest[1:])
+				return 2
+			}
+			if rest[0] == "stop" {
+				return stopDaemon(stdout, stderr)
+			}
+			return statusDaemon(stdout, stderr)
+		}
+		// Only echo the value back in the -addr example when it plausibly is
+		// one — substituting an arbitrary word (say, "restart") produces a
+		// nonsense suggestion like `octo serve -addr restart -d`.
+		example := "`octo serve -addr :8088 -d`"
+		if strings.Contains(rest[0], ":") {
+			example = fmt.Sprintf("`octo serve -addr %s -d`", rest[0])
+		}
+		fmt.Fprintf(stderr, "octo serve: unexpected positional argument(s) %q — use flags for every option (e.g. %s); daemon control is `octo serve stop` / `octo serve status`\n", rest, example)
 		return 2
 	}
 	if *stop {

--- a/cmd/octo/serve_test.go
+++ b/cmd/octo/serve_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -79,5 +80,90 @@ func TestServeRejectsPositionalArgsAlone(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "unexpected positional argument") {
 		t.Errorf("want positional-argument error, got:\n%s", stderr.String())
+	}
+}
+
+// isolatePidFile points the daemon pid-file lookup at a temp dir so the
+// subcommand tests below never see (or touch) a real ~/.octo/serve.pid.
+func isolatePidFile(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	orig := daemonPidFile
+	daemonPidFile = func() (string, error) { return filepath.Join(tmp, "serve.pid"), nil }
+	t.Cleanup(func() { daemonPidFile = orig })
+}
+
+// TestServeStopSubcommand pins the #1842 fix: `octo serve stop` is accepted
+// as a positional subcommand equivalent to --stop. With no daemon running it
+// reaches stopDaemon and reports that, rather than the positional-arg error.
+func TestServeStopSubcommand(t *testing.T) {
+	isolatePidFile(t)
+	var stdout, stderr bytes.Buffer
+	code := runServe([]string{"stop"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (no daemon running)", code)
+	}
+	if !strings.Contains(stderr.String(), "daemon not running") {
+		t.Errorf("want stopDaemon's not-running message, got:\n%s", stderr.String())
+	}
+}
+
+// TestServeStatusSubcommand: `octo serve status` maps to --status.
+func TestServeStatusSubcommand(t *testing.T) {
+	isolatePidFile(t)
+	var stdout, stderr bytes.Buffer
+	code := runServe([]string{"status"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "not running") {
+		t.Errorf("want statusDaemon output, got:\n%s", stdout.String())
+	}
+}
+
+// TestServeStopRejectsExtraArgs: the subcommand form takes nothing after it.
+func TestServeStopRejectsExtraArgs(t *testing.T) {
+	isolatePidFile(t)
+	var stdout, stderr bytes.Buffer
+	code := runServe([]string{"stop", "now"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "unexpected extra argument") {
+		t.Errorf("want extra-argument error, got:\n%s", stderr.String())
+	}
+}
+
+// TestServeStopRejectsTrailingFlags pins the flag-tokenization behavior the
+// dispatch relies on: flag parsing stops at the first non-flag arg, so
+// `octo serve stop -d` yields rest = ["stop", "-d"] and is rejected rather
+// than executing an ambiguous mix of subcommand and flags.
+func TestServeStopRejectsTrailingFlags(t *testing.T) {
+	isolatePidFile(t)
+	var stdout, stderr bytes.Buffer
+	code := runServe([]string{"stop", "-d"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "unexpected extra argument") {
+		t.Errorf("want extra-argument error, got:\n%s", stderr.String())
+	}
+}
+
+// TestServePositionalHintNotMisleading: a word that isn't an address must not
+// be echoed into the -addr example (`octo serve -addr restart -d` — #1842);
+// the error also points at the stop/status subcommands.
+func TestServePositionalHintNotMisleading(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runServe([]string{"restart"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	out := stderr.String()
+	if strings.Contains(out, "-addr restart") {
+		t.Errorf("error must not suggest `-addr restart`, got:\n%s", out)
+	}
+	if !strings.Contains(out, "`octo serve stop`") {
+		t.Errorf("error should mention the stop subcommand, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #1842 (items 1 and 2 of the planned improvements):

- **`octo serve stop` / `octo serve status` now work** as positional subcommands, dispatching to the exact same `stopDaemon`/`statusDaemon` paths as the existing `--stop`/`--status` flags. Anything trailing the subcommand is rejected (Go's flag parsing stops at the first non-flag arg, so `octo serve stop -d` yields `["stop", "-d"]` and errors instead of executing an ambiguous mix).
- **Fixed the misleading positional-arg error hint.** It used to interpolate whatever the user typed into the `-addr` example, producing nonsense like `` `octo serve -addr stop -d` ``. Now the value is only echoed when it plausibly is an address (contains `:`), which preserves the #1614 behavior of suggesting `-addr :19099` for a bare port; otherwise a generic `:8088` example is shown. The message also points at the new `stop`/`status` subcommands.
- Added daemon lifecycle examples (`-d` / `status` / `stop`) to `octo help serve`.

## Testing

- New tests: `stop`/`status` subcommand dispatch (isolated pid file via a swapped `daemonPidFile`, so tests never touch a real `~/.octo/serve.pid`), extra-arg rejection (`stop now`, `stop -d`), and the non-address hint fix (`restart` must not become `-addr restart`).
- Existing #1614 tests (`TestServeRejectsPositionalArgs*`) unchanged and passing.
- `go test -race ./...`, `go vet`, `gofmt -l` all clean.

Fixes part of #1842 (item 3 — `octo upgrade` detecting a running serve on Windows — is a separate change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)