### PR TITLE
chore: bump version to 1.14.5, fix Chrome-version docs

### DIFF
--- a/blog/src/content/posts/en/onboarding-browser-setup.md
+++ b/blog/src/content/posts/en/onboarding-browser-setup.md
@@ -24,7 +24,7 @@ octo's `browser` tool drives a real Chrome tab directly over the Chrome DevTools
 octo browser setup
 ```
 
-This walks you to `chrome://inspect/#remote-debugging` and has you tick "Allow remote debugging for this browser instance" (Chrome 144+ disabled the old `--remote-debugging-port` flag on the default profile, so the inspect-page checkbox is the supported path today), restarting the browser if needed. Once ticked, `octo browser setup` probes port 9222 in a loop — and it checks more than "did it connect": it makes an actual page-level CDP call, because on recent Chrome a browser-level connection can succeed while page control still fails. Once that succeeds, the port is saved to your config, so every future `octo` run reuses it without repeating this step.
+This walks you to `chrome://inspect/#remote-debugging` and has you tick "Allow remote debugging for this browser instance" (Chrome 136 stopped honouring `--remote-debugging-port` when it points at the default profile, and Chrome 144 added this in-browser checkbox as the way to debug that profile — the one holding your logins), restarting the browser if needed. Once ticked, `octo browser setup` probes port 9222 in a loop — and it checks more than "did it connect": it makes an actual page-level CDP call, because on recent Chrome a browser-level connection can succeed while page control still fails. Once that succeeds, the port is saved to your config, so every future `octo` run reuses it without repeating this step.
 
 If you don't finish right away, that's fine — the command waits for you to confirm the toggle is on, retries on Enter, or quits any time on `q`. Run `octo browser setup` again whenever you're ready.
 

--- a/blog/src/content/posts/zh/onboarding-browser-setup.md
+++ b/blog/src/content/posts/zh/onboarding-browser-setup.md
@@ -24,7 +24,7 @@ octo 的 `browser` 工具通过 Chrome DevTools Protocol（CDP）直接操作一
 octo browser setup
 ```
 
-这个命令会带你打开 `chrome://inspect/#remote-debugging`，勾选"Allow remote debugging for this browser instance"（Chrome 144 之后，默认 profile 上原来那个 `--remote-debugging-port` 命令行参数被禁用了，走 inspect 页面的这个勾选框是目前能用的路径），必要时重启一下浏览器。勾完之后，`octo browser setup` 会在本地 9222 端口反复探测——注意，它验证的不只是"连上了"，还会真正发一次页面级的 CDP 调用确认可用，因为在新版 Chrome 上，浏览器级的连接可能成功，但页面控制那一层还是会失败。探测成功后，端口号会存进你的配置，以后每次开 octo 都直接复用，不用再走一遍这个流程。
+这个命令会带你打开 `chrome://inspect/#remote-debugging`，勾选"Allow remote debugging for this browser instance"（Chrome 136 起，`--remote-debugging-port` 指向默认 profile 时不再生效；Chrome 144 加了这个浏览器内的勾选框，作为调试默认 profile——也就是带着你登录态的那个——的途径），必要时重启一下浏览器。勾完之后，`octo browser setup` 会在本地 9222 端口反复探测——注意，它验证的不只是"连上了"，还会真正发一次页面级的 CDP 调用确认可用，因为在新版 Chrome 上，浏览器级的连接可能成功，但页面控制那一层还是会失败。探测成功后，端口号会存进你的配置，以后每次开 octo 都直接复用，不用再走一遍这个流程。
 
 如果一时半会没弄好也没关系：命令会停下来等你确认已经打开开关，回车重试，或者随时按 `q` 退出，下次想起来了再跑一遍 `octo browser setup` 就行。
 

--- a/dev-docs/browser-computer-use-design.md
+++ b/dev-docs/browser-computer-use-design.md
@@ -49,10 +49,13 @@ authorization prompt appears once per process.
 
 ## Connecting to Chrome
 
-Chrome 144+ disabled `--remote-debugging-port` on the default profile, so the
-supported path is the **chrome://inspect checkbox**: open
+Chrome 136 stopped honouring `--remote-debugging-port` when it points at the
+default user-data directory; Chrome 144 added an in-browser checkbox that
+re-enables debugging for that profile. Since the default profile is the one
+carrying the user's logins, that checkbox is the supported path: open
 `chrome://inspect/#remote-debugging`, tick *"Allow remote debugging for this
-browser instance"*, which serves CDP on `127.0.0.1:9222`. The debug port is
+browser instance"*, which serves CDP on `127.0.0.1:9222`. Edge exposes the same
+toggle at `edge://inspect` under **Remote debugging** in the left nav. The debug port is
 fixed at **9222** (the checkbox's port); it is not user-editable in the setup UI
 — a custom port only via config (`browser.connect_port`).
 

--- a/docs/src/content/docs/guides/browser-automation.mdx
+++ b/docs/src/content/docs/guides/browser-automation.mdx
@@ -42,9 +42,10 @@ debugger-attach prompt once, not on every navigation.
 octo browser setup
 ```
 
-Walks you through enabling `chrome://inspect/#remote-debugging` (Chrome 144+ disabled the old
-`--remote-debugging-port` flag on the default profile, so the inspect-page checkbox is the
-supported path), then probes port 9222 in a loop — confirming not just that it connects, but that a
+Walks you through enabling `chrome://inspect/#remote-debugging` (Chrome 136 stopped honouring
+`--remote-debugging-port` when it points at the *default* user-data directory, and Chrome 144 added
+this in-browser checkbox as the way to debug that profile — which is the one carrying your logins),
+then probes port 9222 in a loop — confirming not just that it connects, but that a
 real page-level CDP call succeeds (a browser-level connection can succeed while page control still
 fails on recent Chrome). On success it saves `browser.connect_port` to your config; on failure it
 prompts you to flip the toggle and retry, or quit and resume later.

--- a/docs/src/content/docs/zh/guides/browser-automation.mdx
+++ b/docs/src/content/docs/zh/guides/browser-automation.mdx
@@ -39,9 +39,9 @@ Web UI 的那个）——要操作一个已有标签页，必须显式调用 `pa
 octo browser setup
 ```
 
-带你一步步打开 `chrome://inspect/#remote-debugging`（Chrome 144+ 之后默认 profile 上的旧
-`--remote-debugging-port` flag 被禁用了，所以走 inspect 页面的勾选框是目前支持的路径），然后循环
-探测 9222 端口——不只是确认连上了，还会验证一次真正的页面级 CDP 调用能成功（浏览器级连接可能成功，
+带你一步步打开 `chrome://inspect/#remote-debugging`（Chrome 136 起，`--remote-debugging-port`
+指向**默认** user-data 目录时不再生效；Chrome 144 加了这个浏览器内的勾选框，作为调试默认 profile
+——也就是带着你登录态的那个——的途径），然后循环探测 9222 端口——不只是确认连上了，还会验证一次真正的页面级 CDP 调用能成功（浏览器级连接可能成功，
 但页面控制在新版 Chrome 上还是会失败）。成功之后会把 `browser.connect_port` 存进你的配置；失败就
 提示你去开那个开关，回车重试，或者随时退出、以后再跑一遍。
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.14.4"
+var Version = "1.14.5"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Release prep for v1.14.5, plus the doc fix that missed the #1882 merge window.

## 1. Chrome version behind the inspect-page checkbox

Four docs claimed "Chrome 144+ disabled the old `--remote-debugging-port` flag on the default profile". Two separate changes were conflated:

- **Chrome 136** stopped honouring `--remote-debugging-port` / `--remote-debugging-pipe` **when they point at the default user-data directory**. The flag still works against a non-default `--user-data-dir` — which matters here, since `launchChrome` always passes one. ([Chrome blog](https://developer.chrome.com/blog/remote-debugging-port))
- **Chrome 144** added the in-browser "Allow remote debugging for this browser instance" checkbox, which is what re-enables debugging for the default profile — the one carrying the user's logins. ([chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp))

Corrected in `docs/.../browser-automation.mdx` (en + zh), `blog/.../onboarding-browser-setup.md` (en + zh), and `dev-docs/browser-computer-use-design.md`. The design doc also gains the Edge equivalent (`edge://inspect` → **Remote debugging**), since it is the internal reference for this flow.

This was authored as part of #1882 but landed after that PR was merged, so it comes in here.

## 2. Version bump

`internal/version/version.go` 1.14.4 → 1.14.5. Single source of truth — a repo-wide grep confirms no other file carries the version string.

## Verification

- `gofmt -l .` clean, `go vet ./...` clean.
- `go test ./internal/version/ ./cmd/octo/` passes.
- Repo-wide sweep confirms no surviving "144 disabled" claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)