### PR TITLE
feat: enable Discussions, add star CTA and badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # octo-agent
 
 [![Go CI](https://img.shields.io/github/actions/workflow/status/open-octo/octo-agent/go.yml?label=ci&style=flat-square)](https://github.com/open-octo/octo-agent/actions)
+[![Stars](https://img.shields.io/github/stars/open-octo/octo-agent?style=flat-square)](https://github.com/open-octo/octo-agent/stargazers)
+[![Discussions](https://img.shields.io/github/discussions/open-octo/octo-agent?style=flat-square&label=discussions)](https://github.com/open-octo/octo-agent/discussions)
 [![Website](https://img.shields.io/badge/website-octo--agent.dev-4f46e5?style=flat-square)](https://octo-agent.dev)
 [![Go](https://img.shields.io/badge/go-%3E%3D%201.25-00ADD8?style=flat-square)](https://go.dev)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey?style=flat-square)](LICENSE.txt)
@@ -8,6 +10,8 @@
 <p align="center">
   <a href="README.md">简体中文</a> · <a href="README_EN.md">English</a>
 </p>
+
+<p align="center">觉得有用的话，给 octo 点个 ⭐ 吧！</p>
 
 > **开源、单二进制、自托管的 AI Agent。** coding 能力对标 Claude Code，个人助手
 > 比 OpenClaw 更轻量 —— 一个 MIT 开源的 Go 二进制，无需 Node / Python / Ruby，

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,6 +1,8 @@
 # octo-agent
 
 [![Go CI](https://img.shields.io/github/actions/workflow/status/open-octo/octo-agent/go.yml?label=ci&style=flat-square)](https://github.com/open-octo/octo-agent/actions)
+[![Stars](https://img.shields.io/github/stars/open-octo/octo-agent?style=flat-square)](https://github.com/open-octo/octo-agent/stargazers)
+[![Discussions](https://img.shields.io/github/discussions/open-octo/octo-agent?style=flat-square&label=discussions)](https://github.com/open-octo/octo-agent/discussions)
 [![Website](https://img.shields.io/badge/website-octo--agent.dev-4f46e5?style=flat-square)](https://octo-agent.dev)
 [![Go](https://img.shields.io/badge/go-%3E%3D%201.25-00ADD8?style=flat-square)](https://go.dev)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey?style=flat-square)](LICENSE.txt)
@@ -8,6 +10,8 @@
 <p align="center">
   <a href="README.md">简体中文</a> · <a href="README_EN.md">English</a>
 </p>
+
+<p align="center">If you find octo useful, give it a ⭐ on GitHub!</p>
 
 > **An open-source, single-binary, self-hosted AI agent.** A coding agent on par
 > with Claude Code and a personal assistant lighter than OpenClaw — one MIT-licensed


### PR DESCRIPTION
### Changes

- **Enable GitHub Discussions** — community now has a place for Q&A, ideas, and sharing usage tips
- **Add star & Discussions badges** — live shields.io badges showing star count and discussion count, linked to their respective pages
- **Add star CTA line** — "If you find octo useful, give it a star!" placed right below the language switcher in both README.md and README_EN.md

Closes the README part of the star-growth initiative.