### PR TITLE
chore: bump version to 1.14.4

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.14.3"
+var Version = "1.14.4"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the v1.14.4 release. Ships #1845 (serve stop/status subcommands), #1846 (upgrade daemon hint), #1849/#1850 (postcss GHSA-r28c-9q8g-f849), #1851 (dependabot coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)