### PR TITLE
feat(dist): add dl.octo-agent.dev download mirror for blocked networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ octo "给 octo config show 加一个 --json 参数并跑测试"   # 一句话 �
 
 - **Linux / macOS** — `curl -fsSL https://octo-agent.dev/install.sh | sh`
 - **Windows** — `irm https://octo-agent.dev/install.ps1 | iex`
+- **国内网络** — 官网或 GitHub 打不开时，走下载镜像（安装与 `octo upgrade` 会自动回退到镜像）：
+  `curl -fsSL https://dl.octo-agent.dev/install.sh | sh`（Windows：`irm https://dl.octo-agent.dev/install.ps1 | iex`）
 - **桌面应用** — 从[最新 release](https://github.com/open-octo/octo-agent/releases/latest)下载安装器：
   `octo-setup.pkg`（macOS）、`octo-setup.exe`（Windows）、`Octo-x86_64.AppImage`（Linux）
 - **Go** — `go install github.com/open-octo/octo-agent/cmd/octo@latest`

--- a/README_EN.md
+++ b/README_EN.md
@@ -33,6 +33,8 @@ octo "Add a --json flag to 'octo config show' and run the tests"   # one prompt 
 
 - **Linux / macOS** — `curl -fsSL https://octo-agent.dev/install.sh | sh`
 - **Windows** — `irm https://octo-agent.dev/install.ps1 | iex`
+- **Restricted networks** — if github.com is unreachable, use the download mirror (installs and `octo upgrade` also fall back to it automatically):
+  `curl -fsSL https://dl.octo-agent.dev/install.sh | sh` (Windows: `irm https://dl.octo-agent.dev/install.ps1 | iex`)
 - **Desktop app** — grab the installer from the [latest release](https://github.com/open-octo/octo-agent/releases/latest):
   `octo-setup.pkg` (macOS), `octo-setup.exe` (Windows), `Octo-x86_64.AppImage` (Linux)
 - **Go** — `go install github.com/open-octo/octo-agent/cmd/octo@latest`

--- a/infra/dl-worker/README.md
+++ b/infra/dl-worker/README.md
@@ -1,0 +1,55 @@
+# dl.octo-agent.dev — release download mirror
+
+A Cloudflare Worker that proxies this repository's GitHub release assets so
+downloads and upgrades work from networks where github.com is blocked
+(notably mainland China). Cloudflare's edge is reachable there without a
+proxy; GitHub is fetched from the edge, never from the client.
+
+`internal/upgrade` and `landing/install.sh` / `install.ps1` try GitHub first
+and fall back to this host (then to public gh-proxy mirrors). Keep the three
+mirror lists in sync when anything changes here.
+
+## Endpoints
+
+| Path | Behavior |
+|---|---|
+| `/releases/latest` | 302 passthrough; the release tag is in the `Location` path |
+| `/releases/download/<tag>/<asset>` | streams the asset; edge-cached (immutable) |
+| `/releases/latest/download/<asset>` | streams the asset; uncached |
+| `/install.sh`, `/install.ps1` | installer scripts from `main` — the China-reachable install one-liner |
+| anything else | redirect to the landing page |
+
+## Deploy
+
+One-time setup:
+
+1. Add the `octo-agent.dev` zone to the Cloudflare account (change the
+   nameservers at the registrar). The rest of the site can stay where it is —
+   only the `dl` subdomain is claimed here, via the worker's custom domain.
+2. `npx wrangler login`
+
+Then, from this directory:
+
+```sh
+npx wrangler deploy
+```
+
+`custom_domain = true` in `wrangler.toml` creates the `dl.octo-agent.dev`
+DNS record automatically. There is no CI deploy: the worker changes rarely,
+and a manual `wrangler deploy` keeps the account credentials out of GitHub.
+
+## Verify
+
+```sh
+# tag in the Location header
+curl -sI https://dl.octo-agent.dev/releases/latest | grep -i location
+# a real asset downloads and matches GitHub's checksum
+curl -fsSL https://dl.octo-agent.dev/releases/latest/download/checksums.txt | head
+```
+
+## Limits
+
+Workers free plan: 100k requests/day, no egress charge. Asset responses are
+cached at the edge (Cloudflare's cache serves up to 512 MB objects), so
+repeat downloads of the same release mostly don't re-hit GitHub or count
+against upstream bandwidth.

--- a/infra/dl-worker/worker.js
+++ b/infra/dl-worker/worker.js
@@ -1,0 +1,100 @@
+// Cloudflare Worker behind dl.octo-agent.dev — a download mirror for this
+// repository's GitHub release assets, reachable from networks where
+// github.com is blocked (notably mainland China). Cloudflare's edge fetches
+// from GitHub, so the client never needs to reach GitHub itself.
+//
+// The path layout mirrors GitHub exactly, so everything that builds
+// github.com URLs today (internal/upgrade, install.sh, install.ps1) works
+// against this host unchanged:
+//
+//   /releases/latest                  -> 302, tag in the Location path
+//   /releases/download/<tag>/<asset>  -> asset bytes (edge-cached; immutable)
+//   /releases/latest/download/<asset> -> asset bytes (uncached; tracks latest)
+//   /install.sh, /install.ps1         -> installer scripts from main
+//
+// Only this fixed repository is proxied — the worker is not an open proxy.
+// Trust still anchors on checksum verification in the clients; the mirror
+// serves bytes, it does not vouch for them.
+
+const REPO = 'open-octo/octo-agent'
+const GITHUB = `https://github.com/${REPO}`
+const RAW = `https://raw.githubusercontent.com/${REPO}/main/landing`
+const LANDING = 'https://octo-agent.dev/'
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('method not allowed', { status: 405 })
+    }
+    const { pathname } = new URL(request.url)
+
+    if (pathname === '/releases/latest') {
+      // Pass GitHub's redirect through untouched: clients (upgrade.Check,
+      // the install scripts) parse the tag out of the Location path, and
+      // only look at the path — the github.com host in it is fine.
+      const upstream = await fetch(`${GITHUB}/releases/latest`, { redirect: 'manual' })
+      const loc = upstream.headers.get('location')
+      if (upstream.status >= 300 && upstream.status < 400 && loc) {
+        return new Response(null, { status: 302, headers: { location: loc } })
+      }
+      return new Response(`unexpected upstream status ${upstream.status}`, { status: 502 })
+    }
+
+    if (pathname === '/install.sh' || pathname === '/install.ps1') {
+      const upstream = await fetch(`${RAW}${pathname}`)
+      if (!upstream.ok) {
+        return new Response(`upstream ${upstream.status}`, { status: 502 })
+      }
+      return new Response(upstream.body, {
+        status: 200,
+        headers: {
+          'content-type': 'text/plain; charset=utf-8',
+          'cache-control': 'public, max-age=300',
+        },
+      })
+    }
+
+    if (pathname.startsWith('/releases/download/')) {
+      // Tagged asset URLs never change content — cache at the edge so a
+      // release-day upgrade wave hits GitHub once per asset per colo.
+      return proxyAsset(request, ctx, pathname, true)
+    }
+    if (pathname.startsWith('/releases/latest/download/')) {
+      // Moves with every release — never cache.
+      return proxyAsset(request, ctx, pathname, false)
+    }
+
+    return Response.redirect(LANDING, 302)
+  },
+}
+
+async function proxyAsset(request, ctx, pathname, cacheable) {
+  const cache = caches.default
+  if (cacheable && request.method === 'GET') {
+    const hit = await cache.match(request)
+    if (hit) return hit
+  }
+
+  const upstream = await fetch(`${GITHUB}${pathname}`, {
+    method: request.method,
+    redirect: 'follow', // GitHub 302s assets to objects.githubusercontent.com
+  })
+  if (!upstream.ok) {
+    return new Response(`upstream ${upstream.status} for ${pathname}`, {
+      status: upstream.status === 404 ? 404 : 502,
+    })
+  }
+
+  const headers = new Headers()
+  for (const h of ['content-type', 'content-length', 'content-disposition', 'etag']) {
+    const v = upstream.headers.get(h)
+    if (v) headers.set(h, v)
+  }
+  headers.set('cache-control', cacheable ? 'public, max-age=31536000, immutable' : 'no-store')
+
+  const resp = new Response(upstream.body, { status: 200, headers })
+  if (cacheable && request.method === 'GET') {
+    ctx.waitUntil(cache.put(request, resp.clone()))
+  }
+  return resp
+}

--- a/infra/dl-worker/wrangler.toml
+++ b/infra/dl-worker/wrangler.toml
@@ -1,0 +1,11 @@
+# Deploy from this directory: npx wrangler deploy
+# (one-time: npx wrangler login; the custom domain requires the
+# octo-agent.dev zone to be on this Cloudflare account.)
+name = "octo-dl"
+main = "worker.js"
+compatibility_date = "2026-07-01"
+workers_dev = false
+
+[[routes]]
+pattern = "dl.octo-agent.dev"
+custom_domain = true

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -48,10 +48,13 @@ var DownloadPageURL = "https://octo-agent.dev/"
 // fails to download from BaseURL. They must expose the same path layout as
 // GitHub releases: /releases/download/v<ver>/<asset>.
 //
-// Public, no-cost mirrors come and go; the list is conservative and can be
-// extended. Checksum verification still anchors trust to the original
+// dl.octo-agent.dev is the project's own Cloudflare Worker proxy
+// (infra/dl-worker) and is tried before the public gh-proxy mirrors, which
+// come and go. Checksum verification still anchors trust to the original
 // checksums.txt content, so a mirror cannot silently install a modified binary.
+// Keep this list in sync with landing/install.sh and landing/install.ps1.
 var MirrorBaseURLs = []string{
+	"https://dl.octo-agent.dev",
 	"https://ghproxy.net/https://github.com/open-octo/octo-agent",
 	"https://gh-proxy.com/https://github.com/open-octo/octo-agent",
 	"https://gh.ddlc.top/https://github.com/open-octo/octo-agent",

--- a/landing/install.ps1
+++ b/landing/install.ps1
@@ -2,6 +2,10 @@
 #
 #   irm https://octo-agent.dev/install.ps1 | iex
 #
+# Where github.com is unreachable (e.g. mainland China), the same script is
+# served by the download mirror, and downloads fall back to it automatically:
+#   irm https://dl.octo-agent.dev/install.ps1 | iex
+#
 # Detects your arch, downloads the matching release archive, verifies its
 # SHA-256 against the release's checksums.txt, installs octo.exe to a per-user
 # directory, and adds it to your PATH. No admin/UAC.
@@ -16,7 +20,43 @@
 $ErrorActionPreference = 'Stop'
 $repo = 'open-octo/octo-agent'
 
+# Download bases, tried in order: GitHub first, then mirrors exposing the
+# same /releases/... path layout, for networks where github.com is blocked
+# (notably mainland China). Keep in sync with internal/upgrade's
+# MirrorBaseURLs and install.sh. Checksum verification below applies to
+# whichever base served the bytes.
+$bases = @(
+  "https://github.com/$repo",
+  'https://dl.octo-agent.dev',
+  "https://ghproxy.net/https://github.com/$repo",
+  "https://gh-proxy.com/https://github.com/$repo",
+  "https://gh.ddlc.top/https://github.com/$repo"
+)
+
 function Fail($msg) { Write-Error "octo install: $msg"; exit 1 }
+
+# Read the latest tag from one base's /releases/latest redirect (no GitHub
+# API, so no rate limit): the tag is in the Location path. A mirror that
+# follows the redirect itself returns the release page instead, whose og:url
+# meta tag carries the same /releases/tag/ path — the regex matches either.
+function Resolve-LatestVersion($base) {
+  try {
+    $req = [System.Net.WebRequest]::Create("$base/releases/latest")
+    $req.Method = 'GET'
+    $req.AllowAutoRedirect = $false
+    $req.Timeout = 15000
+    $resp = $req.GetResponse()
+    try {
+      $hint = $resp.Headers['Location']
+      if (-not $hint) {
+        $reader = New-Object System.IO.StreamReader($resp.GetResponseStream())
+        $hint = $reader.ReadToEnd()
+      }
+      if ($hint -match '/releases/tag/v?([^"/?\s]+)') { return $Matches[1] }
+    } finally { $resp.Close() }
+  } catch { }
+  return $null
+}
 
 # --- detect arch (only windows_amd64 is published today) ---------------------
 $arch = 'amd64'
@@ -27,25 +67,35 @@ if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64' -and -not $env:OCTO_INSTALL_DIR) {
 # --- resolve version ---------------------------------------------------------
 $version = $env:OCTO_VERSION
 if (-not $version) {
-  try {
-    $rel = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest"
-    $version = ($rel.tag_name -replace '^v', '')
-  } catch { Fail "could not determine the latest version" }
+  foreach ($b in $bases) {
+    $version = Resolve-LatestVersion $b
+    if ($version) { break }
+  }
 }
 if (-not $version) { Fail "could not determine the latest version" }
 
 $archive = "octo_${version}_windows_${arch}.zip"
-$base = "https://github.com/$repo/releases/download/v$version"
+
+# Download one release asset, trying each base in order.
+function Get-Asset($name, $out) {
+  foreach ($b in $bases) {
+    try {
+      Invoke-WebRequest "$b/releases/download/v$version/$name" -OutFile $out -TimeoutSec 180
+      return $true
+    } catch {
+      Write-Host "octo install: download of $name from $b failed"
+    }
+  }
+  return $false
+}
 
 $tmp = Join-Path $env:TEMP ("octo-" + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Force -Path $tmp | Out-Null
 try {
   # --- download --------------------------------------------------------------
   Write-Host "octo install: downloading $archive"
-  try { Invoke-WebRequest "$base/$archive" -OutFile "$tmp\$archive" }
-  catch { Fail "download failed: $base/$archive" }
-  try { Invoke-WebRequest "$base/checksums.txt" -OutFile "$tmp\checksums.txt" }
-  catch { Fail "could not fetch checksums.txt" }
+  if (-not (Get-Asset $archive "$tmp\$archive")) { Fail "download failed: $archive" }
+  if (-not (Get-Asset 'checksums.txt' "$tmp\checksums.txt")) { Fail "could not fetch checksums.txt" }
 
   # --- verify SHA-256 --------------------------------------------------------
   $line = Get-Content "$tmp\checksums.txt" |

--- a/landing/install.sh
+++ b/landing/install.sh
@@ -3,6 +3,10 @@
 #
 #   curl -fsSL https://octo-agent.dev/install.sh | sh
 #
+# Where github.com is unreachable (e.g. mainland China), the same script is
+# served by the download mirror, and downloads fall back to it automatically:
+#   curl -fsSL https://dl.octo-agent.dev/install.sh | sh
+#
 # Detects your OS/arch, downloads the matching release archive, verifies its
 # SHA-256 against the release's checksums.txt, and installs the `octo` binary
 # to a directory on your PATH (default /usr/local/bin, else ~/.local/bin).
@@ -19,6 +23,13 @@
 set -eu
 
 REPO="open-octo/octo-agent"
+
+# Download bases, tried in order: GitHub first, then mirrors exposing the
+# same /releases/... path layout, for networks where github.com is blocked
+# (notably mainland China). Keep in sync with internal/upgrade's
+# MirrorBaseURLs and install.ps1. Checksum verification below applies to
+# whichever base served the bytes.
+BASES="https://github.com/$REPO https://dl.octo-agent.dev https://ghproxy.net/https://github.com/$REPO https://gh-proxy.com/https://github.com/$REPO https://gh.ddlc.top/https://github.com/$REPO"
 
 err() { printf 'octo install: %s\n' "$1" >&2; exit 1; }
 
@@ -45,23 +56,43 @@ esac
 # --- resolve version ---------------------------------------------------------
 version="${OCTO_VERSION:-}"
 if [ -z "$version" ]; then
-  # Read the latest tag from the GitHub API and strip the leading "v" so it
-  # matches the goreleaser archive name ({{.Version}}, e.g. 1.0.0).
-  version=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
-    | grep '"tag_name"' | head -n1 | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+  # Read the latest tag from the /releases/latest redirect (no GitHub API, so
+  # no rate limit) and strip the leading "v" so it matches the goreleaser
+  # archive name ({{.Version}}, e.g. 1.0.0). -w appends the redirect target;
+  # a mirror that follows the redirect itself returns the release page
+  # instead, whose og:url meta tag carries the same /releases/tag/ path —
+  # the sed matches either.
+  for b in $BASES; do
+    resp=$(curl -fsS --connect-timeout 5 --max-time 20 -w '\n%{redirect_url}' "$b/releases/latest" 2>/dev/null) || continue
+    version=$(printf '%s' "$resp" | sed -n 's#.*/releases/tag/v\{0,1\}\([^"/?[:space:]]*\).*#\1#p' | head -n1)
+    [ -n "$version" ] && break
+  done
 fi
 [ -n "$version" ] || err "could not determine the latest version"
 
 archive="octo_${version}_${os}_${arch}.tar.gz"
-base="https://github.com/$REPO/releases/download/v${version}"
 
 # --- download into a temp dir ------------------------------------------------
 tmp=$(mktemp -d 2>/dev/null || mktemp -d -t octo)
 trap 'rm -rf "$tmp"' EXIT INT TERM
 
+# fetch <asset> <dest>: try each base in order. --speed-limit aborts a
+# transfer that stalls below 1 KB/s for 30s (a blackholed connection would
+# otherwise hang forever and never reach the mirrors).
+fetch() {
+  for b in $BASES; do
+    if curl -fSL --connect-timeout 5 --speed-limit 1024 --speed-time 30 \
+        "$b/releases/download/v${version}/$1" -o "$2"; then
+      return 0
+    fi
+    printf 'octo install: download of %s from %s failed\n' "$1" "$b" >&2
+  done
+  return 1
+}
+
 printf 'octo install: downloading %s\n' "$archive"
-curl -fSL "$base/$archive"     -o "$tmp/$archive"     || err "download failed: $base/$archive"
-curl -fsSL "$base/checksums.txt" -o "$tmp/checksums.txt" || err "could not fetch checksums.txt"
+fetch "$archive" "$tmp/$archive"          || err "download failed: $archive"
+fetch "checksums.txt" "$tmp/checksums.txt" || err "could not fetch checksums.txt"
 
 # --- verify SHA-256 ----------------------------------------------------------
 want=$(grep " $archive\$" "$tmp/checksums.txt" | awk '{print $1}' | head -n1)


### PR DESCRIPTION
## Why

GitHub — and the GitHub-Pages-hosted landing site — is unreachable from mainland China, so first-time installs fail outright: `install.sh`/`install.ps1` resolved versions through `api.github.com` and downloaded straight from `github.com` with no fallback. `octo upgrade` already falls back to public gh-proxy mirrors, but those come and go and we control none of them.

## What

- **`infra/dl-worker/`** — a Cloudflare Worker behind `dl.octo-agent.dev` that proxies this repo's release assets with the exact GitHub path layout (`/releases/latest` redirect passthrough, `/releases/download/...`, `/releases/latest/download/...`), plus `/install.sh` / `/install.ps1` served from `main`. Cloudflare's edge fetches GitHub, so the client never needs to. Tagged assets are edge-cached as immutable. Fixed repo only — not an open proxy.
- **`internal/upgrade`** — `dl.octo-agent.dev` added to `MirrorBaseURLs`, ahead of the public mirrors. No logic change; `Check` and `downloadWithMirrors` already iterate the list.
- **`install.sh` / `install.ps1`** — version resolution moves off `api.github.com` (rate-limited, blocked) to the `/releases/latest` redirect, tried across the same base list as Go; asset downloads get per-mirror fallback with stall detection (`--speed-limit` in sh, `-TimeoutSec` in ps1). SHA-256 verification unchanged and applies to whichever base served the bytes.
- **README / README_EN** — document the restricted-network one-liner: `curl -fsSL https://dl.octo-agent.dev/install.sh | sh`.

## Verified

- `go test ./internal/upgrade/`, `go vet`, `gofmt` clean; `go build ./...` passes.
- Ran `install.sh` end-to-end into a scratch dir (GitHub path): resolves 1.14.7 via redirect, downloads, checksum-verifies, installs; binary runs.
- Simulated GitHub-blocked path under `sh`: an undeployed `dl.octo-agent.dev` fails fast and the chain falls through to `ghproxy.net`, which resolves the tag (200 + og:url case) and serves `checksums.txt`.
- `install.ps1` is syntax-reviewed only — no pwsh on this machine; the WebRequest redirect handling targets both Windows PowerShell 5.1 and PS7.

## Not in this PR (follow-ups)

- Deploying the worker needs one-time account setup: octo-agent.dev zone on Cloudflare + `wrangler deploy` (steps in `infra/dl-worker/README.md`). The mirror entry is a safe no-op until then — an unreachable host just falls through.
- Landing-site migration to Cloudflare Pages (octo-agent.dev itself is on GitHub Pages IPs, blocked in CN).
- Desktop in-place updater still pulls via the Wails GitHub provider; its fallback remains notify-and-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)