### PR TITLE
fix(web): order artifacts by transcript position, not fetch completion

### DIFF
--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -375,5 +375,7 @@ describe('observeArtifact — transcript ordering', () => {
 
     expect(get(artifacts)).toHaveLength(1)
     expect(get(artifacts)[0].code).toBe('v2')
+    // The dropped stale observation must not touch the selection either.
+    expect(get(artifactSel)).toBe(0)
   })
 })

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { get } from 'svelte/store'
-import { artifacts } from './stores'
+import { artifacts, artifactSel } from './stores'
 import { observeArtifact, resetArtifacts } from './artifacts'
 
 // Nothing a preview document references can authenticate: the srcdoc iframe has
@@ -338,5 +338,42 @@ describe('observeArtifact — link rel discrimination', () => {
     await observeArtifact(SID, payload('/tmp/page.html'), false)
 
     expect(get(artifacts)[0].preview).toBe(html)
+  })
+})
+
+// The list must come out in transcript order even though each observation
+// awaits its own fetch and they resolve in arbitrary order (#1894).
+describe('observeArtifact — transcript ordering', () => {
+  it('orders by observation order, not fetch completion, and selects the transcript-newest', async () => {
+    // report.md needs a fetch we hold open; the image needs none, so it lands first.
+    let releaseMd!: (r: Response) => void
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(res => { releaseMd = res })))
+
+    const md = observeArtifact(SID, payload('/tmp/report.md'), false)
+    const png = observeArtifact(SID, payload('/tmp/late.png'), false)
+    await png
+    expect(get(artifacts).map(a => a.name)).toEqual(['late.png'])
+
+    releaseMd(new Response('# report'))
+    await md
+
+    expect(get(artifacts).map(a => a.name)).toEqual(['report.md', 'late.png'])
+    // Selection follows the transcript-newest artifact, not the last fetch to finish.
+    expect(get(artifactSel)).toBe(1)
+  })
+
+  it('keeps the newer observation when a stale fetch of the same path resolves last', async () => {
+    const resolvers: Array<(r: Response) => void> = []
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(res => { resolvers.push(res) })))
+
+    const first = observeArtifact(SID, payload('/tmp/a.md'), false)
+    const second = observeArtifact(SID, payload('/tmp/a.md'), false)
+    resolvers[1](new Response('v2'))
+    await second
+    resolvers[0](new Response('v1'))
+    await first
+
+    expect(get(artifacts)).toHaveLength(1)
+    expect(get(artifacts)[0].code).toBe('v2')
   })
 })

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -46,6 +46,12 @@ const EXT_KIND: Record<string, Kind> = {
 // Once-per-session guard so a live write auto-opens the panel only the first time.
 let autoOpened = false
 
+// Ingest counter for observeArtifact, assigned synchronously before the body
+// fetch starts. The replay loops and the live tool_result handler both call
+// observeArtifact in transcript order, so the counter captures that order even
+// though the fetches resolve in arbitrary order.
+let observeSeq = 0
+
 // How many times each image path has been observed this session, used as the
 // cache-busting revision in its src. Cleared with the artifacts themselves.
 const imageRevisions = new Map<string, number>()
@@ -329,13 +335,14 @@ export function resetArtifacts(sessionId: string): void {
   artifactSel.set(0)
   panelContent.set(null)
   autoOpened = false
+  observeSeq = 0
   imageRevisions.clear()
   artifactSelSession.set(sessionId)
 }
 
 // Ingest one tool ui_payload. `live` distinguishes a current turn (auto-opens
 // the panel once) from history replay (silent). Async: fetches the body, then
-// upserts the artifact (newest selected).
+// upserts the artifact at its transcript position (transcript-newest selected).
 export async function observeArtifact(
   sessionId: string,
   uiPayload: any,
@@ -348,6 +355,10 @@ export async function observeArtifact(
   if (!path) return
   const kind = kindOf(path)
   if (!kind) return
+
+  // Capture the transcript position now — the fetch below resolves in
+  // arbitrary order, and the upsert sorts by this instead of by arrival.
+  const seq = observeSeq++
 
   const url = artifactURL(sessionId, path)
 
@@ -482,14 +493,30 @@ export async function observeArtifact(
     preview,
     path,
     src: src || undefined,
+    seq,
   }
 
+  // Insert at the transcript position, not at the end: a slow fetch (e.g. a
+  // markdown file inlining N images) must not land after — and be selected
+  // over — artifacts that appear later in the transcript. A re-observed path
+  // carries a newer seq and moves accordingly; if a later observation of the
+  // same path already landed, this stale one is dropped.
+  let stale = false
   artifacts.update(list => {
+    const existing = list.find(a => a.path === path)
+    if (existing && existing.seq > seq) {
+      stale = true
+      return list
+    }
     const next = list.filter(a => a.path !== path)
-    next.push(entry)
+    let at = next.length
+    while (at > 0 && next[at - 1].seq > seq) at--
+    next.splice(at, 0, entry)
     return next
   })
-  artifactSel.set(get(artifacts).length - 1)
+  // The list is sorted by seq, so the last entry is the transcript-newest
+  // artifact — select it regardless of which fetch finished last.
+  if (!stale) artifactSel.set(get(artifacts).length - 1)
 
   if (live && !autoOpened) {
     autoOpened = true

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -132,6 +132,10 @@ export interface Artifact {
   // sandboxed `preview` iframe (which cannot authenticate — see lib/artifacts.ts),
   // and the download action saves these bytes.
   src?: string
+  // Ingest sequence, assigned before the body fetch starts. Callers observe
+  // artifacts in transcript order but fetches resolve in arbitrary order, so
+  // the list is kept sorted by seq rather than by arrival (see lib/artifacts.ts).
+  seq: number
 }
 
 // SkillInfo matches the Go server skill struct


### PR DESCRIPTION
Fixes #1894.

## Problem

`observeArtifact` awaits a per-artifact fetch and then appends to the `artifacts` store and selects `length - 1`, so the footer chips came out in fetch-completion order and the auto-selected artifact after a history replay was whichever fetch resolved last — not the last artifact in the transcript. #1888 widened the gap: a markdown/HTML file inlining N local images needs 1+N sequential round-trips, so it reliably lost the race to smaller artifacts written after it.

## Fix

All contained in `web/src/lib/artifacts.ts` (plus one field on the `Artifact` type):

- Assign a monotonically increasing `seq` **synchronously, before the fetch starts**. Both replay loops (`ChatView.svelte`, `mobile/chatWiring.ts`) and the live `tool_result` handlers call `observeArtifact` in transcript order, so `seq` captures transcript order without any caller changes.
- Upsert sorted by `seq` instead of appending. The list is then invariantly in transcript order, so the existing `length - 1` selection now lands on the transcript-newest artifact regardless of which fetch finished last.
- A re-observed path gets a new `seq` and moves to its new position (same as the old move-to-end behaviour); a stale observation of a path whose later observation already landed is dropped instead of displacing it.
- `resetArtifacts` resets the counter along with the rest of the per-session state.

Live turns keep the previous behaviour: artifacts append at the end and the newest is selected.

## Tests

Two new cases in `artifacts.test.ts`, including a direct reproduction of the issue scenario — `[report.md, late.png]` where the markdown fetch is held open until after the image lands — asserting both the final order and the selection. `svelte-check`: 0 errors; full web suite: 108 passed; `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)