### PR TITLE
fix(desktop): keep the updater's primary buttons visible on hover

### DIFF
--- a/cmd/octo-desktop/update.go
+++ b/cmd/octo-desktop/update.go
@@ -119,6 +119,23 @@ func canInplaceUpdate() bool {
 	return false
 }
 
+// updaterWindowCSS patches the hover state of the built-in updater window's
+// primary buttons ("Install Update", "Restart & Apply", "Try Again").
+//
+// Upstream (wails v3 alpha2.118, pkg/updater/assets/window.html) has
+// `.u__btn:hover:not(:disabled) { background: var(--surface-2) }` at specificity
+// 0,3,0, which outranks `.u__btn--primary { background: var(--accent) }` at
+// 0,1,0 — and `.u__btn--primary:hover` only layers on a brightness filter, never
+// re-asserting the accent background. So hovering a primary button swaps it to
+// --surface-2 while its text stays --accent-fg (#ffffff): white on #f0f0f3 in
+// the light palette, i.e. the button vanishes. (Dark mode hides the bug, where
+// --surface-2 is #2c2c30.) Injected CSS lands last in <head>, so re-asserting
+// both at equal specificity wins.
+const updaterWindowCSS = `.u__btn--primary:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--accent-fg);
+}`
+
 // initInplaceUpdater configures app.Updater against the GitHub release feed.
 // Returns false (logging why) when configuration fails; the caller then keeps
 // the notify-and-open flow, so an updater problem never blocks updates
@@ -145,6 +162,7 @@ func initInplaceUpdater(app *application.App) bool {
 	if err := app.Updater.Init(updater.Config{
 		CurrentVersion: strings.TrimPrefix(version.Version, "v"),
 		Providers:      []updater.Provider{verifiedOnly{gh}},
+		Window:         &updater.BuiltinWindow{CSS: updaterWindowCSS},
 	}); err != nil {
 		log.Printf("octo-desktop: in-place updater disabled (init): %v", err)
 		return false


### PR DESCRIPTION
## The bug

In the desktop **Software Update** window, hovering **Restart & Apply** makes the button disappear — white text on a near-white background. Reported with a screenshot: the button reads as an empty box next to *Close*.

## Cause — upstream CSS cascade

`wails/v3@v3.0.0-alpha2.118`, `pkg/updater/assets/window.html`:

```css
.u__btn:hover:not(:disabled)          { background: var(--surface-2); }  /* specificity 0,3,0 */
.u__btn--primary                      { background: var(--accent);    }  /* specificity 0,1,0 */
.u__btn--primary:hover:not(:disabled) { filter: brightness(1.08);     }
```

The generic hover rule outranks `.u__btn--primary`'s accent background, and the primary hover rule only adds a brightness filter — it never re-asserts the background. So on hover a primary button gets `--surface-2` for its background while `color` stays `--accent-fg` (`#ffffff`).

Light palette: `#ffffff` text on `#f0f0f3`, and `border-color: transparent` on top — the button vanishes. Dark mode masks the bug, where `--surface-2` is `#2c2c30`.

This hits all three primary buttons: **Install Update**, **Restart & Apply**, **Try Again**.

## Fix

`updater.Config.Window` accepts `*updater.BuiltinWindow`, whose `CSS` field is appended as the **last** `<style>` in `<head>` (`pkg/updater/window.go:93` — it rewrites the `</head>` tag). So re-asserting both declarations at equal specificity (0,3,0) wins on document order:

```css
.u__btn--primary:hover:not(:disabled) {
  background: var(--accent);
  color: var(--accent-fg);
}
```

Four lines of CSS plus the `Window:` field in `initInplaceUpdater`. Note `config.go`'s comment claims `Window` is "not yet wired in v1" — that comment is stale; `window_lifecycle.go:53` reads it and `window.go:93` acts on `CSS`.

## Verification

Static: `gofmt -l .` clean, `go vet ./...` clean, `go build` of the desktop module succeeds.

Visual: rendered the upstream `window.html` with our CSS injected exactly the way `window.go` does, in headless Chrome, and compared against the unpatched original.

| Case | Before | After |
| --- | --- | --- |
| `ready` state, hovering **Restart & Apply** | blank white box beside *Close* — reproduces the report exactly | accent-blue background, white label |
| `available` state, hovering **Install Update** | same blank box | accent-blue background, white label |
| dark mode, hovering **Restart & Apply** | (not broken upstream) | still correct — the override doesn't regress it |

Before/after renders are pixel-identical outside that one button, so the injected rule has no side effects.

Method note: real `:hover` can't be driven in a headless screenshot, so every `:hover` in the stylesheet was rewritten to an equal-specificity class stand-in (`.u__btn:hover:not(:disabled)` → `.u__btn.h:not(:disabled)`, both 0,3,0) with declaration order untouched, and that class applied to the target button. The cascade outcome is equivalent to a real hover. This avoids downloading and staging a real ~108 MB artifact against the installed app.

## Follow-up

The real fix belongs upstream — `.u__btn--primary:hover` should re-assert its own background. Worth reporting to wailsapp/wails so this override can eventually be deleted; not filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)