### PR TITLE
chore(deps): move the Capacitor family to 8.x, and mobile CI to Node 22

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -38,7 +38,11 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          # 22 is @capacitor/cli 8's floor (engines.node >=22.0.0). It has been
+          # the installed cli major for a while, so 20 was already below the
+          # floor — npm only warns, it doesn't fail, which is why nothing caught
+          # it. Matches the Go/desktop/pages workflows, which are all on 22.
+          node-version: '22'
           cache: npm
           cache-dependency-path: mobile/package-lock.json
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -81,7 +81,7 @@ make web-build
 cd mobile && npm install && npm run bundle-web
 
 # 2. Add the native platforms (generates ios/ and android/, both gitignored).
-#    Capacitor 7 uses Swift Package Manager on iOS — there is no Podfile and no
+#    Capacitor 7+ uses Swift Package Manager on iOS — there is no Podfile and no
 #    `pod install`; Xcode resolves the packages on open.
 npx cap add ios
 npx cap add android

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,36 +8,36 @@
       "name": "octo-mobile",
       "version": "0.0.0",
       "dependencies": {
-        "@capacitor/app": "^6.0.0",
-        "@capacitor/core": "^6.0.0",
+        "@capacitor/app": "^8.1.1",
+        "@capacitor/core": "^8.4.2",
         "jsqr": "^1.4.0"
       },
       "devDependencies": {
-        "@capacitor/android": "^6.0.0",
+        "@capacitor/android": "^8.4.2",
         "@capacitor/cli": "^8.4.2",
-        "@capacitor/ios": "^6.0.0",
+        "@capacitor/ios": "^8.4.2",
         "esbuild": "^0.28.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10"
       }
     },
     "node_modules/@capacitor/android": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-6.2.1.tgz",
-      "integrity": "sha512-8gd4CIiQO5LAIlPIfd5mCuodBRxMMdZZEdj8qG8m+dQ1sQ2xyemVpzHmRK8qSCHorsBUCg3D62j2cp6bEBAkdw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.4.2.tgz",
+      "integrity": "sha512-bzf8XZ9C+ePgOQ+e+T0fnhHGH4aCNY494vvSQIF5w4AY07RwEmkFqZs1678DDSMH0hLSQpxEwXGFNUVcXO6bBA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^6.2.0"
+        "@capacitor/core": "^8.4.0"
       }
     },
     "node_modules/@capacitor/app": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-6.0.3.tgz",
-      "integrity": "sha512-4gFUCbcVz0N/YYN32OBFerocWXslIv3Nc90gDiRsBkJc0plwK6kIUT6PKa5WtW2kfhteUeCVXQbvArH2fH+0Ug==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.1.tgz",
+      "integrity": "sha512-xM2ZTX5jK60tFtmjsmJv+Cdj1Qsb6NcavkqmdEnCPQBeya9oKhamZJxYOnQNj1ZvcJM7sWfG6BEtSLx42pisbA==",
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^6.0.0"
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/cli": {
@@ -89,22 +89,22 @@
       }
     },
     "node_modules/@capacitor/core": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.2.1.tgz",
-      "integrity": "sha512-urZwxa7hVE/BnA18oCFAdizXPse6fCKanQyEqpmz6cBJ2vObwMpyJDG5jBeoSsgocS9+Ax+9vb4ducWJn0y2qQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.4.2.tgz",
+      "integrity": "sha512-fQPRb3JXRaU2pnufDUvqOjhsrYxDQeFRZyaj/sHydIUxD2NxOGHKMpmKUdI+U4OOmKuGZyvRpi7TSJU+7Bjbmg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@capacitor/ios": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-6.2.1.tgz",
-      "integrity": "sha512-tbMlQdQjxe1wyaBvYVU1yTojKJjgluZQsJkALuJxv/6F8QTw5b6vd7X785O/O7cMpIAZfUWo/vtAHzFkRV+kXw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.4.2.tgz",
+      "integrity": "sha512-ClVzIjK++yRjsRPOpdEzhsZfbHfoEc0f4M6vD0v7sWh0qcoF6NkxNAeHpWTn4OPJpJfpGGoYsq+IfEHrYyBiWA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^6.2.0"
+        "@capacitor/core": "^8.4.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -11,14 +11,14 @@
     "wire-native": "node scripts/wire-native.mjs"
   },
   "dependencies": {
-    "@capacitor/app": "^6.0.0",
-    "@capacitor/core": "^6.0.0",
+    "@capacitor/app": "^8.1.1",
+    "@capacitor/core": "^8.4.2",
     "jsqr": "^1.4.0"
   },
   "devDependencies": {
-    "@capacitor/android": "^6.0.0",
+    "@capacitor/android": "^8.4.2",
     "@capacitor/cli": "^8.4.2",
-    "@capacitor/ios": "^6.0.0",
+    "@capacitor/ios": "^8.4.2",
     "esbuild": "^0.28.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"


### PR DESCRIPTION
Doing by hand what Dependabot structurally can't: the Capacitor packages only install as a matched set, so it has opened and had closed four single-package PRs for this (#1906, #1907, #1909, #1912).

| Package | From | To |
|---|---|---|
| `@capacitor/core` | 6.2.1 | 8.4.2 |
| `@capacitor/app` | 6.0.3 | 8.1.1 |
| `@capacitor/android` | 6.2.1 | 8.4.2 |
| `@capacitor/ios` | 6.2.1 | 8.4.2 |
| `@capacitor/cli` | — | already on ^8.4.2 |

The cli was already on 8, so the family was internally inconsistent until now.

**Node 20 → 22 in `mobile.yml`** — `@capacitor/cli` 8 declares `engines.node >=22.0.0`, so that floor was already unmet. npm only warns about engines, so nothing failed and nothing caught it. Every other workflow is on 22.

## Why the JS risk is small

The JS surface barely touches Capacitor: `src/plugin.ts` imports `registerPlugin` from `@capacitor/core`, and `capacitor.config.ts` imports a type from `@capacitor/cli`. `@capacitor/app` is carried for its native side only — `plugin.ts` deliberately registers through core instead of using app's JS wrapper.

## Verification

**TS layer (what CI covers):** `tsc --noEmit` clean, 19 tests green.

**Native, both platforms actually compiled** on a Mac with Xcode 26.6 and the Android SDK — this is the part CI does not cover:

- **Android** — `./gradlew assembleDebug` → `BUILD SUCCESSFUL`, 126 tasks, 4.6 MB `app-debug.apk`. Capacitor 8's template wants compileSdk/targetSdk 36 (installed) and Gradle 8.14.3; JDK 21 from Android Studio's bundled jbr. `compileDebugKotlin` covers our `OctoTunnelPlugin.kt` and its noise-java / okhttp dependencies.
- **iOS** — `xcodebuild -sdk iphonesimulator26.5` → `** BUILD SUCCEEDED **`, fat `App.app` (x86_64 + arm64). Generation went through Swift Package Manager with no Podfile, matching what `mobile/README.md` already described.

**Our native code is really in the build, not just alongside it.** `wire-native.mjs` re-applied every patch site on both platforms, and the results were checked in the build output rather than trusted from the script's own log:

- The generated `App-Swift.h` declares both classes with their Capacitor 8 base types intact — `OctoBridgeViewController : CAPBridgeViewController` and `OctoTunnelPlugin : CAPPlugin <CAPBridgedPlugin>` — so the plugin compiles against the 8.x native API, not just the 6.x one it was written for.
- `project.pbxproj` carries both Swift files as `PBXBuildFile` + `PBXFileReference` + Sources-phase members (the most fragile patch in the script).
- The built `Info.plist` has the camera usage string and the `octo-pair` URL scheme, and `UIMainStoryboardFile` is gone — the programmatic-root rewire landed.
- Android: plugin copy, Kotlin classpath + `kotlin-android`, `jvmTarget`, deps, `MainActivity` `registerPlugin` (the bodyless-template rewrite), manifest camera + deep link.

Remaining gap: nothing was launched on a device or simulator, so this is a compile-and-wiring check, not a runtime one. Gradle also warns that the Capacitor 8 template uses features incompatible with Gradle 9 — pre-existing upstream, not introduced here.

## Not in this PR

`typescript` 6.0.3 → 7.0.2 is available in both `/web` and `/mobile`, but **`svelte-check` cannot take it**: every published version, latest 4.7.4 included, declares `typescript: ^5.0.0 || ^6.0.0`. Upstream isn't ready, so both directories stay on TS 6 until it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)