### PR TITLE
fix(skills): guard InstallDir staging writes with filepath.IsLocal

### DIFF
--- a/internal/skills/install_local.go
+++ b/internal/skills/install_local.go
@@ -144,6 +144,12 @@ func InstallDir(srcDir, destRoot string, force bool) (name, desc string, err err
 		if err != nil {
 			return err
 		}
+		// WalkDir only yields paths under srcDir, but guard anyway so the
+		// write target provably stays inside the staging dir (same barrier
+		// as the zip installer).
+		if !filepath.IsLocal(rel) {
+			return fmt.Errorf("entry %q escapes the skill directory", p)
+		}
 		return copyFile(p, filepath.Join(tmp, rel))
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes the two open CodeQL alerts (go/path-injection, [#162](https://github.com/open-octo/octo-agent/security/code-scanning/162) / [#163](https://github.com/open-octo/octo-agent/security/code-scanning/163)) in `internal/skills/install_local.go`.

## Problem

`InstallDir` is reachable from the web UI's skill-import handler with a user-provided source path. CodeQL traces that path through `filepath.WalkDir` → `filepath.Rel` → `filepath.Join(tmp, rel)` into `copyFile`'s `MkdirAll`/`OpenFile` sinks and reports the write target as attacker-influenced.

In practice `WalkDir` only yields paths under `srcDir`, so `rel` cannot escape the staging directory — but that invariant is non-local and invisible to the analyzer.

## Fix

Add the same `filepath.IsLocal(rel)` barrier the zip installer already uses (`InstallZip`, which CodeQL does not flag) before joining `rel` into the staging dir. This enforces the containment invariant at the write site and is the sanitizer pattern CodeQL recognizes.

## Testing

- `go test -race ./internal/skills/` passes
- `gofmt -l .` / `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)