### PR TITLE
fix(web): rebuild artifact previews when the theme changes

### DIFF
--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -682,3 +682,28 @@ describe('lightAppSource — what Save to Light App persists', () => {
     expect(lightAppSource(a as any)).toBe(a.code)
   })
 })
+
+describe('installArtifactThemeRefresh — theme switch busts baked previews', () => {
+  it('drops loaded text previews and leaves image artifacts alone', async () => {
+    const { installArtifactThemeRefresh } = await import('./artifacts')
+    document.documentElement.setAttribute('data-theme', 'light')
+    installArtifactThemeRefresh()
+    artifacts.set([
+      { id: 'a1', name: 'doc.md', path: '/tmp/doc.md', type: 'Markdown', icon: '',
+        loaded: true, code: '# hi', preview: '<h1>hi</h1>' } as any,
+      { id: 'a2', name: 'shot.png', path: '/tmp/shot.png', type: 'Image', icon: '',
+        loaded: true, src: '/api/x.png', preview: '' } as any,
+    ])
+
+    document.documentElement.setAttribute('data-theme', 'dark')
+    // MutationObserver delivers on a microtask; yield until it has run.
+    await vi.waitFor(() => {
+      expect(get(artifacts)[0].loaded).toBe(false)
+    })
+    expect(get(artifacts)[0].preview).toBe('')
+    // The image entry keeps its src and stays loaded — hydrate would refuse
+    // to rebuild it, so resetting it would strand a permanent spinner.
+    expect(get(artifacts)[1].loaded).toBe(true)
+    expect(get(artifacts)[1].src).toBe('/api/x.png')
+  })
+})

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -544,6 +544,31 @@ export async function hydrateArtifact(a: Artifact | null | undefined): Promise<v
   artifacts.update(list => list.map(e => (e === a ? next : e)))
 }
 
+// Preview documents bake the resolved theme into their inline styles at build
+// time (buildTextBody reads data-theme once), so a live theme switch left
+// stale-themed previews in the panel until the artifact happened to be
+// re-written. Watch the resolved <html data-theme> attribute — one observer
+// catches every path that changes it (manual pick, pack change, the OS
+// listener under "system") — and drop each built text preview back to
+// unloaded. Replacing the entry object is the same move a live re-write
+// makes: hydrateArtifact's in-flight WeakSet doesn't know the clone, so the
+// visible artifact rebuilds immediately, and a stale in-flight build fails
+// its identity-matched write-back instead of resurrecting the old theme.
+// Image artifacts stay untouched: they carry src, never a themed preview,
+// and hydrateArtifact would refuse to re-load them.
+export function installArtifactThemeRefresh(): void {
+  if (typeof MutationObserver === 'undefined' || typeof document === 'undefined') return
+  let last = document.documentElement.getAttribute('data-theme')
+  const obs = new MutationObserver(() => {
+    const cur = document.documentElement.getAttribute('data-theme')
+    if (cur === last) return
+    last = cur
+    artifacts.update(list => list.map(e =>
+      e.loaded && !e.src ? { ...e, loaded: false, loadFailed: false, preview: '', code: '' } : e))
+  })
+  obs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] })
+}
+
 // The fetch + preview build for a text-kind artifact, extracted verbatim from
 // the old eager observeArtifact. null means the body wasn't fetchable.
 async function buildTextBody(

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -3,9 +3,13 @@ import App from './App.svelte'
 import { mount } from 'svelte'
 import { initTheme } from './lib/theme'
 import { initFramelessDrag } from './lib/framelessDrag'
+import { installArtifactThemeRefresh } from './lib/artifacts'
 
 // Apply the persisted theme before first paint so there's no light-mode flash.
 initTheme()
+
+// Rebuild baked-theme artifact previews whenever the resolved theme changes.
+installArtifactThemeRefresh()
 
 // Desktop shell on Windows/Linux: window drag + edge resize (no-op elsewhere).
 initFramelessDrag()


### PR DESCRIPTION
## Summary

Artifact previews are sandboxed srcdoc documents whose colors are baked in at build time (`buildTextBody` reads `data-theme` once). Switching the theme therefore left the open preview in the old theme until close/reopen.

Fix: `installArtifactThemeRefresh()` (called once at boot) observes `<html data-theme>` and, on change, replaces every loaded text-kind artifact entry with an unloaded clone. That is the same path a live re-write takes, so it composes with #1933's guards: the panel's hydrate `$effect` rebuilds the visible preview immediately, `hydrating` (WeakSet) doesn't know the clone, and any stale in-flight build fails its identity-matched write-back. Image artifacts (`src`) are skipped — hydrate refuses to rebuild them, so resetting one would strand a spinner.

Covers manual theme picks, pack changes, and the OS listener under "system" (one observer catches every writer of the attribute).

## Test plan

- New regression test: theme flip drops loaded text previews to unloaded, leaves image entries untouched (vitest, jsdom MutationObserver). 129/129 pass.
- `svelte-check` 0 errors, `make web-build` clean.
- Manual: open a markdown artifact, switch 浅色/深色 — preview follows without reopening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)