### PR TITLE
fix(web): render image artifacts outside the sandboxed preview iframe

### DIFF
--- a/web/src/components/ArtifactModal.svelte
+++ b/web/src/components/ArtifactModal.svelte
@@ -13,7 +13,7 @@
   })
 
   function onCopy() { copyArtifact(cur?.code ?? '', showToast) }
-  function onDownload() { downloadArtifact(cur?.name, cur?.code ?? '', showToast) }
+  function onDownload() { downloadArtifact(cur, showToast) }
 
   // "Back to sidebar": close modal, reopen the side panel.
   function restoreSidebar() {
@@ -53,7 +53,12 @@
 
     <!-- Body — always preview, no toolbar / footer chrome -->
     <div class="body">
-      <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
+      {#if cur.src}
+        <!-- Images render outside the sandboxed iframe (see lib/artifacts.ts). -->
+        <div class="img-wrap"><img src={cur.src} alt={cur.name} /></div>
+      {:else}
+        <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
+      {/if}
     </div>
   </div>
 </div>
@@ -102,4 +107,10 @@
 .icon-btn:hover { background: var(--hover-neutral); color: var(--blue-6); }
 .body { flex: 1; min-height: 0; background: var(--bg-container); }
 iframe { border: 0; width: 100%; height: 100%; display: block; }
+.img-wrap {
+  width: 100%; height: 100%; box-sizing: border-box; padding: 12px;
+  display: flex; align-items: center; justify-content: center;
+  overflow: auto; background: var(--bg-layout);
+}
+.img-wrap img { max-width: 100%; max-height: 100%; object-fit: contain; }
 </style>

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -6,9 +6,11 @@
 
   // ── Session artifacts (existing) ──────────────────────────────────────────
   const cur = $derived($artifacts[$artifactSel] ?? $artifacts[0])
+  // Images render outside the sandboxed iframe and have no source view.
+  const curIsImage = $derived(!!cur?.src)
 
   function onCopy() { copyArtifact(cur?.code ?? '', showToast) }
-  function onDownload() { downloadArtifact(cur?.name, cur?.code ?? '', showToast) }
+  function onDownload() { downloadArtifact(cur, showToast) }
 
   // ── Save to Light App (HTML artifacts only) ─────────────────────────────
   let saveToLAName = $state('')
@@ -179,16 +181,20 @@
         </div>
       {/if}
 
-      <div class="toolbar">
-        <div class="seg">
-          <button class="seg-btn" class:active={$artifactView === 'preview'} onclick={() => artifactView.set('preview')}>{$t('artifacts.preview')}</button>
-          <button class="seg-btn" class:active={$artifactView === 'code'} onclick={() => artifactView.set('code')}>{$t('artifacts.code')}</button>
+      {#if !curIsImage}
+        <div class="toolbar">
+          <div class="seg">
+            <button class="seg-btn" class:active={$artifactView === 'preview'} onclick={() => artifactView.set('preview')}>{$t('artifacts.preview')}</button>
+            <button class="seg-btn" class:active={$artifactView === 'code'} onclick={() => artifactView.set('code')}>{$t('artifacts.code')}</button>
+          </div>
+          <span class="sandboxed-label">{$t('artifacts.sandboxed')}</span>
         </div>
-        <span class="sandboxed-label">{$t('artifacts.sandboxed')}</span>
-      </div>
+      {/if}
 
       <div class="body">
-        {#if $artifactView === 'preview'}
+        {#if curIsImage}
+          <div class="img-wrap"><img src={cur.src} alt={cur.name} /></div>
+        {:else if $artifactView === 'preview'}
           <iframe srcdoc={cur.preview} sandbox="allow-scripts clipboard-write" title={cur.name}></iframe>
         {:else}
           <pre class="code-view">{cur.code}</pre>
@@ -243,6 +249,12 @@
   gap: 12px; padding: 32px; text-align: center; color: var(--text-tertiary); font-size: 13px;
 }
 iframe { border: 0; width: 100%; height: 100%; display: block; }
+.img-wrap {
+  width: 100%; height: 100%; box-sizing: border-box; padding: 8px;
+  display: flex; align-items: center; justify-content: center;
+  overflow: auto; background: var(--bg-layout);
+}
+.img-wrap img { max-width: 100%; max-height: 100%; object-fit: contain; }
 .code-view {
   margin: 0; height: 100%; box-sizing: border-box; overflow: auto;
   padding: 14px 16px; background: var(--bg-sidebar); font-size: 12px; line-height: 1.7;

--- a/web/src/lib/artifact-actions.ts
+++ b/web/src/lib/artifact-actions.ts
@@ -2,6 +2,7 @@ import { get } from 'svelte/store'
 import { nativeShell } from './stores'
 import { tr } from './i18n'
 import * as api from './api'
+import type { Artifact } from './types'
 
 // Shared by ArtifactsPanel and ArtifactModal — both render the same artifact
 // actions (copy to clipboard, download file). Kept in one place so clipboard
@@ -12,13 +13,19 @@ export function copyArtifact(code: string, showToast: (msg: string, type?: strin
     .catch(() => showToast(tr('artifacts.copy_failed'), 'error'))
 }
 
+// Saves the artifact to disk. Text kinds carry their whole body in `code`; an
+// image carries only its on-disk path there, so it takes the binary path below.
 export async function downloadArtifact(
-  name: string | undefined,
-  code: string,
+  artifact: Artifact | undefined,
   showToast: (msg: string, type?: string) => void,
 ) {
-  const fname = name || 'artifact.txt'
-  const content = code ?? ''
+  if (!artifact) return
+  if (artifact.src) {
+    await downloadImage(artifact.name, artifact.src, showToast)
+    return
+  }
+  const fname = artifact.name || 'artifact.txt'
+  const content = artifact.code ?? ''
   if (get(nativeShell)) {
     try {
       const r = await api.nativeSaveFile(fname, content)
@@ -35,4 +42,42 @@ export async function downloadArtifact(
   a.download = fname
   a.click()
   URL.revokeObjectURL(url)
+}
+
+// Image artifacts are binary: saving `code` would write a text file holding a
+// path. Fetch the bytes instead — and fetch rather than point <a download>
+// straight at the endpoint, so a non-2xx surfaces as a toast instead of
+// silently doing nothing (#1109). The desktop webview has no download
+// delegate, so there the bytes go through the native save dialog
+// base64-encoded, same shape as the skill zip export.
+async function downloadImage(
+  name: string,
+  src: string,
+  showToast: (msg: string, type?: string) => void,
+) {
+  const fname = name || 'artifact'
+  try {
+    const res = await fetch(src)
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    if (get(nativeShell)) {
+      const bytes = new Uint8Array(await res.arrayBuffer())
+      // Chunked so a multi-MB screenshot doesn't blow the spread argument limit.
+      let binary = ''
+      const chunk = 0x8000
+      for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+      }
+      const r = await api.nativeSaveBinary(fname, btoa(binary))
+      if (!r.cancelled) showToast(tr('artifacts.saved'))
+      return
+    }
+    const url = URL.createObjectURL(await res.blob())
+    const a = document.createElement('a')
+    a.href = url
+    a.download = fname
+    a.click()
+    URL.revokeObjectURL(url)
+  } catch {
+    showToast(tr('artifacts.save_failed'), 'error')
+  }
 }

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { get } from 'svelte/store'
+import { artifacts } from './stores'
+import { observeArtifact, resetArtifacts } from './artifacts'
+
+// Nothing a preview document references can authenticate: the srcdoc iframe has
+// no allow-same-origin, so its subresource requests are cross-site and the
+// SameSite=Strict access-key cookie is withheld. These tests pin the two halves
+// of that constraint — images stay out of the iframe, and no preview document
+// smuggles an /api/ reference back in.
+
+const SID = 'sess-1'
+
+function payload(path: string) {
+  return { type: 'write', path }
+}
+
+beforeEach(() => {
+  resetArtifacts(SID)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('observeArtifact — image artifacts', () => {
+  it('carries a src for the host document and never fetches the bytes', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await observeArtifact(SID, payload('/tmp/shot.png'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.type).toBe('Image')
+    expect(entry.src).toBe(
+      `/api/sessions/${encodeURIComponent(SID)}/artifacts?path=${encodeURIComponent('/tmp/shot.png')}`,
+    )
+    // The <img> pulls the bytes lazily; observing must not download them.
+    expect(fetchMock).not.toHaveBeenCalled()
+    // No sandboxed preview document at all, so nothing to 401.
+    expect(entry.preview).toBe('')
+    // `code` is the on-disk path — the one text form worth copying.
+    expect(entry.code).toBe('/tmp/shot.png')
+  })
+
+  it('keeps transcript order during replay, since nothing awaits', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+
+    await observeArtifact(SID, payload('/tmp/a.png'), false)
+    await observeArtifact(SID, payload('/tmp/b.png'), false)
+
+    expect(get(artifacts).map(a => a.path)).toEqual(['/tmp/a.png', '/tmp/b.png'])
+  })
+})
+
+describe('observeArtifact — preview documents', () => {
+  // Covers the chrome we generate, not references inside the artifact's own
+  // body: a hand-written `![shot](shot.png)` in a markdown file still resolves
+  // against the host page and still fails inside the iframe.
+  it('builds the markdown preview without referencing /api/', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('# hello')))
+
+    await observeArtifact(SID, payload('/tmp/notes.md'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).not.toBe('')
+    expect(entry.preview).not.toContain('/api/')
+  })
+})

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -6,6 +6,14 @@
 // fetches the file body from the whitelisted GET /api/sessions/{id}/artifacts
 // endpoint, and pushes a previewable entry into the `artifacts` store that
 // ArtifactsPanel renders. Mirrors the old hand-written Artifacts.observe().
+//
+// Constraint on every preview document built here: it must not reference
+// /api/* — nothing inside the sandboxed srcdoc iframe can authenticate. The
+// iframe has no allow-same-origin, so its subresource requests carry an opaque
+// origin and count as cross-site; the SameSite=Strict access-key cookie is
+// withheld and the endpoint answers 401 for every client that isn't exempt as
+// loopback. It works on localhost and breaks over a tunnel or on the LAN.
+// Inline the bytes, or render outside the iframe (what `src` below is for).
 
 import { get, writable } from 'svelte/store'
 import { artifacts, panelContent, artifactSel } from './stores'
@@ -104,13 +112,25 @@ export async function observeArtifact(
 
   let code = ''
   let preview = ''
+  let src = ''
   try {
     const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
     if (kind === 'image') {
-      // The sandboxed iframe loads the image from the same-host endpoint.
-      code = url
-      const imgBg = isDark ? '#1e1e1e' : '#f5f5f5'
-      preview = `<body style="margin:0;display:flex;align-items:center;justify-content:center;background:${imgBg};height:100vh"><img style="max-width:100%;max-height:100vh" src="${url}"></body>`
+      // Images render as a plain <img> in the host document — see the
+      // file-header note on why an <img src="/api/…"> inside the sandboxed
+      // iframe 401s. The host document's own request is same-site and
+      // authenticates normally, and it keeps the browser's lazy loading: the
+      // bytes move only when the user actually looks at the image, which
+      // matters for a session full of multi-MB screenshots on a slow link.
+      //
+      // Dropping the iframe costs no isolation here. The endpoint pins
+      // Content-Type and sends X-Content-Type-Options: nosniff, and an SVG
+      // loaded through <img> runs no script and fetches no external resource.
+      src = url
+      // A binary artifact has no source view, so `code` carries the on-disk
+      // path instead: it is the one text form worth copying. Download saves
+      // the bytes from `src`.
+      code = path
     } else {
       const res = await fetch(url)
       if (!res.ok) return
@@ -181,6 +201,7 @@ export async function observeArtifact(
     code,
     preview,
     path,
+    src: src || undefined,
   }
 
   artifacts.update(list => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -127,6 +127,11 @@ export interface Artifact {
   code: string
   preview: string
   path: string
+  // src is set for image artifacts only: the artifacts endpoint URL. Images are
+  // rendered by a plain <img> in the host document rather than through the
+  // sandboxed `preview` iframe (which cannot authenticate — see lib/artifacts.ts),
+  // and the download action saves these bytes.
+  src?: string
 }
 
 // SkillInfo matches the Go server skill struct

--- a/web/src/mobile/ArtifactViewer.svelte
+++ b/web/src/mobile/ArtifactViewer.svelte
@@ -3,14 +3,16 @@
   // self-contained preview document (built in lib/artifacts.ts for the desktop
   // panel's sandboxed iframe) and the raw source — this just presents them
   // phone-sized: preview in the same sandboxed iframe, code as scrollable text.
+  // Images are the exception: they carry a `src` and render as a plain <img>.
   import type { Artifact } from '../lib/types'
   import { t } from '../lib/i18n'
 
   let { artifact, onClose }: { artifact: Artifact; onClose: () => void } = $props()
 
   let view = $state<'preview' | 'code'>('preview')
-  // Images have no meaningful source view (code is just the fetch URL).
-  const isImage = $derived(artifact.type === 'Image')
+  // Images render as a plain <img> (the sandboxed iframe cannot authenticate
+  // against /api/* — see lib/artifacts.ts) and have no meaningful source view.
+  const isImage = $derived(!!artifact.src)
   // Reset to preview only when a DIFFERENT file opens — a live re-write of the
   // same path swaps the entry object but must not kick the user out of Code.
   // svelte-ignore state_referenced_locally -- the initial path is exactly what we want captured
@@ -41,7 +43,9 @@
   </header>
 
   <div class="vbody">
-    {#if view === 'preview' || isImage}
+    {#if isImage}
+      <div class="img-wrap"><img src={artifact.src} alt={artifact.name} /></div>
+    {:else if view === 'preview'}
       <iframe srcdoc={artifact.preview} sandbox="allow-scripts clipboard-write" title={artifact.name}></iframe>
     {:else}
       <pre class="code-view">{artifact.code}</pre>
@@ -84,6 +88,12 @@
 
   .vbody { flex: 1; min-height: 0; background: var(--m-surface); }
   iframe { border: 0; width: 100%; height: 100%; display: block; }
+  .img-wrap {
+    width: 100%; height: 100%; box-sizing: border-box; padding: 8px;
+    display: flex; align-items: center; justify-content: center;
+    overflow: auto; -webkit-overflow-scrolling: touch; background: var(--m-bg);
+  }
+  .img-wrap img { max-width: 100%; max-height: 100%; object-fit: contain; }
   .code-view {
     margin: 0; height: 100%; box-sizing: border-box; overflow: auto;
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Supersedes #1888, which fixed the same symptom by base64-ing the image into the `srcdoc` document. This takes the iframe out of the picture for images instead.

## Root cause

An `<img src="/api/sessions/…/artifacts?path=…">` placed inside the Artifacts panel's `srcdoc` iframe cannot authenticate. The iframe carries no `allow-same-origin`, so its subresource request has an opaque origin and counts as cross-site; the `SameSite=Strict` `octo_access_key` cookie is withheld and the endpoint answers 401.

Loopback clients are exempt from auth altogether (`requireAuth`'s hardened loopback path), which is why this never reproduced on `localhost` — it only breaks when the UI is reached over a tunnel, the LAN, or `--host`. It is not size-dependent; every image artifact was broken for remote clients.

The response's `Content-Security-Policy: sandbox` header is not involved: the `sandbox` directive is only enforced when a response is loaded as a document, not for an `<img>` subresource.

## Change

Images render as a plain `<img>` in the host document, whose own request is same-site and authenticates normally. `Artifact` gains a `src` field for that URL; the three render sites (desktop panel, maximized modal, mobile viewer) branch on it.

Side benefits:

- **Lazy loading is back.** History replay no longer needs the bytes at all, so a session full of multi-MB browser screenshots costs nothing until the user opens one. The base64 approach downloaded every image on replay, concurrently, and kept each one resident as a UTF-16 string.
- **Replay keeps transcript order** for images, since the image branch no longer awaits.

Dropping the iframe costs no isolation here: the endpoint pins `Content-Type` per extension and sends `X-Content-Type-Options: nosniff`, and an SVG loaded through `<img>` runs no script and fetches no external resource.

Two consequences of the split:

- An image has no source view, so the Preview/Code toggle is hidden (the mobile viewer already did this) and `code` carries the on-disk path — the one text form worth copying.
- **Download now saves the actual bytes.** Previously `code` held the fetch URL, so downloading a `.png` wrote a text file containing a URL. Desktop routes through `nativeSaveBinary`, same shape as the skill zip export.

The file-header comment in `lib/artifacts.ts` now states the constraint, because it applies to every preview document built there, and `artifacts.test.ts` pins both halves: images stay out of the iframe and fetch nothing on observe; generated preview chrome contains no `/api/` reference.

## Known remaining gap

An image reference written by hand inside a **markdown** artifact (`![shot](shot.png)`, or an absolute `/api/…` path) still fails inside the iframe for the same reason — that content is passed through untouched. Out of scope here; worth a follow-up issue.

## Verification

- `vitest run` — 61 passed (5 files, 3 new)
- `svelte-check` — 0 errors (1 pre-existing warning in `LightAppsView.svelte`)
- `vite build` — 298 modules, ok
- No Go changes.

Not verified by me: the remote repro itself. Worth a pass over ngrok on an image artifact, an SVG, and the download button on both desktop and browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)