### PR TITLE
ci(pages): dual-deploy the site to Cloudflare Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -67,6 +67,31 @@ jobs:
         with:
           path: _site
 
+      # Dual-deploy to Cloudflare Pages: Cloudflare's edge is reachable from
+      # networks where GitHub Pages is blocked (notably mainland China), and
+      # will take over octo-agent.dev via the project's custom domain. The
+      # GitHub Pages deploy stays as-is. Skipped quietly when the API token
+      # secret isn't configured (e.g. on forks).
+      - name: Check Cloudflare credentials
+        id: cf
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "CLOUDFLARE_API_TOKEN not set; skipping Cloudflare Pages deploy"
+          fi
+
+      - name: Deploy to Cloudflare Pages
+        if: steps.cf.outputs.enabled == 'true'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy _site --project-name=octo-agent --branch=main
+
   deploy:
     name: Deploy
     needs: build


### PR DESCRIPTION
Follow-up to #1935. GitHub Pages hosts octo-agent.dev, which is blocked in mainland China — the download mirror fixed installs, but the site itself (landing, docs, blog) is still unreachable there.

This adds a Cloudflare Pages deploy of the same assembled `_site` after the GitHub Pages upload, to the `octo-agent` Pages project (already created and verified: https://octo-agent.pages.dev serves /, /docs/, /blog/, and the install scripts). GitHub Pages keeps deploying unchanged; cutover happens later by attaching `octo-agent.dev` as the Pages project's custom domain.

The step is skipped quietly when `CLOUDFLARE_API_TOKEN` isn't configured, so forks and tokenless runs stay green.

Requires two repo secrets (documented in the step comment): `CLOUDFLARE_API_TOKEN` (Account → Cloudflare Pages → Edit) and `CLOUDFLARE_ACCOUNT_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)