### PR TITLE
chore(deps): group @capacitor/* into a single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@
 # top-level /evals harness module, which shares their churn-free intent.
 #
 # Minor and patch bumps are grouped into one PR per directory to keep the
-# weekly noise reviewable; majors stay individual PRs.
+# weekly noise reviewable; majors stay individual PRs, except where a
+# package family is only installable as a matched set (see the capacitor
+# group below).
 version: 2
 updates:
   - package-ecosystem: "gomod"
@@ -35,6 +37,15 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
+      # Capacitor packages only work as a matched set: bumped one at a time,
+      # a new @capacitor/core cannot type-check against the older
+      # @capacitor/app and @capacitor/ios still on the previous major (see
+      # #1906/#1907/#1909, all closed for exactly this). Listed before
+      # npm-minor-patch so it claims capacitor's minor/patch bumps too —
+      # this group is about moving together, not about the bump size.
+      capacitor:
+        patterns:
+          - "@capacitor/*"
       npm-minor-patch:
         update-types: ["minor", "patch"]
 


### PR DESCRIPTION
## Why

Dependabot opened the `/mobile` capacitor upgrade as three separate PRs — `@capacitor/core` 6→8 (#1909), `@capacitor/app` 6→7 (#1906), `@capacitor/ios` 6→7 (#1907). All three failed `Type-check + test`, and necessarily so: the capacitor packages are only installable as a matched set, so a bumped `core` cannot type-check against siblings still on the previous major.

All three were closed. Without a config change dependabot reopens them at the same versions on the next weekly run, so this is the actual fix rather than the cleanup.

Note the family has already drifted from exactly this: `@capacitor/cli` sits at `^8.4.2` while `core`/`app`/`android`/`ios` are still `^6.0.0`. This grouping is what stops that from widening further.

## What

One group added to the npm ecosystem entry:

```yaml
groups:
  capacitor:
    patterns:
      - "@capacitor/*"
  npm-minor-patch:
    update-types: ["minor", "patch"]
```

Listed **ahead of** `npm-minor-patch` — dependabot assigns a dependency to the first group it matches, so capacitor's minor and patch bumps land in the capacitor group too. That is intended: the group is about the family moving together, not about the size of the bump. The header comment's "majors stay individual PRs" line is amended to note the exception.

No dependency versions change here; the actual capacitor 6→latest upgrade will arrive as the single grouped PR dependabot opens next.

## Verification

Config-only change, so there is nothing for the test suite to exercise. Parsed the file with `yaml.safe_load` and asserted the group order survives as `['capacitor', 'npm-minor-patch']` — ordering is load-bearing here, and YAML mapping order is what dependabot uses for group precedence. The grouping itself is only observable in dependabot's next weekly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)