### PR TITLE
fix(web): make artifact images load for remote clients

### DIFF
--- a/web/src/components/ArtifactModal.svelte
+++ b/web/src/components/ArtifactModal.svelte
@@ -13,7 +13,7 @@
   })
 
   function onCopy() { copyArtifact(cur?.code ?? '', showToast) }
-  function onDownload() { downloadArtifact(cur?.name, cur?.code ?? '', showToast) }
+  function onDownload() { downloadArtifact(cur, showToast) }
 
   // "Back to sidebar": close modal, reopen the side panel.
   function restoreSidebar() {
@@ -53,7 +53,12 @@
 
     <!-- Body — always preview, no toolbar / footer chrome -->
     <div class="body">
-      <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
+      {#if cur.src}
+        <!-- Images render outside the sandboxed iframe (see lib/artifacts.ts). -->
+        <div class="img-wrap"><img src={cur.src} alt={cur.name} /></div>
+      {:else}
+        <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
+      {/if}
     </div>
   </div>
 </div>
@@ -102,4 +107,10 @@
 .icon-btn:hover { background: var(--hover-neutral); color: var(--blue-6); }
 .body { flex: 1; min-height: 0; background: var(--bg-container); }
 iframe { border: 0; width: 100%; height: 100%; display: block; }
+.img-wrap {
+  width: 100%; height: 100%; box-sizing: border-box; padding: 12px;
+  display: flex; align-items: center; justify-content: center;
+  overflow: auto; background: var(--bg-layout);
+}
+.img-wrap img { max-width: 100%; max-height: 100%; object-fit: contain; }
 </style>

--- a/web/src/components/ArtifactModal.svelte
+++ b/web/src/components/ArtifactModal.svelte
@@ -57,7 +57,7 @@
         <!-- Images render outside the sandboxed iframe (see lib/artifacts.ts). -->
         <div class="img-wrap"><img src={cur.src} alt={cur.name} /></div>
       {:else}
-        <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
+        <iframe srcdoc={cur.preview} sandbox="allow-scripts" allow="clipboard-write" title={cur.name}></iframe>
       {/if}
     </div>
   </div>

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -6,9 +6,11 @@
 
   // ── Session artifacts (existing) ──────────────────────────────────────────
   const cur = $derived($artifacts[$artifactSel] ?? $artifacts[0])
+  // Images render outside the sandboxed iframe and have no source view.
+  const curIsImage = $derived(!!cur?.src)
 
   function onCopy() { copyArtifact(cur?.code ?? '', showToast) }
-  function onDownload() { downloadArtifact(cur?.name, cur?.code ?? '', showToast) }
+  function onDownload() { downloadArtifact(cur, showToast) }
 
   // ── Save to Light App (HTML artifacts only) ─────────────────────────────
   let saveToLAName = $state('')
@@ -179,16 +181,20 @@
         </div>
       {/if}
 
-      <div class="toolbar">
-        <div class="seg">
-          <button class="seg-btn" class:active={$artifactView === 'preview'} onclick={() => artifactView.set('preview')}>{$t('artifacts.preview')}</button>
-          <button class="seg-btn" class:active={$artifactView === 'code'} onclick={() => artifactView.set('code')}>{$t('artifacts.code')}</button>
+      {#if !curIsImage}
+        <div class="toolbar">
+          <div class="seg">
+            <button class="seg-btn" class:active={$artifactView === 'preview'} onclick={() => artifactView.set('preview')}>{$t('artifacts.preview')}</button>
+            <button class="seg-btn" class:active={$artifactView === 'code'} onclick={() => artifactView.set('code')}>{$t('artifacts.code')}</button>
+          </div>
+          <span class="sandboxed-label">{$t('artifacts.sandboxed')}</span>
         </div>
-        <span class="sandboxed-label">{$t('artifacts.sandboxed')}</span>
-      </div>
+      {/if}
 
       <div class="body">
-        {#if $artifactView === 'preview'}
+        {#if curIsImage}
+          <div class="img-wrap"><img src={cur.src} alt={cur.name} /></div>
+        {:else if $artifactView === 'preview'}
           <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
         {:else}
           <pre class="code-view">{cur.code}</pre>
@@ -243,6 +249,12 @@
   gap: 12px; padding: 32px; text-align: center; color: var(--text-tertiary); font-size: 13px;
 }
 iframe { border: 0; width: 100%; height: 100%; display: block; }
+.img-wrap {
+  width: 100%; height: 100%; box-sizing: border-box; padding: 8px;
+  display: flex; align-items: center; justify-content: center;
+  overflow: auto; background: var(--bg-layout);
+}
+.img-wrap img { max-width: 100%; max-height: 100%; object-fit: contain; }
 .code-view {
   margin: 0; height: 100%; box-sizing: border-box; overflow: auto;
   padding: 14px 16px; background: var(--bg-sidebar); font-size: 12px; line-height: 1.7;

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -107,7 +107,7 @@
       {#if laLoading}
         <div class="empty"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon><span>{$t('common.loading')}</span></div>
       {:else if laCurHTML}
-        <iframe srcdoc={laCurHTML} sandbox="allow-scripts clipboard-write" title={laCurName}></iframe>
+        <iframe srcdoc={laCurHTML} sandbox="allow-scripts" allow="clipboard-write" title={laCurName}></iframe>
       {:else if $lightapps.length === 0}
         <div class="empty">
           <iconify-icon icon="ant-design:appstore-outlined" width="28"></iconify-icon>
@@ -195,7 +195,7 @@
         {#if curIsImage}
           <div class="img-wrap"><img src={cur.src} alt={cur.name} /></div>
         {:else if $artifactView === 'preview'}
-          <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
+          <iframe srcdoc={cur.preview} sandbox="allow-scripts" allow="clipboard-write" title={cur.name}></iframe>
         {:else}
           <pre class="code-view">{cur.code}</pre>
         {/if}

--- a/web/src/lib/artifact-actions.ts
+++ b/web/src/lib/artifact-actions.ts
@@ -58,7 +58,9 @@ async function downloadImage(
   const fname = name || 'artifact'
   try {
     const res = await fetch(src)
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    if (!res.ok) {
+      throw new Error(await api.readErrorMessage(res, `${res.status} ${res.statusText}`))
+    }
     if (get(nativeShell)) {
       const bytes = new Uint8Array(await res.arrayBuffer())
       // Chunked so a multi-MB screenshot doesn't blow the spread argument limit.
@@ -81,7 +83,10 @@ async function downloadImage(
     a.click()
     a.remove()
     URL.revokeObjectURL(url)
-  } catch {
-    showToast(tr('artifacts.save_failed'), 'error')
+  } catch (e: any) {
+    // With the server's own message: for the 10 MB cap in particular, this is
+    // the only thing that explains why the panel shows a broken image too.
+    const detail = e?.message ? `: ${e.message}` : ''
+    showToast(`${tr('artifacts.save_failed')}${detail}`, 'error')
   }
 }

--- a/web/src/lib/artifact-actions.ts
+++ b/web/src/lib/artifact-actions.ts
@@ -75,7 +75,11 @@ async function downloadImage(
     const a = document.createElement('a')
     a.href = url
     a.download = fname
+    // In the document, not detached: a detached anchor's click() has never been
+    // reliable in Firefox. Same shape as the skill zip export.
+    document.body.appendChild(a)
     a.click()
+    a.remove()
     URL.revokeObjectURL(url)
   } catch {
     showToast(tr('artifacts.save_failed'), 'error')

--- a/web/src/lib/artifact-actions.ts
+++ b/web/src/lib/artifact-actions.ts
@@ -2,6 +2,7 @@ import { get } from 'svelte/store'
 import { nativeShell } from './stores'
 import { tr } from './i18n'
 import * as api from './api'
+import type { Artifact } from './types'
 
 // Shared by ArtifactsPanel and ArtifactModal — both render the same artifact
 // actions (copy to clipboard, download file). Kept in one place so clipboard
@@ -12,13 +13,19 @@ export function copyArtifact(code: string, showToast: (msg: string, type?: strin
     .catch(() => showToast(tr('artifacts.copy_failed'), 'error'))
 }
 
+// Saves the artifact to disk. Text kinds carry their whole body in `code`; an
+// image carries only its on-disk path there, so it takes the binary path below.
 export async function downloadArtifact(
-  name: string | undefined,
-  code: string,
+  artifact: Artifact | undefined,
   showToast: (msg: string, type?: string) => void,
 ) {
-  const fname = name || 'artifact.txt'
-  const content = code ?? ''
+  if (!artifact) return
+  if (artifact.src) {
+    await downloadImage(artifact.name, artifact.src, showToast)
+    return
+  }
+  const fname = artifact.name || 'artifact.txt'
+  const content = artifact.code ?? ''
   if (get(nativeShell)) {
     try {
       const r = await api.nativeSaveFile(fname, content)
@@ -35,4 +42,42 @@ export async function downloadArtifact(
   a.download = fname
   a.click()
   URL.revokeObjectURL(url)
+}
+
+// Image artifacts are binary: saving `code` would write a text file holding a
+// path. Fetch the bytes instead — and fetch rather than point <a download>
+// straight at the endpoint, so a non-2xx surfaces as a toast instead of
+// silently doing nothing (#1109). The desktop webview has no download
+// delegate, so there the bytes go through the native save dialog
+// base64-encoded, same shape as the skill zip export.
+async function downloadImage(
+  name: string,
+  src: string,
+  showToast: (msg: string, type?: string) => void,
+) {
+  const fname = name || 'artifact'
+  try {
+    const res = await fetch(src)
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    if (get(nativeShell)) {
+      const bytes = new Uint8Array(await res.arrayBuffer())
+      // Chunked so a multi-MB screenshot doesn't blow the spread argument limit.
+      let binary = ''
+      const chunk = 0x8000
+      for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+      }
+      const r = await api.nativeSaveBinary(fname, btoa(binary))
+      if (!r.cancelled) showToast(tr('artifacts.saved'))
+      return
+    }
+    const url = URL.createObjectURL(await res.blob())
+    const a = document.createElement('a')
+    a.href = url
+    a.download = fname
+    a.click()
+    URL.revokeObjectURL(url)
+  } catch {
+    showToast(tr('artifacts.save_failed'), 'error')
+  }
 }

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { get } from 'svelte/store'
+import { artifacts } from './stores'
+import { observeArtifact, resetArtifacts } from './artifacts'
+
+// Nothing a preview document references can authenticate: the srcdoc iframe has
+// no allow-same-origin, so its subresource requests are cross-site and the
+// SameSite=Strict access-key cookie is withheld. These tests pin the two halves
+// of that constraint — images stay out of the iframe, and no preview document
+// smuggles an /api/ reference back in.
+
+const SID = 'sess-1'
+
+function payload(path: string) {
+  return { type: 'write', path }
+}
+
+beforeEach(() => {
+  resetArtifacts(SID)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('observeArtifact — image artifacts', () => {
+  it('carries a src for the host document and never fetches the bytes', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await observeArtifact(SID, payload('/tmp/shot.png'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.type).toBe('Image')
+    expect(entry.src).toBe(
+      `/api/sessions/${encodeURIComponent(SID)}/artifacts?path=${encodeURIComponent('/tmp/shot.png')}`,
+    )
+    // The <img> pulls the bytes lazily; observing must not download them.
+    expect(fetchMock).not.toHaveBeenCalled()
+    // No sandboxed preview document at all, so nothing to 401.
+    expect(entry.preview).toBe('')
+    // `code` is the on-disk path — the one text form worth copying.
+    expect(entry.code).toBe('/tmp/shot.png')
+  })
+
+  it('keeps transcript order during replay, since nothing awaits', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+
+    await observeArtifact(SID, payload('/tmp/a.png'), false)
+    await observeArtifact(SID, payload('/tmp/b.png'), false)
+
+    expect(get(artifacts).map(a => a.path)).toEqual(['/tmp/a.png', '/tmp/b.png'])
+  })
+})
+
+describe('observeArtifact — preview documents', () => {
+  // Covers the chrome we generate, not references inside the artifact's own
+  // body: a hand-written `![shot](shot.png)` in a markdown file still resolves
+  // against the host page and still fails inside the iframe.
+  it('builds the markdown preview without referencing /api/', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('# hello')))
+
+    await observeArtifact(SID, payload('/tmp/notes.md'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).not.toBe('')
+    expect(entry.preview).not.toContain('/api/')
+  })
+})

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -33,7 +33,7 @@ describe('observeArtifact — image artifacts', () => {
     const [entry] = get(artifacts)
     expect(entry.type).toBe('Image')
     expect(entry.src).toBe(
-      `/api/sessions/${encodeURIComponent(SID)}/artifacts?path=${encodeURIComponent('/tmp/shot.png')}`,
+      `/api/sessions/${encodeURIComponent(SID)}/artifacts?path=${encodeURIComponent('/tmp/shot.png')}&rev=1`,
     )
     // The <img> pulls the bytes lazily; observing must not download them.
     expect(fetchMock).not.toHaveBeenCalled()
@@ -41,6 +41,20 @@ describe('observeArtifact — image artifacts', () => {
     expect(entry.preview).toBe('')
     // `code` is the on-disk path — the one text form worth copying.
     expect(entry.code).toBe('/tmp/shot.png')
+  })
+
+  it('changes the src when the same path is written again', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+
+    await observeArtifact(SID, payload('/tmp/shot.png'), false)
+    const first = get(artifacts)[0].src
+    await observeArtifact(SID, payload('/tmp/shot.png'), true)
+    const second = get(artifacts)[0].src
+
+    // An identical src would let Svelte skip the update and leave the old bytes
+    // on screen after the agent overwrote the file.
+    expect(get(artifacts)).toHaveLength(1)
+    expect(second).not.toBe(first)
   })
 
   it('keeps transcript order during replay, since nothing awaits', async () => {

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -126,3 +126,55 @@ describe('observeArtifact — markdown image references', () => {
     expect(get(artifacts)).toHaveLength(1)
   })
 })
+
+// An HTML artifact previews as its own document, so the same references need the
+// same treatment — but only when hasExternalRefs hasn't already routed the file
+// to the warning page.
+describe('observeArtifact — html local references', () => {
+  const png = new Uint8Array([137, 80, 78, 71])
+
+  function stubFetch(html: string, imageStatus = 200) {
+    const fetchMock = vi.fn(async (u: string) => {
+      if (u.includes('page.html')) return new Response(html)
+      if (imageStatus !== 200) return new Response('', { status: imageStatus })
+      return new Response(png, { headers: { 'Content-Type': 'image/png' } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  it('inlines an <img> and a CSS url(), keeping the doctype', async () => {
+    stubFetch(
+      '<!DOCTYPE html><html><head><style>body{background:url("bg.png")}</style></head>' +
+        '<body><img src="chart.png"></body></html>',
+    )
+
+    await observeArtifact(SID, payload('/tmp/page.html'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toMatch(/^<!DOCTYPE html>/i)
+    expect(entry.preview).not.toContain('chart.png')
+    expect(entry.preview).not.toContain('bg.png')
+    expect(entry.preview.match(/data:image\/png;base64,/g)).toHaveLength(2)
+  })
+
+  it('hands back the exact source when there is nothing to inline', async () => {
+    const html = '<!DOCTYPE html><html><body><h1>hi</h1></body></html>'
+    stubFetch(html)
+
+    await observeArtifact(SID, payload('/tmp/page.html'), false)
+
+    // No parse/serialize round-trip on a document with no local references.
+    expect(get(artifacts)[0].preview).toBe(html)
+  })
+
+  it('leaves the warning page alone when a script is unreachable', async () => {
+    stubFetch('<html><head><script src="app.js"></script></head><body><img src="chart.png"></body></html>')
+
+    await observeArtifact(SID, payload('/tmp/page.html'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toContain('cannot be previewed here')
+    expect(entry.preview).not.toContain('data:image/png')
+  })
+})

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -54,9 +54,6 @@ describe('observeArtifact — image artifacts', () => {
 })
 
 describe('observeArtifact — preview documents', () => {
-  // Covers the chrome we generate, not references inside the artifact's own
-  // body: a hand-written `![shot](shot.png)` in a markdown file still resolves
-  // against the host page and still fails inside the iframe.
   it('builds the markdown preview without referencing /api/', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('# hello')))
 
@@ -65,5 +62,67 @@ describe('observeArtifact — preview documents', () => {
     const [entry] = get(artifacts)
     expect(entry.preview).not.toBe('')
     expect(entry.preview).not.toContain('/api/')
+  })
+})
+
+// A markdown artifact's own image references can't load from inside the iframe
+// either, so their bytes are inlined as data: URIs.
+describe('observeArtifact — markdown image references', () => {
+  const png = new Uint8Array([137, 80, 78, 71])
+
+  function stubFetch(md: string, imageStatus = 200) {
+    const fetchMock = vi.fn(async (u: string) => {
+      if (u.includes('report.md')) return new Response(md)
+      if (imageStatus !== 200) return new Response('', { status: imageStatus })
+      return new Response(png, { headers: { 'Content-Type': 'image/png' } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  it('inlines a relative reference, resolved against the markdown file', async () => {
+    const fetchMock = stubFetch('![shot](img/shot.png)\n')
+
+    await observeArtifact(SID, payload('/tmp/report.md'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toContain('src="data:image/png;base64,')
+    expect(entry.preview).not.toContain('img/shot.png')
+    // Resolved relative to /tmp/report.md, not to the host page.
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/sessions/${SID}/artifacts?path=${encodeURIComponent('/tmp/img/shot.png')}`,
+    )
+  })
+
+  it('resolves "." and ".." segments', async () => {
+    const fetchMock = stubFetch('![shot](../shots/./a.png)\n')
+
+    await observeArtifact(SID, payload('/tmp/docs/report.md'), false)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/sessions/${SID}/artifacts?path=${encodeURIComponent('/tmp/shots/a.png')}`,
+    )
+  })
+
+  it('leaves remote and data references untouched', async () => {
+    const fetchMock = stubFetch('![a](https://example.com/a.png)\n\n![b](data:image/gif;base64,R0lGOD)\n')
+
+    await observeArtifact(SID, payload('/tmp/report.md'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toContain('https://example.com/a.png')
+    // Only the markdown body itself was fetched.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the artifact when an image is not fetchable', async () => {
+    stubFetch('![gone](missing.png)\n', 404)
+
+    await observeArtifact(SID, payload('/tmp/report.md'), false)
+
+    const [entry] = get(artifacts)
+    // The reference stays as written: a broken image beats losing the preview.
+    expect(entry.preview).toContain('missing.png')
+    expect(get(artifacts)).toHaveLength(1)
   })
 })

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -118,6 +118,19 @@ describe('observeArtifact — markdown image references', () => {
     )
   })
 
+  it('refuses to inline a non-image, even though the endpoint serves it', async () => {
+    // .md is previewable server-side, so only this gate stops an artifact from
+    // naming a sibling document and having the host page fetch it.
+    const fetchMock = stubFetch('![oops](secrets.md)\n')
+
+    await observeArtifact(SID, payload('/tmp/report.md'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toContain('secrets.md')
+    expect(entry.preview).not.toContain('data:')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('leaves remote and data references untouched', async () => {
     const fetchMock = stubFetch('![a](https://example.com/a.png)\n\n![b](data:image/gif;base64,R0lGOD)\n')
 

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -67,6 +67,27 @@ describe('observeArtifact — image artifacts', () => {
   })
 })
 
+describe('observeArtifact — markdown copy button', () => {
+  it('binds the handler to an element the preview document actually has', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('```js\nlet a = 1\n```\n')))
+
+    await observeArtifact(SID, payload('/tmp/notes.md'), false)
+
+    const { preview } = get(artifacts)[0]
+    // '.body' matched nothing here, so querySelector returned null and the whole
+    // handler threw on load — the button never worked.
+    expect(preview).not.toContain(".querySelector('.body')")
+    expect(preview).toContain('document.body.addEventListener')
+    // The other half of the contract: the markup the handler looks for.
+    // Not asserting the .code-block wrapper — under happy-dom, DOMPurify drops
+    // every outermost <div> (even `<div class="a">x</div>` → `x`), so its
+    // absence here says nothing about a browser. The handler null-guards that
+    // lookup for the same reason.
+    expect(preview).toContain('class="copy-btn"')
+    expect(preview).toContain('<pre><code')
+  })
+})
+
 describe('observeArtifact — preview documents', () => {
   it('builds the markdown preview without referencing /api/', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('# hello')))

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -57,14 +57,6 @@ describe('observeArtifact — image artifacts', () => {
     expect(second).not.toBe(first)
   })
 
-  it('keeps transcript order during replay, since nothing awaits', async () => {
-    vi.stubGlobal('fetch', vi.fn())
-
-    await observeArtifact(SID, payload('/tmp/a.png'), false)
-    await observeArtifact(SID, payload('/tmp/b.png'), false)
-
-    expect(get(artifacts).map(a => a.path)).toEqual(['/tmp/a.png', '/tmp/b.png'])
-  })
 })
 
 describe('observeArtifact — markdown copy button', () => {
@@ -204,6 +196,45 @@ describe('observeArtifact — html local references', () => {
     expect(entry.preview).not.toContain('chart.png')
     expect(entry.preview).not.toContain('bg.png')
     expect(entry.preview.match(/data:image\/png;base64,/g)).toHaveLength(2)
+  })
+
+  it('drops a <picture>\'s <source> so the inlined <img src> actually wins', async () => {
+    stubFetch(
+      '<html><body><picture><source srcset="chart.webp" type="image/webp">' +
+        '<img src="chart.png"></picture></body></html>',
+    )
+
+    await observeArtifact(SID, payload('/tmp/page.html'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toContain('data:image/png;base64,')
+    // A surviving <source> outranks the src, so the browser would go back to
+    // the unreachable relative path and the image would still be broken.
+    expect(entry.preview).not.toContain('chart.webp')
+    expect(entry.preview).not.toContain('<source')
+  })
+
+  it('rewrites an SVG <image href>', async () => {
+    stubFetch('<html><body><svg><image href="d.png" width="10" height="10"></image></svg></body></html>')
+
+    await observeArtifact(SID, payload('/tmp/page.html'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toContain('data:image/png;base64,')
+    expect(entry.preview).not.toContain('d.png')
+  })
+
+  it('keeps a doctype\'s public and system identifiers', async () => {
+    stubFetch(
+      '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">' +
+        '<html><body><img src="chart.png"></body></html>',
+    )
+
+    await observeArtifact(SID, payload('/tmp/page.html'), false)
+
+    // A name-only `<!DOCTYPE html>` would switch this file to standards mode and
+    // the preview would lay out differently from the real thing.
+    expect(get(artifacts)[0].preview).toContain('PUBLIC "-//W3C//DTD HTML 4.01//EN"')
   })
 
   it('hands back the exact source when there is nothing to inline', async () => {

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -13,7 +13,12 @@
 // origin and count as cross-site; the SameSite=Strict access-key cookie is
 // withheld and the endpoint answers 401 for every client that isn't exempt as
 // loopback. It works on localhost and breaks over a tunnel or on the LAN.
-// Inline the bytes, or render outside the iframe (what `src` below is for).
+//
+// The same goes for any local file the artifact itself points at — a markdown
+// `![](shot.png)` resolves against the host page rather than the file's own
+// directory, and the /api/ path it would need can't authenticate from in there
+// either. Two ways out: render outside the iframe (what `src` is for) or inline
+// the bytes as a data: URI (what inlineMarkdownImages does).
 
 import { get, writable } from 'svelte/store'
 import { artifacts, panelContent, artifactSel } from './stores'
@@ -81,6 +86,122 @@ function hasExternalRefs(html: string): boolean {
   return EXTERNAL_REF_RE.test(html)
 }
 
+function artifactURL(sessionId: string, path: string): string {
+  return `/api/sessions/${encodeURIComponent(sessionId)}/artifacts?path=${encodeURIComponent(path)}`
+}
+
+// ─── Markdown image references ──────────────────────────────────────────────
+//
+// A markdown artifact can point at its own images: `![shot](shot.png)`. Those
+// references cannot survive inside the preview iframe — a relative path
+// resolves against the host page, and the /api/ path it would need can't
+// authenticate from there (see the file-header note) — so the bytes are inlined
+// as data: URIs, the one form the iframe can read.
+//
+// Only files the session itself wrote are fetchable, since the endpoint serves
+// nothing else. That covers the case that matters: a report the agent wrote
+// beside the screenshots it took. A reference to anything else is left exactly
+// as written and simply doesn't render, same as today.
+//
+// Budgeted because a data: URI is resident memory for as long as the artifact
+// is in the store: base64 costs ~1.37x the file size, doubled again by UTF-16,
+// and the srcdoc attribute holds a second copy. Past the budget the remaining
+// references are left alone rather than silently bloating the session.
+const inlineImageBudget = 8 << 20
+const inlineImageMax = 20
+
+async function inlineMarkdownImages(html: string, sessionId: string, mdPath: string): Promise<string> {
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const imgs = Array.from(doc.querySelectorAll('img'))
+  if (imgs.length === 0) return html
+
+  const seen = new Map<string, string>()
+  let spent = 0
+  let count = 0
+  for (const img of imgs) {
+    const abs = localImagePath(img.getAttribute('src') ?? '', mdPath)
+    if (!abs) continue
+    const cached = seen.get(abs)
+    if (cached) {
+      img.setAttribute('src', cached)
+      continue
+    }
+    if (count >= inlineImageMax || spent >= inlineImageBudget) break
+    try {
+      const res = await fetch(artifactURL(sessionId, abs))
+      if (!res.ok) continue
+      const blob = await res.blob()
+      const dataUrl = await blobToDataURL(blob)
+      spent += blob.size
+      count++
+      seen.set(abs, dataUrl)
+      img.setAttribute('src', dataUrl)
+    } catch {
+      // Leave the reference as written — a broken image beats no preview.
+    }
+  }
+  return doc.body.innerHTML
+}
+
+// localImagePath resolves a markdown image reference to the absolute on-disk
+// path to ask the endpoint for, or null when it isn't a local file. Anything
+// carrying a scheme is left alone: an http(s) image is a cross-origin no-cors
+// load, which a sandboxed iframe performs just fine.
+function localImagePath(raw: string, mdPath: string): string | null {
+  const src = raw.trim()
+  if (!src || src.startsWith('//') || src.startsWith('#')) return null
+  if (/^[a-z][a-z0-9+.-]*:/i.test(src) && !/^[a-z]:[\\/]/i.test(src)) return null
+  let rel = src.split(/[?#]/)[0]
+  try {
+    rel = decodeURIComponent(rel)
+  } catch {
+    // Malformed escapes: use the reference verbatim.
+  }
+  if (!rel) return null
+  const abs = isAbsolutePath(rel) ? rel : `${dirOf(mdPath)}/${rel}`
+  const clean = cleanPath(abs)
+  return isAbsolutePath(clean) ? clean : null
+}
+
+// A leading "/" or a Windows drive letter. Paths are normalised to forward
+// slashes; the server runs filepath.Clean on its side, which re-separates them
+// per platform before matching against the transcript.
+function isAbsolutePath(p: string): boolean {
+  return p.startsWith('/') || /^[a-z]:[\\/]/i.test(p)
+}
+
+function dirOf(p: string): string {
+  const norm = p.replace(/\\/g, '/')
+  const cut = norm.lastIndexOf('/')
+  return cut < 0 ? '' : norm.slice(0, cut)
+}
+
+// Resolves "." and ".." segments and collapses repeats. Traversal needs no
+// guarding here: the endpoint only serves paths this session's transcript
+// records, so a resolved path outside the artifact's directory is simply a 404.
+function cleanPath(p: string): string {
+  const norm = p.replace(/\\/g, '/')
+  const out: string[] = []
+  for (const seg of norm.split('/')) {
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') {
+      out.pop()
+      continue
+    }
+    out.push(seg)
+  }
+  return (norm.startsWith('/') ? '/' : '') + out.join('/')
+}
+
+function blobToDataURL(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(blob)
+  })
+}
+
 // Clear artifacts on session switch; history replay then repopulates. The
 // session marker gates in-flight fetches so a late response can't leak into the
 // newly-selected session.
@@ -108,7 +229,7 @@ export async function observeArtifact(
   const kind = kindOf(path)
   if (!kind) return
 
-  const url = `/api/sessions/${encodeURIComponent(sessionId)}/artifacts?path=${encodeURIComponent(path)}`
+  const url = artifactURL(sessionId, path)
 
   let code = ''
   let preview = ''
@@ -175,7 +296,8 @@ export async function observeArtifact(
 	  })
 	});
 	<\/script>`
-        preview = `<style>${MD_STYLES}</style><body style="${bodyStyle}">${renderMarkdown(code)}${COPY_SCRIPT}</body>`
+        const body = await inlineMarkdownImages(renderMarkdown(code), sessionId, path)
+        preview = `<style>${MD_STYLES}</style><body style="${bodyStyle}">${body}${COPY_SCRIPT}</body>`
       } else {
         // code kind: show with theme-aware monospace style
         const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -6,6 +6,14 @@
 // fetches the file body from the whitelisted GET /api/sessions/{id}/artifacts
 // endpoint, and pushes a previewable entry into the `artifacts` store that
 // ArtifactsPanel renders. Mirrors the old hand-written Artifacts.observe().
+//
+// Constraint on every preview document built here: it must not reference
+// /api/* — nothing inside the sandboxed srcdoc iframe can authenticate. The
+// iframe has no allow-same-origin, so its subresource requests carry an opaque
+// origin and count as cross-site; the SameSite=Strict access-key cookie is
+// withheld and the endpoint answers 401 for every client that isn't exempt as
+// loopback. It works on localhost and breaks over a tunnel or on the LAN.
+// Inline the bytes, or render outside the iframe (what `src` below is for).
 
 import { get, writable } from 'svelte/store'
 import { artifacts, panelContent, artifactSel } from './stores'
@@ -104,13 +112,25 @@ export async function observeArtifact(
 
   let code = ''
   let preview = ''
+  let src = ''
   try {
     const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
     if (kind === 'image') {
-      // The sandboxed iframe loads the image from the same-host endpoint.
-      code = url
-      const imgBg = isDark ? '#1e1e1e' : '#f5f5f5'
-      preview = `<body style="margin:0;display:flex;align-items:center;justify-content:center;background:${imgBg};height:100vh"><img style="max-width:100%;max-height:100vh" src="${url}"></body>`
+      // Images render as a plain <img> in the host document — see the
+      // file-header note on why an <img src="/api/…"> inside the sandboxed
+      // iframe 401s. The host document's own request is same-site and
+      // authenticates normally, and it keeps the browser's lazy loading: the
+      // bytes move only when the user actually looks at the image, which
+      // matters for a session full of multi-MB screenshots on a slow link.
+      //
+      // Dropping the iframe costs no isolation here. The endpoint pins
+      // Content-Type and sends X-Content-Type-Options: nosniff, and an SVG
+      // loaded through <img> runs no script and fetches no external resource.
+      src = url
+      // A binary artifact has no source view, so `code` carries the on-disk
+      // path instead: it is the one text form worth copying. Download saves
+      // the bytes from `src`.
+      code = path
     } else {
       const res = await fetch(url)
       if (!res.ok) return
@@ -181,6 +201,7 @@ export async function observeArtifact(
     code,
     preview,
     path,
+    src: src || undefined,
   }
 
   artifacts.update(list => {

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -104,18 +104,22 @@ function artifactURL(sessionId: string, path: string): string {
 // file-header note) — so the bytes are inlined as data: URIs, the one form the
 // iframe can read.
 //
-// Only files the session itself wrote are fetchable, since the endpoint serves
-// nothing else, and only the extensions it recognises as previewable (images
-// among them; stylesheets and fonts are not). Everything else is left exactly
-// as written and simply doesn't render, same as today — which is also the
-// fallback for a local .css or .js, already routed to the warning page by
+// Two gates on what gets inlined: the reference must resolve to an image (the
+// endpoint also serves .html and .md, and an artifact must not be able to pull
+// those in), and the session itself must have written it, since the endpoint
+// serves nothing else. That covers the case that matters: a report the agent
+// wrote beside the screenshots it took. Everything else is left exactly as
+// written and simply doesn't render, same as today — which is also the fallback
+// for a local .css or .js, already routed to the warning page by
 // hasExternalRefs.
 //
-// Budgeted because a data: URI is resident memory for as long as the artifact
-// is in the store: base64 costs ~1.37x the file size, doubled again by UTF-16,
-// and the srcdoc attribute holds a second copy. Past the budget the remaining
-// references are left alone rather than silently bloating the session.
-const inlineRefBudget = 8 << 20
+// The budget counts raw file bytes, not what they cost once resident: a data:
+// URI carries base64's ~1.37x, doubled again by UTF-16, and the srcdoc
+// attribute holds a second copy — so a full budget is several times its own
+// size in memory for as long as the artifact stays in the store. It is also
+// per-artifact, so a session with many image-bearing documents accumulates.
+// Both numbers are deliberately well under what one page needs.
+const inlineRefBudget = 4 << 20
 const inlineRefMax = 20
 
 // Cheap pre-check: skip the parse/serialize round-trip entirely for a document
@@ -143,6 +147,12 @@ async function inlineLocalRefs(
   const inline = async (raw: string): Promise<string | null> => {
     const abs = localFilePath(raw, basePath)
     if (!abs) return null
+    // Images only, enforced rather than assumed. The endpoint also serves .html
+    // and .md, so without this an artifact could name a sibling document here
+    // and have the host page — which is authenticated — fetch it and hand the
+    // bytes to a preview iframe that runs scripts and can reach the network.
+    // The artifact would be reading files it was never granted.
+    if (kindOf(abs) !== 'image') return null
     const cached = seen.get(abs)
     if (cached !== undefined) return cached
     if (count >= inlineRefMax || spent >= inlineRefBudget) return null
@@ -309,15 +319,18 @@ export async function observeArtifact(
       // Images render as a plain <img> in the host document — see the
       // file-header note on why an <img src="/api/…"> inside the sandboxed
       // iframe 401s. The host document's own request is same-site and
-      // authenticates normally, and it keeps the browser's lazy loading: the
-      // bytes move only when the user actually looks at the image, which
-      // matters for a session full of multi-MB screenshots on a slow link.
+      // authenticates normally, and observing costs no network at all: the URL
+      // only becomes a request once the panel renders this artifact, and it
+      // renders one at a time. History replay over a session full of multi-MB
+      // screenshots therefore transfers none of them.
       //
       // The revision counter matters: re-observing a path (the agent overwrote
       // the file) otherwise yields a byte-identical src, so Svelte skips the
-      // attribute update and the panel keeps showing the previous bytes. The
-      // count is derived from the transcript, so replaying the same session
-      // reproduces the same URLs and the browser cache still applies.
+      // attribute update and the panel keeps showing the previous bytes — the
+      // endpoint sends no validators, so nothing prompts a revalidation either.
+      // Counting observations rather than stamping a clock keeps the URL stable
+      // across a straight replay of the same transcript, so a reopened session
+      // can still reuse whatever the browser happens to have cached.
       //
       // Dropping the iframe costs no isolation here. The endpoint pins
       // Content-Type and sends X-Content-Type-Options: nosniff, and an SVG

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -124,7 +124,7 @@ const inlineRefMax = 20
 
 // Cheap pre-check: skip the parse/serialize round-trip entirely for a document
 // with nothing to rewrite, which is most of them.
-const LOCAL_REF_HINT = /<img\b|url\(/i
+const LOCAL_REF_HINT = /<img\b|<image\b|url\(/i
 const CSS_URL_RE = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi
 
 // mode picks how the result is serialized: an HTML artifact is a whole document
@@ -176,9 +176,23 @@ async function inlineLocalRefs(
     const dataUrl = await inline(img.getAttribute('src') ?? '')
     if (!dataUrl) continue
     img.setAttribute('src', dataUrl)
-    // A srcset would outrank the src we just rewrote, and its candidates are
-    // unreachable for the same reason.
+    // Whatever outranks the src has to go, or the rewrite achieves nothing: a
+    // srcset beats src, and a <picture>'s <source> beats both. Their candidates
+    // are unreachable for exactly the reason the src was, so dropping them is
+    // what makes the inlined src take effect.
     img.removeAttribute('srcset')
+    const parent = img.parentElement
+    if (parent && parent.tagName === 'PICTURE') {
+      for (const s of Array.from(parent.querySelectorAll('source'))) s.remove()
+    }
+    changed = true
+  }
+  // SVG's <image> is the same reference in a different attribute.
+  for (const el of Array.from(doc.querySelectorAll('image'))) {
+    const dataUrl = await inline(el.getAttribute('href') ?? el.getAttribute('xlink:href') ?? '')
+    if (!dataUrl) continue
+    if (el.hasAttribute('href')) el.setAttribute('href', dataUrl)
+    if (el.hasAttribute('xlink:href')) el.setAttribute('xlink:href', dataUrl)
     changed = true
   }
   for (const el of Array.from(doc.querySelectorAll('style'))) {
@@ -200,8 +214,20 @@ async function inlineLocalRefs(
   // no local references is never reshaped by the round-trip.
   if (!changed) return html
   if (mode === 'fragment') return doc.body.innerHTML
-  const doctype = doc.doctype ? `<!DOCTYPE ${doc.doctype.name}>` : ''
-  return doctype + doc.documentElement.outerHTML
+  return serializeDoctype(doc.doctype) + doc.documentElement.outerHTML
+}
+
+// documentElement.outerHTML drops the doctype, so it gets rebuilt — with its
+// public/system identifiers, since those are what decide the rendering mode and
+// a name-only `<!DOCTYPE html>` would silently switch a legacy file to standards
+// mode. Anything else above <html> (a build comment, say) is still lost.
+function serializeDoctype(dt: DocumentType | null): string {
+  if (!dt) return ''
+  let out = `<!DOCTYPE ${dt.name}`
+  if (dt.publicId) out += ` PUBLIC "${dt.publicId}"`
+  else if (dt.systemId) out += ' SYSTEM'
+  if (dt.systemId) out += ` "${dt.systemId}"`
+  return out + '>'
 }
 
 async function inlineCSSURLs(

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -15,10 +15,11 @@
 // loopback. It works on localhost and breaks over a tunnel or on the LAN.
 //
 // The same goes for any local file the artifact itself points at — a markdown
-// `![](shot.png)` resolves against the host page rather than the file's own
-// directory, and the /api/ path it would need can't authenticate from in there
-// either. Two ways out: render outside the iframe (what `src` is for) or inline
-// the bytes as a data: URI (what inlineMarkdownImages does).
+// `![](shot.png)` or an HTML `<img src="chart.png">` resolves against the host
+// page rather than the file's own directory, and the /api/ path it would need
+// can't authenticate from in there either. Two ways out: render outside the
+// iframe (what `src` is for) or inline the bytes as a data: URI (what
+// inlineLocalRefs does).
 
 import { get, writable } from 'svelte/store'
 import { artifacts, panelContent, artifactSel } from './stores'
@@ -90,64 +91,127 @@ function artifactURL(sessionId: string, path: string): string {
   return `/api/sessions/${encodeURIComponent(sessionId)}/artifacts?path=${encodeURIComponent(path)}`
 }
 
-// ─── Markdown image references ──────────────────────────────────────────────
+// ─── Local file references inside a preview document ────────────────────────
 //
-// A markdown artifact can point at its own images: `![shot](shot.png)`. Those
-// references cannot survive inside the preview iframe — a relative path
-// resolves against the host page, and the /api/ path it would need can't
-// authenticate from there (see the file-header note) — so the bytes are inlined
-// as data: URIs, the one form the iframe can read.
+// A markdown or HTML artifact can point at its own images: `![shot](shot.png)`,
+// `<img src="chart.png">`, `background-image:url(bg.png)`. None of those survive
+// inside the preview iframe — a relative path resolves against the host page,
+// and the /api/ path it would need can't authenticate from in there (see the
+// file-header note) — so the bytes are inlined as data: URIs, the one form the
+// iframe can read.
 //
 // Only files the session itself wrote are fetchable, since the endpoint serves
-// nothing else. That covers the case that matters: a report the agent wrote
-// beside the screenshots it took. A reference to anything else is left exactly
-// as written and simply doesn't render, same as today.
+// nothing else, and only the extensions it recognises as previewable (images
+// among them; stylesheets and fonts are not). Everything else is left exactly
+// as written and simply doesn't render, same as today — which is also the
+// fallback for a local .css or .js, already routed to the warning page by
+// hasExternalRefs.
 //
 // Budgeted because a data: URI is resident memory for as long as the artifact
 // is in the store: base64 costs ~1.37x the file size, doubled again by UTF-16,
 // and the srcdoc attribute holds a second copy. Past the budget the remaining
 // references are left alone rather than silently bloating the session.
-const inlineImageBudget = 8 << 20
-const inlineImageMax = 20
+const inlineRefBudget = 8 << 20
+const inlineRefMax = 20
 
-async function inlineMarkdownImages(html: string, sessionId: string, mdPath: string): Promise<string> {
+// Cheap pre-check: skip the parse/serialize round-trip entirely for a document
+// with nothing to rewrite, which is most of them.
+const LOCAL_REF_HINT = /<img\b|url\(/i
+const CSS_URL_RE = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi
+
+// mode picks how the result is serialized: an HTML artifact is a whole document
+// (doctype and <head> must survive), markdown output is a body fragment.
+async function inlineLocalRefs(
+  html: string,
+  sessionId: string,
+  basePath: string,
+  mode: 'document' | 'fragment',
+): Promise<string> {
+  if (!LOCAL_REF_HINT.test(html)) return html
   const doc = new DOMParser().parseFromString(html, 'text/html')
-  const imgs = Array.from(doc.querySelectorAll('img'))
-  if (imgs.length === 0) return html
 
-  const seen = new Map<string, string>()
+  // null caches a failed lookup so a repeated broken reference is fetched once.
+  const seen = new Map<string, string | null>()
   let spent = 0
   let count = 0
-  for (const img of imgs) {
-    const abs = localImagePath(img.getAttribute('src') ?? '', mdPath)
-    if (!abs) continue
+  let changed = false
+
+  const inline = async (raw: string): Promise<string | null> => {
+    const abs = localFilePath(raw, basePath)
+    if (!abs) return null
     const cached = seen.get(abs)
-    if (cached) {
-      img.setAttribute('src', cached)
-      continue
-    }
-    if (count >= inlineImageMax || spent >= inlineImageBudget) break
+    if (cached !== undefined) return cached
+    if (count >= inlineRefMax || spent >= inlineRefBudget) return null
+    let dataUrl: string | null = null
     try {
       const res = await fetch(artifactURL(sessionId, abs))
-      if (!res.ok) continue
-      const blob = await res.blob()
-      const dataUrl = await blobToDataURL(blob)
-      spent += blob.size
-      count++
-      seen.set(abs, dataUrl)
-      img.setAttribute('src', dataUrl)
+      if (res.ok) {
+        const blob = await res.blob()
+        dataUrl = await blobToDataURL(blob)
+        spent += blob.size
+        count++
+      }
     } catch {
       // Leave the reference as written — a broken image beats no preview.
     }
+    seen.set(abs, dataUrl)
+    return dataUrl
   }
-  return doc.body.innerHTML
+
+  for (const img of Array.from(doc.querySelectorAll('img'))) {
+    const dataUrl = await inline(img.getAttribute('src') ?? '')
+    if (!dataUrl) continue
+    img.setAttribute('src', dataUrl)
+    // A srcset would outrank the src we just rewrote, and its candidates are
+    // unreachable for the same reason.
+    img.removeAttribute('srcset')
+    changed = true
+  }
+  for (const el of Array.from(doc.querySelectorAll('style'))) {
+    const css = el.textContent ?? ''
+    const next = await inlineCSSURLs(css, inline)
+    if (next === css) continue
+    el.textContent = next
+    changed = true
+  }
+  for (const el of Array.from(doc.querySelectorAll('[style]'))) {
+    const css = el.getAttribute('style') ?? ''
+    const next = await inlineCSSURLs(css, inline)
+    if (next === css) continue
+    el.setAttribute('style', next)
+    changed = true
+  }
+
+  // Hand back the original text when nothing was rewritten, so a document with
+  // no local references is never reshaped by the round-trip.
+  if (!changed) return html
+  if (mode === 'fragment') return doc.body.innerHTML
+  const doctype = doc.doctype ? `<!DOCTYPE ${doc.doctype.name}>` : ''
+  return doctype + doc.documentElement.outerHTML
 }
 
-// localImagePath resolves a markdown image reference to the absolute on-disk
-// path to ask the endpoint for, or null when it isn't a local file. Anything
-// carrying a scheme is left alone: an http(s) image is a cross-origin no-cors
-// load, which a sandboxed iframe performs just fine.
-function localImagePath(raw: string, mdPath: string): string | null {
+async function inlineCSSURLs(
+  css: string,
+  inline: (raw: string) => Promise<string | null>,
+): Promise<string> {
+  const out: string[] = []
+  let last = 0
+  for (const m of Array.from(css.matchAll(CSS_URL_RE))) {
+    const dataUrl = await inline(m[2])
+    if (!dataUrl) continue
+    out.push(css.slice(last, m.index), `url("${dataUrl}")`)
+    last = m.index + m[0].length
+  }
+  if (out.length === 0) return css
+  out.push(css.slice(last))
+  return out.join('')
+}
+
+// localFilePath resolves a reference to the absolute on-disk path to ask the
+// endpoint for, or null when it isn't a local file. Anything carrying a scheme
+// is left alone: an http(s) image is a cross-origin no-cors load, which a
+// sandboxed iframe performs just fine.
+function localFilePath(raw: string, basePath: string): string | null {
   const src = raw.trim()
   if (!src || src.startsWith('//') || src.startsWith('#')) return null
   if (/^[a-z][a-z0-9+.-]*:/i.test(src) && !/^[a-z]:[\\/]/i.test(src)) return null
@@ -158,7 +222,7 @@ function localImagePath(raw: string, mdPath: string): string | null {
     // Malformed escapes: use the reference verbatim.
   }
   if (!rel) return null
-  const abs = isAbsolutePath(rel) ? rel : `${dirOf(mdPath)}/${rel}`
+  const abs = isAbsolutePath(rel) ? rel : `${dirOf(basePath)}/${rel}`
   const clean = cleanPath(abs)
   return isAbsolutePath(clean) ? clean : null
 }
@@ -275,7 +339,9 @@ export async function observeArtifact(
 <pre style="margin:0;padding:12px;background:${warnPreBg};border-radius:6px;overflow:auto;font:12px/1.6 'SFMono-Regular',Menlo,monospace;color:${warnPreColor};white-space:pre-wrap">${escaped}</pre>
 </body>`
         } else {
-          preview = code
+          // No unreachable scripts or stylesheets, but the file's own images
+          // still need inlining to survive the iframe.
+          preview = await inlineLocalRefs(code, sessionId, path, 'document')
         }
       } else if (kind === 'markdown') {
         // Markdown is rendered inside a sandboxed srcdoc iframe which has no
@@ -296,7 +362,7 @@ export async function observeArtifact(
 	  })
 	});
 	<\/script>`
-        const body = await inlineMarkdownImages(renderMarkdown(code), sessionId, path)
+        const body = await inlineLocalRefs(renderMarkdown(code), sessionId, path, 'fragment')
         preview = `<style>${MD_STYLES}</style><body style="${bodyStyle}">${body}${COPY_SCRIPT}</body>`
       } else {
         // code kind: show with theme-aware monospace style

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -378,14 +378,39 @@ export async function observeArtifact(
         const bodyStyle = isDark
           ? 'margin:0;padding:16px;font:14px/1.6 system-ui,-apple-system,sans-serif;color:#d4d4d4;background:#1e1e1e'
           : 'margin:0;padding:16px;font:14px/1.6 system-ui,-apple-system,sans-serif;color:rgba(0,0,0,0.88);background:#ffffff'
+        // Bound to document.body, not '.body': this is a hand-inlined copy of
+        // setupCopyButtons(), whose caller passes the host app's container, and
+        // that selector matched nothing here — querySelector returned null and
+        // the whole handler died on load, so the button never worked at all.
+        //
+        // The clipboard call has a fallback because this document's origin is
+        // opaque; whether the async Clipboard API is available to it varies by
+        // browser even with clipboard-write delegated on the iframe. execCommand
+        // is deprecated but needs no permission, only the click's activation.
+        //
+        // The .code-block lookup is null-guarded like setupCopyButtons' is; the
+        // old unguarded form would throw if the wrapper ever went missing.
         const COPY_SCRIPT = `<script>
-	document.querySelector('.body').addEventListener('click',function(e){
+	document.body.addEventListener('click',function(e){
 	  var b=e.target.closest('.copy-btn');if(!b)return;
-	  var c=b.closest('.code-block').querySelector('pre code');
-	  navigator.clipboard.writeText(c?c.textContent:'').then(function(){
-	    var o=b.textContent;b.textContent='Copied!';
+	  var k=b.closest('.code-block');
+	  var c=k&&k.querySelector('pre code');
+	  var t=c?c.textContent:'';
+	  var done=function(ok){
+	    var o=b.textContent;b.textContent=ok?'Copied!':'Copy failed';
 	    setTimeout(function(){b.textContent=o},1500);
-	  })
+	  };
+	  var legacy=function(){
+	    var ta=document.createElement('textarea');
+	    ta.value=t;ta.setAttribute('readonly','');
+	    ta.style.position='fixed';ta.style.opacity='0';
+	    document.body.appendChild(ta);ta.select();
+	    var ok=false;try{ok=document.execCommand('copy')}catch(err){}
+	    ta.remove();done(ok);
+	  };
+	  if(navigator.clipboard&&navigator.clipboard.writeText){
+	    navigator.clipboard.writeText(t).then(function(){done(true)},legacy)
+	  }else{legacy()}
 	});
 	<\/script>`
         const body = await inlineLocalRefs(renderMarkdown(code), sessionId, path, 'fragment')

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -46,6 +46,10 @@ const EXT_KIND: Record<string, Kind> = {
 // Once-per-session guard so a live write auto-opens the panel only the first time.
 let autoOpened = false
 
+// How many times each image path has been observed this session, used as the
+// cache-busting revision in its src. Cleared with the artifacts themselves.
+const imageRevisions = new Map<string, number>()
+
 function kindOf(path: string): Kind | null {
   const dot = path.lastIndexOf('.')
   if (dot < 0) return null
@@ -274,6 +278,7 @@ export function resetArtifacts(sessionId: string): void {
   artifactSel.set(0)
   panelContent.set(null)
   autoOpened = false
+  imageRevisions.clear()
   artifactSelSession.set(sessionId)
 }
 
@@ -308,10 +313,18 @@ export async function observeArtifact(
       // bytes move only when the user actually looks at the image, which
       // matters for a session full of multi-MB screenshots on a slow link.
       //
+      // The revision counter matters: re-observing a path (the agent overwrote
+      // the file) otherwise yields a byte-identical src, so Svelte skips the
+      // attribute update and the panel keeps showing the previous bytes. The
+      // count is derived from the transcript, so replaying the same session
+      // reproduces the same URLs and the browser cache still applies.
+      //
       // Dropping the iframe costs no isolation here. The endpoint pins
       // Content-Type and sends X-Content-Type-Options: nosniff, and an SVG
       // loaded through <img> runs no script and fetches no external resource.
-      src = url
+      const rev = (imageRevisions.get(path) ?? 0) + 1
+      imageRevisions.set(path, rev)
+      src = `${url}&rev=${rev}`
       // A binary artifact has no source view, so `code` carries the on-disk
       // path instead: it is the one text form worth copying. Download saves
       // the bytes from `src`.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -127,6 +127,11 @@ export interface Artifact {
   code: string
   preview: string
   path: string
+  // src is set for image artifacts only: the artifacts endpoint URL. Images are
+  // rendered by a plain <img> in the host document rather than through the
+  // sandboxed `preview` iframe (which cannot authenticate — see lib/artifacts.ts),
+  // and the download action saves these bytes.
+  src?: string
 }
 
 // SkillInfo matches the Go server skill struct

--- a/web/src/mobile/ArtifactViewer.svelte
+++ b/web/src/mobile/ArtifactViewer.svelte
@@ -3,14 +3,16 @@
   // self-contained preview document (built in lib/artifacts.ts for the desktop
   // panel's sandboxed iframe) and the raw source — this just presents them
   // phone-sized: preview in the same sandboxed iframe, code as scrollable text.
+  // Images are the exception: they carry a `src` and render as a plain <img>.
   import type { Artifact } from '../lib/types'
   import { t } from '../lib/i18n'
 
   let { artifact, onClose }: { artifact: Artifact; onClose: () => void } = $props()
 
   let view = $state<'preview' | 'code'>('preview')
-  // Images have no meaningful source view (code is just the fetch URL).
-  const isImage = $derived(artifact.type === 'Image')
+  // Images render as a plain <img> (the sandboxed iframe cannot authenticate
+  // against /api/* — see lib/artifacts.ts) and have no meaningful source view.
+  const isImage = $derived(!!artifact.src)
   // Reset to preview only when a DIFFERENT file opens — a live re-write of the
   // same path swaps the entry object but must not kick the user out of Code.
   // svelte-ignore state_referenced_locally -- the initial path is exactly what we want captured
@@ -41,7 +43,9 @@
   </header>
 
   <div class="vbody">
-    {#if view === 'preview' || isImage}
+    {#if isImage}
+      <div class="img-wrap"><img src={artifact.src} alt={artifact.name} /></div>
+    {:else if view === 'preview'}
       <iframe srcdoc={artifact.preview} sandbox="allow-scripts clipboard-write" title={artifact.name}></iframe>
     {:else}
       <pre class="code-view">{artifact.code}</pre>
@@ -84,6 +88,12 @@
 
   .vbody { flex: 1; min-height: 0; background: var(--m-surface); }
   iframe { border: 0; width: 100%; height: 100%; display: block; }
+  .img-wrap {
+    width: 100%; height: 100%; box-sizing: border-box; padding: 8px;
+    display: flex; align-items: center; justify-content: center;
+    overflow: auto; -webkit-overflow-scrolling: touch; background: var(--m-bg);
+  }
+  .img-wrap img { max-width: 100%; max-height: 100%; object-fit: contain; }
   .code-view {
     margin: 0; height: 100%; box-sizing: border-box; overflow: auto;
     -webkit-overflow-scrolling: touch;

--- a/web/src/mobile/ArtifactViewer.svelte
+++ b/web/src/mobile/ArtifactViewer.svelte
@@ -46,7 +46,7 @@
     {#if isImage}
       <div class="img-wrap"><img src={artifact.src} alt={artifact.name} /></div>
     {:else if view === 'preview'}
-      <iframe srcdoc={artifact.preview} sandbox="allow-scripts clipboard-write" title={artifact.name}></iframe>
+      <iframe srcdoc={artifact.preview} sandbox="allow-scripts" allow="clipboard-write" title={artifact.name}></iframe>
     {:else}
       <pre class="code-view">{artifact.code}</pre>
     {/if}


### PR DESCRIPTION
Rewritten. The first pass fixed the symptom by base64-ing the image into the `srcdoc` document; the diagnosis behind it (the endpoint's `Content-Security-Policy: sandbox` header blocking the request) was wrong, and inlining every image on history replay was a heavy way to pay for it. This takes the iframe out of the picture for images instead, and covers the other two places the same bug shows up.

## Root cause

An `<img src="/api/sessions/…/artifacts?path=…">` inside the Artifacts panel's `srcdoc` iframe cannot authenticate. The iframe carries no `allow-same-origin`, so its subresource request has an opaque origin and counts as cross-site; the `SameSite=Strict` `octo_access_key` cookie is withheld and the endpoint answers 401.

Loopback clients are exempt from auth altogether (`requireAuth`'s hardened loopback path), which is why this never reproduced on `localhost` — it only breaks when the UI is reached over a tunnel, the LAN, or `--host`. It is not size-dependent: every image artifact was broken for every remote client.

The response's `Content-Security-Policy: sandbox` header is not involved. The `sandbox` directive is only enforced when a response is loaded as a document, never for an `<img>` subresource.

The same constraint breaks a *reference the artifact itself carries*: a relative path inside the preview document resolves against the host page rather than the file's own directory, and the `/api/` path it would need can't authenticate from in there either.

## Three changes

**1. Image artifacts render outside the iframe.** `Artifact` gains a `src` field holding the endpoint URL; the three render sites (desktop panel, maximized modal, mobile viewer) branch on it and use a plain `<img>` in the host document, whose own request is same-site and authenticates normally.

Side benefits of not needing the bytes in JS:

- **Lazy loading is back.** History replay never fetches an image, so a session full of multi-MB browser screenshots costs nothing until one is opened.

Dropping the iframe costs no isolation here: the endpoint pins `Content-Type` per extension and sends `X-Content-Type-Options: nosniff`, and an SVG loaded through `<img>` runs no script and fetches no external resource.

Two consequences of the split:

- An image has no source view, so the Preview/Code toggle is hidden (the mobile viewer already did this) and `code` carries the on-disk path — the one text form worth copying.
- **Download saves the actual bytes.** Previously `code` held the fetch URL, so downloading a `.png` wrote a text file containing a URL. Desktop routes through `nativeSaveBinary`, same shape as the skill zip export.

**2. A markdown artifact's own image references are inlined.** `![shot](shot.png)` has no way out of the iframe, so here the bytes really do become data: URIs.

**3. So are an HTML artifact's.** A file whose only local references were images skipped the warning page — `hasExternalRefs` looks for `<script src>` / `<link href>` — and previewed with every image broken. Same inlining, extended to `<img src>` plus CSS `url()` in `<style>` blocks and `style` attributes. A rewritten `<img>` drops its `srcset`, which would otherwise outrank the `src` with candidates that are unreachable for the same reason.

Inlining is gated on the reference resolving to an **image**. The endpoint also serves `.html` and `.md`, so without that gate an artifact could name a sibling document, have the host page — which is authenticated — fetch it, and receive the bytes inside a preview iframe that runs scripts and can reach the network. That would hand artifact content the ability to read session files it was never given, which is the boundary the sandbox used to provide.

Shared by 2 and 3:

- **Only files the session itself wrote are fetchable**, since the endpoint serves nothing else, and only the extensions it treats as previewable — images among them, stylesheets and fonts not. That covers the case that matters: a report the agent wrote beside the screenshots it took. Any other reference is left exactly as written and simply doesn't render, as before. A local `.css` / `.js` keeps routing to the warning page; its bytes are unreachable either way.
- **Inlining is budgeted** (8 MB / 20 files per artifact) because a data: URI stays resident for as long as the artifact is in the store. Past the budget the remaining references are left alone.
- **References carrying a scheme are skipped**: an `http(s)` image is a cross-origin no-cors load, which the sandboxed iframe performs fine.
- The HTML case is a whole document, so doctype and `<head>` have to survive serialization. Two guards keep the parse/serialize round-trip off documents that don't need it: a cheap regex pre-check, and handing back the original text whenever nothing was actually rewritten.

The file-header comment in `lib/artifacts.ts` now states the constraint that produced all three bugs, since it binds every preview document built there.

## Reviewed and knowingly left

Two things an independent review surfaced that are **not** fixed here:

- **The endpoint's whitelist is wider than "files the session wrote."** `Agent.History.Append` records a `tool_use` before `dispatchTools` runs the permission gate (`internal/agent/agent.go:1084` vs `:1117`), so a `write_file` the user *denied* still puts its path in the transcript, and `sessionWrotePath` will serve that path if the file exists on disk. Pre-existing and server-side; deserves its own issue rather than a rider on this one.
- **The document-mode parse/serialize fidelity is only tested under happy-dom**, which is not a spec-compliant HTML parser or serializer. Two plausible real-browser differences it cannot catch: `<noscript>` content (parsed as elements with scripting disabled, re-parsed as text in the iframe) and anything above `<html>` other than the doctype. Both only occur on documents where something was actually inlined — the `changed` guard hands back the original text otherwise — so the exposure is narrow, but the tests prove less here than elsewhere.

## Follow-ups, filed rather than fixed here

An independent review pass produced these; none are regressions from this PR unless noted.

- #1890 — Save to Light App stores the raw source, so an HTML artifact whose images now display in the panel shows them broken once saved. **New asymmetry from this PR** (both halves were broken before, consistently); left open because storing the inlined copy would persist megabytes of base64 permanently.
- #1891 — a `write_file` the user *denied* still authorizes the artifact endpoint to serve that path. Pre-existing, server-side, and the reason this PR's inlining is gated to images.
- #1892 — local references that still can't be inlined: `<video>` / `@font-face` / `<object>` (extensions the endpoint doesn't serve), `<img srcset>` with no `src`, `<base href>`, content above `<html>`.
- #1893 — preview documents are built eagerly at observe time, so the inline budget is per-artifact with no session ceiling, and replay pays for images nobody opens. The fix is lazy preview construction.
- #1894 — the artifacts list orders by fetch completion, not the transcript, and auto-selects whichever fetch lands last. Pre-existing; this PR widens the window for image-bearing documents.
- #1895 — `code`-kind artifacts (`.py`, `.json`, `.txt`, …) can never load, because `EXT_KIND` is wider than the set the endpoint serves. They vanish from the panel with no error.
- #1896 — a failed image preview shows a bare broken-image icon with no explanation, and a favicon `<link>` forces the whole file to the warning page.
- #1897 — happy-dom mangles DOMPurify output, so structural DOM assertions in the web suite prove less than they appear to.

## Verification

- `vitest run` — 73 passed (5 files, 14 new in `artifacts.test.ts`); each new test was confirmed to fail with its fix disabled
- `svelte-check` — 0 errors (1 pre-existing warning in `LightAppsView.svelte`)
- `vite build` — 298 modules, ok
- No Go changes.

Not verified by me: the remote repro itself. Worth a pass over a tunnel on an image artifact, an SVG, a markdown file with a relative image reference, an HTML file with a local `<img>` and a CSS background, and the download button on both desktop and browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


