### PR TITLE
fix(server): serve code-kind artifacts as text/plain so the panel can show them

### DIFF
--- a/dev-docs/web-artifacts-panel-design.md
+++ b/dev-docs/web-artifacts-panel-design.md
@@ -82,7 +82,7 @@ Agent-generated HTML is untrusted by definition (prompt injection can author it)
 ```
 
 - Mirrors the existing left `<aside id="sidebar">` pattern on the right of `<main id="main">`: a `<aside id="artifacts-panel">` that is hidden until the session has at least one artifact, then shows a header toggle with a count badge.
-- Collapsed by default; auto-opens the first time an artifact appears in a **live** turn (not on history replay — reloading an old session shouldn't pop the panel).
+- Collapsed by default; auto-opens the first time an artifact appears in a **live** turn (not on history replay — reloading an old session shouldn't pop the panel). Code kinds enter the list but never trigger the auto-open and don't consume its once-per-session flag: source-file writes are the routine bulk of a coding session, and a later HTML report or chart should still pop the panel.
 - List rows: kind icon, basename, relative time. Row actions: preview (default), open raw in new tab, download.
 - Preview fills the lower pane; HTML previews get a refresh button (re-fetch + re-render).
 - Narrow viewports (≤768px, the existing mobile breakpoint): the panel becomes an overlay like the left sidebar's mobile mode.

--- a/dev-docs/web-artifacts-panel-design.md
+++ b/dev-docs/web-artifacts-panel-design.md
@@ -1,6 +1,6 @@
 # Web Artifacts Panel
 
-A collapsible right sidebar in the web session view that collects previewable files the agent produces during a session — HTML pages, Markdown documents, and images — and renders them in place. The flagship case is a skill like `web-artifacts-builder` emitting a self-contained `bundle.html`: the user sees it rendered next to the conversation instead of hunting for a path in tool output.
+A collapsible right sidebar in the web session view that collects previewable files the agent produces during a session — HTML pages, Markdown documents, images, and plain-text/code files — and renders them in place. The flagship case is a skill like `web-artifacts-builder` emitting a self-contained `bundle.html`: the user sees it rendered next to the conversation instead of hunting for a path in tool output.
 
 ## Goals
 
@@ -12,7 +12,7 @@ A collapsible right sidebar in the web session view that collects previewable fi
 
 - Not a file browser: only files this session's agent wrote appear, nothing else on disk.
 - No artifact persistence layer of its own — the session transcript is the source of truth.
-- Code files (`.go`, `.ts`, …) don't enter the panel; diffs and editors are a different feature.
+- No diff or editor views; code files preview as read-only plain text.
 - No editing inside the preview.
 
 ## Artifact model
@@ -24,6 +24,9 @@ An artifact is identified by its absolute path. It qualifies by extension:
 | html | `.html`, `.htm` | sandboxed iframe |
 | markdown | `.md`, `.markdown` | `marked` render (same pipeline as chat messages) |
 | image | `.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.webp` | `<img>` via blob URL |
+| code | `.js`, `.ts`, `.jsx`, `.tsx`, `.mjs`, `.cjs`, `.css`, `.scss`, `.less`, `.json`, `.yaml`, `.yml`, `.toml`, `.py`, `.go`, `.rs`, `.sh`, `.bash`, `.zsh`, `.txt`, `.xml`, `.csv` | escaped monospace text in the sandboxed iframe |
+
+The code-kind extension set is defined twice — `EXT_KIND` in `web/src/lib/artifacts.ts` and `artifactTextExts` in `internal/tools/artifact.go` — and the two must stay identical: a kind the client recognizes but the endpoint refuses makes the fetch 404 and the artifact silently vanish from the panel.
 
 A write to an already-listed path updates that entry (and refreshes the preview if it is open) rather than appending a duplicate. The list orders by last-write time, newest first. Artifacts are per-session; switching sessions swaps the list.
 
@@ -50,7 +53,7 @@ GET /api/sessions/{id}/artifacts?path=<absolute path>
 
 Response headers:
 
-- `Content-Type` from the extension (`text/html`, `text/markdown`, `image/*`)
+- `Content-Type` from the extension (`text/html`, `text/markdown`, `image/*`; every code kind is pinned to `text/plain` — never its native type — so a directly-opened URL can only ever be a plain-text document)
 - `X-Content-Type-Options: nosniff`
 - `Content-Security-Policy: sandbox` — defense in depth should anyone open the URL directly in a tab; the primary isolation is the iframe sandbox below
 - Size cap 10 MB (artifact HTML bundles run 200 KB–2 MB); larger files return 413 and the panel shows a download-only entry
@@ -62,6 +65,7 @@ Agent-generated HTML is untrusted by definition (prompt injection can author it)
 - **HTML**: fetched as text, injected into `<iframe sandbox="allow-scripts" srcdoc=…>`. No `allow-same-origin` — scripts run, but in an opaque origin with no cookies, no `localStorage`, no reach back into the app. This is the same model claude.ai artifacts use.
 - **Markdown**: rendered with the existing `marked` pipeline used for assistant chat messages — the same trust class (model-authored content) with the same posture.
 - **Images**: fetched as a blob, shown via object URL; never interpreted as HTML (nosniff + explicit Content-Type).
+- **Code/text**: fetched as text, HTML-escaped, and rendered as a `<pre>` inside the same sandboxed iframe; served as `text/plain` so the bytes never gain a script, stylesheet, or XML rendering context.
 
 ## UI
 

--- a/internal/server/artifact_handler_test.go
+++ b/internal/server/artifact_handler_test.go
@@ -85,15 +85,20 @@ func TestHandleGetArtifact(t *testing.T) {
 	if err := os.WriteFile(secretPath, []byte("<h1>secret</h1>"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Written by the session but not a previewable type.
+	// Written by the session; a code kind, served as plain text (#1895).
 	goPath := filepath.Join(artDir, "main.go")
 	if err := os.WriteFile(goPath, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Written by the session but not a previewable type.
+	binPath := filepath.Join(artDir, "tool.bin")
+	if err := os.WriteFile(binPath, []byte{0x00, 0x01}, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	// UI payloads carry absolute paths, so the transcript stores absolute paths.
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-	id := newArtifactSession(t, htmlPath, goPath)
+	id := newArtifactSession(t, htmlPath, goPath, binPath)
 	otherID := newArtifactSession(t /* wrote nothing */)
 
 	// Whitelisted write → 200 with explicit headers.
@@ -122,8 +127,23 @@ func TestHandleGetArtifact(t *testing.T) {
 	if w := getArtifact(t, srv, otherID, htmlPath); w.Code != http.StatusNotFound {
 		t.Errorf("other session: status = %d, want 404", w.Code)
 	}
+	// A written code file serves as plain text — never its native type — with
+	// the same defensive headers (#1895).
+	w = getArtifact(t, srv, id, goPath)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code kind: status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Errorf("code kind Content-Type = %q, want text/plain", ct)
+	}
+	if w.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Error("code kind: missing nosniff header")
+	}
+	if !strings.Contains(w.Header().Get("Content-Security-Policy"), "sandbox") {
+		t.Error("code kind: missing CSP sandbox header")
+	}
 	// Written but not a previewable extension → 404.
-	if w := getArtifact(t, srv, id, goPath); w.Code != http.StatusNotFound {
+	if w := getArtifact(t, srv, id, binPath); w.Code != http.StatusNotFound {
 		t.Errorf("non-previewable ext: status = %d, want 404", w.Code)
 	}
 	// Unknown session → 404.

--- a/internal/tools/artifact.go
+++ b/internal/tools/artifact.go
@@ -28,6 +28,27 @@ var artifactContentTypes = map[string]string{
 	".webp":     "image/webp",
 }
 
+// artifactTextExts are the source/config/data kinds the web panel renders in
+// its monospace code view. They must stay in sync with the web client's
+// EXT_KIND table (web/src/lib/artifacts.ts) — a kind the client knows but the
+// endpoint refuses silently drops the artifact (#1895). All of them are served
+// as text/plain — never their native type — so a URL opened directly in a tab
+// can only ever be a plain-text document, not a script, stylesheet, or XML
+// rendering context.
+var artifactTextExts = []string{
+	".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs",
+	".css", ".scss", ".less",
+	".json", ".yaml", ".yml", ".toml",
+	".py", ".go", ".rs", ".sh", ".bash", ".zsh",
+	".txt", ".xml", ".csv",
+}
+
+func init() {
+	for _, ext := range artifactTextExts {
+		artifactContentTypes[ext] = "text/plain; charset=utf-8"
+	}
+}
+
 // ArtifactContentType returns the Content-Type for a previewable artifact
 // path, or ok=false when the extension isn't previewable.
 func ArtifactContentType(path string) (ctype string, ok bool) {
@@ -55,10 +76,11 @@ type ShowArtifactTool struct{}
 func (ShowArtifactTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "show_artifact",
-		Description: "Present a previewable file (HTML page, Markdown document, or image) to the " +
-			"user as an artifact. ALWAYS call this right after you produce a previewable file the " +
-			"user would want to look at — a generated HTML page or slide deck, a Markdown report, a " +
-			"chart or image — whenever it was created by some means other than write_file (a terminal " +
+		Description: "Present a previewable file (HTML page, Markdown document, image, or a " +
+			"plain-text/code file) to the user as an artifact. ALWAYS call this right after you " +
+			"produce a previewable file the user would want to look at — a generated HTML page or " +
+			"slide deck, a Markdown report, a chart or image, a script or config file — whenever " +
+			"it was created by some means other than write_file (a terminal " +
 			"heredoc/redirect like `cat > x.html`, a script, a build step, or a download). Files you " +
 			"create with write_file/edit_file are surfaced automatically and do NOT need this. In the " +
 			"web UI the file opens in the Artifacts panel (HTML renders in a sandboxed preview); in " +

--- a/internal/tools/artifact_test.go
+++ b/internal/tools/artifact_test.go
@@ -31,8 +31,8 @@ func TestShowArtifact_HappyPath(t *testing.T) {
 
 func TestShowArtifact_Errors(t *testing.T) {
 	dir := t.TempDir()
-	goFile := filepath.Join(dir, "main.go")
-	if err := os.WriteFile(goFile, []byte("package main"), 0o644); err != nil {
+	binFile := filepath.Join(dir, "tool.exe")
+	if err := os.WriteFile(binFile, []byte{0x4d, 0x5a}, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -42,7 +42,7 @@ func TestShowArtifact_Errors(t *testing.T) {
 	}{
 		{"missing path", map[string]any{}},
 		{"nonexistent file", map[string]any{"path": filepath.Join(dir, "nope.html")}},
-		{"non-previewable extension", map[string]any{"path": goFile}},
+		{"non-previewable extension", map[string]any{"path": binFile}},
 		{"directory", map[string]any{"path": dir + string(filepath.Separator) + "sub.html"}},
 	}
 	if err := os.MkdirAll(filepath.Join(dir, "sub.html"), 0o755); err != nil {
@@ -61,5 +61,12 @@ func TestArtifactContentType(t *testing.T) {
 	}
 	if _, ok := ArtifactContentType("/x/y/binary.exe"); ok {
 		t.Error("exe should not be previewable")
+	}
+	// Code/text kinds are previewable but always plain text, never their native
+	// type (#1895).
+	for _, p := range []string{"/x/script.py", "/x/main.go", "/x/app.js", "/x/data.csv", "/x/notes.TXT"} {
+		if ct, ok := ArtifactContentType(p); !ok || ct != "text/plain; charset=utf-8" {
+			t.Errorf("%s: ct=%q ok=%v, want text/plain", p, ct, ok)
+		}
 	}
 }

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -87,6 +87,27 @@ describe('observeArtifact — markdown copy button', () => {
   })
 })
 
+// Code-kind artifacts fetch their body like markdown does and preview as
+// escaped monospace text. The server serves these extensions as text/plain
+// (#1895) — before that, the fetch 404ed and the artifact silently vanished.
+describe('observeArtifact — code artifacts', () => {
+  it('previews a code file as escaped monospace text', async () => {
+    const source = 'if x < 1 && y > 2:\n    print("ok")\n'
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(source)))
+
+    await observeArtifact(SID, payload('/tmp/script.py'), false)
+
+    const [entry] = get(artifacts)
+    expect(entry.type).toBe('PY')
+    expect(entry.code).toBe(source)
+    // The source lands inside a <pre>, so its markup-significant characters
+    // must arrive escaped.
+    expect(entry.preview).toContain('<pre')
+    expect(entry.preview).toContain('x &lt; 1 &amp;&amp; y &gt; 2')
+    expect(entry.preview).not.toContain('x < 1')
+  })
+})
+
 describe('observeArtifact — preview documents', () => {
   it('builds the markdown preview without referencing /api/', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('# hello')))

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { get } from 'svelte/store'
-import { artifacts } from './stores'
+import { artifacts, panelContent } from './stores'
 import { observeArtifact, resetArtifacts } from './artifacts'
 
 // Nothing a preview document references can authenticate: the srcdoc iframe has
@@ -105,6 +105,21 @@ describe('observeArtifact — code artifacts', () => {
     expect(entry.preview).toContain('<pre')
     expect(entry.preview).toContain('x &lt; 1 &amp;&amp; y &gt; 2')
     expect(entry.preview).not.toContain('x < 1')
+  })
+
+  it('never auto-opens the panel for a live code write', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('x = 1\n')))
+
+    await observeArtifact(SID, { type: 'write', path: '/tmp/script.py' }, true)
+
+    // Source-file writes are the routine bulk of a coding session; the panel
+    // must not pop open on them.
+    expect(get(panelContent)).toBe(null)
+
+    // And the code write must not consume the once-per-session flag: a later
+    // rich-kind artifact still auto-opens.
+    await observeArtifact(SID, { type: 'write', path: '/tmp/report.md' }, true)
+    expect(get(panelContent)).toBe('session')
   })
 })
 

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -492,7 +492,12 @@ export async function observeArtifact(
   })
   artifactSel.set(get(artifacts).length - 1)
 
-  if (live && !autoOpened) {
+  // Code kinds enter the list but never auto-open the panel: source-file
+  // writes are the routine bulk of a coding session, and popping the sidebar
+  // on the first one would make every such session open with it. They also
+  // don't consume the once-per-session flag, so a later HTML report or chart
+  // still auto-opens.
+  if (live && !autoOpened && kind !== 'code') {
     autoOpened = true
     panelContent.set('session')
   }

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -120,8 +120,9 @@ function artifactURL(sessionId: string, path: string): string {
 // iframe can read.
 //
 // Two gates on what gets inlined: the reference must resolve to an image (the
-// endpoint also serves .html and .md, and an artifact must not be able to pull
-// those in), and the session itself must have written it, since the endpoint
+// endpoint also serves .html, .md, and the plain-text code kinds, and an
+// artifact must not be able to pull those in), and the session itself must have
+// written it, since the endpoint
 // serves nothing else. That covers the case that matters: a report the agent
 // wrote beside the screenshots it took. Everything else is left exactly as
 // written and simply doesn't render, same as today — which is also the fallback
@@ -162,11 +163,11 @@ async function inlineLocalRefs(
   const inline = async (raw: string): Promise<string | null> => {
     const abs = localFilePath(raw, basePath)
     if (!abs) return null
-    // Images only, enforced rather than assumed. The endpoint also serves .html
-    // and .md, so without this an artifact could name a sibling document here
-    // and have the host page — which is authenticated — fetch it and hand the
-    // bytes to a preview iframe that runs scripts and can reach the network.
-    // The artifact would be reading files it was never granted.
+    // Images only, enforced rather than assumed. The endpoint also serves .html,
+    // .md, and the plain-text code kinds, so without this an artifact could name
+    // a sibling document here and have the host page — which is authenticated —
+    // fetch it and hand the bytes to a preview iframe that runs scripts and can
+    // reach the network. The artifact would be reading files it was never granted.
     if (kindOf(abs) !== 'image') return null
     const cached = seen.get(abs)
     if (cached !== undefined) return cached


### PR DESCRIPTION
Fixes #1895.

## Problem

The web client's `EXT_KIND` table (`web/src/lib/artifacts.ts`) classifies 22 source/config/data extensions as a `code` artifact kind and has a dedicated monospace preview branch — but the artifact endpoint's extension whitelist (`tools.ArtifactContentType`) only allowed HTML, Markdown, and images. The intersection was empty: for a `code`-kind artifact the panel's fetch got a 404, `observeArtifact` bailed on `!res.ok`, and the artifact silently never appeared. The agent writes `script.py` or `config.json` and the panel looks like it ignored the write.

## Fix

Of the two resolutions the issue offers, this takes **widening the endpoint** — the client's preview branch was written deliberately and now does what it was written to do:

- `internal/tools/artifact.go`: add the client's 22 code/text extensions to the shared `artifactContentTypes` table, all pinned to `text/plain; charset=utf-8` — never their native type — so a directly-opened URL can only ever be a plain-text document, not a script, stylesheet, or XML rendering context. The existing `nosniff` + `CSP: sandbox` headers apply unchanged.
- `show_artifact` accepts the same kinds (the table is shared exactly so the tool's validation and the endpoint's gate can't drift), and its description now mentions plain-text/code files.
- `web/src/lib/artifacts.ts`: comment-only updates where the old text claimed the endpoint serves only `.html` and `.md`. The image-only gate on `inlineLocalRefs` is unchanged, so the wider endpoint surface is not reachable from artifact *content* — only from the panel's own fetch. Code kinds enter the list but never auto-open the panel (and don't consume the once-per-session flag): source-file writes are the routine bulk of a coding session, and popping the sidebar on the first one would make every such session open with it.
- `dev-docs/web-artifacts-panel-design.md`: extension table, headers, and non-goals updated to the current state.

## Why the wider read surface is acceptable now

The issue flagged that serving arbitrary text extensions from the session's write set needed a look. Since #1898 the endpoint only serves a path whose write **actually ran** (a denied `write_file` no longer authorizes a read), so the exposure stays capped at files the user already watched the agent write or explicitly present in this session.

## Tests

- `internal/server/artifact_handler_test.go`: a written `.go` file now serves 200 with `text/plain` + `nosniff` + CSP sandbox; the written-but-non-previewable case moved to a `.bin` file.
- `internal/tools/artifact_test.go`: `ArtifactContentType` pins every code kind to `text/plain`; the non-previewable `show_artifact` case moved to `.exe`.
- `web/src/lib/artifacts.test.ts`: new code-kind case — `script.py` lands in the store with type `PY` and an HTML-escaped `<pre>` preview.

`go test ./internal/tools/ ./internal/server/`, `go build ./...`, `gofmt -l`, `go vet`, and the full web vitest suite (107 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
