### PR TITLE
fix: keep attachments when an IM message answers an ask or steers

### DIFF
--- a/internal/channel/ask.go
+++ b/internal/channel/ask.go
@@ -49,6 +49,16 @@ func (s *Session) SetAskButtonsOnly() {
 	s.askMu.Unlock()
 }
 
+// HasPendingAsk reports whether an ask is currently waiting for a reply.
+// The inbound dispatcher uses it to decide whether an incoming message's
+// attachments must be persisted up front: an ask answer (or a mid-turn
+// steer) travels as text only, so files would otherwise be dropped.
+func (s *Session) HasPendingAsk() bool {
+	s.askMu.Lock()
+	defer s.askMu.Unlock()
+	return s.pendingAsk != nil
+}
+
 // DeliverAskReply routes text to a pending ask and reports whether it was
 // consumed. False means no ask is waiting (or the reply came from the wrong
 // chat or user) — the caller should treat the message as normal chat input.

--- a/internal/channel/ask_test.go
+++ b/internal/channel/ask_test.go
@@ -47,6 +47,24 @@ func TestSession_SecondBeginAskRefused(t *testing.T) {
 	}
 }
 
+func TestSession_HasPendingAsk(t *testing.T) {
+	sess := &Session{}
+	if sess.HasPendingAsk() {
+		t.Fatal("no ask armed, HasPendingAsk must be false")
+	}
+	_, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sess.HasPendingAsk() {
+		t.Fatal("ask armed, HasPendingAsk must be true")
+	}
+	release()
+	if sess.HasPendingAsk() {
+		t.Fatal("ask released, HasPendingAsk must be false")
+	}
+}
+
 func TestSession_ReleaseClearsPending(t *testing.T) {
 	sess := &Session{}
 	_, release, err := sess.BeginAsk("c1", "u1")

--- a/internal/server/attachments.go
+++ b/internal/server/attachments.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -11,7 +12,31 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/channel"
 )
+
+// inboundFileNotes persists an inbound IM event's file attachments and
+// returns one "[Attached file: <path>]" note per file. Unlike
+// attachInboundFiles there is no vision branch — the ask-reply and steer
+// paths carry text only, so every file must be reachable by path. Attachments
+// without retrievable bytes (voice/video placeholders) are skipped.
+func inboundFileNotes(files []channel.FileAttachment) []string {
+	var notes []string
+	for _, f := range files {
+		switch {
+		case f.DataURL != "":
+			block, _, err := saveImageAttachment(f.Name, f.DataURL)
+			if err != nil {
+				slog.Debug("inbound file note", "name", f.Name, "err", err)
+				continue
+			}
+			notes = append(notes, agent.AttachmentNote(block.ImagePath))
+		case f.Path != "":
+			notes = append(notes, agent.AttachmentNote(f.Path))
+		}
+	}
+	return notes
+}
 
 // docChipRefs strips "[Attached file: …]" notes from display text and returns
 // the cleaned text plus one chip ref per note. Image attachments persisted

--- a/internal/server/attachments.go
+++ b/internal/server/attachments.go
@@ -27,7 +27,11 @@ func inboundFileNotes(files []channel.FileAttachment) []string {
 		case f.DataURL != "":
 			block, _, err := saveImageAttachment(f.Name, f.DataURL)
 			if err != nil {
-				slog.Debug("inbound file note", "name", f.Name, "err", err)
+				// This is a silent-drop path: the caller only appends notes
+				// that were built successfully, so a persist failure here
+				// means the attachment goes missing from the ask/steer text
+				// with no visible signal to the user. Warn, not Debug.
+				slog.Warn("inbound file note: persist failed, attachment dropped", "name", f.Name, "err", err)
 				continue
 			}
 			notes = append(notes, agent.AttachmentNote(block.ImagePath))

--- a/internal/server/channel_ask.go
+++ b/internal/server/channel_ask.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/app"
 	"github.com/open-octo/octo-agent/internal/channel"
 	"github.com/open-octo/octo-agent/internal/tools"
@@ -126,7 +127,11 @@ func (s *Server) channelPermissionAsk(sess *channel.Session, ad channel.Adapter,
 		// mode resolves Ask→Deny before the gate ever calls it.
 		select {
 		case text := <-replyCh:
-			return isAffirmative(text), isAlways(text), nil
+			// The dispatcher folds "[Attached file: …]" notes into replies
+			// that carry files; strip them so an approving word accompanied
+			// by a screenshot still parses as the approval it is.
+			cleaned, _ := agent.StripAttachmentNotes(text)
+			return isAffirmative(cleaned), isAlways(cleaned), nil
 		case <-ctx.Done():
 			return false, false, ctx.Err()
 		}

--- a/internal/server/channel_ask_test.go
+++ b/internal/server/channel_ask_test.go
@@ -90,6 +90,28 @@ func TestChannelPermissionAsk_NonAffirmativeDenies(t *testing.T) {
 	}
 }
 
+// TestChannelPermissionAsk_AffirmativeWithAttachmentNote: the dispatcher
+// folds "[Attached file: …]" notes into replies that carry files; an
+// approving word accompanied by a screenshot must still approve.
+func TestChannelPermissionAsk_AffirmativeWithAttachmentNote(t *testing.T) {
+	srv, sess, ad, ev := askEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	done := make(chan struct{})
+	var allow bool
+	go func() {
+		allow, _, _ = ask(context.Background(), "terminal", nil)
+		close(done)
+	}()
+	waitFor(t, func() bool { return len(ad.texts()) == 1 })
+	sess.DeliverAskReply("c1", "", "允许\n\n[Attached file: /tmp/shot.png]")
+	<-done
+
+	if !allow {
+		t.Error("affirmative reply with an attachment note must allow")
+	}
+}
+
 func TestChannelPermissionAsk_ContextCancelDenies(t *testing.T) {
 	srv, sess, ad, ev := askEnv(t)
 	ask := srv.channelPermissionAsk(sess, ad, ev)

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -358,6 +358,48 @@ func TestRouteChannelEvent_ImageAnswersPendingAsk(t *testing.T) {
 	}
 }
 
+// TestRouteChannelEvent_EmptyTextImageAnswersPendingAsk: unlike weixin, the
+// dingtalk/discord/feishu/telegram/wecom adapters construct an empty Text
+// (not a placeholder) for a pure-image inbound message. Before the dispatcher
+// gated the persist step on ev.Files rather than ev.Text alone, an empty-text
+// image answering a pending ask fell through the old empty-text guard
+// entirely — the ask never saw the image, and it kept waiting while the
+// image spawned an unrelated new turn. Regression test for that class of
+// message, distinct from weixin's "[图片]"-placeholder case above.
+func TestRouteChannelEvent_EmptyTextImageAnswersPendingAsk(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	ev := evFor("") // empty text, as dingtalk/discord/feishu/telegram/wecom construct it
+	ev.Files = []channel.FileAttachment{{Type: "image", Name: "qr.png", MimeType: "image/png", DataURL: pngDataURL()}}
+	srv.routeChannelEvent(context.Background(), ad, ev)
+
+	var got string
+	select {
+	case got = <-replyCh:
+	case <-time.After(time.Second):
+		t.Fatal("pending ask did not receive the empty-text image answer")
+	}
+	if !strings.Contains(got, "[Attached file:") || !strings.Contains(filepath.ToSlash(got), ".octo/uploads") {
+		t.Fatalf("answer missing the persisted-upload note: %q", got)
+	}
+	path := strings.TrimSuffix(strings.Split(got, "[Attached file: ")[1], "]")
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		t.Errorf("persisted image unreadable: err=%v bytes=%d", err, len(data))
+	}
+}
+
 // TestRouteChannelEvent_ImageSteerCarriesAttachment: an image sent mid-turn
 // rides the Inbox as a steer — the attachment must reach the model as a
 // persisted path note, not vanish (same drop class as the ask-reply bug).

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -300,6 +302,98 @@ func TestRouteChannelEvent_EmptyTextNeverAnswers(t *testing.T) {
 	case got := <-replyCh:
 		t.Fatalf("empty text %q answered the ask", got)
 	default:
+	}
+}
+
+// pngDataURL is a tiny valid PNG as a data URL, the shape the weixin adapter
+// hands routeChannelEvent for an inbound image message.
+func pngDataURL() string {
+	// 1x1 transparent PNG.
+	raw, _ := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==")
+	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(raw)
+}
+
+// TestRouteChannelEvent_ImageAnswersPendingAsk: an image message sent as the
+// answer to a pending ask (ask_user_question) must not lose the image — the
+// adapter's "[图片]" placeholder text makes the message look like a text
+// reply, so the dispatcher persists the attachment and folds an
+// "[Attached file: <path>]" note into the answer text. Regression test for
+// the bug where such an answer arrived as the bare placeholder and the image
+// bytes were silently dropped.
+func TestRouteChannelEvent_ImageAnswersPendingAsk(t *testing.T) {
+	tmp := t.TempDir() // uploads land in ~/.octo/uploads — isolate HOME
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"), nil)
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	ev := evFor("[图片]")
+	ev.Files = []channel.FileAttachment{{Type: "image", Name: "qr.png", MimeType: "image/png", DataURL: pngDataURL()}}
+	srv.routeChannelEvent(context.Background(), ad, ev)
+
+	var got string
+	select {
+	case got = <-replyCh:
+	case <-time.After(time.Second):
+		t.Fatal("pending ask did not receive the image answer")
+	}
+	if !strings.Contains(got, "[图片]") {
+		t.Errorf("answer lost the message text: %q", got)
+	}
+	if !strings.Contains(got, "[Attached file:") || !strings.Contains(filepath.ToSlash(got), ".octo/uploads") {
+		t.Fatalf("answer missing the persisted-upload note: %q", got)
+	}
+	path := strings.TrimSuffix(strings.Split(got, "[Attached file: ")[1], "]")
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		t.Errorf("persisted image unreadable: err=%v bytes=%d", err, len(data))
+	}
+}
+
+// TestRouteChannelEvent_ImageSteerCarriesAttachment: an image sent mid-turn
+// rides the Inbox as a steer — the attachment must reach the model as a
+// persisted path note, not vanish (same drop class as the ask-reply bug).
+func TestRouteChannelEvent_ImageSteerCarriesAttachment(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	sender := &blockingSender{started: make(chan struct{}, 8), release: make(chan struct{})}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
+		a := agent.New(sender, "stub-model")
+		a.LiteSender, a.LiteModel = stubSender{}, "stub-model"
+		return a
+	}, channel.BindByChat)
+	ad := &fullFakeAdapter{}
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("first message"))
+	<-sender.started // turn 1 is now blocked inside the sender
+
+	ev := evFor("[图片]")
+	ev.Files = []channel.FileAttachment{{Type: "image", Name: "shot.png", MimeType: "image/png", DataURL: pngDataURL()}}
+	srv.routeChannelEvent(context.Background(), ad, ev)
+
+	close(sender.release) // let turn 1 finish; the leftover steers must chain
+	<-sender.started      // the chained turn hit the sender
+
+	waitFor(t, func() bool { calls, _ := sender.snapshot(); return calls >= 2 })
+	_, inputs := sender.snapshot()
+	found := false
+	for _, in := range inputs {
+		if strings.Contains(in, "[Attached file:") && strings.Contains(filepath.ToSlash(in), ".octo/uploads") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("steered image never reached the model as a path note; inputs = %q", inputs)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2750,9 +2750,24 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 	// Text-less events (stickers, images, voice) never answer an ask or
 	// steer — an empty reply would consume the ask slot and deny for
 	// nothing, and an empty steer adds noise.
-	if strings.TrimSpace(ev.Text) != "" {
-		if sess := s.channelMgr.GetSession(ev, profile.ID); sess != nil {
-			if sess.DeliverAskReply(ev.ChatID, ev.UserID, ev.Text) {
+	if sess := s.channelMgr.GetSession(ev, profile.ID); sess != nil {
+		// The ask-reply and steer paths carry text only. When either could
+		// claim this message, persist its attachments up front and fold the
+		// path notes into the text — otherwise an image sent as the answer
+		// to ask_user_question (or as a mid-turn steer) silently vanishes:
+		// the adapter's "[图片]" placeholder text made the guard below pass,
+		// the ask consumed it, and the image bytes in ev.Files went nowhere.
+		// When neither path consumes the message, handleChannelMessage
+		// persists the files instead (attachInboundFiles), so persisting is
+		// gated on HasPendingAsk/IsRunning to avoid a duplicate upload.
+		text := ev.Text
+		if len(ev.Files) > 0 && (sess.HasPendingAsk() || sess.IsRunning()) {
+			if notes := inboundFileNotes(ev.Files); len(notes) > 0 {
+				text = strings.TrimSpace(text + "\n\n" + strings.Join(notes, "\n"))
+			}
+		}
+		if strings.TrimSpace(text) != "" {
+			if sess.DeliverAskReply(ev.ChatID, ev.UserID, text) {
 				return
 			}
 			// Steer: a message arriving mid-turn rides the running turn's
@@ -2766,7 +2781,7 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 			// for a shared conversation, but a behavior those modes should
 			// revisit if the server ever stops hardcoding BindByChatUser.
 			if sess.IsRunning() {
-				sess.Agent.Inbox.Enqueue(ev.Text)
+				sess.Agent.Inbox.Enqueue(text)
 				return
 			}
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2760,8 +2760,17 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 		// When neither path consumes the message, handleChannelMessage
 		// persists the files instead (attachInboundFiles), so persisting is
 		// gated on HasPendingAsk/IsRunning to avoid a duplicate upload.
+		// running is snapshotted once and reused for both the persist gate
+		// and the steer check below: two separate IsRunning() calls could
+		// observe the turn finish in between, in which case DeliverAskReply
+		// also finds no pending ask and the message falls through to
+		// handleChannelMessage — which re-persists the same attachment via
+		// attachInboundFiles, leaking the first copy as an orphaned upload
+		// nothing ever references. Reusing one snapshot keeps the persist
+		// decision and the enqueue decision consistent.
+		running := sess.IsRunning()
 		text := ev.Text
-		if len(ev.Files) > 0 && (sess.HasPendingAsk() || sess.IsRunning()) {
+		if len(ev.Files) > 0 && (sess.HasPendingAsk() || running) {
 			if notes := inboundFileNotes(ev.Files); len(notes) > 0 {
 				text = strings.TrimSpace(text + "\n\n" + strings.Join(notes, "\n"))
 			}
@@ -2774,13 +2783,14 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 			// Inbox (drained between loop iterations; leftovers chain in
 			// handleChannelMessage) — web/CLI parity, instead of queueing a
 			// whole second turn. Known small race: a turn that finishes
-			// between this check and the enqueue leaves the message in the
-			// Inbox until the chat's next turn — delayed, not lost. Under
-			// shared-session bindings (BindByChat/BindByUser) this folds
-			// OTHER users' messages into the running turn too — coherent
-			// for a shared conversation, but a behavior those modes should
-			// revisit if the server ever stops hardcoding BindByChatUser.
-			if sess.IsRunning() {
+			// between the running snapshot above and here leaves the
+			// message in the Inbox until the chat's next turn — delayed,
+			// not lost. Under shared-session bindings (BindByChat/BindByUser)
+			// this folds OTHER users' messages into the running turn too —
+			// coherent for a shared conversation, but a behavior those modes
+			// should revisit if the server ever stops hardcoding
+			// BindByChatUser.
+			if running {
 				sess.Agent.Inbox.Enqueue(text)
 				return
 			}


### PR DESCRIPTION
## 问题

微信里用图片回答 `ask_user_question` 时，agent 只收到 `User chose: Other — [图片]`，图片本体神秘失踪。

根因链条：

1. 微信 adapter 给纯图片消息生成占位文本 `[图片]`（`weixin.go` extractText），真正的图片转成 data URL 挂在 `ev.Files` 上，不落盘。
2. `routeChannelEvent` 的守卫是 `strings.TrimSpace(ev.Text) != ""`——注释本意是「图片/表情等无文本事件不回答 ask」，但 `[图片]` 占位文本让守卫失效。
3. `DeliverAskReply` 把 `[图片]` 当自由文本答案消费掉，`ev.Files` 里的图片没有走 `attachInboundFiles`，直接进了黑洞。

steer 路径（`Inbox.Enqueue(ev.Text)`）同样只带文本、丢附件，同类问题一并修。

## 修复

- 当 pending ask 或运行中的 turn 可能消费这条消息时，dispatcher 先把附件持久化（复用 `saveImageAttachment`，落 `~/.octo/uploads`），把 `[Attached file: <path>]` 注记折进投递/排队的文本——模型用 read_file 就能拿到图片。
- 权限审批在解析前剥离附件注记，`允许` + 截图仍然算批准（fail-closed 行为不回归）。
- 走正常 turn 路径的消息不受影响（`attachInboundFiles` 在那里持久化），持久化以 `HasPendingAsk()/IsRunning()` 为门，不会产生重复上传。

## 改动

- `internal/channel/ask.go`：新增 `Session.HasPendingAsk()`
- `internal/server/attachments.go`：新增 `inboundFileNotes`（持久化 + 生成路径注记）
- `internal/server/server.go`：`routeChannelEvent` 在 ask/steer 路径前富化文本
- `internal/server/channel_ask.go`：权限审批解析前 `StripAttachmentNotes`

## 测试

- `TestRouteChannelEvent_ImageAnswersPendingAsk`：带图回答 pending ask，答案文本含持久化路径注记、文件真实落盘可读
- `TestRouteChannelEvent_ImageSteerCarriesAttachment`：mid-turn 图片 steer 经 Inbox 到达模型，带路径注记
- `TestChannelPermissionAsk_AffirmativeWithAttachmentNote`：`允许` + 附件注记仍批准
- `TestSession_HasPendingAsk`：slot 状态
- `go test ./internal/channel/... ./internal/server/...` 全绿
