### PR TITLE
chore: bump version to 1.14.7

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.14.6"
+var Version = "1.14.7"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over v1.14.6 — two fixes plus a dependabot batch.

- #1917 — hand the typed text back when a turn errors (web + TUI). The web restore added in #1647 never ran, and the TUI's recall mechanism had been dead since #340; the rollback fact now comes from the agent instead of a history-length guess.
- #1918 — keep the composer draft when picking a slash command.
- Dependency bumps: #1901–#1911 (setup-node, configure-pages, wails/v3, goldmark, typescript ×2, npm minor/patch group, @capacitor grouping).

version.go only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)