### PR TITLE
test(server): tolerate torn session reads in attachment tests

### DIFF
--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -426,10 +426,13 @@ drain:
 	// but the turn runs on a background goroutine and the assert reads a file
 	// that goroutine just wrote; poll briefly so a loaded CI runner's scheduling
 	// jitter can't flake the read (it succeeds on the first iteration normally).
+	// A load error is "not yet", not fatal: Save rewrites the file in place
+	// (O_TRUNC, not atomic), so a read that lands mid-rewrite parses a torn
+	// transcript — the retry loop below absorbs that window too.
 	hasRehydratableImage := func() bool {
 		loaded, err := agent.LoadSession(sess.ID)
 		if err != nil {
-			t.Fatalf("reload: %v", err)
+			return false
 		}
 		for _, m := range loaded.Messages {
 			for _, blk := range m.Blocks {
@@ -578,9 +581,16 @@ drain:
 	if !hasNote {
 		t.Error("persisted user message missing the image path note")
 	}
-	// Re-load once more for the block check (cheap; the note poll above has
-	// already absorbed the cross-handle visibility lag).
-	if loaded, err := agent.LoadSession(sess.ID); err != nil {
+	// Re-load once more for the block check. The note poll above absorbed the
+	// cross-handle visibility lag, but a session Save may still be in flight
+	// (rewrites are in-place O_TRUNC, not atomic), and one read landing
+	// mid-rewrite parses a torn transcript — retry until the file parses.
+	loaded, err := agent.LoadSession(sess.ID)
+	for deadline := time.Now().Add(2 * time.Second); err != nil && time.Now().Before(deadline); {
+		time.Sleep(20 * time.Millisecond)
+		loaded, err = agent.LoadSession(sess.ID)
+	}
+	if err != nil {
 		t.Fatalf("reload: %v", err)
 	} else {
 		for _, m := range loaded.Messages {


### PR DESCRIPTION
## Summary

`TestHandleWSUserMessage_ImageOnly_NonVision` flaked on Windows CI (PR #1945's run): the final `LoadSession` failed with `invalid character '7' after top-level value`. Session `Save()` rewrites the transcript **in place** (`O_TRUNC`, not atomic), so a reader landing mid-rewrite parses a torn file. The first assertion's poll already treats errors as retryable; the final reload didn't, and the sibling vision test even fatals on a load error inside its poll.

- Non-vision test: retry the final reload with the same 2s/20ms bounded loop.
- Vision test: a load error inside `hasRehydratableImage` becomes "not yet" (the existing poll retries) instead of `t.Fatalf`.

Assertions are unweakened — the steady-state file must still parse and carry/not-carry the expected blocks. A product-side question remains (something still writes after `turnRunning` flips false, post-#1934) but that's beyond this test fix.

## Test plan

- `go test ./internal/server/ -run TestHandleWSUserMessage_ImageOnly -count=3` green.
- `go test -race ./internal/server/` green.
- gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)