### PR TITLE
fix(server): require a write to have run before serving it as an artifact

### DIFF
--- a/internal/server/artifact_handler.go
+++ b/internal/server/artifact_handler.go
@@ -15,10 +15,10 @@ import (
 //
 // Serves a previewable file the session's agent wrote, for the web Artifacts
 // panel (dev-docs/web-artifacts-panel-design.md). The path must be one this
-// session actually wrote: the whitelist is derived from the transcript's
-// tool_use blocks on each request, so it needs no extra state and survives
-// restarts. Anything not on the whitelist — including files that exist but
-// were never written by this session — is a 404.
+// session actually wrote: the whitelist is derived on each request from the
+// transcript's tool_use blocks *and the results answering them*, so it needs no
+// extra state and survives restarts. Anything not on the whitelist — including
+// files that exist but were never written by this session — is a 404.
 
 // artifactMaxBytes caps what the panel will serve inline; bigger files get a
 // 413 and the panel offers no preview. Artifact HTML bundles run 200 KB–2 MB.
@@ -91,16 +91,26 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 
 // sessionWrotePath looks for a write_file, edit_file, or show_artifact tool_use
 // in the transcript whose path input matches reqPath (after Clean on both
-// sides — the payloads carry absolute paths, so no base-dir join is needed).
-// show_artifact is how script-produced files (built rather than written through
-// the file tools) enter the whitelist. On a match it returns the transcript's
-// own copy of the path so callers serve a value sourced from what the agent
-// recorded rather than from the raw request.
+// sides — the payloads carry absolute paths, so no base-dir join is needed) and
+// which actually ran. show_artifact is how script-produced files (built rather
+// than written through the file tools) enter the whitelist. On a match it
+// returns the transcript's own copy of the path so callers serve a value sourced
+// from what the agent recorded rather than from the raw request.
+//
+// The "actually ran" half matters: the agent records a tool_use before the
+// permission gate rules on it, so a write the user *denied* sits in the
+// transcript looking exactly like one that succeeded. Trusting the call alone
+// means refusing a write grants a read of that path instead — the reverse of
+// what the user just decided.
 func sessionWrotePath(sess *agent.Session, reqPath string) (string, bool) {
 	want := filepath.Clean(reqPath)
+	ran := succeededToolUses(sess)
 	for _, m := range sess.Messages {
 		for _, b := range m.Blocks {
 			if b.Type != "tool_use" || (b.Name != "write_file" && b.Name != "edit_file" && b.Name != "show_artifact") {
+				continue
+			}
+			if !ran[b.ID] {
 				continue
 			}
 			p, ok := b.Input["path"].(string)
@@ -112,6 +122,30 @@ func sessionWrotePath(sess *agent.Session, reqPath string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// succeededToolUses collects the ids of tool calls whose paired tool_result
+// reports success. A gate denial and a genuine execution failure both come back
+// as IsError=true (see dispatchTools), and the result is the only place the
+// transcript distinguishes either from a call that ran.
+//
+// Unanswered calls count as not-run, which is deliberate: a write with no result
+// at all cannot be shown to have happened. The cost is that a file written by a
+// turn whose results never landed — a crash mid-turn, or the orphan repair in
+// ensureToolPairing stamping a synthetic error over an interrupted batch — stops
+// previewing until something writes it again. That is the right way to be wrong
+// here, and context reclamation is safe for this: it rewrites a stale result's
+// text but preserves ToolUseID and IsError.
+func succeededToolUses(sess *agent.Session) map[string]bool {
+	ran := make(map[string]bool)
+	for _, m := range sess.Messages {
+		for _, b := range m.Blocks {
+			if b.Type == "tool_result" && !b.IsError && b.ToolUseID != "" {
+				ran[b.ToolUseID] = true
+			}
+		}
+	}
+	return ran
 }
 
 // resolveArtifactPath validates a path from a tool UI payload. UI payloads carry

--- a/internal/server/artifact_handler.go
+++ b/internal/server/artifact_handler.go
@@ -104,48 +104,72 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 // what the user just decided.
 func sessionWrotePath(sess *agent.Session, reqPath string) (string, bool) {
 	want := filepath.Clean(reqPath)
-	ran := succeededToolUses(sess)
-	for _, m := range sess.Messages {
+	for i, m := range sess.Messages {
 		for _, b := range m.Blocks {
 			if b.Type != "tool_use" || (b.Name != "write_file" && b.Name != "edit_file" && b.Name != "show_artifact") {
 				continue
 			}
-			if !ran[b.ID] {
+			p, ok := b.Input["path"].(string)
+			if !ok {
 				continue
 			}
-			p, ok := b.Input["path"].(string)
-			if ok {
-				if clean := filepath.Clean(p); clean == want {
-					return clean, true
-				}
+			clean := filepath.Clean(p)
+			if clean != want || !callSucceeded(sess.Messages, i, b.ID) {
+				continue
 			}
+			return clean, true
 		}
 	}
 	return "", false
 }
 
-// succeededToolUses collects the ids of tool calls whose paired tool_result
-// reports success. A gate denial and a genuine execution failure both come back
-// as IsError=true (see dispatchTools), and the result is the only place the
-// transcript distinguishes either from a call that ran.
+// callSucceeded reports whether the tool_use with the given id in messages[i]
+// was answered by a non-error result in the message immediately after it. A gate
+// denial and a genuine execution failure both come back as IsError=true (see
+// dispatchTools), and the result is the only place the transcript records that a
+// call ran at all.
 //
-// Unanswered calls count as not-run, which is deliberate: a write with no result
-// at all cannot be shown to have happened. The cost is that a file written by a
-// turn whose results never landed — a crash mid-turn, or the orphan repair in
-// ensureToolPairing stamping a synthetic error over an interrupted batch — stops
-// previewing until something writes it again. That is the right way to be wrong
-// here, and context reclamation is safe for this: it rewrites a stale result's
+// Pairing is scoped to the next message rather than searched for across the
+// transcript, because tool-call ids come from the model, not the runtime. A
+// transcript-wide set of "ids that succeeded" is forgeable: emit a write the
+// user is going to deny, then reuse that same id on a trivial call that
+// succeeds, and the denial inherits the success. Scoping also just matches the
+// wire format — an assistant tool_use message is answered by the next user
+// message, and the agent loop appends the two back to back — so nothing
+// legitimate depends on a wider search.
+//
+// Unanswered calls count as not-run. The cost is that a file written by a turn
+// whose results never landed — a crash mid-turn, or ensureToolPairing stamping a
+// synthetic error over an interrupted batch — stops previewing until something
+// writes it again. That is the right way to be wrong about whether a read was
+// authorized. Context reclamation is safe for this: it rewrites a stale result's
 // text but preserves ToolUseID and IsError.
-func succeededToolUses(sess *agent.Session) map[string]bool {
-	ran := make(map[string]bool)
-	for _, m := range sess.Messages {
-		for _, b := range m.Blocks {
-			if b.Type == "tool_result" && !b.IsError && b.ToolUseID != "" {
-				ran[b.ToolUseID] = true
-			}
+func callSucceeded(msgs []agent.Message, i int, id string) bool {
+	if id == "" || i+1 >= len(msgs) {
+		return false
+	}
+	// An id repeated inside one batch is unusable for the same reason: whichever
+	// sibling succeeded would vouch for the other.
+	uses := 0
+	for _, b := range msgs[i].Blocks {
+		if b.Type == "tool_use" && b.ID == id {
+			uses++
 		}
 	}
-	return ran
+	if uses != 1 {
+		return false
+	}
+	answered := false
+	for _, b := range msgs[i+1].Blocks {
+		if b.Type != "tool_result" || b.ToolUseID != id {
+			continue
+		}
+		if b.IsError {
+			return false
+		}
+		answered = true
+	}
+	return answered
 }
 
 // resolveArtifactPath validates a path from a tool UI payload. UI payloads carry

--- a/internal/server/artifact_handler.go
+++ b/internal/server/artifact_handler.go
@@ -114,7 +114,7 @@ func sessionWrotePath(sess *agent.Session, reqPath string) (string, bool) {
 				continue
 			}
 			clean := filepath.Clean(p)
-			if clean != want || !callSucceeded(sess.Messages, i, b.ID) {
+			if clean != want || !callAuthorized(sess.Messages, i, b.ID) {
 				continue
 			}
 			return clean, true
@@ -123,11 +123,11 @@ func sessionWrotePath(sess *agent.Session, reqPath string) (string, bool) {
 	return "", false
 }
 
-// callSucceeded reports whether the tool_use with the given id in messages[i]
-// was answered by a non-error result in the message immediately after it. A gate
-// denial and a genuine execution failure both come back as IsError=true (see
-// dispatchTools), and the result is the only place the transcript records that a
-// call ran at all.
+// callAuthorized reports whether the tool_use with the given id in messages[i]
+// may serve its path. A gate denial and a genuine execution failure both come
+// back as IsError=true (see dispatchTools), and the result is the only place the
+// transcript records what became of a call — so the rule is that an *answered*
+// call must have been answered without error.
 //
 // Pairing is scoped to the next message rather than searched for across the
 // transcript, because tool-call ids come from the model, not the runtime. A
@@ -138,18 +138,30 @@ func sessionWrotePath(sess *agent.Session, reqPath string) (string, bool) {
 // message, and the agent loop appends the two back to back — so nothing
 // legitimate depends on a wider search.
 //
-// Unanswered calls count as not-run. The cost is that a file written by a turn
-// whose results never landed — a crash mid-turn, or ensureToolPairing stamping a
-// synthetic error over an interrupted batch — stops previewing until something
-// writes it again. That is the right way to be wrong about whether a read was
-// authorized. Context reclamation is safe for this: it rewrites a stale result's
-// text but preserves ToolUseID and IsError.
-func callSucceeded(msgs []agent.Message, i int, id string) bool {
-	if id == "" || i+1 >= len(msgs) {
+// A call with nothing after it at all is allowed, and that is not laxness — it
+// is the live case. The panel is told to fetch from inside dispatchTools:
+// EventToolDone carries the ui_payload, the web handler broadcasts it and then
+// persists (ws_handlers.go), and the tool_result message is only appended once
+// dispatchTools returns. So at the moment the client asks, the newest thing on
+// disk is the tool_use itself. Requiring a result here would 404 every write the
+// user just watched happen.
+//
+// The window that leaves open is narrow and bounded: a denied write is
+// momentarily unanswered too, until the error result reaches disk on the next
+// event. Nothing points a client at that path in the meantime — a denied call
+// produces no ui_payload — so reaching it means already knowing the path and
+// racing a sub-second write. Once any later message exists, an unanswered call
+// is stale and refused, which is what keeps a denial from being harvestable
+// afterwards. That is the property #1891 was actually about.
+//
+// Context reclamation is safe for all of this: it rewrites a stale result's text
+// but preserves ToolUseID and IsError.
+func callAuthorized(msgs []agent.Message, i int, id string) bool {
+	if id == "" {
 		return false
 	}
-	// An id repeated inside one batch is unusable for the same reason: whichever
-	// sibling succeeded would vouch for the other.
+	// An id repeated inside one batch is unusable: whichever sibling succeeded
+	// would vouch for the other.
 	uses := 0
 	for _, b := range msgs[i].Blocks {
 		if b.Type == "tool_use" && b.ID == id {
@@ -158,6 +170,9 @@ func callSucceeded(msgs []agent.Message, i int, id string) bool {
 	}
 	if uses != 1 {
 		return false
+	}
+	if i+1 >= len(msgs) {
+		return true // in flight, or the process died holding it
 	}
 	answered := false
 	for _, b := range msgs[i+1].Blocks {

--- a/internal/server/artifact_handler_test.go
+++ b/internal/server/artifact_handler_test.go
@@ -307,3 +307,65 @@ func TestHandleGetArtifact_DeniedWriteIsNotServed(t *testing.T) {
 		t.Errorf("allowed write: status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
 }
+
+// Tool-call ids come from the model, so "this id succeeded somewhere in the
+// transcript" is not a fact about the call being asked about. Both of these
+// borrow an unrelated success to vouch for a denied write.
+func TestHandleGetArtifact_ForgedSuccessIsRejected(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	artDir := t.TempDir()
+	private := filepath.Join(artDir, "private.md")
+	if err := os.WriteFile(private, []byte("# my notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deniedWrite := agent.ContentBlock{
+		Type: "tool_use", ID: "X", Name: "write_file",
+		Input: map[string]any{"path": private, "content": "x"},
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	// Across turns: the denied write in turn 1, then any harmless call in turn 2
+	// reusing its id and succeeding.
+	crossTurn := agent.NewSession("stub-model", "")
+	crossTurn.Messages = append(crossTurn.Messages,
+		agent.Message{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{deniedWrite}},
+		agent.Message{Role: agent.RoleUser, Blocks: []agent.ContentBlock{
+			agent.NewToolResultBlock("X", "permission_denied: user declined", true),
+		}},
+		agent.Message{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{{
+			Type: "tool_use", ID: "X", Name: "terminal",
+			Input: map[string]any{"command": "true"},
+		}}},
+		agent.Message{Role: agent.RoleUser, Blocks: []agent.ContentBlock{
+			agent.NewToolResultBlock("X", "ok", false),
+		}},
+	)
+	if err := crossTurn.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if w := getArtifact(t, srv, crossTurn.ID, private); w.Code != http.StatusNotFound {
+		t.Errorf("id reused across turns: status = %d, want 404; body=%s", w.Code, w.Body.String())
+	}
+
+	// Within one batch: two calls share an id, and the surviving result is the
+	// sibling's success (normalizeMessages keeps the first of a duplicate pair).
+	sameBatch := agent.NewSession("stub-model", "")
+	sameBatch.Messages = append(sameBatch.Messages,
+		agent.Message{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{
+			{Type: "tool_use", ID: "X", Name: "terminal", Input: map[string]any{"command": "true"}},
+			deniedWrite,
+		}},
+		agent.Message{Role: agent.RoleUser, Blocks: []agent.ContentBlock{
+			agent.NewToolResultBlock("X", "ok", false),
+		}},
+	)
+	if err := sameBatch.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if w := getArtifact(t, srv, sameBatch.ID, private); w.Code != http.StatusNotFound {
+		t.Errorf("id reused in one batch: status = %d, want 404; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/artifact_handler_test.go
+++ b/internal/server/artifact_handler_test.go
@@ -14,19 +14,49 @@ import (
 )
 
 // newArtifactSession persists a session whose transcript wrote the given
-// paths (one write_file tool_use per path) and returns its id.
+// paths — one write_file tool_use per path, each answered by a successful
+// tool_result, which is what the whitelist requires — and returns its id.
 func newArtifactSession(t *testing.T, paths ...string) string {
+	t.Helper()
+	return newArtifactSessionWith(t, "write_file", writeOK, paths...)
+}
+
+// writeOutcome describes the tool_result answering a recorded write.
+type writeOutcome int
+
+const (
+	writeOK         writeOutcome = iota // succeeded
+	writeDenied                         // the permission gate refused it
+	writeUnanswered                     // no tool_result at all
+)
+
+// newArtifactSessionWith builds a transcript with one call per path under the
+// given tool name, each paired with the described outcome.
+func newArtifactSessionWith(t *testing.T, tool string, outcome writeOutcome, paths ...string) string {
 	t.Helper()
 	sess := agent.NewSession("stub-model", "")
 	for i, p := range paths {
+		id := "t" + string(rune('0'+i))
 		sess.Messages = append(sess.Messages, agent.Message{
 			Role: agent.RoleAssistant,
 			Blocks: []agent.ContentBlock{{
 				Type:  "tool_use",
-				ID:    "t" + string(rune('0'+i)),
-				Name:  "write_file",
+				ID:    id,
+				Name:  tool,
 				Input: map[string]any{"path": p, "content": "x"},
 			}},
+		})
+		if outcome == writeUnanswered {
+			continue
+		}
+		result := agent.NewToolResultBlock(id, "wrote "+p, false)
+		if outcome == writeDenied {
+			// Exactly what dispatchTools synthesises for a denied call.
+			result = agent.NewToolResultBlock(id, "permission_denied: user declined to run "+tool, true)
+		}
+		sess.Messages = append(sess.Messages, agent.Message{
+			Role:   agent.RoleUser,
+			Blocks: []agent.ContentBlock{result},
 		})
 	}
 	if err := sess.Save(); err != nil {
@@ -155,6 +185,10 @@ func TestHandleGetArtifact_ShowArtifactCountsAsWrite(t *testing.T) {
 			Type: "tool_use", ID: "t1", Name: "show_artifact",
 			Input: map[string]any{"path": p},
 		}}})
+	sess.Messages = append(sess.Messages, agent.Message{
+		Role:   agent.RoleUser,
+		Blocks: []agent.ContentBlock{agent.NewToolResultBlock("t1", "shown", false)},
+	})
 	if err := sess.Save(); err != nil {
 		t.Fatal(err)
 	}
@@ -186,6 +220,10 @@ func TestHandleGetArtifact_EditCountsAsWrite(t *testing.T) {
 			Type: "tool_use", ID: "t1", Name: "edit_file",
 			Input: map[string]any{"path": p, "old_string": "a", "new_string": "b"},
 		}},
+	})
+	sess.Messages = append(sess.Messages, agent.Message{
+		Role:   agent.RoleUser,
+		Blocks: []agent.ContentBlock{agent.NewToolResultBlock("t1", "edited", false)},
 	})
 	if err := sess.Save(); err != nil {
 		t.Fatal(err)
@@ -224,5 +262,48 @@ func TestHandleGetArtifact_WorktreeOutsideServerCWD(t *testing.T) {
 	}
 	if w.Body.String() != "<p>worktree</p>" {
 		t.Errorf("body = %q", w.Body.String())
+	}
+}
+
+// A write the user refused must not become a readable path. The tool_use lands
+// in the transcript before the permission gate rules on it, so the call alone
+// cannot be the whitelist — otherwise denying a write grants a read.
+func TestHandleGetArtifact_DeniedWriteIsNotServed(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	// The realistic shape: the file already exists, the agent proposes
+	// overwriting it, and the user says no. The bytes on disk are the user's.
+	artDir := t.TempDir()
+	private := filepath.Join(artDir, "private.md")
+	if err := os.WriteFile(private, []byte("# my notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	denied := newArtifactSessionWith(t, "write_file", writeDenied, private)
+	if w := getArtifact(t, srv, denied, private); w.Code != http.StatusNotFound {
+		t.Errorf("denied write: status = %d, want 404; body=%s", w.Code, w.Body.String())
+	}
+
+	// An unanswered call proves nothing either — a crashed turn, or the orphan
+	// repair stamping an error over an interrupted batch.
+	unanswered := newArtifactSessionWith(t, "write_file", writeUnanswered, private)
+	if w := getArtifact(t, srv, unanswered, private); w.Code != http.StatusNotFound {
+		t.Errorf("unanswered write: status = %d, want 404", w.Code)
+	}
+
+	// Same for a refused show_artifact, the other way into the whitelist.
+	deniedShow := newArtifactSessionWith(t, "show_artifact", writeDenied, private)
+	if w := getArtifact(t, srv, deniedShow, private); w.Code != http.StatusNotFound {
+		t.Errorf("denied show_artifact: status = %d, want 404", w.Code)
+	}
+
+	// The control: the same call, allowed, still serves.
+	allowed := newArtifactSessionWith(t, "write_file", writeOK, private)
+	if w := getArtifact(t, srv, allowed, private); w.Code != http.StatusOK {
+		t.Errorf("allowed write: status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
 }

--- a/internal/server/artifact_handler_test.go
+++ b/internal/server/artifact_handler_test.go
@@ -25,9 +25,8 @@ func newArtifactSession(t *testing.T, paths ...string) string {
 type writeOutcome int
 
 const (
-	writeOK         writeOutcome = iota // succeeded
-	writeDenied                         // the permission gate refused it
-	writeUnanswered                     // no tool_result at all
+	writeOK     writeOutcome = iota // succeeded
+	writeDenied                     // the permission gate refused it
 )
 
 // newArtifactSessionWith builds a transcript with one call per path under the
@@ -46,9 +45,6 @@ func newArtifactSessionWith(t *testing.T, tool string, outcome writeOutcome, pat
 				Input: map[string]any{"path": p, "content": "x"},
 			}},
 		})
-		if outcome == writeUnanswered {
-			continue
-		}
 		result := agent.NewToolResultBlock(id, "wrote "+p, false)
 		if outcome == writeDenied {
 			// Exactly what dispatchTools synthesises for a denied call.
@@ -288,11 +284,22 @@ func TestHandleGetArtifact_DeniedWriteIsNotServed(t *testing.T) {
 		t.Errorf("denied write: status = %d, want 404; body=%s", w.Code, w.Body.String())
 	}
 
-	// An unanswered call proves nothing either — a crashed turn, or the orphan
-	// repair stamping an error over an interrupted batch.
-	unanswered := newArtifactSessionWith(t, "write_file", writeUnanswered, private)
-	if w := getArtifact(t, srv, unanswered, private); w.Code != http.StatusNotFound {
-		t.Errorf("unanswered write: status = %d, want 404", w.Code)
+	// An unanswered call that something else has already moved past is stale:
+	// this is what stops a denial from being harvestable after the fact, and it
+	// is the difference from the in-flight case covered by the test below.
+	stale := agent.NewSession("stub-model", "")
+	stale.Messages = append(stale.Messages,
+		agent.Message{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{{
+			Type: "tool_use", ID: "t0", Name: "write_file",
+			Input: map[string]any{"path": private, "content": "x"},
+		}}},
+		agent.Message{Role: agent.RoleUser, Content: "never mind"},
+	)
+	if err := stale.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if w := getArtifact(t, srv, stale.ID, private); w.Code != http.StatusNotFound {
+		t.Errorf("stale unanswered write: status = %d, want 404", w.Code)
 	}
 
 	// Same for a refused show_artifact, the other way into the whitelist.
@@ -367,5 +374,45 @@ func TestHandleGetArtifact_ForgedSuccessIsRejected(t *testing.T) {
 	}
 	if w := getArtifact(t, srv, sameBatch.ID, private); w.Code != http.StatusNotFound {
 		t.Errorf("id reused in one batch: status = %d, want 404; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// The live case, which is the whole reason an unanswered call is servable. The
+// panel is told to fetch from inside dispatchTools: EventToolDone carries the
+// ui_payload, the web handler broadcasts it and then persists (ws_handlers.go),
+// and the tool_result message is only appended once dispatchTools returns. So
+// the transcript the client's fetch reads ends at the tool_use. Requiring a
+// result would 404 every write the user just watched happen.
+func TestHandleGetArtifact_ServesAWriteStillInFlight(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	artDir := t.TempDir()
+	p := filepath.Join(artDir, "report.md")
+	if err := os.WriteFile(p, []byte("# report"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Exactly the mid-turn shape: user message, then the assistant's tool_use,
+	// and nothing yet after it.
+	sess := agent.NewSession("stub-model", "")
+	sess.Messages = append(sess.Messages,
+		agent.Message{Role: agent.RoleUser, Content: "write the report"},
+		agent.Message{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{{
+			Type: "tool_use", ID: "t0", Name: "write_file",
+			Input: map[string]any{"path": p, "content": "# report"},
+		}}},
+	)
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := getArtifact(t, srv, sess.ID, p)
+	if w.Code != http.StatusOK {
+		t.Fatalf("in-flight write: status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "# report" {
+		t.Errorf("body = %q", w.Body.String())
 	}
 }


### PR DESCRIPTION
Fixes #1891.

## The hole

The artifact endpoint's whitelist is derived from the transcript, and the transcript records a tool call **before** the permission gate rules on it (`agent.go` appends `NewToolUseMessage`, then `dispatchTools` consults the gate). `sessionWrotePath` only looked for a `write_file` / `edit_file` / `show_artifact` `tool_use` whose `path` matched, so a write the user **denied** was indistinguishable from one that ran.

**Refusing a write granted a read**, indefinitely. The shape that bites is an overwrite of a file that already exists: the agent proposes writing to a private note, the user declines, the bytes on disk stay theirs — and `GET /api/sessions/{id}/artifacts?path=…` returns them, `.md` being previewable.

## The rule now

A recorded write serves its path only if the `tool_use`'s **id is unique within its batch**, and the message **immediately after** it either answers that id without error, or does not exist yet.

Three things that each turned out to matter, arrived at over three commits:

**1. The result, not the call.** A gate denial and a genuine execution failure both come back as `IsError=true`; the result is the only place the transcript records what became of a call.

**2. Pairing scoped to the next message, ids unique per batch.** Tool-call ids come from the model, not the runtime, so a transcript-wide set of "ids that succeeded" is forgeable. Two working bypasses of the first version, both demonstrated returning **200 with the file's real contents**:

- *Across turns* — emit `write_file` on the target, let the user deny it, then reuse that id on any trivial call in a later turn that succeeds. The denial inherits the success.
- *Within one batch* — two `tool_use` blocks share an id, one benign and one the write. `normalizeMessages` keeps the first of a duplicate result pair, so the surviving result is the sibling's success.

Scoping is also just the wire format: the agent loop appends `NewToolUseMessage` and `NewToolResultMessage` back to back, compaction drops pairs together, and `normalizeMessages`' coalescing only ever shortens the distance.

**3. An unanswered call is allowed, because that is the live case.** The panel is told to fetch from *inside* `dispatchTools` — `EventToolDone` carries the `ui_payload`, `ws_handlers.go`'s handler broadcasts it and then persists, and the `tool_result` message is appended only once `dispatchTools` returns. At the moment the client asks, the newest thing on disk is the `tool_use`. Requiring a result 404'd every write the user had just watched happen, and for html/markdown the entry never enters the store and nothing retries, so it stayed missing for the rest of the session view. `tasks_handlers.go` persists on the same pattern, so cron sessions behaved the same.

## What that leaves open, stated plainly

A denied write is momentarily unanswered too, until its error result reaches disk on the next event. Reaching it in that window means already knowing the path and racing a sub-second write, against a path nothing advertises — a denied call produces no `ui_payload`. Once any later message exists, an unanswered call is stale and refused, which is what stops a denial from being harvestable afterwards. That permanence is what #1891 was actually about.

Closing the race too would mean either persisting between the append and the broadcast, or having the handler consult live turn state — both restructure the event ordering, and neither belongs in a fix this size.

Also worth knowing, and noted on the issue: `POST /api/file-action` with `action:"download"` serves any file under the server CWD to an authenticated client with no transcript gate at all. So for CWD-relative paths "deny a write, gain a read" remains true by another route. This fix is what protects paths *outside* CWD (`~/notes/…`) and the content-driven fetch added in #1888.

## Checked for interference, all safe

- **Context reclamation** (`reclaimStaleToolResults`) rewrites a stale result's text but preserves `ToolUseID` and `IsError`.
- **Compaction** splits on a plain user turn, so a `tool_use` and its `tool_result` are dropped together — a compacted-away write falls off the whitelist entirely, as it already did.
- **`applyPostToolUse`** only appends text; it never flips `IsError`.

## Verification

Every assertion was checked against a deliberately broken implementation:

- With the gate removed: denied write, stale-unanswered write, denied `show_artifact`, and both id forgeries all return **200 with the file's real contents**.
- With the strict "must be answered" rule: the in-flight write returns **404**, which is the regression commit 3 fixes.
- Two pre-existing tests built transcripts from a bare `tool_use` and needed a success result added — the behaviour change made visible.
- `go build ./...`, `go vet ./...`, `gofmt -l`, and `go test -race` on `internal/server` + `internal/agent` all clean.

Not verified: the live path end to end through the real event loop. The server builds its executor inline (`tools.NewDefaultRegistry()`), so a test cannot inject a probe tool to observe the `EventToolDone` window; the in-flight test asserts the transcript shape that window produces instead, with the ordering cited in the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)