### PR TITLE
chore: bump version to 1.14.6

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.14.5"
+var Version = "1.14.6"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over v1.14.5, carrying four merged PRs:

- #1886 `feat(web_search)`: name the backend and nudge toward a free key
- #1887 `feat(web)`: queue a mid-turn message as its own turn with Cmd/Ctrl+Enter
- #1888 `fix(web)`: make artifact images load for remote clients
- #1898 `fix(server)`: require a write to have run before serving it as an artifact

version.go only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)