### PR TITLE
fix(server): reject branch message_index that is not a plain user message

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -634,7 +634,7 @@ func (a *Agent) compactKeepBudget() int {
 func safeSplitIndexByBudget(msgs []Message, keepBudget int) int {
 	var userTurns []int
 	for i, m := range msgs {
-		if m.Role == RoleUser && !hasToolResult(m) {
+		if IsPlainUserMessage(m) {
 			userTurns = append(userTurns, i)
 		}
 	}
@@ -658,7 +658,7 @@ func safeSplitIndexByBudget(msgs []Message, keepBudget int) int {
 func countKeptUserTurns(msgs []Message, split int) int {
 	n := 0
 	for i := split; i < len(msgs); i++ {
-		if msgs[i].Role == RoleUser && !hasToolResult(msgs[i]) {
+		if IsPlainUserMessage(msgs[i]) {
 			n++
 		}
 	}

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -665,6 +665,15 @@ func countKeptUserTurns(msgs []Message, split int) int {
 	return n
 }
 
+// IsPlainUserMessage reports whether m is a real user turn: role user with no
+// tool_result blocks (tool results ride on synthetic user-role messages).
+// History may only be cut just before such a message — anywhere else splits an
+// assistant tool_use from the tool_result answering it. Compaction's split
+// point and the server's branch endpoint both enforce this invariant.
+func IsPlainUserMessage(m Message) bool {
+	return m.Role == RoleUser && !hasToolResult(m)
+}
+
 // hasToolResult reports whether m carries any tool_result block (i.e. it's a
 // synthetic user message returning tool output, not a real user turn).
 func hasToolResult(m Message) bool {

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -676,3 +676,21 @@ func TestSummarize_NoLiteConfiguredUsesPrimary(t *testing.T) {
 		t.Errorf("got %q after %d calls; want primary summary after 1", sum, len(primary.models))
 	}
 }
+
+func TestIsPlainUserMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  Message
+		want bool
+	}{
+		{"user text", Message{Role: RoleUser, Content: "hi"}, true},
+		{"user with text block", Message{Role: RoleUser, Blocks: []ContentBlock{{Type: "text", Text: "hi"}}}, true},
+		{"assistant", Message{Role: RoleAssistant, Content: "hello"}, false},
+		{"tool_result carrier", Message{Role: RoleUser, Blocks: []ContentBlock{{Type: "tool_result", ToolUseID: "tu-1", Result: "out"}}}, false},
+	}
+	for _, tc := range cases {
+		if got := IsPlainUserMessage(tc.msg); got != tc.want {
+			t.Errorf("%s: IsPlainUserMessage = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -889,9 +889,12 @@ func (s *Server) handleEditMessage(w http.ResponseWriter, r *http.Request) {
 	var blocks []agent.ContentBlock
 	if req.MessageIndex < len(sess.Messages) {
 		target := sess.Messages[req.MessageIndex]
-		if target.Role != agent.RoleUser {
+		// Same invariant as branching: tool results ride on user-role messages,
+		// so a bare Role check would still let an edit truncate between an
+		// assistant tool_use and its tool_result (issue #1899).
+		if !agent.IsPlainUserMessage(target) {
 			mu.Unlock()
-			writeError(w, http.StatusBadRequest, "message_index does not name a user message")
+			writeError(w, http.StatusBadRequest, "message_index does not name a plain user message")
 			return
 		}
 		// Keep the original image attachments (rehydrated by LoadSession) so

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -807,7 +807,7 @@ func (s *Server) handleBranchSession(w http.ResponseWriter, r *http.Request) {
 	// message or a tool_result message would leave the branch's last assistant
 	// tool_use with no answering result (issue #1899).
 	if !agent.IsPlainUserMessage(src.Messages[req.MessageIndex]) {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("message_index %d does not name a plain user message; branching there would orphan a tool_use", req.MessageIndex))
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("message_index %d does not name a plain user message; history can only branch at a user turn", req.MessageIndex))
 		return
 	}
 	branch := agent.BranchFrom(src, req.MessageIndex) // BranchFrom takes an exclusive count; exclude the user message so the client can send it fresh

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -803,6 +803,13 @@ func (s *Server) handleBranchSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("message_index out of range: %d (have %d messages)", req.MessageIndex, len(src.Messages)))
 		return
 	}
+	// Branching is only valid at a plain user message: cutting at an assistant
+	// message or a tool_result message would leave the branch's last assistant
+	// tool_use with no answering result (issue #1899).
+	if !agent.IsPlainUserMessage(src.Messages[req.MessageIndex]) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("message_index %d does not name a plain user message; branching there would orphan a tool_use", req.MessageIndex))
+		return
+	}
 	branch := agent.BranchFrom(src, req.MessageIndex) // BranchFrom takes an exclusive count; exclude the user message so the client can send it fresh
 
 	if err := branch.Save(); err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -273,6 +273,12 @@ func TestHandleEditMessage(t *testing.T) {
 		{Role: agent.RoleUser, Content: "one"},
 		{Role: agent.RoleAssistant, Content: "two"},
 		{Role: agent.RoleUser, Content: "three"},
+		{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{
+			{Type: "tool_use", ID: "tu-1", Name: "terminal", Input: map[string]any{"command": "ls"}},
+		}},
+		{Role: agent.RoleUser, Blocks: []agent.ContentBlock{
+			{Type: "tool_result", ToolUseID: "tu-1", Result: "file.txt"},
+		}},
 		{Role: agent.RoleAssistant, Content: "four"},
 	}
 	if err := sess.Save(); err != nil {
@@ -299,6 +305,16 @@ func TestHandleEditMessage(t *testing.T) {
 	serveLoopback(srv.mux, w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("assistant-index: status = %d, want 400", w.Code)
+	}
+
+	// 400 — index names a tool_result message (user role, but not a real user
+	// turn): truncating there would orphan the assistant tool_use before it
+	req = httptest.NewRequest(http.MethodPost, "/api/sessions/"+sess.ID+"/edit_message",
+		strings.NewReader(`{"message_index":4,"new_content":"x"}`))
+	w = httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("tool_result-index: status = %d, want 400", w.Code)
 	}
 
 	// 200 — edit the second user prompt; the rerun regenerates from it

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -145,7 +145,9 @@ func TestHandleDeleteSession(t *testing.T) {
 
 // TestHandleBranchSession verifies POST /api/sessions/{id}/branch:
 // 200 with a new session whose history is copied up to message_index, 400
-// when the index is out of range, and 404 when the source does not exist.
+// when the index is out of range or does not name a plain user message
+// (branching at an assistant or tool_result message would orphan a tool_use —
+// issue #1899), and 404 when the source does not exist.
 func TestHandleBranchSession(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -156,6 +158,12 @@ func TestHandleBranchSession(t *testing.T) {
 		{Role: agent.RoleUser, Content: "hello"},
 		{Role: agent.RoleAssistant, Content: "hi"},
 		{Role: agent.RoleUser, Content: "branch here"},
+		{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{
+			{Type: "tool_use", ID: "tu-1", Name: "terminal", Input: map[string]any{"command": "ls"}},
+		}},
+		{Role: agent.RoleUser, Blocks: []agent.ContentBlock{
+			{Type: "tool_result", ToolUseID: "tu-1", Result: "file.txt"},
+		}},
 		{Role: agent.RoleAssistant, Content: "ok"},
 	}
 	if err := sess.Save(); err != nil {
@@ -180,6 +188,25 @@ func TestHandleBranchSession(t *testing.T) {
 	serveLoopback(srv.mux, w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("out-of-range: status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+
+	// 400 — index names an assistant message
+	req = httptest.NewRequest(http.MethodPost, "/api/sessions/"+sess.ID+"/branch",
+		strings.NewReader(`{"message_index":1}`))
+	w = httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("assistant index: status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+
+	// 400 — index names a tool_result message: the branch would end on the
+	// assistant tool_use with no answering result
+	req = httptest.NewRequest(http.MethodPost, "/api/sessions/"+sess.ID+"/branch",
+		strings.NewReader(`{"message_index":4}`))
+	w = httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("tool_result index: status = %d, want 400; body=%s", w.Code, w.Body.String())
 	}
 
 	// 200 — valid branch with prompt override
@@ -225,8 +252,8 @@ func TestHandleBranchSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload source: %v", err)
 	}
-	if len(srcReloaded.Messages) != 4 {
-		t.Fatalf("source Messages len = %d, want 4 (untouched)", len(srcReloaded.Messages))
+	if len(srcReloaded.Messages) != 6 {
+		t.Fatalf("source Messages len = %d, want 6 (untouched)", len(srcReloaded.Messages))
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -165,6 +165,9 @@ func TestHandleBranchSession(t *testing.T) {
 			{Type: "tool_result", ToolUseID: "tu-1", Result: "file.txt"},
 		}},
 		{Role: agent.RoleAssistant, Content: "ok"},
+		// Steer-shaped user message: blocks-only text, no Content — the closest
+		// legitimate neighbour of the rejected shapes above; must stay branchable.
+		{Role: agent.RoleUser, Blocks: []agent.ContentBlock{{Type: "text", Text: "steer"}}},
 	}
 	if err := sess.Save(); err != nil {
 		t.Fatalf("save: %v", err)
@@ -207,6 +210,16 @@ func TestHandleBranchSession(t *testing.T) {
 	serveLoopback(srv.mux, w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("tool_result index: status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+
+	// 200 — a steer-shaped user message (blocks-only text) right after the tool
+	// exchange is a plain user turn and must remain branchable
+	req = httptest.NewRequest(http.MethodPost, "/api/sessions/"+sess.ID+"/branch",
+		strings.NewReader(`{"message_index":6}`))
+	w = httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("steer index: status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
 
 	// 200 — valid branch with prompt override
@@ -252,8 +265,8 @@ func TestHandleBranchSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload source: %v", err)
 	}
-	if len(srcReloaded.Messages) != 6 {
-		t.Fatalf("source Messages len = %d, want 6 (untouched)", len(srcReloaded.Messages))
+	if len(srcReloaded.Messages) != 7 {
+		t.Fatalf("source Messages len = %d, want 7 (untouched)", len(srcReloaded.Messages))
 	}
 }
 


### PR DESCRIPTION
Fixes #1899.

## Problem

`handleBranchSession` range-checked `message_index` but accepted any index. Branching at a `tool_result` message truncates between an assistant `tool_use` and the result answering it, so the branched session holds a write with no result. Since #1898 made the artifact whitelist depend on that pairing, such a branch also loses previews for writes that really ran (the leftover later message reads as stale).

`handleEditMessage` had the same gap in a weaker form: it checked `Role != RoleUser`, but tool results ride on user-role messages, so an edit at a `tool_result` index would truncate at the same invalid point.

## Fix

Enforce the same invariant compaction already maintains for its split point (`safeSplitIndexByBudget` only splits on a user turn with no `tool_result` blocks): history may only be cut just before a plain user message. Per the issue's fix direction, an explicit 400 was chosen over silently snapping to the nearest valid index.

- `internal/agent/compaction.go` — export the invariant as `IsPlainUserMessage` (role user, no `tool_result` blocks), next to the existing `hasToolResult` helper it wraps.
- `internal/server/handlers.go` — `handleBranchSession` rejects any index that is not a plain user message with 400; `handleEditMessage` upgrades its bare `Role` check to the same helper.

No web UI change needed: the UI only offers branch/edit from the user-message rail, so valid requests are unaffected.

## Tests

- `TestHandleBranchSession` and `TestHandleEditMessage` now build histories containing a `tool_use`/`tool_result` pair and assert 400 for assistant and `tool_result` indexes, alongside the existing out-of-range/404/200 cases.
- `TestIsPlainUserMessage` covers the helper directly.

`go test -race ./...`, `go vet`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)