### PR TITLE
chore: bump version to 1.14.8

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.14.7"
+var Version = "1.14.8"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Default version string for dev builds; release binaries already carry 1.14.8 via ldflags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)