### PR TITLE
fix(config): make reasoning "off" actually read and act as off

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -527,6 +527,8 @@ func (c Config) Validate() []string {
 		pm != "interactive" && pm != "auto" && pm != "strict" {
 		problems = append(problems, fmt.Sprintf("permission_mode %q is not one of interactive, auto, strict", c.PermissionMode))
 	}
+	// "off" stays accepted here for Configs constructed in memory; anything
+	// arriving through Load never carries it (normalize maps it to "").
 	if re := strings.ToLower(strings.TrimSpace(c.ReasoningEffort)); re != "" &&
 		re != "off" && re != "low" && re != "medium" && re != "high" && re != "xhigh" && re != "max" {
 		problems = append(problems, fmt.Sprintf("reasoning_effort %q is not one of off, low, medium, high, xhigh, max", c.ReasoningEffort))
@@ -970,6 +972,13 @@ type fileConfig struct {
 // shape.
 func (f fileConfig) normalize() Config {
 	c := f.Config
+	// "off" is only ever a wire/UI sentinel; the canonical stored form of
+	// disabled reasoning is "". Files written by the pre-fix global PUT (or
+	// by hand) can carry the literal, which the provider layer would treat
+	// as thinking-ON (any non-empty effort enables) — normalize it away.
+	if strings.EqualFold(c.ReasoningEffort, "off") {
+		c.ReasoningEffort = ""
+	}
 	if len(c.Endpoints) > 0 {
 		// Already on the new schema — Endpoints/Default/Lite are authoritative.
 		// Migrate any provider aliases on legacy Models (now only in

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1635,3 +1635,19 @@ func TestMutate_FnErrorAbortsSave(t *testing.T) {
 		t.Errorf("PermissionMode = %q, want strict (fn aborted, save must not have happened)", final.PermissionMode)
 	}
 }
+
+// TestLoad_NormalizesLegacyOffReasoningEffort: files written by the pre-fix
+// global PUT handler carry the literal "off", which the provider layer would
+// treat as thinking-ON (any non-empty effort enables). Load must map it to
+// "", the canonical stored form of disabled reasoning.
+func TestLoad_NormalizesLegacyOffReasoningEffort(t *testing.T) {
+	home := setHome(t)
+	writeOcto(t, home, "config.yml", "reasoning_effort: off\n")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ReasoningEffort != "" {
+		t.Errorf("ReasoningEffort = %q, want \"\" (normalized from legacy \"off\")", cfg.ReasoningEffort)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -198,6 +198,11 @@ func (srv *Server) sessionStatusFields(sess *agent.Session) (workingDir, permiss
 	}
 	if cfg, err := config.Load(); err == nil {
 		reasoningEffort = cfg.ReasoningEffort
+		if reasoningEffort == "" {
+			// Wire sentinel: "" is the stored form of off, but session_update
+			// consumers guard on non-empty strings (ChatView) — send "off".
+			reasoningEffort = "off"
+		}
 		eff := cfg.EffectiveShowReasoning(nil)
 		showReasoning = &eff
 	}

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -225,13 +225,21 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	// commits actually get. Report the resolved value the Settings toggle is
 	// meant to reflect, not the on-disk-only one.
 	effCoauthor := cfg.EffectiveCoauthor()
+	// The stored form of disabled reasoning is "" — but serialized through
+	// the omitempty tag that drops the field entirely, and the frontend
+	// defaults an absent value to "medium" (SettingsView). Send the wire
+	// sentinel "off" so off actually reads as off.
+	re := cfg.ReasoningEffort
+	if re == "" {
+		re = "off"
+	}
 	writeJSON(w, http.StatusOK, configResponse{
 		FontSize:        "medium",
 		Language:        cfg.Language,
 		ShowReasoning:   cfg.ShowReasoning,
 		Coauthor:        &effCoauthor,
 		WorkspaceDir:    cfg.WorkspaceDir,
-		ReasoningEffort: cfg.ReasoningEffort,
+		ReasoningEffort: re,
 		PermissionMode:  cfg.PermissionMode,
 	})
 }
@@ -510,7 +518,19 @@ func (s *Server) handlePutReasoningEffort(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	cfg.ReasoningEffort = level
+	// "off" is only ever a wire/UI sentinel — persist "" (matching
+	// handleUpdateSessionReasoningEffort): the provider layer treats any
+	// non-empty effort as thinking-ON, so a stored literal "off" would
+	// actually enable reasoning. With reasoning off there is also nothing to
+	// trace, so drop show_reasoning too instead of leaving a toggle that
+	// looks on but does nothing.
+	if level == "off" {
+		cfg.ReasoningEffort = ""
+		off := false
+		cfg.ShowReasoning = &off
+	} else {
+		cfg.ReasoningEffort = level
+	}
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -983,3 +983,66 @@ func TestUnsetEndpointLite_DifferentEndpointHoldsLite_IsNoOp(t *testing.T) {
 		t.Errorf("lite = %q, want ep-b::claude-haiku-4-5 (unchanged)", cfg.Lite)
 	}
 }
+
+// TestPutReasoningEffort_Off_PersistsEmptyAndDisablesShowReasoning pins the
+// global PUT to the same "off is a wire sentinel" contract as the per-session
+// PATCH: persist "" (a stored literal "off" reads as thinking-ON at the
+// provider layer) and drop show_reasoning, which has nothing to show.
+func TestPutReasoningEffort_Off_PersistsEmptyAndDisablesShowReasoning(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPut, "/api/config/reasoning_effort", `{"reasoning_effort":"off"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT /api/config/reasoning_effort = %d: %s", w.Code, w.Body.String())
+	}
+	// The response echoes the wire sentinel, not the stored "".
+	var resp struct {
+		ReasoningEffort string `json:"reasoning_effort"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.ReasoningEffort != "off" {
+		t.Errorf("response reasoning_effort = %q, want \"off\"", resp.ReasoningEffort)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ReasoningEffort != "" {
+		t.Errorf("config.ReasoningEffort = %q, want \"\" (off persists as empty)", cfg.ReasoningEffort)
+	}
+	if cfg.ShowReasoning == nil || *cfg.ShowReasoning {
+		t.Errorf("config.ShowReasoning = %v, want false when reasoning is off", cfg.ShowReasoning)
+	}
+
+	// The broadcast/status surface applies the same sentinel: "" must never
+	// reach session_update consumers (ChatView drops empty-string updates).
+	if _, _, re, _, _ := srv.sessionStatusFields(nil); re != "off" {
+		t.Errorf("sessionStatusFields reasoning_effort = %q, want \"off\"", re)
+	}
+}
+
+// TestGetConfig_ReasoningEffortOffSentinel: "" (the stored form of off) must
+// surface as "off" on the wire — through omitempty the field used to vanish,
+// and the frontend defaulted an absent value to "medium".
+func TestGetConfig_ReasoningEffortOffSentinel(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodGet, "/api/config", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/config = %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		ReasoningEffort string `json:"reasoning_effort"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.ReasoningEffort != "off" {
+		t.Errorf("reasoning_effort = %q, want \"off\"", resp.ReasoningEffort)
+	}
+}

--- a/internal/skills/defaults/onboard/SKILL.md
+++ b/internal/skills/defaults/onboard/SKILL.md
@@ -184,7 +184,7 @@ en:
 > - **max** — maximum reasoning
 
 Store as `prefs.reasoning_effort` (default `""`). If the user picks `"off"`, store as `""`. If the user gives an invalid value, silently fall back to `""`.
-If `prefs.reasoning_effort` is `""` (off), **skip** the **Show reasoning trace** question below — there is no reasoning output to show.
+If `prefs.reasoning_effort` is `""` (off), **skip** the **Show reasoning trace** question below — there is no reasoning output to show — and set `prefs.show_reasoning` to `false`.
 
 **Show reasoning trace** — whether to stream the model's thinking chain to the terminal.
 
@@ -284,10 +284,10 @@ Read `~/.octo/config.yml` (it already exists — the setup panel wrote provider/
 Use `write_file` to rewrite it with the behaviour-preference fields appended:
 
 - `permission_mode` — `prefs.permission_mode` (or omit if default `"interactive"`)
-- `show_reasoning` — `prefs.show_reasoning` boolean (or omit if default `true`)
-- `reasoning_effort` — `prefs.reasoning_effort` (or omit if empty)
+- `show_reasoning` — `prefs.show_reasoning` boolean (or omit if default `true`; when reasoning is off this is `false`, so it IS written)
+- `reasoning_effort` — `prefs.reasoning_effort`. **If empty (the user chose off), do not just omit it: also DELETE any `reasoning_effort:` line already in the file.** A stale value (e.g. `reasoning_effort: medium` from an earlier setup) left in place would silently keep reasoning on — this is the one exception to the preserve-everything rule below.
 
-Preserve every existing field (provider, model, base_url, api_key, etc.). Do NOT change or remove anything already in the file. Only add the three new keys.
+Preserve every existing field (provider, model, base_url, api_key, etc.). Do NOT change or remove anything already in the file — except a stale `reasoning_effort` when the user chose off, per above. Only add/adjust the three keys.
 
 Example diff:
 ```yaml

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -528,11 +528,13 @@
   // to the session record, then to sensible defaults.
   let modelName = $derived($chatModel[sid] || currentSession?.model || currentSession?.model_id || '—')
   // "" (off) is a legitimate resolved value, not "no data yet" — only fall
-  // back to the 'medium' bootstrap default when neither source has reported
-  // anything at all (?? only skips null/undefined, not "").
+  // back to the bootstrap default when neither source has reported anything
+  // at all (?? only skips null/undefined, not ""). That default is 'off':
+  // an absent reasoning_effort in config means reasoning disabled, so
+  // claiming 'medium' before data arrives misreports the real state.
   let reasoning = $derived.by(() => {
     const v = $chatReasoningEffort[sid] ?? currentSession?.reasoning_effort
-    return v === undefined ? 'medium' : (v || 'off')
+    return v === undefined ? 'off' : (v || 'off')
   })
   let workingDir = $derived($chatWorkingDir[sid] || currentSession?.working_dir || '')
   let permMode = $derived($chatPermMode[sid] || currentSession?.permission_mode || $globalPermissionMode)

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -197,7 +197,7 @@ export interface WsSessionInfo {
   total_turns: number
   working_dir: string
   permission_mode: 'interactive' | 'auto' | 'strict'
-  reasoning_effort: 'low' | 'medium' | 'high'
+  reasoning_effort: 'off' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | string
   show_reasoning?: boolean
   context_usage: number
   pending_question?: boolean
@@ -276,7 +276,7 @@ export interface WsEventSessionUpdate {
   context_usage: number
   working_dir: string
   permission_mode: 'interactive' | 'auto' | 'strict'
-  reasoning_effort: 'low' | 'medium' | 'high'
+  reasoning_effort: 'off' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | string
   show_reasoning: boolean
 }
 

--- a/web/src/views/SettingsView.svelte
+++ b/web/src/views/SettingsView.svelte
@@ -29,7 +29,7 @@
   let tunnelPairing = $state<api.TunnelPairing | null>(null)
 
   // ── Agent defaults (display-only, configured through conversation) ──────────
-  let reasoningEffort  = $state('medium')
+  let reasoningEffort  = $state('off')
   let permissionMode   = $state('interactive')
   let showReasoningVal = $state(true)
   let coauthorVal      = $state(true)
@@ -43,9 +43,9 @@
   // ── helpers ─────────────────────────────────────────────────────────────────
   function effortLabel(effort: string): string {
     const labels: Record<string, string> = {
-      low: 'Low', medium: 'Medium', high: 'High', xhigh: 'Xhigh', max: 'Max',
+      off: 'Off', low: 'Low', medium: 'Medium', high: 'High', xhigh: 'Xhigh', max: 'Max',
     }
-    return labels[effort.toLowerCase()] ?? 'Medium'
+    return labels[effort.toLowerCase()] ?? 'Off'
   }
 
   function permissionLabel(mode: string): string {
@@ -76,7 +76,8 @@
     loading = true
     try {
       const cfg = await api.getConfig() as any
-      reasoningEffort  = cfg.reasoning_effort ?? 'medium'
+      // Absent = old server dropping "" through omitempty = reasoning off.
+      reasoningEffort  = cfg.reasoning_effort ?? 'off'
       permissionMode   = cfg.permission_mode ?? 'interactive'
       showReasoningVal = cfg.show_reasoning ?? true
       coauthorVal      = cfg.coauthor ?? true


### PR DESCRIPTION
## Summary

User report (onboard flow): set reasoning_effort to **off**, but the UI kept saying **medium** and `reasoning_content` still streamed. Three independent root causes, fixed together. Background contract (established by the per-session PATCH handler): *"off" is only ever a wire/UI sentinel — the stored/runtime form of disabled reasoning is `""`*, and the provider layer treats any non-empty effort as thinking-ON.

**1. The wire dropped the off state (why the UI said medium).**
`GET /api/config` marshalled `ReasoningEffort` through `omitempty`, so the stored off (`""`) vanished from the JSON and `SettingsView` defaulted the absent field to `'medium'`. Fixed by sending the sentinel `"off"`; `sessionStatusFields` (feeding `session_update` broadcasts) gets the same mapping, since ChatView drops empty-string updates.

**2. The global PUT persisted the literal `"off"` (why reasoning stayed on).**
`PUT /api/config/reasoning_effort` stored `"off"` verbatim — at the provider layer that's non-empty, i.e. thinking-ON (and an invalid enum for some backends). The per-session PATCH had already fixed this exact bug for its own path; the global PUT now matches: off → persist `""`, force `show_reasoning: false` alongside. `config.Load` additionally normalizes a legacy literal `"off"` (files written by the old handler) back to `""`.

**3. The onboard skill left stale values in place.**
SKILL.md §A.10 said "omit reasoning_effort if empty" AND "preserve every existing field" — so choosing off preserved a pre-existing `reasoning_effort: medium` untouched. The skill now explicitly deletes the stale key when off (documented as the one exception to preserve-everything) and writes `show_reasoning: false`.

**Frontend truthfulness:** Settings/Composer bootstrap defaults claimed Medium before data arrived; the truthful default (absent = off) is used, the label map learns Off, and the `reasoning_effort` unions in types.ts match the actual wire values.

## Testing

- `TestLoad_NormalizesLegacyOffReasoningEffort` — legacy literal normalization (also pins yaml decoding of bare `off` into a string field).
- `TestPutReasoningEffort_Off_PersistsEmptyAndDisablesShowReasoning` — stored `""`, `show_reasoning=false`, response echoes `"off"`, and `sessionStatusFields` reports the sentinel.
- `TestGetConfig_ReasoningEffortOffSentinel` — GET surfaces `"off"` for the default (empty) config.
- `go test -race` (server + config), `gofmt`, `svelte-check` (0 errors), `npm run build` all clean. webdist not committed per repo convention.

An isolated review pass verified all 13 `sessionStatusFields` call sites get the mapped value, no remaining literal-"off" persistence paths (CLI's `normalizeOffEffort` is now a second line of defense), mobile/TUI unaffected.

Known deeper gap (out of scope, noted for a follow-up issue): the generic OpenAI-compatible dialect expresses off by omitting the field, which cannot disable thinking on backends that default it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)