### PR TITLE
test(web): use the jsdom-safe imageResponse stub in the link-rel tests

### DIFF
--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -275,7 +275,7 @@ describe('observeArtifact — link rel discrimination', () => {
   function stubFetch(html: string) {
     vi.stubGlobal('fetch', vi.fn(async (u: string) => {
       if (u.includes('page.html')) return new Response(html)
-      return new Response(png, { headers: { 'Content-Type': 'image/png' } })
+      return imageResponse(png)
     }))
   }
 


### PR DESCRIPTION
## Problem

main's Svelte Check job is red: `artifacts.test.ts > link rel discrimination > previews past a favicon link and still inlines the images` fails with the preview coming back un-rewritten (no `data:image/png;base64,`).

This is a two-PR race: #1926 added the link-rel tests with a raw `new Response(png)` binary fetch stub while #1925 (happy-dom → jsdom) was in flight. Each was green against the main it saw; combined, under jsdom on Node 22, undici's `Response.blob()` mints a Blob that jsdom's `FileReader` brand-checks and rejects — the inliner's catch swallows that, and the test asserts on an untouched document. (Node 26 unifies the Blob classes, which is why it doesn't reproduce locally on Node 26 — only in CI's Node 22.)

## Fix

One line: switch the stub to the `imageResponse` helper #1925 introduced for exactly this failure mode — the same conversion it already applied to every other binary stub in this file; this block just merged in parallel and was missed.

## Verification

- `npx vitest run` in `web/`: 106/106 pass locally (Node 26).
- The true red→green check is CI's Node 22 — the failing job on main reproduces it, and this PR's Svelte Check run is the verification.

Fixes the CI breakage introduced by the #1925 + #1926 combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)