### PR TITLE
feat(desktop): fall back to the download mirror for in-place updates

### DIFF
--- a/cmd/octo-desktop/mirror.go
+++ b/cmd/octo-desktop/mirror.go
@@ -1,0 +1,69 @@
+// Mirror fallback for the in-place updater's HTTP traffic: when a GitHub
+// request fails at the transport level (github.com is blocked on some
+// networks, notably mainland China), retry the equivalent URL on the
+// project's download mirror (infra/dl-worker). Only connection-level
+// failures are retried — an HTTP error status is a real answer from GitHub
+// and passes through untouched, so the mirror never masks one.
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// mirrorBase is the download mirror origin. A var so tests can point it at
+// httptest. Keep in sync with internal/upgrade's MirrorBaseURLs and
+// infra/dl-worker.
+var mirrorBase = "https://dl.octo-agent.dev"
+
+// mirrorURL maps a GitHub URL the updater uses onto its mirror equivalent,
+// or "" when there is no mapping — any other repository, and presigned
+// objects.githubusercontent.com URLs, whose paths cannot be derived.
+func mirrorURL(u *url.URL) string {
+	repoPath := "/" + releaseRepo
+	switch u.Host {
+	case "api.github.com":
+		if rest, ok := strings.CutPrefix(u.Path, "/repos"+repoPath+"/"); ok {
+			return mirrorBase + "/api/" + rest
+		}
+	case "github.com":
+		if rest, ok := strings.CutPrefix(u.Path, repoPath+"/releases/download/"); ok {
+			return mirrorBase + "/releases/download/" + rest
+		}
+	}
+	return ""
+}
+
+// mirrorTransport wraps a RoundTripper with the mirror retry.
+type mirrorTransport struct {
+	base http.RoundTripper
+}
+
+func (t mirrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err == nil || req.Context().Err() != nil {
+		return resp, err
+	}
+	var m string
+	if req.Method == http.MethodGet || req.Method == http.MethodHead {
+		m = mirrorURL(req.URL)
+	}
+	if m == "" {
+		return resp, err
+	}
+	mu, perr := url.Parse(m)
+	if perr != nil {
+		return resp, err
+	}
+	mreq := req.Clone(req.Context())
+	mreq.URL = mu
+	mreq.Host = ""
+	// Never forward GitHub credentials to the mirror.
+	mreq.Header.Del("Authorization")
+	mresp, merr := t.base.RoundTrip(mreq)
+	if merr != nil {
+		return resp, err // the direct failure is the more truthful error
+	}
+	return mresp, nil
+}

--- a/cmd/octo-desktop/mirror_test.go
+++ b/cmd/octo-desktop/mirror_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestMirrorURL(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://api.github.com/repos/" + releaseRepo + "/releases/latest",
+			"https://dl.octo-agent.dev/api/releases/latest"},
+		{"https://github.com/" + releaseRepo + "/releases/download/v1.2.3/Octo-darwin-universal.zip",
+			"https://dl.octo-agent.dev/releases/download/v1.2.3/Octo-darwin-universal.zip"},
+		// Other repositories must not be routed through the mirror.
+		{"https://api.github.com/repos/someone/else/releases/latest", ""},
+		{"https://github.com/someone/else/releases/download/v1/a.zip", ""},
+		// Presigned asset hosts have no derivable mirror path.
+		{"https://objects.githubusercontent.com/github-production-release-asset/abc", ""},
+		// Non-release GitHub paths stay direct.
+		{"https://github.com/" + releaseRepo + "/issues", ""},
+	}
+	for _, c := range cases {
+		u, err := url.Parse(c.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := mirrorURL(u); got != c.want {
+			t.Errorf("mirrorURL(%s) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// failGitHub fails transport-level for GitHub hosts and passes everything
+// else to the default transport (the httptest mirror on 127.0.0.1).
+type failGitHub struct{ failed *[]string }
+
+func (f failGitHub) RoundTrip(req *http.Request) (*http.Response, error) {
+	switch req.Host {
+	case "api.github.com", "github.com":
+		*f.failed = append(*f.failed, req.URL.String())
+		return nil, errors.New("connection reset by peer")
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestMirrorTransportRetriesOnTransportError(t *testing.T) {
+	var gotAuth string
+	mirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/api/releases/latest" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, `{"tag_name":"v9.9.9"}`)
+	}))
+	defer mirror.Close()
+
+	origBase := mirrorBase
+	mirrorBase = mirror.URL
+	defer func() { mirrorBase = origBase }()
+
+	var failed []string
+	client := &http.Client{Transport: mirrorTransport{base: failGitHub{failed: &failed}}}
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/"+releaseRepo+"/releases/latest", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer secret")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("expected mirror to answer, got %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != `{"tag_name":"v9.9.9"}` {
+		t.Errorf("unexpected body %q", body)
+	}
+	if len(failed) != 1 {
+		t.Errorf("expected exactly one direct attempt, got %v", failed)
+	}
+	if gotAuth != "" {
+		t.Errorf("Authorization header must not reach the mirror, got %q", gotAuth)
+	}
+}
+
+func TestMirrorTransportDoesNotRetryUnmappedHosts(t *testing.T) {
+	var failed []string
+	client := &http.Client{Transport: mirrorTransport{base: failGitHub{failed: &failed}}}
+	_, err := client.Get("https://github.com/someone/else/releases/download/v1/a.zip")
+	if err == nil {
+		t.Fatal("expected the direct failure to propagate")
+	}
+	if len(failed) != 1 {
+		t.Errorf("expected one attempt, got %v", failed)
+	}
+}
+
+func TestMirrorTransportPassesThroughHTTPErrors(t *testing.T) {
+	// An HTTP status from GitHub is a real answer — no mirror retry.
+	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer direct.Close()
+
+	client := &http.Client{Transport: mirrorTransport{base: http.DefaultTransport}}
+	resp, err := client.Get(direct.URL + "/repos/" + releaseRepo + "/releases/latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 passthrough, got %d", resp.StatusCode)
+	}
+}

--- a/cmd/octo-desktop/update.go
+++ b/cmd/octo-desktop/update.go
@@ -69,11 +69,13 @@ func desktopAssetIndex(assets []ghprovider.ReleaseAsset, want string) int {
 // response body — and so truncates a ~100 MB artifact download on any link
 // slower than ~27 Mbps. Timeouts move to the connection phases instead; the
 // body stream is unbounded (the updater window surfaces progress, and a lost
-// connection still fails through the transport).
+// connection still fails through the transport). mirrorTransport retries a
+// connection-level GitHub failure against the download mirror, matching the
+// CLI upgrade's mirror fallback.
 func updateHTTPClient() *http.Client {
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	tr.ResponseHeaderTimeout = 30 * time.Second
-	return &http.Client{Transport: tr}
+	return &http.Client{Transport: mirrorTransport{base: tr}}
 }
 
 // verifiedOnly wraps a Provider to fail closed when a release carries no

--- a/infra/dl-worker/.wrangler/cache/wrangler-account.json
+++ b/infra/dl-worker/.wrangler/cache/wrangler-account.json
@@ -1,0 +1,6 @@
+{
+  "account": {
+    "id": "7a127a0ecf786479f763f93a85f29504",
+    "name": "Leihaibo1992@gmail.com's Account"
+  }
+}

--- a/infra/dl-worker/README.md
+++ b/infra/dl-worker/README.md
@@ -17,6 +17,7 @@ mirror lists in sync when anything changes here.
 | `/releases/download/<tag>/<asset>` | streams the asset; edge-cached (immutable) |
 | `/releases/latest/download/<asset>` | streams the asset; uncached |
 | `/install.sh`, `/install.ps1` | installer scripts from `main` — the China-reachable install one-liner |
+| `/api/releases/latest` | GitHub API release JSON for the desktop updater; cached 5 min (shared egress IPs vs GitHub's per-IP anonymous rate limit) |
 | anything else | redirect to the landing page |
 
 ## Deploy
@@ -37,6 +38,11 @@ npx wrangler deploy
 `custom_domain = true` in `wrangler.toml` creates the `dl.octo-agent.dev`
 DNS record automatically. There is no CI deploy: the worker changes rarely,
 and a manual `wrangler deploy` keeps the account credentials out of GitHub.
+
+Optional: `npx wrangler secret put GITHUB_TOKEN` (a public-repo read-only
+token) authenticates the `/api/releases/latest` upstream call. Without it
+the endpoint 403s intermittently — GitHub's anonymous API limit is per-IP
+and the worker's egress IPs are shared with other Cloudflare tenants.
 
 ## Verify
 

--- a/infra/dl-worker/worker.js
+++ b/infra/dl-worker/worker.js
@@ -11,6 +11,8 @@
 //   /releases/download/<tag>/<asset>  -> asset bytes (edge-cached; immutable)
 //   /releases/latest/download/<asset> -> asset bytes (uncached; tracks latest)
 //   /install.sh, /install.ps1         -> installer scripts from main
+//   /api/releases/latest              -> the GitHub API release JSON, for the
+//                                        desktop updater (cached 5 min)
 //
 // Only this fixed repository is proxied — the worker is not an open proxy.
 // Trust still anchors on checksum verification in the clients; the mirror
@@ -38,6 +40,51 @@ export default {
         return new Response(null, { status: 302, headers: { location: loc } })
       }
       return new Response(`unexpected upstream status ${upstream.status}`, { status: 502 })
+    }
+
+    if (pathname === '/api/releases/latest') {
+      // The desktop updater's Wails GitHub provider checks the API, not the
+      // web redirect. The asset URLs inside the JSON still point at
+      // github.com — the desktop's mirrorTransport rewrites those requests
+      // when they fail, so the JSON passes through unmodified. Cached
+      // briefly: the worker's egress IPs are shared, and GitHub's anonymous
+      // API rate limit is per-IP.
+      const cache = caches.default
+      if (request.method === 'GET') {
+        const hit = await cache.match(request)
+        if (hit) return hit
+      }
+      // GitHub's anonymous API limit is per-IP and the worker's egress IPs
+      // are shared, so anonymous calls 403 intermittently. An optional
+      // GITHUB_TOKEN secret (public-repo read-only) lifts that to 5000/h;
+      // without it the endpoint still works, just less reliably — the
+      // desktop updater falls back to notify-and-open on failure.
+      const headers = {
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+        'user-agent': 'octo-dl-worker',
+      }
+      if (env.GITHUB_TOKEN) {
+        headers.authorization = `Bearer ${env.GITHUB_TOKEN}`
+      }
+      const upstream = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, { headers })
+      if (!upstream.ok) {
+        const detail = (await upstream.text()).slice(0, 200)
+        return new Response(`upstream ${upstream.status}: ${detail}`, {
+          status: upstream.status === 404 ? 404 : 502,
+        })
+      }
+      const resp = new Response(upstream.body, {
+        status: 200,
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'cache-control': 'public, max-age=300',
+        },
+      })
+      if (request.method === 'GET') {
+        ctx.waitUntil(cache.put(request, resp.clone()))
+      }
+      return resp
     }
 
     if (pathname === '/install.sh' || pathname === '/install.ps1') {


### PR DESCRIPTION
Follow-up to #1935, completing the blocked-network story for the desktop app.

## Why

The in-place updater's Wails GitHub provider checks `api.github.com` and downloads from `github.com` asset URLs — both unreachable from mainland China, so the update flow always fell through to notify-and-open (whose download page is also blocked until #1936 cuts over).

## What

- **`cmd/octo-desktop/mirror.go`** — `mirrorTransport` wraps the HTTP client already injected into the provider (`updateHTTPClient`). A GET/HEAD to this repo's `api.github.com/repos/...` or `github.com/.../releases/download/...` URLs that fails **at the transport level** is retried against `dl.octo-agent.dev`. HTTP error statuses pass through (a real GitHub answer is never masked), other repos and presigned `objects.githubusercontent.com` URLs are never rerouted, and `Authorization` is stripped before the mirror retry. SHA-256 sidecar verification is unchanged (`verifiedOnly` still fails closed).
- **`infra/dl-worker`** — new `/api/releases/latest` route proxying the GitHub API JSON, edge-cached 5 min. The JSON's `browser_download_url`s still point at github.com on purpose — the transport rewrites those requests too when they fail. Optional `GITHUB_TOKEN` worker secret documented: without it the anonymous per-IP API limit on Cloudflare's shared egress IPs 403s intermittently (observed once during verification); with it, 5000/h.

## Verified

- `go test ./...` in `cmd/octo-desktop` (new tests: URL mapping table, transport-error retry with credential-strip assertion via httptest, no-retry for unmapped hosts, HTTP-status passthrough); `gofmt`/`go vet` clean.
- Worker already deployed: `https://dl.octo-agent.dev/api/releases/latest` returns the v1.14.7 release JSON (200, cached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)