### PR TITLE
chore(ci): add dependabot.yml covering all real manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+# Version-update coverage for every real dependency manifest. Before this
+# file existed only GitHub's default security updates ran, and they opened
+# fix PRs for some manifests but not others (see #1842-era postcss alerts:
+# /blog got a PR, /web and /docs did not).
+#
+# Deliberately NOT covered: evals/tasks/*/repo/go.mod — those are eval
+# fixtures whose dependencies are part of the task definition, and the
+# top-level /evals harness module, which shares their churn-free intent.
+#
+# Minor and patch bumps are grouped into one PR per directory to keep the
+# weekly noise reviewable; majors stay individual PRs.
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/cmd/octo-desktop"
+      - "/cmd/octo-relay"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      go-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/web"
+      - "/docs"
+      - "/blog"
+      - "/mobile"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

The repo had no `.github/dependabot.yml` — only GitHub's default security updates ran, and they proved spotty: the postcss GHSA-r28c-9q8g-f849 alerts got a fix PR for `/blog` (#1849) but nothing for `/web` or `/docs` (hand-fixed in #1850).

This adds weekly version-update coverage for every real manifest:

- **gomod**: `/`, `/cmd/octo-desktop`, `/cmd/octo-relay` — covering the nested desktop module also guards against the root-bump desync class of issue (#1535)
- **npm**: `/web`, `/docs`, `/blog`, `/mobile`
- **github-actions**: `/`

Noise control: minor+patch bumps are **grouped into one PR per directory**; majors arrive as individual PRs. Commit-message prefix pinned to `chore(deps)` to match the repo's conventional-commit style.

**Deliberately excluded**: `evals/tasks/*/repo/go.mod` (eval fixtures — their dependencies are part of the task definitions) and the `/evals` harness module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)