### PR TITLE
chore(landing): lead the hero carousel with demo 5

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -300,11 +300,11 @@
         </div>
         <div class="shot-media">
           <div class="carousel" id="demo-carousel">
-            <div class="slide active"><video src="octo-demo.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 1"></video></div>
-            <div class="slide"><video src="octo-demo-2.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 2"></video></div>
-            <div class="slide"><video src="octo-demo-3.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 3"></video></div>
-            <div class="slide"><video src="octo-demo-4.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 4"></video></div>
-            <div class="slide"><video src="octo-demo-5.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 5"></video></div>
+            <div class="slide active"><video src="octo-demo-5.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 1"></video></div>
+            <div class="slide"><video src="octo-demo.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 2"></video></div>
+            <div class="slide"><video src="octo-demo-2.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 3"></video></div>
+            <div class="slide"><video src="octo-demo-3.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 4"></video></div>
+            <div class="slide"><video src="octo-demo-4.mp4" muted playsinline preload="auto" aria-label="Octo Desktop demo 5"></video></div>
             <div class="carousel-playpause" aria-hidden="true"></div>
             <button class="carousel-arrow prev" type="button" aria-label="Previous">‹</button>
             <button class="carousel-arrow next" type="button" aria-label="Next">›</button>


### PR DESCRIPTION
## What

Reorders the landing-page hero carousel so `octo-demo-5.mp4` plays first. The other four demos shift back one position, keeping their relative order.

## Why

Demo 5 is the stronger opener for first-time visitors.

## Notes

- `aria-label`s are renumbered 1–5 to match the new display order.
- The carousel script iterates `.slide` elements in DOM order and hardcodes no filenames or indices, so no JS change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)