### PR TITLE
chore(deps): stop reopening the unmergeable TypeScript 7 PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,18 @@ updates:
           - "@capacitor/*"
       npm-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # TypeScript 7 is blocked upstream, not declined on its merits: every
+      # published svelte-check, latest 4.7.4 included, declares
+      # `typescript: ^5.0.0 || ^6.0.0` in its peers. /web therefore cannot take
+      # 7, and /mobile stays on 6 so both npm projects share a major. Without
+      # this, every weekly run reopens the same two unmergeable PRs.
+      #
+      # Scoped to 7.x on purpose — a later major still gets a PR. Drop this
+      # entry once svelte-check ships TypeScript 7 support and bump both
+      # directories together.
+      - dependency-name: "typescript"
+        versions: ["7.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
`typescript` 6.0.3 → 7.0.2 is available in `/web` and `/mobile`, but it cannot be merged: **every published `svelte-check`, latest 4.7.4 included, declares `typescript: ^5.0.0 || ^6.0.0`** in its peer dependencies. So `/web` can't take TS 7, and `/mobile` stays on 6 to keep both npm projects on one major.

Left alone, each weekly Dependabot run reopens the same two PRs that can never land. This adds a scoped ignore.

Scoped to `7.x` rather than ignoring the `major` update type, so a later major still opens a PR. The comment in the file records the condition for removing it: once svelte-check ships TypeScript 7 support, drop the entry and bump both directories together.

Verified `.github/dependabot.yml` still parses and that the existing `capacitor` / `npm-minor-patch` groups are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)