### PR TITLE
fix: hand the typed text back when a turn errors (web + TUI)

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -988,6 +988,40 @@ func (m *tuiModel) startCompact() tea.Cmd {
 	return m.startTicker()
 }
 
+// restoreFailedInput hands the typed text of a failed turn back to the input box
+// and drops its deferred echo, mirroring the Esc take-back. It reports whether
+// it restored.
+//
+// A turn that errored with the echo still pending produced no visible output at
+// all, which means the failure was on its first round — the send that never got
+// an answer — so the agent rolled the user message back out of history. The
+// typed text then exists nowhere: not in context, and not in the input box
+// (submit reset it). Leaving the echo in the scrollback on top of the restore
+// would show the message twice, once as a line that isn't in context. A failure
+// after the first round already committed its echo, so that message keeps its
+// place in the transcript and nothing is restored. Interrupts are not this
+// path's business — Esc owns the take-back.
+//
+// Text the user started typing while the turn ran is never overwritten: the
+// failed message is still one ↑ away (submit recorded it in the input history),
+// while half-typed text clobbered here would be unrecoverable. That case keeps
+// the echo, so the failed message stays visible in the scrollback.
+func (m *tuiModel) restoreFailedInput(err error) bool {
+	if err == nil || err == context.Canceled || m.echoPending == "" || m.echoRestore == "" {
+		return false
+	}
+	if strings.TrimSpace(m.ta.Value()) != "" {
+		return false
+	}
+	m.ta.SetValue(m.echoRestore)
+	m.ta.CursorEnd()
+	m.inputHistoryIdx = -1
+	m.echoPending = ""
+	m.echoRestore = ""
+	_ = m.updateTextAreaHeight()
+	return true
+}
+
 // commitEcho promotes the deferred user-message echo from the live View() area
 // to the scrollback, so it lands just above the turn's first output. Idempotent
 // — a no-op once the echo has been committed or dropped.
@@ -1247,6 +1281,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Release any answer text still held by an in-flight hand-off sprint so
 		// the trailing-block flush below sees it.
 		m.flushSprint()
+		m.restoreFailedInput(msg.err)
 		// Commit a still-pending echo (a turn that produced no events — error,
 		// or Ctrl+C). The Esc take-back path clears it before cancelling, so this
 		// is a no-op there.

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -902,9 +902,11 @@ func (m *tuiModel) startTurnEcho(line, echo string) tea.Cmd {
 }
 
 // startTurnEchoRestore is startTurnEcho plus restore: the raw text put back
-// into the input box if the user hits Esc before the model produces any output.
-// Pass "" for turns that aren't a verbatim typed message (skills, /init,
-// dequeued items) — those can't be meaningfully restored.
+// into the input box if the turn is taken back before the model produces any
+// output — by Esc, or by a first-round failure (restoreFailedInput). Pass ""
+// for turns that aren't a verbatim typed message (skills, /init, dequeued
+// items) — those can't be meaningfully restored, which is why startTurnEcho
+// exists. Only the plain-submit path in tuirepl_view.go passes real text.
 func (m *tuiModel) startTurnEchoRestore(line, echo, restore string) tea.Cmd {
 	// Any turn start cancels a pending /goal edit — async idle auto-turns
 	// (background exits, sub-agent notes, loop wakeups) can fire while the

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -1979,3 +1979,51 @@ func TestTUI_FirstRoundErrorKeepsUserTypedText(t *testing.T) {
 		t.Errorf("with no restore the echo must stay in the scrollback, got %q", joined)
 	}
 }
+
+// The take-back paths (Esc, and a first-round failure) can only hand text back
+// if submit actually recorded it. It didn't for a long time — startTurnEchoRestore
+// had no caller passing a non-empty restore, so every unit test that set
+// echoRestore by hand passed while the real thing was dead. Drive the real
+// submit and assert the recall survives an error end-to-end.
+func TestTUI_SubmitRecordsRestoreText(t *testing.T) {
+	m := newTestModel()
+	setInput(m, "the prompt I typed")
+
+	_, _ = m.submit()
+
+	if !m.turnRunning {
+		t.Fatal("submit should have started a turn")
+	}
+	if m.echoRestore != "the prompt I typed" {
+		t.Fatalf("echoRestore = %q, want the typed text — the restore paths are dead without it", m.echoRestore)
+	}
+	if m.ta.Value() != "" {
+		t.Fatalf("submit should clear the box, got %q", m.ta.Value())
+	}
+
+	// The turn fails on its first round: the text must come back.
+	if !m.restoreFailedInput(fmt.Errorf("anthropic: HTTP 403: usage limit reached")) {
+		t.Fatal("a first-round failure after a real submit should restore")
+	}
+	if m.ta.Value() != "the prompt I typed" {
+		t.Errorf("input box = %q, want the typed text back", m.ta.Value())
+	}
+}
+
+// A paste is submitted expanded but echoed collapsed as "[#N pasted …]", and
+// submit clears the paste registry — so the recall must carry the expanded text,
+// not the token, which would come back as a dead literal.
+func TestTUI_SubmitRestoreTextExpandsPastes(t *testing.T) {
+	m := newTestModel()
+	m2, _ := m.handleKey(pasteKey("alpha\nbeta\ngamma\ndelta"))
+	m = m2.(*tuiModel)
+
+	_, _ = m.submit()
+
+	if strings.Contains(m.echoRestore, "pasted") {
+		t.Fatalf("echoRestore = %q, want the expanded paste, not the collapsed token", m.echoRestore)
+	}
+	if !strings.Contains(m.echoRestore, "alpha") || !strings.Contains(m.echoRestore, "delta") {
+		t.Fatalf("echoRestore = %q, want the pasted body", m.echoRestore)
+	}
+}

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -1892,3 +1892,90 @@ func TestModalSecretEscCancels(t *testing.T) {
 		t.Fatal("Esc should answer the modal")
 	}
 }
+
+// A turn that fails on its first LLM round (usage limit, bad key, network) never
+// produced any output, so the agent rolled the user message back out of history
+// — the typed text survives nowhere. The TUI must hand it back to the input box
+// and drop the deferred echo, instead of leaving the user with an error line, an
+// empty box, and a scrollback line that is no longer in context.
+func TestTUI_FirstRoundErrorRestoresInput(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.echoPending = userEchoStyle.Render("> ") + "a long prompt"
+	m.echoRestore = "a long prompt"
+
+	if !m.restoreFailedInput(fmt.Errorf("anthropic: HTTP 403 (permission_error): usage limit reached")) {
+		t.Fatal("a first-round failure should restore the typed text")
+	}
+	if m.ta.Value() != "a long prompt" {
+		t.Errorf("input box = %q, want the failed prompt back for editing", m.ta.Value())
+	}
+	if m.echoPending != "" {
+		t.Error("the echo must be dropped, not committed — the message is in the box and no longer in context")
+	}
+	// commitEcho (which the turnEndedMsg path runs next) must now be a no-op.
+	m.commitEcho()
+	if len(m.printlnBuf) != 0 {
+		t.Errorf("nothing should reach the scrollback, got %v", m.printlnBuf)
+	}
+}
+
+// A failure AFTER the first round kept the user message in history and already
+// committed its echo, so nothing is restored: refilling the box there would
+// resend a message that is still in the transcript and in context.
+func TestTUI_MidTurnErrorKeepsInput(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.echoPending = userEchoStyle.Render("> ") + "run the tool"
+	m.echoRestore = "run the tool"
+
+	// First visible output commits the echo — the turn got past round one.
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "working on it"})
+
+	if m.restoreFailedInput(fmt.Errorf("anthropic: HTTP 429: rate limited")) {
+		t.Error("a mid-turn failure must not restore — the message is still in the transcript")
+	}
+	if m.ta.Value() != "" {
+		t.Errorf("input box = %q, want empty", m.ta.Value())
+	}
+}
+
+// An interrupt is Esc's business: the take-back already recalled the text before
+// cancelling, and after output has streamed Esc deliberately leaves the message
+// in the transcript. Either way this path must stay out of it.
+func TestTUI_InterruptNotRestoredHere(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.echoPending = userEchoStyle.Render("> ") + "fix the bug"
+	m.echoRestore = "fix the bug"
+
+	if m.restoreFailedInput(context.Canceled) {
+		t.Error("an interrupt must not restore here — Esc owns the take-back")
+	}
+	if m.echoPending == "" {
+		t.Error("the echo must be left for commitEcho to handle")
+	}
+}
+
+// Text the user typed while the turn ran must never be clobbered by the restore:
+// the failed message is still one ↑ away in the input history, a half-typed one
+// would be gone for good. The echo stays pending so commitEcho keeps that
+// message visible in the scrollback.
+func TestTUI_FirstRoundErrorKeepsUserTypedText(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.echoPending = userEchoStyle.Render("> ") + "a long prompt"
+	m.echoRestore = "a long prompt"
+	setInput(m, "something else I started typing")
+
+	if m.restoreFailedInput(fmt.Errorf("anthropic: HTTP 403: usage limit reached")) {
+		t.Error("must not restore over text the user is composing")
+	}
+	if m.ta.Value() != "something else I started typing" {
+		t.Errorf("input box = %q, want the text the user was typing left untouched", m.ta.Value())
+	}
+	m.commitEcho()
+	if joined := strings.Join(m.printlnBuf, "\n"); !strings.Contains(joined, "a long prompt") {
+		t.Errorf("with no restore the echo must stay in the scrollback, got %q", joined)
+	}
+}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -847,7 +847,11 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 			echo = strings.TrimSpace(collapsed + "  " + m.attachmentChips())
 			m.pendingAttachments = nil
 		}
-		return m, m.startTurnEcho(text, echo)
+		// Pass text (paste tokens expanded), not collapsed: clearPastes above
+		// dropped the registry, so a recalled "[#N pasted …]" token would be a
+		// dead literal. Attachments are not recoverable — AttachUserBlocks
+		// already handed them to the agent.
+		return m, m.startTurnEchoRestore(text, echo, text)
 	}
 
 	// Mid-turn: enqueue the steer text, folding in any pending image

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -308,6 +308,18 @@ type Agent struct {
 	// runLoop returns so callers can surface it in UI (e.g. "3 iterations").
 	turnIterations int
 
+	// inputRolledBack records whether the most recent turn undid its own user
+	// input — the first-round-failure contract, where History is restored to
+	// its pre-turn state so a retry doesn't duplicate the message. Callers use
+	// it to decide whether the text the user typed still exists anywhere (the
+	// web/TUI composers hand it back when it doesn't). It is a recorded fact
+	// rather than something callers can infer from a history-length diff:
+	// a turn may also compact history (which shrinks it without losing the
+	// input) or drain inbox messages (which grows it), so length says nothing
+	// about this message's fate. Written on the same goroutine that runs the
+	// turn, read after it returns.
+	inputRolledBack bool
+
 	// recentToolCalls tracks the fingerprints of the last few tool-use batches
 	// so runLoop can detect when the model is stuck repeating the same call(s).
 	// Guarded by the implicit serialisation of runLoop (single goroutine).
@@ -604,6 +616,7 @@ func (a *Agent) turn(ctx context.Context, userInput string, finishInterrupt bool
 	}
 
 	// Append user message first so the snapshot the Sender sees includes it.
+	a.inputRolledBack = false
 	a.appendUserInput(ctx, userInput)
 
 	a.ResetGoalBaseline()
@@ -616,6 +629,7 @@ func (a *Agent) turn(ctx context.Context, userInput string, finishInterrupt bool
 		// History doesn't duplicate it. Cheaper than transactional locking
 		// since History is only mutated from this goroutine in M1.2.
 		a.History.popLast()
+		a.inputRolledBack = true
 		return Reply{}, fmt.Errorf("agent: send: %w", err)
 	}
 
@@ -673,6 +687,7 @@ func (a *Agent) turnStream(
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
 
+	a.inputRolledBack = false
 	a.appendUserInput(ctx, userInput)
 
 	a.ResetGoalBaseline()
@@ -696,6 +711,7 @@ func (a *Agent) turnStream(
 			return a.finishInterrupted(handler)
 		}
 		a.History.popLast()
+		a.inputRolledBack = true
 		return Reply{}, fmt.Errorf("agent: stream: %w", err)
 	}
 
@@ -916,6 +932,7 @@ func (a *Agent) runLoop(
 	// user input (drained inbox messages), so truncating to this baseline is
 	// what restores the pre-turn state — popLast would only remove one message.
 	baseHistoryLen := a.History.Len()
+	a.inputRolledBack = false
 	a.appendUserInput(ctx, userInput)
 
 	limit := a.turnLimit()
@@ -996,6 +1013,7 @@ func (a *Agent) runLoop(
 
 			if i == 0 {
 				a.History.TruncateTo(baseHistoryLen)
+				a.inputRolledBack = true
 			}
 			return Reply{}, fmt.Errorf("agent: loop[%d]: %w", i, err)
 		}
@@ -1030,6 +1048,7 @@ func (a *Agent) runLoop(
 			default:
 				if i == 0 {
 					a.History.TruncateTo(baseHistoryLen)
+					a.inputRolledBack = true
 				}
 				return Reply{}, fmt.Errorf("agent: loop[%d] escalate: %w", i, eerr)
 			}
@@ -1257,6 +1276,15 @@ func (a *Agent) TakeBackInterrupted() bool {
 // the most recent Run/RunStream call. It is 0 before the first run.
 func (a *Agent) TurnIterations() int {
 	return a.turnIterations
+}
+
+// InputRolledBack reports whether the most recent turn undid its own user input
+// (the first-round-failure contract). True means the message the user sent is
+// gone from History, so a UI that cleared its input box on send is the last
+// place that text could come back from. False covers both a clean turn and a
+// failure past the first round, where the message stayed in History.
+func (a *Agent) InputRolledBack() bool {
+	return a.inputRolledBack
 }
 
 // turnLimit resolves the per-Run loop cap.

--- a/internal/agent/inputrollback_test.go
+++ b/internal/agent/inputrollback_test.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A first-round failure undoes the user message, so InputRolledBack must say so
+// — it is the only way a UI that cleared its input box on send can tell that the
+// text it dropped is now gone everywhere.
+func TestInputRolledBack_FirstRoundError(t *testing.T) {
+	send := &fakeToolSender{errs: []error{errors.New("provider boom")}}
+	a := New(send, "m")
+	a.History.Append(NewUserMessage("earlier"))
+	a.History.Append(NewAssistantMessage("earlier answer"))
+	before := a.History.Len()
+
+	if _, err := a.RunStream(context.Background(), "the prompt", nil, nil, nil); err == nil {
+		t.Fatal("want an error from the failing sender")
+	}
+	if !a.InputRolledBack() {
+		t.Error("InputRolledBack() = false, want true — the user message was popped")
+	}
+	if a.History.Len() != before {
+		t.Errorf("history len = %d, want %d (pre-turn state)", a.History.Len(), before)
+	}
+}
+
+// A failure after the first round keeps the user message (and the completed
+// round) in history, so nothing was lost and the flag must stay false —
+// otherwise a UI would refill its composer with a message still in the
+// transcript and the user would send it twice.
+func TestInputRolledBack_MidTurnError(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{{
+			Blocks:     []ContentBlock{NewToolUseBlock("tu1", "terminal", map[string]any{})},
+			StopReason: "tool_use",
+		}},
+		errs: []error{nil, errors.New("provider boom")},
+	}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "terminal"}}
+
+	if _, err := a.RunStream(context.Background(), "run it", defs, &fakeExecutor{}, nil); err == nil {
+		t.Fatal("want an error from the second round")
+	}
+	if a.InputRolledBack() {
+		t.Error("InputRolledBack() = true, want false — the message survived the turn")
+	}
+	if !historyHasUserText(a, "run it") {
+		t.Error("the user message should still be in history after a mid-turn failure")
+	}
+}
+
+// The regression that a history-length comparison gets wrong: a turn that
+// compacts at its start and then fails mid-turn ends up with FEWER messages
+// than it began with, while the user message is untouched. Inferring the
+// rollback from that shrink would hand the composer a message that is still in
+// the transcript.
+func TestInputRolledBack_CompactionThenMidTurnErrorIsNotRollback(t *testing.T) {
+	long := strings.Repeat("x ", 500) // ~250 tokens each
+	send := &fakeToolSender{
+		replies: []Reply{
+			{Content: "SUMMARY"}, // consumed by maybeCompact's summarize call
+			{
+				Blocks:     []ContentBlock{NewToolUseBlock("tu1", "terminal", map[string]any{})},
+				StopReason: "tool_use",
+			},
+		},
+		errs: []error{nil, nil, errors.New("provider boom")},
+	}
+	a := New(send, "m")
+	a.CompactThreshold = 100
+	for i := 0; i < 6; i++ {
+		a.History.Append(NewUserMessage(long))
+		a.History.Append(NewAssistantMessage(long))
+	}
+	watermark := a.History.Len() + 1 // what the server counts before the turn
+
+	if _, err := a.RunStream(context.Background(), "run it", []ToolDefinition{{Name: "terminal"}}, &fakeExecutor{}, nil); err == nil {
+		t.Fatal("want an error from the round after the tool call")
+	}
+	if send.calls < 3 {
+		t.Fatalf("sender calls = %d, want 3 (summarize, tool round, failing round) — the setup didn't compact", send.calls)
+	}
+	if a.History.Len() >= watermark {
+		t.Fatalf("history len = %d, want < %d — this test only means something when the turn shrank history", a.History.Len(), watermark)
+	}
+	if a.InputRolledBack() {
+		t.Error("InputRolledBack() = true, want false — compaction shrank history but kept the user message")
+	}
+	if !historyHasUserText(a, "run it") {
+		t.Error("the user message should still be in history")
+	}
+}
+
+// The flag is per-turn: a failed turn must not leave it set for the next one.
+func TestInputRolledBack_ResetByNextTurn(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{{}, {Content: "fine", StopReason: "end_turn"}},
+		errs:    []error{errors.New("provider boom")},
+	}
+	a := New(send, "m")
+
+	if _, err := a.RunStream(context.Background(), "first", nil, nil, nil); err == nil {
+		t.Fatal("want an error on the first turn")
+	}
+	if !a.InputRolledBack() {
+		t.Fatal("the failed turn should have set the flag")
+	}
+	if _, err := a.RunStream(context.Background(), "second", nil, nil, nil); err != nil {
+		t.Fatalf("second turn: %v", err)
+	}
+	if a.InputRolledBack() {
+		t.Error("InputRolledBack() = true after a clean turn, want false")
+	}
+}
+
+func historyHasUserText(a *Agent, want string) bool {
+	for _, m := range a.History.Snapshot() {
+		if m.Role == RoleUser && strings.Contains(m.Content, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/turn_error_input_test.go
+++ b/internal/server/turn_error_input_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+)
+
+// findTurnError returns the first turn_error event in seen, or nil.
+func findTurnError(seen []map[string]any) map[string]any {
+	for _, ev := range seen {
+		if ev["type"] == "turn_error" {
+			return ev
+		}
+	}
+	return nil
+}
+
+// TestDoAgentTurn_FirstRoundError_TurnErrorMarksInputRolledBack: a failure on
+// the first LLM round rolls the user message back out of history, so the text
+// the user typed survives nowhere — the composer cleared it optimistically and
+// the history_reload wipes the bubble. turn_error must say so, or the browser
+// has no way to tell this apart from a mid-turn failure and the prompt is lost.
+func TestDoAgentTurn_FirstRoundError_TurnErrorMarksInputRolledBack(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.sender = erroringSender{}
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]queuedTurn)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Title = "fixed title"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.wsHub.subscribe(conn, sess.ID)
+
+	srv.doAgentTurn(sess, "a long prompt the user typed", nil, nil)
+
+	var seen []map[string]any
+	waitFor(t, func() bool {
+		seen = append(seen, drainConn(t, conn)...)
+		return findTurnError(seen) != nil
+	})
+	ev := findTurnError(seen)
+	if rolled, _ := ev["input_rolled_back"].(bool); !rolled {
+		t.Errorf("turn_error = %+v, want input_rolled_back true — the typed text is unrecoverable without it", ev)
+	}
+}
+
+// TestDoAgentTurn_MidTurnError_TurnErrorKeepsInput is the other half of the
+// gate: a failure after the first round keeps the user message in history and
+// in the transcript, so the flag must stay off — restoring the text there would
+// duplicate the message on the next send.
+func TestDoAgentTurn_MidTurnError_TurnErrorKeepsInput(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+	srv.sender = &failSecondRoundSender{}
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]queuedTurn)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Title = "fixed title"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.wsHub.subscribe(conn, sess.ID)
+
+	srv.doAgentTurn(sess, "run the tool", nil, nil)
+
+	var seen []map[string]any
+	waitFor(t, func() bool {
+		seen = append(seen, drainConn(t, conn)...)
+		return findTurnError(seen) != nil
+	})
+	ev := findTurnError(seen)
+	if _, present := ev["input_rolled_back"]; present {
+		t.Errorf("turn_error = %+v, want no input_rolled_back — the user message survived the turn", ev)
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1603,6 +1603,12 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	s.liveStateMu.Unlock()
 
 	if err != nil {
+		// Did the turn lose the user's message? A first-round failure makes
+		// runLoop roll history back past it, so the text the user typed exists
+		// nowhere anymore — neither on disk nor (once the reload below lands) in
+		// the browser's transcript. Both the turn_error hint and the history
+		// reload key off this single condition so they stay in lockstep.
+		inputRolledBack := len(sess.Messages) < historyWatermark
 		// Any aborted or errored turn parks the continuation loop: an
 		// interrupt means the user said stop (continuing immediately would
 		// make the loop interrupt-proof), and chaining fresh turns onto a
@@ -1635,11 +1641,10 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// session_update tail. Returning here would skip `complete`, leaving
 			// the web UI's streaming flag (and its caret) stuck on forever; the
 			// tail's session_update is a superset of what we'd emit here.
-			sw.userError(err)
+			sw.userErrorInput(err, inputRolledBack)
 		}
-		// A first-round failure makes runLoop roll history back past the user
-		// message (appendUserInput's error-path contract), and the SyncFrom+
-		// Save above erased the crash-safety copy persisted before the turn.
+		// The rolled-back user message means the SyncFrom+Save above erased the
+		// crash-safety copy persisted before the turn.
 		// The browser still shows that user bubble with a now out-of-range
 		// message_index, so a later edit/branch would 400. Tell it to re-fetch
 		// the (shorter) transcript so its indices realign with disk. An
@@ -1651,7 +1656,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		// turn-start watermark (deliberately not the live state's
 		// compaction-adjusted copy) so a mid-turn failure that kept the
 		// message doesn't trigger a needless reload.
-		if len(sess.Messages) < historyWatermark {
+		if inputRolledBack {
 			s.broadcastHistoryReload(sess.ID)
 		}
 	} else {
@@ -1883,11 +1888,24 @@ func (w *wsStreamWriter) sendRaw(data []byte) {
 // tool_id): a turn error belongs to no tool card, so the frontend renders it as
 // a standalone error notice in the transcript rather than dropping it.
 func (w *wsStreamWriter) error(msg string) {
-	w.hub.broadcast(w.sessionID, map[string]string{
+	w.errorInput(msg, false)
+}
+
+// errorInput is error plus the inputRolledBack hint: the failed turn's user
+// message was rolled back out of history, so the text the user typed is gone
+// from the transcript too and the browser should put it back in the composer.
+// Absent (or false) means the message survived — a mid-turn failure keeps the
+// bubble, and restoring the text there would duplicate it on the next send.
+func (w *wsStreamWriter) errorInput(msg string, inputRolledBack bool) {
+	ev := map[string]any{
 		"type":       "turn_error",
 		"session_id": w.sessionID,
 		"error":      msg,
-	})
+	}
+	if inputRolledBack {
+		ev["input_rolled_back"] = true
+	}
+	w.hub.broadcast(w.sessionID, ev)
 }
 
 // userError is like error but strips internal agent-loop prefixes so the
@@ -1895,6 +1913,11 @@ func (w *wsStreamWriter) error(msg string) {
 // "agent: loop[0]: anthropic: HTTP 403 ...".
 func (w *wsStreamWriter) userError(err error) {
 	w.error(agent.UserFacingError(err))
+}
+
+// userErrorInput is userError carrying errorInput's inputRolledBack hint.
+func (w *wsStreamWriter) userErrorInput(err error, inputRolledBack bool) {
+	w.errorInput(agent.UserFacingError(err), inputRolledBack)
 }
 
 // bufferTurnEvent records an already-broadcast turn event in the session's

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1603,12 +1603,14 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	s.liveStateMu.Unlock()
 
 	if err != nil {
-		// Did the turn lose the user's message? A first-round failure makes
-		// runLoop roll history back past it, so the text the user typed exists
-		// nowhere anymore — neither on disk nor (once the reload below lands) in
-		// the browser's transcript. Both the turn_error hint and the history
-		// reload key off this single condition so they stay in lockstep.
-		inputRolledBack := len(sess.Messages) < historyWatermark
+		// Did the turn lose the user's message? A first-round failure rolls
+		// history back past it, so the text the user typed exists nowhere
+		// anymore — neither on disk nor (once the reload below lands) in the
+		// browser's transcript. Ask the agent, which records the rollback:
+		// the history-length shrink that gates the reload below is a weaker
+		// signal, since a turn that compacted its history also shrinks it
+		// while keeping the user message.
+		inputRolledBack := a.InputRolledBack()
 		// Any aborted or errored turn parks the continuation loop: an
 		// interrupt means the user said stop (continuing immediately would
 		// make the loop interrupt-proof), and chaining fresh turns onto a
@@ -1643,8 +1645,9 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// tail's session_update is a superset of what we'd emit here.
 			sw.userErrorInput(err, inputRolledBack)
 		}
-		// The rolled-back user message means the SyncFrom+Save above erased the
-		// crash-safety copy persisted before the turn.
+		// A first-round failure makes runLoop roll history back past the user
+		// message (appendUserInput's error-path contract), and the SyncFrom+
+		// Save above erased the crash-safety copy persisted before the turn.
 		// The browser still shows that user bubble with a now out-of-range
 		// message_index, so a later edit/branch would 400. Tell it to re-fetch
 		// the (shorter) transcript so its indices realign with disk. An
@@ -1655,8 +1658,10 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		// which also realigns its indices. Gated on an actual shrink below the
 		// turn-start watermark (deliberately not the live state's
 		// compaction-adjusted copy) so a mid-turn failure that kept the
-		// message doesn't trigger a needless reload.
-		if inputRolledBack {
+		// message doesn't trigger a needless reload. Deliberately NOT the
+		// rollback fact above: a compacted turn keeps its user message but
+		// still shifts every index below the fold.
+		if len(sess.Messages) < historyWatermark {
 			s.broadcastHistoryReload(sess.ID)
 		}
 	} else {

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -65,6 +65,13 @@
     queueMicrotask(() => textareaEl?.focus())
   }
 
+  // Whether the box already holds something the user typed. Callers that push
+  // text back in unprompted (a turn error handing back the failed message) check
+  // this first so they never clobber a message being composed.
+  export function isEmpty(): boolean {
+    return text.trim() === '' && attachments.length === 0
+  }
+
   // Auto-grow the textarea with its content up to a max height, then scroll
   // inside (matches the max-height in CSS). The $effect re-runs on every text
   // change — typing, paste, send-clear, or programmatic setText.

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -499,6 +499,10 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
         chatStreaming.update(s => ({ ...s, [sid]: meta.wasStreaming }))
       }
       bindRequiredFor = null
+      // No turn started, so no turn_error/complete will consume the restore
+      // slot — drop it here or it would outlive this send and be handed to a
+      // later turn's failure.
+      turnInput.delete(sid)
       showToast((ev as any).message ?? 'Error', 'error')
     }))
 
@@ -1092,6 +1096,10 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       cancelled = true
       ws.unsubscribe(sid)
       for (const cleanup of cleanups) cleanup()
+      // Switching away tears down the handlers that would have consumed the
+      // restore slot, so drop it: on the way back the turn that owned it is
+      // long over, and a later failure must not push its text at the composer.
+      turnInput.delete(sid)
       // Drop this session's pending sub-agent dismiss timers so they can't fire
       // against a session no longer shown in this view.
       for (const [key, timer] of subAgentDismissTimers) {

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -862,10 +862,13 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       // The slot is consumed either way, so a failure that kept the message
       // (or one whose turn never reaches `complete`) can't leak this text into a
       // later turn's error.
+      // Never overwrite a message already being composed (typed while the turn
+      // ran): the failed one is still one ↑ away in the input history, while
+      // half-typed text clobbered here would be unrecoverable.
       const lostInput = turnInput.get(sid)
       turnInput.delete(sid)
-      if ((ev as any).input_rolled_back && lostInput) {
-        composer?.restore(lostInput.text, lostInput.files)
+      if ((ev as any).input_rolled_back && lostInput && composer?.isEmpty()) {
+        composer.restore(lostInput.text, lostInput.files)
       }
       // Forget any send still tracked for rollback (a message the server never
       // confirmed — e.g. reminder-only text that gets no history_user_message).
@@ -1355,7 +1358,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   }
 
   // ── edit a prior user message: load it back into the composer for resend ─────
-  let composer = $state<{ setText: (v: string) => void; restore: (v: string, files?: any[]) => void } | null>(null)
+  let composer = $state<{ setText: (v: string) => void; restore: (v: string, files?: any[]) => void; isEmpty: () => boolean } | null>(null)
   function editMessage(content: string) {
     composer?.setText(content)
   }

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -102,6 +102,15 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   // force takeover can retry the same message.
   const pendingSends = new Map<string, { pendingId: string; wasStreaming: boolean; text: string; files?: any[]; queued?: boolean }[]>()
 
+  // The message that started the running turn, kept for the whole turn so a
+  // turn_error can put it back in the composer. pendingSends can't serve that:
+  // the server confirms the user bubble (history_user_message) BEFORE it calls
+  // the LLM, so the pending entry is already shifted out of the queue by the
+  // time a provider error lands. Written on every fresh (non-steer) send and
+  // dropped when the turn ends — a turn started elsewhere (another tab, cron,
+  // a wakeup) must never restore this tab's stale text.
+  const turnInput = new Map<string, { text: string; files?: any[] }>()
+
   // Pending auto-dismiss timers for background sub-agents that finished with no
   // active turn (keyed by `${sid}\x00${agentId}`). A turn-less `done` has no
   // `complete` event to clear it, so we show it briefly then drop it. Cleared
@@ -773,6 +782,9 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
         return { ...m, [sid]: msgs }
       })
       if (meta?.queued) {
+        // This queued message is now the input of a turn of its own, so it takes
+        // over the restore slot the fresh-send path fills in send().
+        turnInput.set(sid, { text: meta.text, files: meta.files })
         // A queued message starts its own turn, and the previous turn's
         // `complete` already flipped streaming off. The `progress phase=active`
         // that doAgentTurn broadcasts right after this event flips it back — this
@@ -844,21 +856,28 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       // follows), and send() already cleared the composer optimistically — so
       // the text the user typed is gone from both places. Pull it back into the
       // composer so a long prompt isn't lost to a transient error; the user can
-      // fix the cause and resend. The fresh message that started this turn is
-      // the queue's single non-streaming entry (a follow-up sent mid-turn is
-      // classified as a steer, wasStreaming:true, and its text belongs to the
-      // running turn — not a fresh compose). Find it by that flag rather than by
-      // position: a leaked steer from an earlier turn can sit ahead of it, and a
-      // trailing steer can sit after it. Mirrors the steer_retracted restore
-      // above, including forgetting the rollback entry (a rolled-back message is
-      // never confirmed by history_user_message).
+      // fix the cause and resend. Only when the server says the message was
+      // rolled back: a failure after the first round keeps the bubble in the
+      // transcript, and restoring there would resend it twice.
+      // The slot is consumed either way, so a failure that kept the message
+      // (or one whose turn never reaches `complete`) can't leak this text into a
+      // later turn's error.
+      const lostInput = turnInput.get(sid)
+      turnInput.delete(sid)
+      if ((ev as any).input_rolled_back && lostInput) {
+        composer?.restore(lostInput.text, lostInput.files)
+      }
+      // Forget any send still tracked for rollback (a message the server never
+      // confirmed — e.g. reminder-only text that gets no history_user_message).
+      // Leaving it would misalign the FIFO for the next turn's confirmation.
+      // Steers are left alone: their text belongs to the running turn and
+      // steer_retracted owns that path.
       const errQueue = pendingSends.get(sid)
       const errMeta = errQueue?.find(m => !m.wasStreaming)
       if (errQueue && errMeta) {
         const next = errQueue.filter(m => m.pendingId !== errMeta.pendingId)
         if (next.length) pendingSends.set(sid, next)
         else pendingSends.delete(sid)
-        composer?.restore(errMeta.text, errMeta.files)
       }
     }))
 
@@ -883,6 +902,10 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
     cleanups.push(ws.on('complete', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
+      // The turn is over: turn_error (which arrives before this) already had its
+      // chance to restore the input, so drop it rather than letting it leak into
+      // a later turn this tab didn't compose.
+      turnInput.delete(sid)
       chatStreaming.update(s => ({ ...s, [sid]: false }))
       chatProgress.update(p => ({ ...p, [sid]: null }))
       // A turn that ends without an assistant_message (interrupt / error) would
@@ -1466,6 +1489,8 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       // moved on and must not re-render when this turn ends), and flip the
       // session into streaming.
       turnError = null
+      // Remember what started this turn so turn_error can hand it back.
+      turnInput.set(sid, { text, files })
       clearDoneSubAgents(sid)
       chatThinking.update(tt => ({ ...tt, [sid]: '' }))
       chatSuggestion.update(s => ({ ...s, [sid]: '' }))


### PR DESCRIPTION
## Problem

When the LLM call fails on the first round of a turn — usage limit, bad key, network — the user's message disappears without a trace. All that's left is the error line.

**Web:** the transcript bubble is rolled back by `history_reload`, and the composer had already been cleared optimistically on send. #1647 was supposed to fix exactly this, but the restore it added never runs: it looks the failed message up in `pendingSends`, and the server broadcasts `history_user_message` — which confirms the optimistic bubble and shifts that entry out of the queue — *before* it calls the LLM. By the time `turn_error` lands the queue no longer holds the message, so `composer.restore()` was unreachable. Its premise ("a rolled-back message is never confirmed by history_user_message") is wrong: the confirmation is what swaps the ghost bubble for the real one, and it happens first.

**TUI:** the input box is left empty and the deferred echo is committed to the scrollback — even though the agent rolled that message out of history, so the line looks like context but isn't.

## Fix

**Where the rollback fact comes from.** `Agent` now records whether a turn undid its own user input, at the four sites that actually roll back, exposed as `InputRolledBack()`. The server had inferred it from `len(sess.Messages) < historyWatermark`, which conflates "history shrank" with "the message is gone": a turn that compacts at its start (`maybeCompact` runs before the input is appended) and then fails mid-turn shrinks history while keeping the message. The `history_reload` gate keeps the length check on purpose — a compacted turn does need a reload, since every index below the fold moved.

**Web.** The turn's input lives in a slot of its own (`turnInput`) that survives confirmation — written on each fresh send, and on a queued message when its own turn starts — consumed when the turn ends, and dropped when a send is rejected outright or the view switches sessions. `turn_error` restores from that instead of the queue, gated on the new `input_rolled_back` field on the event.

**TUI.** An error arriving while the echo is still pending means the turn produced no visible output, so the echo can still be dropped: `restoreFailedInput` recalls the text and drops it, the same take-back Esc performs. This also fixes the mechanism it stands on — `startTurnEchoRestore`'s restore parameter has had exactly one caller since #340 (`startTurnEcho`, hardcoding `""`), so the plain-submit path never recorded the text and the Esc take-back's recall had been dead for just as long. Submit now passes the paste-expanded text; the collapsed `[#N pasted …]` token would come back as a dead literal because `clearPastes` already dropped the registry.

**Both.** Never overwrite a message the user started composing while the turn ran: the failed one is still one ↑ away in the input history, half-typed text would not be. Web gets a `Composer.isEmpty()` for that check.

## Tests

- `internal/agent`: rollback flag set on a first-round failure, not set after a mid-turn failure, **not set when compaction shrank history but the message survived**, and reset by the next turn.
- `internal/server`: `input_rolled_back` present on a first-round failure, absent on a mid-turn one.
- `cmd/octo`: the four `restoreFailedInput` branches, plus two tests that drive the real `submit()` so the recall can't silently die again (they fail if the `startTurnEchoRestore` wiring is reverted).

## Known gaps

- Mobile (`web/src/mobile/chatWiring.ts`) has the same loss but no composer-restore path at all; unchanged here.
- Only the fresh message is restored. A follow-up typed before the error lands is classified as a steer and is rolled back with it, but a composer holds one message — the steer's text is not recovered.
- TUI attachments are not recoverable (`AttachUserBlocks` already handed them to the agent); the web path does restore its attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)