### PR TITLE
fix(server): keep the drain gate held until a turn's trailing session writes finish

### DIFF
--- a/internal/server/bg_tasks.go
+++ b/internal/server/bg_tasks.go
@@ -145,6 +145,12 @@ func (s *Server) kickIdleSteerTurn(sessionID string) bool {
 
 	content, blocks := foldQueuedBatch(batches[0])
 	go func() {
+		// Hold the drain gate past the deferred binding release, whose session
+		// write would otherwise escape a drain — see the same pattern (and the
+		// full rationale) in handleWSUserMessage.
+		if s.drain.begin() == nil {
+			defer s.drain.end()
+		}
 		defer func() {
 			mu.Lock()
 			s.turnRunning[sessionID] = false

--- a/internal/server/send_rejected_test.go
+++ b/internal/server/send_rejected_test.go
@@ -274,6 +274,76 @@ drainLoop:
 	}
 }
 
+// TestHandleWSUserMessage_DrainWaitsForBindingRelease: a drain must not report
+// idle while the turn goroutine's deferred wind-down — releaseSessionBinding
+// and the idle-steer kick, both of which write the session file — is still
+// running. A drain that returns early lets a restart, or a test's t.TempDir
+// cleanup on Windows, race those writes ("The directory is not empty"). The
+// binding still being on disk after a clean drain is the observable form of
+// that escape.
+func TestHandleWSUserMessage_DrainWaitsForBindingRelease(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]queuedTurn)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+	srv.wsHub.subscribe(conn, sess.ID)
+
+	block := make(chan struct{})
+	started := make(chan struct{})
+	srv.sender = &holdSender{block: block, started: started}
+
+	srv.handleWSUserMessage(conn, &wsMsgUserMessage{
+		SessionID: sess.ID,
+		Content:   json.RawMessage(`"hello from web"`),
+	})
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("turn never reached sender")
+	}
+
+	// Start the drain while the turn is held open, then release the turn. The
+	// drain may only return once the whole goroutine — including its deferred
+	// session writes — has finished.
+	drained := make(chan bool, 1)
+	go func() { drained <- srv.drain.drain(5 * time.Second) }()
+	close(block)
+
+	select {
+	case ok := <-drained:
+		if !ok {
+			t.Fatal("drain timed out waiting for the turn")
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("drain never returned")
+	}
+
+	fresh, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload session: %v", err)
+	}
+	if fresh.BoundTo(agent.EntryWeb) {
+		t.Fatal("binding release escaped the drain gate: session still bound to web after a clean drain")
+	}
+}
+
 // TestHandleWSUserMessage_ForceRejectedWhenLeaseActive: force=true still cannot
 // steal a session while another entry holds an active turn lease.
 func TestHandleWSUserMessage_ForceRejectedWhenLeaseActive(t *testing.T) {

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -609,13 +609,21 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 	mu.Unlock()
 
 	go func() {
+		// Hold the drain gate across the deferred wind-down too, not just for
+		// runAgentTurnLoop's own begin/end (nested counting is fine): the
+		// binding release below — and the idle-steer kick's acquire/release —
+		// writes the session file after the loop returns. A drain that reports
+		// idle before those trailing writes land lets a restart, or a test's
+		// t.TempDir cleanup on Windows, race an open session-file handle
+		// ("The directory is not empty").
+		if s.drain.begin() == nil {
+			defer s.drain.end()
+		}
 		defer func() {
 			// Release the binding — which reloads the session and appends a
 			// lease-clear record, writing the session file — BEFORE clearing
-			// turnRunning. That flag is the "turn fully wound down" barrier
-			// (tests and drain logic wait on it); flipping it while a session
-			// write is still pending lets t.TempDir() cleanup race the open
-			// handle on Windows ("directory is not empty").
+			// turnRunning, so the flag only flips once the session write is
+			// done.
 			sess.DecFlight()
 			s.releaseSessionBinding(sid, agent.EntryWeb)
 			mu.Lock()


### PR DESCRIPTION
Fixes the Windows CI flake in `TestHandleWSUserMessage_ForceTakesOverStaleBinding`:

```
testing.go:1369: TempDir RemoveAll cleanup: unlinkat ...\.octo\sessions: The directory is not empty.
```

## Root cause

`runAgentTurnLoop` deregisters from the drain gate (`defer s.drain.end()`) the moment it returns — but the goroutines that spawn it still write the session file **after** that, in their deferred wind-down:

- `handleWSUserMessage`'s defer calls `releaseSessionBinding` (reload + clear lease + save), then `kickIdleSteerTurn`, which acquires and releases the binding even when the steer queue is empty — two more saves.
- `kickIdleSteerTurn`'s own spawned turn has the same shape: `releaseSessionBinding` in the defer, after the loop returned.

So `mustServer`'s cleanup (`srv.drain.drain(10s)` + the titlePending wait) can return while up to three session-file writes are still in flight. POSIX unlinks the open file fine; Windows leaves it delete-pending and then refuses to remove `.octo\sessions` ("directory is not empty"). The same window exists in production: a restart's drain could proceed while a binding-release write is mid-flight.

## Fix

Hold the drain gate for the **whole spawned goroutine** at both sites — `begin()` on entry, `end()` deferred first so it runs after the wind-down defer. The nested `begin`/`end` inside `runAgentTurnLoop` keeps working (the gate counts, it doesn't binarize); the counter just stays above zero until the trailing writes are done. When a drain is already in progress, `begin()` fails and the goroutine simply isn't gated — same semantics as before, and the inner gate still refuses the turn.

## Test

`TestHandleWSUserMessage_DrainWaitsForBindingRelease` pins the observable contract: start a turn against a `holdSender`, start a drain while the turn is held open, release the turn, and require that once the drain returns cleanly the binding release has already hit disk (session no longer bound to web). Under the old code the drain returns before the deferred release, and the assertion catches the escape.

`go test -race ./internal/server/` passes; the targeted tests pass with `-count=3 -race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)