### PR TITLE
fix(web): render markdown inside blockquotes instead of leaking the source

### DIFF
--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { renderMarkdown } from './markdown'
+
+// These assert on what a quote's CONTENTS render to, never on the surrounding
+// <blockquote> tag. Under happy-dom, DOMPurify strips block wrappers it keeps
+// in a real browser — `sanitize('<div class="q">x</div>')` returns bare `x`
+// here, and blockquote goes the same way, while the <p>/<strong> inside
+// survive. That is a test-environment artifact, not the shipped behavior (the
+// code-block renderer emits a <div> that is plainly present in the UI), so
+// asserting on the wrapper would pin the artifact instead of the fix.
+describe('renderMarkdown: blockquote contents', () => {
+  it('renders bold inside a quote instead of leaking asterisks', () => {
+    const out = renderMarkdown('> quoted **bold**')
+    expect(out).toContain('<strong>bold</strong>')
+    expect(out).not.toContain('**bold**')
+  })
+
+  it('renders inline code inside a quote', () => {
+    const out = renderMarkdown('> use `npm ci` first')
+    expect(out).toContain('<code>npm ci</code>')
+    expect(out).not.toContain('`npm ci`')
+  })
+
+  it('renders links inside a quote through the custom link renderer', () => {
+    const out = renderMarkdown('> see [docs](https://example.com)')
+    expect(out).toContain('href="https://example.com"')
+    expect(out).toContain('>docs</a>')
+  })
+
+  it('keeps a multi-line quote as one quote with both lines rendered', () => {
+    const out = renderMarkdown('> first **line**\n> second *line*')
+    expect(out).toContain('<strong>line</strong>')
+    expect(out).toContain('<em>line</em>')
+  })
+
+  it('still renders markdown outside a quote', () => {
+    const out = renderMarkdown('Outside **bold** and `code`.')
+    expect(out).toContain('<strong>bold</strong>')
+    expect(out).toContain('<code>code</code>')
+  })
+})

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -1,4 +1,4 @@
-import { marked, Renderer } from "marked"
+import { marked, Renderer, type Tokens } from "marked"
 import DOMPurify from "dompurify"
 import hljs from "highlight.js/lib/core"
 import javascript from "highlight.js/lib/languages/javascript"
@@ -78,8 +78,13 @@ export function renderMarkdown(text: string, showReasoning = true): string {
     return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("mailto:") || lower.startsWith("tel:")
   }
 
-  renderer.blockquote = function ({ text: bqText }: { text: string }) {
-    return `<blockquote class="md-bq">${bqText}</blockquote>`
+  // Render the quote's children, don't interpolate token.text — that field is
+  // the raw markdown source, so `> quoted **bold**` reached the DOM with the
+  // asterisks intact and every link, inline code span and nested list inside a
+  // quote came out as literal text. The default renderer parses token.tokens;
+  // this override exists only to add the md-bq class, so it has to do the same.
+  renderer.blockquote = function ({ tokens }: Tokens.Blockquote) {
+    return `<blockquote class="md-bq">${this.parser.parse(tokens)}</blockquote>`
   }
 
   marked.use({ renderer })


### PR DESCRIPTION
## Problem

`renderer.blockquote` in `web/src/lib/markdown.ts` interpolated `token.text` — the **raw markdown source**. The override exists only to add the `md-bq` class, but by not parsing the children the way the default renderer does, it dropped all rendering inside a quote:

| Input | Rendered (before) | Rendered (after) |
|---|---|---|
| `> quoted **bold**` | `quoted **bold**` | `quoted <strong>bold</strong>` |
| `> use \`npm ci\`` | `use \`npm ci\`` | `use <code>npm ci</code>` |
| `> see [docs](https://example.com)` | `see [docs](https://example.com)` | a real link |

Model replies quote things often — user text, docs, error output — so this is visible in ordinary use.

## Fix

Parse `token.tokens` (three lines). Found while diffing marked 15 against 18 for #1915; it predates that bump and reproduces identically on both versions, so it is not fallout from the upgrade.

## A trap worth knowing about, in the tests

The tests assert on what a quote's *contents* render to, never on the surrounding `<blockquote>` tag. Under happy-dom, DOMPurify strips block wrappers that it keeps in a real browser:

```js
DOMPurify.sanitize('<div class="q">x</div>')  // → 'x'   (happy-dom)
DOMPurify.sanitize('<blockquote>x</blockquote>')  // → 'x'
DOMPurify.sanitize('<blockquote><p>x</p></blockquote>')  // → '<p>x</p>'
```

The `<p>`/`<strong>` inside survive, which is why these tests work. This is a test-environment artifact, not shipped behavior — `renderer.code` emits a `<div class="code-block">` that is plainly present in the UI. Asserting on the wrapper would pin the artifact instead of the fix, so the test file says so explicitly; it is also the likely reason this module had no coverage until now.

## Verification

- 5 new tests; reverting `markdown.ts` turns 4 of them red (the fifth is the "outside a quote still works" control, which stays green either way).
- `svelte-check` 0 errors, full suite 97 tests / 9 files green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)