### PR TITLE
chore: bump version to 1.14.3

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.14.2"
+var Version = "1.14.3"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the 1.14.3 release — first release carrying the desktop in-place updater (#1844) and its swappable release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)