### PR TITLE
fix(web): lazy artifact preview build + inliner gap fixes (#1893, #1892)

### DIFF
--- a/web/src/components/ArtifactModal.svelte
+++ b/web/src/components/ArtifactModal.svelte
@@ -2,9 +2,18 @@
   import { artifacts, panelContent, artifactSel, artifactModalOpen, showToast } from '../lib/stores'
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact, imagePreviewError } from '../lib/artifact-actions'
+  import { hydrateArtifact } from '../lib/artifacts'
 
   const cur = $derived($artifacts[$artifactSel] ?? $artifacts[0])
   let modalEl = $state<HTMLDivElement | null>(null)
+
+  // Entries observe metadata-only; the body is fetched and the preview built
+  // on first selection (see hydrateArtifact). Usually a no-op — the sidebar
+  // hydrates before the maximize button is reachable — but the modal must not
+  // depend on having passed through the sidebar.
+  $effect(() => {
+    if ($artifactModalOpen && cur && !cur.loaded) hydrateArtifact(cur)
+  })
 
   // A failed image load would otherwise show only the browser's broken-image
   // glyph; surface the server's reason instead (e.g. the 10 MB preview cap).
@@ -65,8 +74,8 @@
         <span class="file-name">{cur.name}</span>
         <span class="file-meta">{cur.type}</span>
       </div>
-      <button class="icon-btn" title={$t('artifacts.copy')} onclick={onCopy}><iconify-icon icon="ant-design:copy-outlined" width="14"></iconify-icon></button>
-      <button class="icon-btn" title={$t('artifacts.download')} onclick={onDownload}><iconify-icon icon="ant-design:download-outlined" width="14"></iconify-icon></button>
+      <button class="icon-btn" title={$t('artifacts.copy')} disabled={!cur.loaded} onclick={onCopy}><iconify-icon icon="ant-design:copy-outlined" width="14"></iconify-icon></button>
+      <button class="icon-btn" title={$t('artifacts.download')} disabled={!cur.loaded} onclick={onDownload}><iconify-icon icon="ant-design:download-outlined" width="14"></iconify-icon></button>
       <button class="icon-btn" title={$t('artifacts.restore')} onclick={restoreSidebar}>
         <iconify-icon icon="ant-design:compress-outlined" width="14"></iconify-icon>
       </button>
@@ -88,6 +97,8 @@
           {/if}
           <img src={cur.src} alt={cur.name} class:img-hidden={imgFailed} onerror={onImgError} onload={onImgLoad} />
         </div>
+      {:else if !cur.loaded}
+        <div class="body-loading"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon></div>
       {:else}
         <iframe srcdoc={cur.preview} sandbox="allow-scripts" allow="clipboard-write" title={cur.name}></iframe>
       {/if}
@@ -136,8 +147,10 @@
   border-radius: 6px; display: flex; align-items: center; justify-content: center;
   cursor: pointer; color: var(--text-tertiary);
 }
-.icon-btn:hover { background: var(--hover-neutral); color: var(--blue-6); }
+.icon-btn:hover:not(:disabled) { background: var(--hover-neutral); color: var(--blue-6); }
+.icon-btn:disabled { opacity: 0.45; cursor: default; }
 .body { flex: 1; min-height: 0; background: var(--bg-container); }
+.body-loading { height: 100%; display: flex; align-items: center; justify-content: center; color: var(--text-tertiary); }
 iframe { border: 0; width: 100%; height: 100%; display: block; }
 .img-wrap {
   width: 100%; height: 100%; box-sizing: border-box; padding: 12px;

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -2,12 +2,21 @@
   import { artifacts, panelContent, artifactSel, artifactView, artifactModalOpen, lightappSel, lightapps, lightappHTML, showToast } from '../lib/stores'
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact, imagePreviewError } from '../lib/artifact-actions'
+  import { hydrateArtifact } from '../lib/artifacts'
   import * as api from '../lib/api'
 
   // ── Session artifacts (existing) ──────────────────────────────────────────
   const cur = $derived($artifacts[$artifactSel] ?? $artifacts[0])
   // Images render outside the sandboxed iframe and have no source view.
   const curIsImage = $derived(!!cur?.src)
+
+  // Entries observe metadata-only; the body is fetched and the preview built
+  // on first selection. Re-runs when a live re-write swaps the entry object,
+  // so the rebuilt document replaces the stale one. hydrateArtifact itself
+  // no-ops on loaded entries and in-flight builds.
+  $effect(() => {
+    if ($panelContent === 'session' && cur && !cur.loaded) hydrateArtifact(cur)
+  })
 
   // A failed image load would otherwise show only the browser's broken-image
   // glyph; surface the server's reason instead (e.g. the 10 MB preview cap).
@@ -174,10 +183,10 @@
           <span class="file-name">{cur.name}</span>
           <span class="file-meta">{cur.type}</span>
         </div>
-        <button class="icon-btn" title={$t('artifacts.copy')} onclick={onCopy}><iconify-icon icon="ant-design:copy-outlined" width="14"></iconify-icon></button>
-        <button class="icon-btn" title={$t('artifacts.download')} onclick={onDownload}><iconify-icon icon="ant-design:download-outlined" width="14"></iconify-icon></button>
+        <button class="icon-btn" title={$t('artifacts.copy')} disabled={!cur.loaded} onclick={onCopy}><iconify-icon icon="ant-design:copy-outlined" width="14"></iconify-icon></button>
+        <button class="icon-btn" title={$t('artifacts.download')} disabled={!cur.loaded} onclick={onDownload}><iconify-icon icon="ant-design:download-outlined" width="14"></iconify-icon></button>
         {#if curIsHTML}
-          <button class="icon-btn" title={$t('artifacts.save_to_lightapp')} onclick={openSaveToLA}>
+          <button class="icon-btn" title={$t('artifacts.save_to_lightapp')} disabled={!cur.loaded} onclick={openSaveToLA}>
             <iconify-icon icon="ant-design:save-outlined" width="14"></iconify-icon>
           </button>
         {/if}
@@ -226,6 +235,8 @@
             {/if}
             <img src={cur.src} alt={cur.name} class:img-hidden={imgFailed} onerror={onImgError} onload={onImgLoad} />
           </div>
+        {:else if !cur.loaded}
+          <div class="body-loading"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon></div>
         {:else if $artifactView === 'preview'}
           <iframe srcdoc={cur.preview} sandbox="allow-scripts" allow="clipboard-write" title={cur.name}></iframe>
         {:else}
@@ -263,7 +274,8 @@
   border-radius: 6px; display: flex; align-items: center; justify-content: center;
   cursor: pointer; color: var(--text-tertiary);
 }
-.icon-btn:hover { background: var(--hover-neutral); color: var(--blue-6); }
+.icon-btn:hover:not(:disabled) { background: var(--hover-neutral); color: var(--blue-6); }
+.icon-btn:disabled { opacity: 0.45; cursor: default; }
 .toolbar {
   flex: 0 0 auto; padding: 8px 12px; border-bottom: 1px solid var(--border-table);
   display: flex; align-items: center; gap: 8px;
@@ -276,6 +288,7 @@
 .seg-btn.active { background: var(--bg-container); color: var(--blue-6); }
 .sandboxed-label { margin-left: auto; font-size: 11px; color: var(--text-tertiary); }
 .body { flex: 1; min-height: 0; background: var(--bg-container); }
+.body-loading { height: 100%; display: flex; align-items: center; justify-content: center; color: var(--text-tertiary); }
 .empty {
   flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 12px; padding: 32px; text-align: center; color: var(--text-tertiary); font-size: 13px;

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { get } from 'svelte/store'
 import { artifacts } from './stores'
-import { observeArtifact, resetArtifacts } from './artifacts'
+import { observeArtifact, hydrateArtifact, resetArtifacts } from './artifacts'
 
 // Nothing a preview document references can authenticate: the srcdoc iframe has
 // no allow-same-origin, so its subresource requests are cross-site and the
@@ -13,6 +13,14 @@ const SID = 'sess-1'
 
 function payload(path: string) {
   return { type: 'write', path }
+}
+
+// Observing is metadata-only since #1893 — the body fetch and preview build run
+// on first selection. Most cases below assert on the preview document, so this
+// drives that second step the way the panel's $effect does.
+async function observeHydrated(path: string) {
+  observeArtifact(SID, payload(path), false)
+  await hydrateArtifact(get(artifacts).at(-1))
 }
 
 // Image bytes must come back as the test environment's own Blob. Node's fetch
@@ -34,11 +42,11 @@ afterEach(() => {
 })
 
 describe('observeArtifact — image artifacts', () => {
-  it('carries a src for the host document and never fetches the bytes', async () => {
+  it('carries a src for the host document and never fetches the bytes', () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
-    await observeArtifact(SID, payload('/tmp/shot.png'), false)
+    observeArtifact(SID, payload('/tmp/shot.png'), false)
 
     const [entry] = get(artifacts)
     expect(entry.type).toBe('Image')
@@ -47,18 +55,20 @@ describe('observeArtifact — image artifacts', () => {
     )
     // The <img> pulls the bytes lazily; observing must not download them.
     expect(fetchMock).not.toHaveBeenCalled()
-    // No sandboxed preview document at all, so nothing to 401.
+    // No sandboxed preview document at all, so nothing to 401 — and nothing
+    // for hydrateArtifact to build either.
     expect(entry.preview).toBe('')
+    expect(entry.loaded).toBe(true)
     // `code` is the on-disk path — the one text form worth copying.
     expect(entry.code).toBe('/tmp/shot.png')
   })
 
-  it('changes the src when the same path is written again', async () => {
+  it('changes the src when the same path is written again', () => {
     vi.stubGlobal('fetch', vi.fn())
 
-    await observeArtifact(SID, payload('/tmp/shot.png'), false)
+    observeArtifact(SID, payload('/tmp/shot.png'), false)
     const first = get(artifacts)[0].src
-    await observeArtifact(SID, payload('/tmp/shot.png'), true)
+    observeArtifact(SID, payload('/tmp/shot.png'), true)
     const second = get(artifacts)[0].src
 
     // An identical src would let Svelte skip the update and leave the old bytes
@@ -69,11 +79,90 @@ describe('observeArtifact — image artifacts', () => {
 
 })
 
+// Entries land in the store metadata-only and the body is built on first
+// selection, so history replay costs no network and a session's unopened
+// artifacts hold no data: URIs (#1893).
+describe('hydrateArtifact — lazy body build', () => {
+  it('observing a text artifact fetches nothing', () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    observeArtifact(SID, payload('/tmp/report.md'), false)
+
+    const [entry] = get(artifacts)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(entry.loaded).toBe(false)
+    expect(entry.preview).toBe('')
+    expect(entry.code).toBe('')
+  })
+
+  it('builds the body once on first selection', async () => {
+    const fetchMock = vi.fn(async () => new Response('# hello'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    observeArtifact(SID, payload('/tmp/report.md'), false)
+    await hydrateArtifact(get(artifacts)[0])
+    // Re-selecting a loaded entry must not refetch.
+    await hydrateArtifact(get(artifacts)[0])
+
+    const [entry] = get(artifacts)
+    expect(entry.loaded).toBe(true)
+    expect(entry.code).toBe('# hello')
+    expect(entry.preview).toContain('hello')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a stale build when a re-write replaced the entry', async () => {
+    let release!: (r: Response) => void
+    const gate = new Promise<Response>(r => { release = r })
+    vi.stubGlobal('fetch', vi.fn(() => gate))
+
+    observeArtifact(SID, payload('/tmp/report.md'), false)
+    const stale = hydrateArtifact(get(artifacts)[0])
+    // The agent re-wrote the file while the old body was still being fetched.
+    observeArtifact(SID, payload('/tmp/report.md'), false)
+    release(new Response('# v1'))
+    await stale
+
+    // The build began against the replaced entry; the fresh one must not
+    // inherit those bytes — it hydrates itself when next selected.
+    expect(get(artifacts)).toHaveLength(1)
+    expect(get(artifacts)[0].loaded).toBe(false)
+  })
+
+  it('discards a build that resolves after a session switch', async () => {
+    let release!: (r: Response) => void
+    const gate = new Promise<Response>(r => { release = r })
+    vi.stubGlobal('fetch', vi.fn(() => gate))
+
+    observeArtifact(SID, payload('/tmp/report.md'), false)
+    const inflight = hydrateArtifact(get(artifacts)[0])
+    resetArtifacts('sess-2')
+    release(new Response('# hello'))
+    await inflight
+
+    expect(get(artifacts)).toHaveLength(0)
+  })
+
+  it('shows a placeholder instead of loading forever when the fetch fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })))
+
+    observeArtifact(SID, payload('/tmp/report.md'), false)
+    await hydrateArtifact(get(artifacts)[0])
+
+    const [entry] = get(artifacts)
+    // loaded, or the panel would spin forever; a re-write replaces the entry
+    // and retries.
+    expect(entry.loaded).toBe(true)
+    expect(entry.preview).toContain('could not be loaded')
+  })
+})
+
 describe('observeArtifact — markdown copy button', () => {
   it('binds the handler to an element the preview document actually has', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('```js\nlet a = 1\n```\n')))
 
-    await observeArtifact(SID, payload('/tmp/notes.md'), false)
+    await observeHydrated('/tmp/notes.md')
 
     const { preview } = get(artifacts)[0]
     // '.body' matched nothing here, so querySelector returned null and the whole
@@ -91,7 +180,7 @@ describe('observeArtifact — preview documents', () => {
   it('builds the markdown preview without referencing /api/', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('# hello')))
 
-    await observeArtifact(SID, payload('/tmp/notes.md'), false)
+    await observeHydrated('/tmp/notes.md')
 
     const [entry] = get(artifacts)
     expect(entry.preview).not.toBe('')
@@ -117,7 +206,7 @@ describe('observeArtifact — markdown image references', () => {
   it('inlines a relative reference, resolved against the markdown file', async () => {
     const fetchMock = stubFetch('![shot](img/shot.png)\n')
 
-    await observeArtifact(SID, payload('/tmp/report.md'), false)
+    await observeHydrated('/tmp/report.md')
 
     const [entry] = get(artifacts)
     expect(entry.preview).toContain('src="data:image/png;base64,')
@@ -131,7 +220,7 @@ describe('observeArtifact — markdown image references', () => {
   it('resolves "." and ".." segments', async () => {
     const fetchMock = stubFetch('![shot](../shots/./a.png)\n')
 
-    await observeArtifact(SID, payload('/tmp/docs/report.md'), false)
+    await observeHydrated('/tmp/docs/report.md')
 
     expect(fetchMock).toHaveBeenCalledWith(
       `/api/sessions/${SID}/artifacts?path=${encodeURIComponent('/tmp/shots/a.png')}`,
@@ -143,7 +232,7 @@ describe('observeArtifact — markdown image references', () => {
     // naming a sibling document and having the host page fetch it.
     const fetchMock = stubFetch('![oops](secrets.md)\n')
 
-    await observeArtifact(SID, payload('/tmp/report.md'), false)
+    await observeHydrated('/tmp/report.md')
 
     const [entry] = get(artifacts)
     expect(entry.preview).toContain('secrets.md')
@@ -154,7 +243,7 @@ describe('observeArtifact — markdown image references', () => {
   it('leaves remote and data references untouched', async () => {
     const fetchMock = stubFetch('![a](https://example.com/a.png)\n\n![b](data:image/gif;base64,R0lGOD)\n')
 
-    await observeArtifact(SID, payload('/tmp/report.md'), false)
+    await observeHydrated('/tmp/report.md')
 
     const [entry] = get(artifacts)
     expect(entry.preview).toContain('https://example.com/a.png')
@@ -165,7 +254,7 @@ describe('observeArtifact — markdown image references', () => {
   it('keeps the artifact when an image is not fetchable', async () => {
     stubFetch('![gone](missing.png)\n', 404)
 
-    await observeArtifact(SID, payload('/tmp/report.md'), false)
+    await observeHydrated('/tmp/report.md')
 
     const [entry] = get(artifacts)
     // The reference stays as written: a broken image beats losing the preview.
@@ -196,7 +285,7 @@ describe('observeArtifact — html local references', () => {
         '<body><img src="chart.png"></body></html>',
     )
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     const [entry] = get(artifacts)
     expect(entry.preview).toMatch(/^<!DOCTYPE html>/i)
@@ -211,7 +300,7 @@ describe('observeArtifact — html local references', () => {
         '<img src="chart.png"></picture></body></html>',
     )
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     const [entry] = get(artifacts)
     expect(entry.preview).toContain('data:image/png;base64,')
@@ -224,7 +313,7 @@ describe('observeArtifact — html local references', () => {
   it('rewrites an SVG <image href>', async () => {
     stubFetch('<html><body><svg><image href="d.png" width="10" height="10"></image></svg></body></html>')
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     const [entry] = get(artifacts)
     expect(entry.preview).toContain('data:image/png;base64,')
@@ -237,7 +326,7 @@ describe('observeArtifact — html local references', () => {
         '<html><body><img src="chart.png"></body></html>',
     )
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     // A name-only `<!DOCTYPE html>` would switch this file to standards mode and
     // the preview would lay out differently from the real thing.
@@ -248,7 +337,7 @@ describe('observeArtifact — html local references', () => {
     const html = '<!DOCTYPE html><html><body><h1>hi</h1></body></html>'
     stubFetch(html)
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     // No parse/serialize round-trip on a document with no local references.
     expect(get(artifacts)[0].preview).toBe(html)
@@ -257,7 +346,7 @@ describe('observeArtifact — html local references', () => {
   it('leaves the warning page alone when a script is unreachable', async () => {
     stubFetch('<html><head><script src="app.js"></script></head><body><img src="chart.png"></body></html>')
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     const [entry] = get(artifacts)
     expect(entry.preview).toContain('cannot be previewed here')
@@ -285,7 +374,7 @@ describe('observeArtifact — link rel discrimination', () => {
         '<body><img src="chart.png"></body></html>',
     )
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     const [entry] = get(artifacts)
     expect(entry.preview).not.toContain('cannot be previewed here')
@@ -301,7 +390,7 @@ describe('observeArtifact — link rel discrimination', () => {
       '<body><h1>hi</h1></body></html>'
     stubFetch(html)
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     expect(get(artifacts)[0].preview).toBe(html)
   })
@@ -309,7 +398,7 @@ describe('observeArtifact — link rel discrimination', () => {
   it('still warns for an external stylesheet', async () => {
     stubFetch('<html><head><link rel="stylesheet" href="https://cdn.example.com/x.css"></head><body></body></html>')
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     expect(get(artifacts)[0].preview).toContain('cannot be previewed here')
   })
@@ -317,7 +406,7 @@ describe('observeArtifact — link rel discrimination', () => {
   it('still warns when the rel attribute is unquoted or trails the href', async () => {
     stubFetch('<html><head><link href="style.css" rel=stylesheet></head><body></body></html>')
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     expect(get(artifacts)[0].preview).toContain('cannot be previewed here')
   })
@@ -326,7 +415,7 @@ describe('observeArtifact — link rel discrimination', () => {
     // The rel="preload" onload="this.rel='stylesheet'" idiom makes it one.
     stubFetch('<html><head><link rel="preload" as="style" href="x.css"></head><body></body></html>')
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     expect(get(artifacts)[0].preview).toContain('cannot be previewed here')
   })
@@ -335,7 +424,7 @@ describe('observeArtifact — link rel discrimination', () => {
     const html = '<html><head><link rel="stylesheet" href="data:text/css,body{margin:0}"></head><body></body></html>'
     stubFetch(html)
 
-    await observeArtifact(SID, payload('/tmp/page.html'), false)
+    await observeHydrated('/tmp/page.html')
 
     expect(get(artifacts)[0].preview).toBe(html)
   })

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -429,3 +429,104 @@ describe('observeArtifact — link rel discrimination', () => {
     expect(get(artifacts)[0].preview).toBe(html)
   })
 })
+
+// The #1888 review collected reference kinds the inliner skipped; these pin
+// the client-side-fixable ones (#1892). What stays out: file kinds the
+// artifact endpoint deliberately doesn't serve (video, audio, fonts).
+describe('observeArtifact — inliner gaps (#1892)', () => {
+  const png = new Uint8Array([137, 80, 78, 71])
+
+  function stubFetch(html: string) {
+    const fetchMock = vi.fn(async (u: string) => {
+      if (u.includes('page.html')) return new Response(html)
+      return imageResponse(png)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  it('inlines a srcset-only <img> via its first candidate', async () => {
+    const fetchMock = stubFetch('<html><body><img srcset="chart.png 1x, chart@2x.png 2x"></body></html>')
+
+    await observeHydrated('/tmp/page.html')
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toContain('src="data:image/png;base64,')
+    expect(entry.preview).not.toContain('srcset')
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/sessions/${SID}/artifacts?path=${encodeURIComponent('/tmp/chart.png')}`,
+    )
+  })
+
+  it('does not second-guess a remote src just because the srcset is local', async () => {
+    const html = '<html><body><img src="https://example.com/c.png" srcset="chart.png 1x"></body></html>'
+    const fetchMock = stubFetch(html)
+
+    await observeHydrated('/tmp/page.html')
+
+    // The remote src is a load the iframe performs fine; replacing it with a
+    // sibling file's bytes would show the wrong image.
+    expect(get(artifacts)[0].preview).toBe(html)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves references against a local <base href>', async () => {
+    const fetchMock = stubFetch(
+      '<html><head><base href="assets/"></head><body><img src="chart.png"></body></html>',
+    )
+
+    await observeHydrated('/tmp/page.html')
+
+    expect(get(artifacts)[0].preview).toContain('data:image/png;base64,')
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/sessions/${SID}/artifacts?path=${encodeURIComponent('/tmp/assets/chart.png')}`,
+    )
+  })
+
+  it('inlines nothing under a remote <base href>', async () => {
+    const html = '<html><head><base href="https://cdn.example.com/"></head><body><img src="chart.png"></body></html>'
+    const fetchMock = stubFetch(html)
+
+    await observeHydrated('/tmp/page.html')
+
+    // chart.png resolves against the remote base — again a load the iframe
+    // performs itself — so the document rides through untouched.
+    expect(get(artifacts)[0].preview).toBe(html)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a comment above <html>', async () => {
+    stubFetch('<!-- built 2026-07-30 --><!DOCTYPE html><html><body><img src="chart.png"></body></html>')
+
+    await observeHydrated('/tmp/page.html')
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toContain('<!-- built 2026-07-30 -->')
+    expect(entry.preview).toContain('<!DOCTYPE html>')
+    expect(entry.preview).toContain('data:image/png;base64,')
+  })
+
+  it('inlines a quoted CSS url() whose file name contains a parenthesis', async () => {
+    const fetchMock = stubFetch(
+      '<html><head><style>body{background:url("bg (1).png")}</style></head><body></body></html>',
+    )
+
+    await observeHydrated('/tmp/page.html')
+
+    expect(get(artifacts)[0].preview).toContain('data:image/png;base64,')
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/sessions/${SID}/artifacts?path=${encodeURIComponent('/tmp/bg (1).png')}`,
+    )
+  })
+
+  it('leaves a quoted data: url() with parentheses alone', async () => {
+    const html =
+      `<html><head><style>body{background:url("data:image/svg+xml,<svg fill='rgb(1,2,3)'/>")}</style></head><body></body></html>`
+    const fetchMock = stubFetch(html)
+
+    await observeHydrated('/tmp/page.html')
+
+    expect(get(artifacts)[0].preview).toBe(html)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -2,10 +2,13 @@
 //
 // Previewable files the agent writes ride the existing ui_payload stream: the
 // write / edit / show_artifact tools each emit { type, path }. observeArtifact()
-// picks those up (from both the live tool_result path and history replay),
-// fetches the file body from the whitelisted GET /api/sessions/{id}/artifacts
-// endpoint, and pushes a previewable entry into the `artifacts` store that
-// ArtifactsPanel renders. Mirrors the old hand-written Artifacts.observe().
+// picks those up (from both the live tool_result path and history replay) and
+// pushes a metadata-only entry into the `artifacts` store that ArtifactsPanel
+// renders. The body — fetched from the whitelisted GET
+// /api/sessions/{id}/artifacts endpoint, and for markdown/HTML the preview
+// document built from it — is produced lazily on first selection
+// (hydrateArtifact), so history replay costs no network and a session's
+// unopened artifacts hold no data: URIs.
 //
 // Constraint on every preview document built here: it must not reference
 // /api/* — nothing inside the sandboxed srcdoc iframe can authenticate. The
@@ -334,13 +337,15 @@ export function resetArtifacts(sessionId: string): void {
 }
 
 // Ingest one tool ui_payload. `live` distinguishes a current turn (auto-opens
-// the panel once) from history replay (silent). Async: fetches the body, then
-// upserts the artifact (newest selected).
-export async function observeArtifact(
+// the panel once) from history replay (silent). Observing is metadata-only:
+// text kinds land with an empty body and `loaded: false`, and the fetch +
+// preview build run on first selection instead (hydrateArtifact). History
+// replay over any number of artifacts therefore transfers nothing.
+export function observeArtifact(
   sessionId: string,
   uiPayload: any,
   live: boolean,
-): Promise<void> {
+): void {
   if (!sessionId || !uiPayload) return
   const t = uiPayload.type
   if (t !== 'write' && t !== 'edit' && t !== 'artifact') return
@@ -349,89 +354,167 @@ export async function observeArtifact(
   const kind = kindOf(path)
   if (!kind) return
 
-  const url = artifactURL(sessionId, path)
-
   let code = ''
-  let preview = ''
   let src = ''
+  let loaded = false
+  if (kind === 'image') {
+    // Images render as a plain <img> in the host document — see the
+    // file-header note on why an <img src="/api/…"> inside the sandboxed
+    // iframe 401s. The host document's own request is same-site and
+    // authenticates normally, and observing costs no network at all: the URL
+    // only becomes a request once the panel renders this artifact, and it
+    // renders one at a time. There is no preview document to build either, so
+    // an image observes as already loaded.
+    //
+    // The revision counter matters: re-observing a path (the agent overwrote
+    // the file) otherwise yields a byte-identical src, so Svelte skips the
+    // attribute update and the panel keeps showing the previous bytes — the
+    // endpoint sends no validators, so nothing prompts a revalidation either.
+    // Counting observations rather than stamping a clock keeps the URL stable
+    // across a straight replay of the same transcript, so a reopened session
+    // can still reuse whatever the browser happens to have cached.
+    //
+    // Dropping the iframe costs no isolation here. The endpoint pins
+    // Content-Type and sends X-Content-Type-Options: nosniff, and an SVG
+    // loaded through <img> runs no script and fetches no external resource.
+    const rev = (imageRevisions.get(path) ?? 0) + 1
+    imageRevisions.set(path, rev)
+    src = `${artifactURL(sessionId, path)}&rev=${rev}`
+    // A binary artifact has no source view, so `code` carries the on-disk
+    // path instead: it is the one text form worth copying. Download saves
+    // the bytes from `src`.
+    code = path
+    loaded = true
+  }
+
+  const name = basename(path)
+  const entry: Artifact = {
+    name,
+    type: typeLabel(kind, path),
+    ver: '',
+    short: name.length > 22 ? name.slice(0, 21) + '…' : name,
+    icon: iconFor(kind),
+    code,
+    preview: '',
+    path,
+    src: src || undefined,
+    loaded,
+  }
+
+  artifacts.update(list => {
+    const next = list.filter(a => a.path !== path)
+    next.push(entry)
+    return next
+  })
+  artifactSel.set(get(artifacts).length - 1)
+
+  if (live && !autoOpened) {
+    autoOpened = true
+    panelContent.set('session')
+  }
+}
+
+// In-flight builds, keyed by entry identity: a live re-write replaces the
+// entry object in the store, so a stale build can never land on the fresh
+// entry, and the fresh entry is free to start its own.
+const hydrating = new WeakSet<Artifact>()
+
+// Shown instead of a spinner-forever when the body can't be fetched any more
+// (the file was deleted, say). Grey on the panel's own background reads fine
+// on either theme; a re-write of the path replaces the entry and retries.
+const LOAD_FAILED_PREVIEW =
+  '<body style="margin:0;padding:16px;font:13px/1.5 system-ui,sans-serif;color:#8b949e">' +
+  '⚠️ This file could not be loaded for preview. It may have been deleted or moved.</body>'
+
+// Builds an artifact's body on first selection rather than at observe time:
+// the fetch — and for markdown/HTML the image inlining behind it, whose data:
+// URIs stay resident for as long as the entry does — is paid only for what
+// the user actually opens (#1893). Safe to call on every render; it no-ops
+// once the entry is loaded and while a build is in flight.
+export async function hydrateArtifact(a: Artifact | null | undefined): Promise<void> {
+  if (!a || a.loaded || hydrating.has(a)) return
+  const sessionId = get(artifactSelSession)
+  const kind = kindOf(a.path)
+  if (!sessionId || !kind || kind === 'image') return
+  hydrating.add(a)
+  let body: { code: string; preview: string } | null = null
   try {
-    const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
-    if (kind === 'image') {
-      // Images render as a plain <img> in the host document — see the
-      // file-header note on why an <img src="/api/…"> inside the sandboxed
-      // iframe 401s. The host document's own request is same-site and
-      // authenticates normally, and observing costs no network at all: the URL
-      // only becomes a request once the panel renders this artifact, and it
-      // renders one at a time. History replay over a session full of multi-MB
-      // screenshots therefore transfers none of them.
-      //
-      // The revision counter matters: re-observing a path (the agent overwrote
-      // the file) otherwise yields a byte-identical src, so Svelte skips the
-      // attribute update and the panel keeps showing the previous bytes — the
-      // endpoint sends no validators, so nothing prompts a revalidation either.
-      // Counting observations rather than stamping a clock keeps the URL stable
-      // across a straight replay of the same transcript, so a reopened session
-      // can still reuse whatever the browser happens to have cached.
-      //
-      // Dropping the iframe costs no isolation here. The endpoint pins
-      // Content-Type and sends X-Content-Type-Options: nosniff, and an SVG
-      // loaded through <img> runs no script and fetches no external resource.
-      const rev = (imageRevisions.get(path) ?? 0) + 1
-      imageRevisions.set(path, rev)
-      src = `${url}&rev=${rev}`
-      // A binary artifact has no source view, so `code` carries the on-disk
-      // path instead: it is the one text form worth copying. Download saves
-      // the bytes from `src`.
-      code = path
-    } else {
-      const res = await fetch(url)
-      if (!res.ok) return
-      code = await res.text()
-      if (kind === 'html') {
-        if (hasExternalRefs(code)) {
-          // External scripts/stylesheets can't load inside a sandboxed srcdoc
-          // iframe without same-origin access. Show a warning + the raw source.
-          const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-          const warnBodyBg = isDark ? '#0d1117' : '#fafafa'
-          const warnBodyColor = isDark ? '#8b949e' : '#555'
-          const warnCardBg = isDark ? '#2b2111' : '#fff8e1'
-          const warnCardBorder = isDark ? '#594214' : '#f0c040'
-          const warnCardColor = isDark ? '#e8b339' : '#7a5c00'
-          const warnPreBg = isDark ? '#161b22' : '#f5f5f5'
-          const warnPreColor = isDark ? '#c9d1d9' : '#333'
-          preview = `<body style="margin:0;padding:16px;font:13px/1.5 system-ui,sans-serif;color:${warnBodyColor};background:${warnBodyBg}">
+    body = await buildTextBody(sessionId, a.path, kind)
+  } catch {
+    body = null
+  } finally {
+    hydrating.delete(a)
+  }
+  // The active session may have changed while the fetch was in flight — the
+  // guard that used to live in observeArtifact moves here with the fetch. The
+  // identity match below likewise drops the result when a re-write replaced
+  // the entry meanwhile: the replacement hydrates itself with the new bytes.
+  if (get(artifactSelSession) !== sessionId) return
+  const next: Artifact = {
+    ...a,
+    ...(body ?? { code: '', preview: LOAD_FAILED_PREVIEW }),
+    loaded: true,
+  }
+  artifacts.update(list => list.map(e => (e === a ? next : e)))
+}
+
+// The fetch + preview build for a text-kind artifact, extracted verbatim from
+// the old eager observeArtifact. null means the body wasn't fetchable.
+async function buildTextBody(
+  sessionId: string,
+  path: string,
+  kind: Kind,
+): Promise<{ code: string; preview: string } | null> {
+  const res = await fetch(artifactURL(sessionId, path))
+  if (!res.ok) return null
+  const code = await res.text()
+  const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
+  let preview = ''
+  if (kind === 'html') {
+    if (hasExternalRefs(code)) {
+      // External scripts/stylesheets can't load inside a sandboxed srcdoc
+      // iframe without same-origin access. Show a warning + the raw source.
+      const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      const warnBodyBg = isDark ? '#0d1117' : '#fafafa'
+      const warnBodyColor = isDark ? '#8b949e' : '#555'
+      const warnCardBg = isDark ? '#2b2111' : '#fff8e1'
+      const warnCardBorder = isDark ? '#594214' : '#f0c040'
+      const warnCardColor = isDark ? '#e8b339' : '#7a5c00'
+      const warnPreBg = isDark ? '#161b22' : '#f5f5f5'
+      const warnPreColor = isDark ? '#c9d1d9' : '#333'
+      preview = `<body style="margin:0;padding:16px;font:13px/1.5 system-ui,sans-serif;color:${warnBodyColor};background:${warnBodyBg}">
 <div style="padding:10px 14px;background:${warnCardBg};border:1px solid ${warnCardBorder};border-radius:6px;margin-bottom:14px;font-size:13px;color:${warnCardColor}">
 ⚠️ This file references external resources and cannot be previewed here. Use <b>Open in new tab</b> or switch to <b>Code</b> view.
 </div>
 <pre style="margin:0;padding:12px;background:${warnPreBg};border-radius:6px;overflow:auto;font:12px/1.6 'SFMono-Regular',Menlo,monospace;color:${warnPreColor};white-space:pre-wrap">${escaped}</pre>
 </body>`
-        } else {
-          // No unreachable scripts or stylesheets, but the file's own images
-          // still need inlining to survive the iframe.
-          preview = await inlineLocalRefs(code, sessionId, path, 'document')
-        }
-      } else if (kind === 'markdown') {
-        // Markdown is rendered inside a sandboxed srcdoc iframe which has no
-        // access to the host app's CSS or JS.  Inline the highlight.js theme
-        // CSS, code-block layout, and a copy-button handler so syntax
-        // highlighting and the "Copy" button actually work in preview mode.
-        const MD_STYLES = isDark ? darkMDStyles() : lightMDStyles()
-        const bodyStyle = isDark
-          ? 'margin:0;padding:16px;font:14px/1.6 system-ui,-apple-system,sans-serif;color:#d4d4d4;background:#1e1e1e'
-          : 'margin:0;padding:16px;font:14px/1.6 system-ui,-apple-system,sans-serif;color:rgba(0,0,0,0.88);background:#ffffff'
-        // Bound to document.body, not '.body': this is a hand-inlined copy of
-        // setupCopyButtons(), whose caller passes the host app's container, and
-        // that selector matched nothing here — querySelector returned null and
-        // the whole handler died on load, so the button never worked at all.
-        //
-        // The clipboard call has a fallback because this document's origin is
-        // opaque; whether the async Clipboard API is available to it varies by
-        // browser even with clipboard-write delegated on the iframe. execCommand
-        // is deprecated but needs no permission, only the click's activation.
-        //
-        // The .code-block lookup is null-guarded like setupCopyButtons' is; the
-        // old unguarded form would throw if the wrapper ever went missing.
-        const COPY_SCRIPT = `<script>
+    } else {
+      // No unreachable scripts or stylesheets, but the file's own images
+      // still need inlining to survive the iframe.
+      preview = await inlineLocalRefs(code, sessionId, path, 'document')
+    }
+  } else if (kind === 'markdown') {
+    // Markdown is rendered inside a sandboxed srcdoc iframe which has no
+    // access to the host app's CSS or JS.  Inline the highlight.js theme
+    // CSS, code-block layout, and a copy-button handler so syntax
+    // highlighting and the "Copy" button actually work in preview mode.
+    const MD_STYLES = isDark ? darkMDStyles() : lightMDStyles()
+    const bodyStyle = isDark
+      ? 'margin:0;padding:16px;font:14px/1.6 system-ui,-apple-system,sans-serif;color:#d4d4d4;background:#1e1e1e'
+      : 'margin:0;padding:16px;font:14px/1.6 system-ui,-apple-system,sans-serif;color:rgba(0,0,0,0.88);background:#ffffff'
+    // Bound to document.body, not '.body': this is a hand-inlined copy of
+    // setupCopyButtons(), whose caller passes the host app's container, and
+    // that selector matched nothing here — querySelector returned null and
+    // the whole handler died on load, so the button never worked at all.
+    //
+    // The clipboard call has a fallback because this document's origin is
+    // opaque; whether the async Clipboard API is available to it varies by
+    // browser even with clipboard-write delegated on the iframe. execCommand
+    // is deprecated but needs no permission, only the click's activation.
+    //
+    // The .code-block lookup is null-guarded like setupCopyButtons' is; the
+    // old unguarded form would throw if the wrapper ever went missing.
+    const COPY_SCRIPT = `<script>
 	document.body.addEventListener('click',function(e){
 	  var b=e.target.closest('.copy-btn');if(!b)return;
 	  var k=b.closest('.code-block');
@@ -454,47 +537,16 @@ export async function observeArtifact(
 	  }else{legacy()}
 	});
 	<\/script>`
-        const body = await inlineLocalRefs(renderMarkdown(code), sessionId, path, 'fragment')
-        preview = `<style>${MD_STYLES}</style><body style="${bodyStyle}">${body}${COPY_SCRIPT}</body>`
-      } else {
-        // code kind: show with theme-aware monospace style
-        const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-        const codeBg = isDark ? '#1e1e1e' : '#ffffff'
-        const codeColor = isDark ? '#d4d4d4' : 'rgba(0,0,0,0.88)'
-        preview = `<body style="margin:0;background:${codeBg}"><pre style="margin:0;padding:16px;color:${codeColor};font:13px/1.6 'SFMono-Regular',Menlo,monospace;white-space:pre-wrap;word-break:break-all">${escaped}</pre></body>`
-      }
-    }
-  } catch {
-    return
+    const body = await inlineLocalRefs(renderMarkdown(code), sessionId, path, 'fragment')
+    preview = `<style>${MD_STYLES}</style><body style="${bodyStyle}">${body}${COPY_SCRIPT}</body>`
+  } else {
+    // code kind: show with theme-aware monospace style
+    const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    const codeBg = isDark ? '#1e1e1e' : '#ffffff'
+    const codeColor = isDark ? '#d4d4d4' : 'rgba(0,0,0,0.88)'
+    preview = `<body style="margin:0;background:${codeBg}"><pre style="margin:0;padding:16px;color:${codeColor};font:13px/1.6 'SFMono-Regular',Menlo,monospace;white-space:pre-wrap;word-break:break-all">${escaped}</pre></body>`
   }
-
-  // The active session may have changed while the fetch was in flight.
-  if (get(artifactSelSession) !== sessionId) return
-
-  const name = basename(path)
-  const entry: Artifact = {
-    name,
-    type: typeLabel(kind, path),
-    ver: '',
-    short: name.length > 22 ? name.slice(0, 21) + '…' : name,
-    icon: iconFor(kind),
-    code,
-    preview,
-    path,
-    src: src || undefined,
-  }
-
-  artifacts.update(list => {
-    const next = list.filter(a => a.path !== path)
-    next.push(entry)
-    return next
-  })
-  artifactSel.set(get(artifacts).length - 1)
-
-  if (live && !autoOpened) {
-    autoOpened = true
-    panelContent.set('session')
-  }
+  return { code, preview }
 }
 
 // darkMDStyles returns inline CSS for code blocks and syntax highlighting

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -143,7 +143,11 @@ const inlineRefMax = 20
 // Cheap pre-check: skip the parse/serialize round-trip entirely for a document
 // with nothing to rewrite, which is most of them.
 const LOCAL_REF_HINT = /<img\b|<image\b|url\(/i
-const CSS_URL_RE = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi
+// A quoted url() body may legally contain ')' — an SVG data URI holding
+// rgb(...), a file name with parentheses — so the quoted forms get their own
+// alternatives (#1892). The unquoted form may not, short of CSS escapes this
+// best-effort pass doesn't attempt.
+const CSS_URL_RE = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^'")]*?))\s*\)/gi
 
 // mode picks how the result is serialized: an HTML artifact is a whole document
 // (doctype and <head> must survive), markdown output is a body fragment.
@@ -155,6 +159,21 @@ async function inlineLocalRefs(
 ): Promise<string> {
   if (!LOCAL_REF_HINT.test(html)) return html
   const doc = new DOMParser().parseFromString(html, 'text/html')
+
+  // A <base href> re-aims every relative reference, and the iframe honors it,
+  // so the inliner must resolve the same way (#1892). A local base substitutes
+  // its directory for the artifact's own; a base with a scheme (or protocol-
+  // relative) means every relative reference is remote — a load the sandboxed
+  // iframe performs fine — so there is nothing local left to inline.
+  const baseHref = doc.querySelector('base[href]')?.getAttribute('href')?.trim()
+  if (baseHref) {
+    if (baseHref.startsWith('//')) return html
+    if (/^[a-z][a-z0-9+.-]*:/i.test(baseHref) && !/^[a-z]:[\\/]/i.test(baseHref)) return html
+    // URL semantics: the base itself resolves against the document, and
+    // references then resolve against everything up to its last slash — so
+    // "assets/" appends a directory while a slashless "assets" changes nothing.
+    basePath = isAbsolutePath(baseHref) ? baseHref : `${dirOf(basePath)}/${baseHref}`
+  }
 
   // null caches a failed lookup so a repeated broken reference is fetched once.
   const seen = new Map<string, string | null>()
@@ -191,7 +210,15 @@ async function inlineLocalRefs(
   }
 
   for (const img of Array.from(doc.querySelectorAll('img'))) {
-    const dataUrl = await inline(img.getAttribute('src') ?? '')
+    const src = img.getAttribute('src')
+    let dataUrl = await inline(src ?? '')
+    // A srcset-only <img> has nothing in src to inline, and generating data:
+    // URIs *inside* a srcset is what's hairy (their commas collide with the
+    // candidate separator). Promoting one candidate to src isn't: inline the
+    // first candidate and let the srcset removal below make it take effect
+    // (#1892). Only when src is absent — a present-but-remote src is a load
+    // the iframe performs fine and must not be second-guessed.
+    if (!dataUrl && !src) dataUrl = await inline(firstSrcsetCandidate(img.getAttribute('srcset')))
     if (!dataUrl) continue
     img.setAttribute('src', dataUrl)
     // Whatever outranks the src has to go, or the rewrite achieves nothing: a
@@ -232,13 +259,39 @@ async function inlineLocalRefs(
   // no local references is never reshaped by the round-trip.
   if (!changed) return html
   if (mode === 'fragment') return doc.body.innerHTML
-  return serializeDoctype(doc.doctype) + doc.documentElement.outerHTML
+  return serializeDocument(doc)
 }
 
-// documentElement.outerHTML drops the doctype, so it gets rebuilt — with its
-// public/system identifiers, since those are what decide the rendering mode and
-// a name-only `<!DOCTYPE html>` would silently switch a legacy file to standards
-// mode. Anything else above <html> (a build comment, say) is still lost.
+// First URL in a srcset, parsed just far enough to promote it to src. Split
+// on commas and take each candidate's first token: a data: URI candidate
+// (whose own commas defeat the split) yields fragments that resolve to
+// nothing and fail the inliner's gates, same as any other broken reference.
+function firstSrcsetCandidate(srcset: string | null): string {
+  for (const part of (srcset ?? '').split(',')) {
+    const url = part.trim().split(/\s+/)[0]
+    if (url) return url
+  }
+  return ''
+}
+
+// documentElement.outerHTML alone drops everything at document level: the
+// doctype and any comments beside it (a build stamp above <html>, say).
+// Serialize the document's own children instead (#1892) — the parser keeps no
+// document-level whitespace, so the pieces butt against each other, same as
+// the old doctype + <html> pair did.
+function serializeDocument(doc: Document): string {
+  let out = ''
+  for (const node of Array.from(doc.childNodes)) {
+    if (node.nodeType === Node.DOCUMENT_TYPE_NODE) out += serializeDoctype(node as DocumentType)
+    else if (node.nodeType === Node.COMMENT_NODE) out += `<!--${(node as Comment).data}-->`
+    else if (node.nodeType === Node.ELEMENT_NODE) out += (node as Element).outerHTML
+  }
+  return out
+}
+
+// The doctype is rebuilt with its public/system identifiers, since those are
+// what decide the rendering mode and a name-only `<!DOCTYPE html>` would
+// silently switch a legacy file to standards mode.
 function serializeDoctype(dt: DocumentType | null): string {
   if (!dt) return ''
   let out = `<!DOCTYPE ${dt.name}`
@@ -255,7 +308,7 @@ async function inlineCSSURLs(
   const out: string[] = []
   let last = 0
   for (const m of Array.from(css.matchAll(CSS_URL_RE))) {
-    const dataUrl = await inline(m[2])
+    const dataUrl = await inline(m[1] ?? m[2] ?? m[3] ?? '')
     if (!dataUrl) continue
     out.push(css.slice(last, m.index), `url("${dataUrl}")`)
     last = m.index + m[0].length

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -132,6 +132,10 @@ export interface Artifact {
   // sandboxed `preview` iframe (which cannot authenticate — see lib/artifacts.ts),
   // and the download action saves these bytes.
   src?: string
+  // code and preview are built lazily on first selection (hydrateArtifact in
+  // lib/artifacts.ts); loaded flips true once they are populated. Image
+  // artifacts observe as loaded — they carry src instead of a preview document.
+  loaded: boolean
 }
 
 // SkillInfo matches the Go server skill struct

--- a/web/src/mobile/ArtifactViewer.svelte
+++ b/web/src/mobile/ArtifactViewer.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
-  // Full-screen artifact viewer. The artifacts store entries already carry a
-  // self-contained preview document (built in lib/artifacts.ts for the desktop
-  // panel's sandboxed iframe) and the raw source — this just presents them
-  // phone-sized: preview in the same sandboxed iframe, code as scrollable text.
+  // Full-screen artifact viewer. The artifacts store entries observe
+  // metadata-only; their self-contained preview document and raw source are
+  // built on first selection (hydrateArtifact in lib/artifacts.ts) — this
+  // triggers that build and presents the result phone-sized: preview in the
+  // same sandboxed iframe the desktop panel uses, code as scrollable text.
   // Images are the exception: they carry a `src` and render as a plain <img>.
   import type { Artifact } from '../lib/types'
   import { t } from '../lib/i18n'
   import { imagePreviewError } from '../lib/artifact-actions'
+  import { hydrateArtifact } from '../lib/artifacts'
 
   let { artifact, onClose }: { artifact: Artifact; onClose: () => void } = $props()
+
+  // Re-runs when a live re-write swaps the entry object (the owner derives the
+  // prop from the store by path); no-ops once loaded or while in flight.
+  $effect(() => {
+    if (!artifact.loaded) hydrateArtifact(artifact)
+  })
 
   let view = $state<'preview' | 'code'>('preview')
   // Images render as a plain <img> (the sandboxed iframe cannot authenticate
@@ -77,6 +85,8 @@
         {/if}
         <img src={artifact.src} alt={artifact.name} class:img-hidden={imgFailed} onerror={onImgError} onload={onImgLoad} />
       </div>
+    {:else if !artifact.loaded}
+      <div class="body-loading"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon></div>
     {:else if view === 'preview'}
       <iframe srcdoc={artifact.preview} sandbox="allow-scripts" allow="clipboard-write" title={artifact.name}></iframe>
     {:else}
@@ -119,6 +129,7 @@
   .segi.on { background: var(--m-accent); color: #fff; font-weight: 600; }
 
   .vbody { flex: 1; min-height: 0; background: var(--m-surface); }
+  .body-loading { height: 100%; display: flex; align-items: center; justify-content: center; color: var(--m-text-3); }
   iframe { border: 0; width: 100%; height: 100%; display: block; }
   .img-wrap {
     width: 100%; height: 100%; box-sizing: border-box; padding: 8px;


### PR DESCRIPTION
Follow-ups from the #1888 review, both confined to the web artifact preview layer.

## Lazy preview build (fixes #1893)

`observeArtifact` built each artifact's whole preview document at observe time, so the body fetch — and for markdown/HTML the image inlining, whose `data:` URIs stay resident in the store — was paid for every artifact in a session's history, concurrently during replay, whether or not the user ever opened it.

- Entries now land in the store metadata-only with `loaded: false`; the fetch + preview build moved to a new `hydrateArtifact`, triggered from an `$effect` in the three consumers (`ArtifactsPanel`, `ArtifactModal`, mobile `ArtifactViewer`) when the selected entry is not loaded. History replay goes back to costing nothing, and the per-artifact inline budget is only ever spent on documents the user opens.
- The session-switch guard moves with the fetch; a live re-write replaces the entry object, and the identity match drops any in-flight stale build (the fresh entry hydrates itself on next selection).
- Image artifacts already observed without a fetch and have no preview document, so they observe as loaded.
- While a body builds, the panel/modal/viewer show a spinner and copy/download are disabled; a body that can no longer be fetched renders a placeholder note instead of spinning forever.
- A side benefit: the preview's light/dark styling is now captured at open time rather than observe time.

## Inliner gaps (fixes #1892)

The client-side-fixable items from the issue:

- **srcset-only `<img>`** inlines its first srcset candidate as the `src` (generating `data:` URIs *inside* a srcset is what's awkward — their commas collide with the candidate separator; promoting one candidate to src isn't). An `<img>` with a present-but-remote `src` is not second-guessed.
- **`<base href>`** is honored: a local base substitutes its directory when resolving relative references; a remote base skips inlining entirely, since every relative reference is then a remote load the iframe performs fine.
- **Content above `<html>`** survives serialization: the document serializer walks the document's own child nodes (doctype, comments, root element), so a build comment above `<html>` is no longer dropped.
- **`CSS_URL_RE`** matches quoted `url()` bodies containing `)` (an SVG data URI holding `rgb(...)`, a file name with parentheses) via separate quoted alternatives.

Still out of scope, as #1892 records: `<video>`/`<audio>`/`<source>`/`<object>`/`@font-face` point at file kinds the artifact endpoint deliberately refuses to serve, so they cannot be fetched client-side at all.

## Testing

- `web/`: vitest 118/118 (includes new cases for lazy hydration — no fetch at observe, single build, stale-build drop on re-write, session-switch discard, failure placeholder — and one per inliner gap), `svelte-check` 0 errors, `npm run build` clean.
- Existing preview tests drive the new second step through an `observeHydrated` helper mirroring the panel's `$effect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)