### PR TITLE
fix(skills): config-setup — correct server discovery and add no-server fallback

### DIFF
--- a/internal/skills/defaults/config-setup/SKILL.md
+++ b/internal/skills/defaults/config-setup/SKILL.md
@@ -31,12 +31,25 @@ workspace_dir                     default / lite model
 All of these live in `~/.octo/config.yml` and are editable through the REST API
 on the running octo server at `http://localhost:<port>` (use `curl` via the `terminal` tool — do NOT use `web_fetch`, localhost is blocked by SSRF).
 
-## Finding the server port
+## Reaching the server
 
-Run `cat ~/.octo/octo.pid` to find the PID, then `lsof -i -P -n | grep LISTEN | grep <PID>`
-or check the default port (the web UI URL in the browser's address bar).
+The server listens on `127.0.0.1:8088` by default (the desktop app's built-in
+server uses the same port). Loopback requests need no access key.
 
-If you can't determine the port, use `24222` (the default).
+1. **Try the default first**: `curl -s http://127.0.0.1:8088/api/config`.
+   JSON back = you're connected; skip the rest of this section.
+2. **Connection refused?** The server may be on a custom port:
+   - Started as a daemon (`octo serve -d`): `cat ~/.octo/serve.pid` for the PID,
+     then find its listen port — macOS/Linux:
+     `lsof -iTCP -sTCP:LISTEN -P -n -a -p <PID>`; Windows (PowerShell):
+     `Get-NetTCPConnection -State Listen -OwningProcess <PID>`.
+   - A foreground `octo serve` writes no pid file — ask the user which port they
+     started it on (it's also in the web UI's address bar).
+3. **No server running at all?** Don't stop — fall back to editing
+   `~/.octo/config.yml` directly (it is the same file every API call below
+   mutates). Read the file first, apply the smallest edit that matches the
+   structure you see, then validate with `octo doctor`. Changes are picked up
+   by new CLI sessions and by the server next time it starts.
 
 ---
 
@@ -124,10 +137,10 @@ Endpoint "anthropic"                  Endpoint "relay-a"
   provider: anthropic                   provider: custom
   api_key: sk-ant-…                     api_key: sk-…
   models:                               models:
-    - claude-sonnet-4-20250514            - gpt-4o
-    - claude-haiku-3-5                    - deepseek-v3
-  default_model: claude-sonnet-4-…      default_model: gpt-4o
-  lite_model: claude-haiku-3-5          lite_model: deepseek-v3
+    - claude-sonnet-5                     - gpt-4o
+    - claude-haiku-4-5                    - deepseek-v3
+  default_model: claude-sonnet-5        default_model: gpt-4o
+  lite_model: claude-haiku-4-5          lite_model: deepseek-v3
 ```
 
 The **default model** is what the agent uses for normal turns.
@@ -215,7 +228,9 @@ POST /api/config/endpoints/{id}/models
 DELETE /api/config/endpoints/{id}/models/{model}
 ```
 
-The model name must be URL-encoded (e.g. `claude-sonnet-4-20250514`).
+The model name must be URL-encoded when it contains special characters — this
+matters for slash-style names like `deepseek/deepseek-chat`, which becomes
+`deepseek%2Fdeepseek-chat` in the path.
 
 ### Set Default / Lite Model
 


### PR DESCRIPTION
## Summary

The `config-setup` default skill's "Finding the server port" section was wrong end to end, so an agent following it failed at step one of any configuration request:

| Skill said | Reality |
|---|---|
| `cat ~/.octo/octo.pid` | File has never existed — the pid file is `~/.octo/serve.pid` (`internal/serveproc`), and only `octo serve -d` / the desktop hub write it; a foreground serve has no pid file |
| default port `24222` | The server binds `127.0.0.1:8088` (`cmd/octo/serve.go`); 24222 appears nowhere in the codebase |
| `lsof …` | Unix-only; octo's terminal tool runs PowerShell on Windows |

The section is rewritten as **try `127.0.0.1:8088` first** (the desktop hub uses the same port; loopback requests pass `requireAuth` without an access key), with the pid-file + `lsof` / `Get-NetTCPConnection` chain demoted to the custom-port case, plus a **no-server fallback** the skill previously lacked: a pure CLI/TUI user triggering "配置模型" has nothing listening on localhost — the agent now edits `~/.octo/config.yml` directly (the same file the API mutates) and validates with `octo doctor`.

Minor fixes riding along:

- Example model names refreshed (`claude-sonnet-4-20250514` → `claude-sonnet-5` etc.).
- The URL-encoding note now uses an example that actually needs encoding (`deepseek/deepseek-chat` → `deepseek%2Fdeepseek-chat`).

Everything else in the skill was verified against the live route table (`internal/server/server.go`, `onboard_config_handlers.go`) and left untouched: endpoints CRUD, query-param default/lite, `{model, vision}`, `model_id` session switch, reasoning-effort/permission-mode value sets, `workspace_dir` rules — all match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)