### PR TITLE
feat(upgrade): call out a running serve daemon on upgrade failure and success

### DIFF
--- a/cmd/octo/upgrade.go
+++ b/cmd/octo/upgrade.go
@@ -43,35 +43,38 @@ func runUpgrade(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	daemonPid, daemonRunning := runningServeDaemon()
-
 	err := upgrade.Run(ctx, upgrade.Options{
 		Force: *force,
 		Log:   func(line string) { fmt.Fprintln(stdout, line) },
 	})
+	// Checked after Run, not before: a download can take minutes, and what
+	// matters is who is alive when the message prints.
+	backendPid, backendRunning := runningServeDaemon()
 	switch {
 	case errors.Is(err, upgrade.ErrUpToDate):
 		fmt.Fprintln(stdout, "already up to date")
 		return 0
 	case err != nil:
 		fmt.Fprintf(stderr, "octo upgrade: %v\n", err)
-		if daemonRunning {
-			fmt.Fprintf(stderr, "hint: an `octo serve` daemon is running (pid %d) and may be holding the binary in place (Windows locks a running executable) — run `octo serve stop`, retry the upgrade, then `octo serve -d`\n", daemonPid)
+		if backendRunning {
+			fmt.Fprintf(stderr, "hint: an octo backend is running (pid %d) — if it's an `octo serve -d` daemon it may be locking the binary (Windows locks a running executable): run `octo serve stop`, retry the upgrade, then restart the daemon with your usual flags\n", backendPid)
 		}
 		return 1
 	}
-	if daemonRunning {
-		fmt.Fprintf(stdout, "done — the running `octo serve` daemon (pid %d) keeps using the old binary; restart it (`octo serve stop && octo serve -d`) to switch\n", daemonPid)
+	if backendRunning {
+		fmt.Fprintf(stdout, "done — an octo backend is still running (pid %d); if it's an `octo serve -d` daemon it keeps using the old binary until restarted (`octo serve stop`, then relaunch with your usual flags)\n", backendPid)
 	} else {
 		fmt.Fprintln(stdout, "done — a running `octo serve` picks the new binary up on its next restart")
 	}
 	return 0
 }
 
-// runningServeDaemon reports the pid of a live `octo serve -d` daemon, if
-// any, via the shared ~/.octo/serve.pid contract. A foreground serve has no
-// pid file and is invisible here — that's fine, the messages this feeds are
-// best-effort guidance, not a gate.
+// runningServeDaemon reports the pid of a live backend registered in the
+// shared ~/.octo/serve.pid. The owner may be an `octo serve -d` daemon or the
+// desktop hub (which serves in-process from a different executable), and the
+// file can't tell them apart — messages built on this must hedge accordingly.
+// A foreground serve has no pid file and is invisible here — that's fine, the
+// messages this feeds are best-effort guidance, not a gate.
 func runningServeDaemon() (int, bool) {
 	pidFile, err := daemonPidFile()
 	if err != nil {

--- a/cmd/octo/upgrade.go
+++ b/cmd/octo/upgrade.go
@@ -43,6 +43,8 @@ func runUpgrade(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
+	daemonPid, daemonRunning := runningServeDaemon()
+
 	err := upgrade.Run(ctx, upgrade.Options{
 		Force: *force,
 		Log:   func(line string) { fmt.Fprintln(stdout, line) },
@@ -53,8 +55,31 @@ func runUpgrade(args []string, stdout, stderr io.Writer) int {
 		return 0
 	case err != nil:
 		fmt.Fprintf(stderr, "octo upgrade: %v\n", err)
+		if daemonRunning {
+			fmt.Fprintf(stderr, "hint: an `octo serve` daemon is running (pid %d) and may be holding the binary in place (Windows locks a running executable) — run `octo serve stop`, retry the upgrade, then `octo serve -d`\n", daemonPid)
+		}
 		return 1
 	}
-	fmt.Fprintln(stdout, "done — a running `octo serve` picks the new binary up on its next restart")
+	if daemonRunning {
+		fmt.Fprintf(stdout, "done — the running `octo serve` daemon (pid %d) keeps using the old binary; restart it (`octo serve stop && octo serve -d`) to switch\n", daemonPid)
+	} else {
+		fmt.Fprintln(stdout, "done — a running `octo serve` picks the new binary up on its next restart")
+	}
 	return 0
+}
+
+// runningServeDaemon reports the pid of a live `octo serve -d` daemon, if
+// any, via the shared ~/.octo/serve.pid contract. A foreground serve has no
+// pid file and is invisible here — that's fine, the messages this feeds are
+// best-effort guidance, not a gate.
+func runningServeDaemon() (int, bool) {
+	pidFile, err := daemonPidFile()
+	if err != nil {
+		return 0, false
+	}
+	pid, err := readPidFile(pidFile)
+	if err != nil || !isProcessAlive(pid) {
+		return 0, false
+	}
+	return pid, true
 }

--- a/cmd/octo/upgrade_test.go
+++ b/cmd/octo/upgrade_test.go
@@ -68,6 +68,7 @@ func TestRunUpgrade_DevRefusalExitCode(t *testing.T) {
 	orig := upgrade.BaseURL
 	upgrade.BaseURL = "http://127.0.0.1:0"
 	t.Cleanup(func() { upgrade.BaseURL = orig })
+	isolatePidFile(t)
 
 	var stdout, stderr bytes.Buffer
 	code := runUpgrade(nil, &stdout, &stderr)
@@ -76,6 +77,9 @@ func TestRunUpgrade_DevRefusalExitCode(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "--force") {
 		t.Errorf("refusal should hint at --force, got: %s", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "hint:") {
+		t.Errorf("no backend is registered, so no hint should print, got: %s", stderr.String())
 	}
 }
 
@@ -135,8 +139,8 @@ func TestRunUpgrade_FailureHintsRunningServeDaemon(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1; stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "hint: an `octo serve` daemon is running") {
-		t.Errorf("stderr should hint at the running daemon, got:\n%s", stderr.String())
+	if !strings.Contains(stderr.String(), "hint: an octo backend is running") {
+		t.Errorf("stderr should hint at the running backend, got:\n%s", stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "`octo serve stop`") {
 		t.Errorf("hint should mention `octo serve stop`, got:\n%s", stderr.String())

--- a/cmd/octo/upgrade_test.go
+++ b/cmd/octo/upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -82,5 +83,62 @@ func TestRunUpgrade_BadFlag(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if code := runUpgrade([]string{"--no-such-flag"}, &stdout, &stderr); code != 2 {
 		t.Fatalf("exit = %d, want 2 for flag errors", code)
+	}
+}
+
+func TestRunningServeDaemon(t *testing.T) {
+	isolatePidFile(t)
+	if pid, ok := runningServeDaemon(); ok {
+		t.Fatalf("no pid file: got running daemon pid %d", pid)
+	}
+	pidFile, err := daemonPidFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Our own pid is guaranteed alive.
+	if err := writePidFile(pidFile, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	pid, ok := runningServeDaemon()
+	if !ok || pid != os.Getpid() {
+		t.Fatalf("got (%d, %v), want (%d, true)", pid, ok, os.Getpid())
+	}
+}
+
+// TestRunUpgrade_FailureHintsRunningServeDaemon pins the #1842 follow-up: when
+// the upgrade fails while an `octo serve` daemon is running, the error is
+// followed by a hint that the daemon may be locking the binary (Windows) and
+// how to stop/retry/restart.
+func TestRunUpgrade_FailureHintsRunningServeDaemon(t *testing.T) {
+	// The fake origin serves only releases/latest, so the asset download 404s
+	// and Run fails after the version check. Clear the mirrors so the failing
+	// download never leaves the httptest server.
+	fakeLatest(t, "9.9.9")
+	origMirrors := upgrade.MirrorBaseURLs
+	upgrade.MirrorBaseURLs = nil
+	t.Cleanup(func() { upgrade.MirrorBaseURLs = origMirrors })
+	origV := version.Version
+	version.Version = "0.18.0"
+	t.Cleanup(func() { version.Version = origV })
+
+	isolatePidFile(t)
+	pidFile, err := daemonPidFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writePidFile(pidFile, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runUpgrade([]string{"--force"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "hint: an `octo serve` daemon is running") {
+		t.Errorf("stderr should hint at the running daemon, got:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "`octo serve stop`") {
+		t.Errorf("hint should mention `octo serve stop`, got:\n%s", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #1842 (item 3 of the planned improvements). The reporter ran `octo upgrade` on Windows while `octo serve` was running and the binary swap "silently" failed — a running executable is locked on Windows, and even when the swap succeeds the daemon keeps executing the old image.

`octo upgrade` now detects a live daemon through the shared `~/.octo/serve.pid` contract (`runningServeDaemon`, reusing the `serveproc` aliases from `serve_daemon.go`) and adjusts its messaging:

- **On failure**: appends a hint that the daemon (pid shown) may be holding the binary in place, with the recovery sequence — `octo serve stop`, retry the upgrade, `octo serve -d`.
- **On success**: states explicitly that the running daemon still uses the old binary and how to restart it, replacing the generic "picks the new binary up on its next restart" note.

Detection is best-effort guidance, never a gate: the upgrade behavior itself is unchanged, and a foreground `octo serve` (no pid file) stays invisible.

## Testing

- `TestRunningServeDaemon` — pid-file detection (isolated via the swapped `daemonPidFile`, faking a live daemon with the test process's own pid).
- `TestRunUpgrade_FailureHintsRunningServeDaemon` — full `runUpgrade --force` against an httptest origin that serves only `releases/latest` (asset download 404s), mirrors cleared so nothing leaves the fake server; asserts the hint lands on stderr.
- `go test -race ./cmd/octo/`, `go vet`, `gofmt -l` all clean.

Closes the remaining code change promised in #1842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)