### PR TITLE
feat(web): reskin tasks/agents/skills/workflows views (redesign phase 6, batch 1)

### DIFF
--- a/web/src/components/ui/StatCard.svelte
+++ b/web/src/components/ui/StatCard.svelte
@@ -18,15 +18,16 @@
 <style>
 .card {
   background: var(--bg-container);
-  border-radius: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
   box-shadow: var(--card-shadow);
-  padding: 20px 24px;
+  padding: 16px 18px;
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
-.lbl { font-size: 13px; color: var(--text-tertiary); }
-.val { font-size: 28px; font-weight: 600; color: var(--text-heading); }
+.lbl { font-size: 12px; color: var(--text-secondary); }
+.val { font-size: 26px; font-weight: 700; letter-spacing: -0.02em; color: var(--text-heading); }
 .delta { font-size: 12px; color: var(--text-tertiary); }
 .delta.up { color: var(--success-text); }
 .delta.down { color: var(--error); }

--- a/web/src/components/ui/StatusTag.svelte
+++ b/web/src/components/ui/StatusTag.svelte
@@ -3,14 +3,14 @@
   let { status = 'default', children }: { status?: TagStatus, children?: any } = $props()
 
   const styles: Record<TagStatus, string> = {
-    success: 'background:var(--success-bg);border-color:var(--success-border);color:var(--success)',
-    info:    'background:var(--blue-1);border-color:var(--info-border);color:var(--blue-6)',
-    warning: 'background:var(--warning-bg);border-color:var(--warning-border);color:var(--warning)',
-    error:   'background:var(--error-bg);border-color:var(--error-border);color:var(--error)',
-    default: 'background:var(--bg-table-header);border-color:var(--border);color:var(--text)',
+    success: 'background:var(--success-bg);color:var(--success-text)',
+    info:    'background:var(--active-blue-bg);color:var(--blue-6)',
+    warning: 'background:var(--warning-bg);color:var(--warning-text)',
+    error:   'background:var(--error-bg);color:var(--error-text)',
+    default: 'background:var(--hover-neutral);color:var(--text-secondary)',
   }
 </script>
 
-<span style="display:inline-flex;align-items:center;height:22px;padding:0 8px;border:1px solid;border-radius:4px;font-size:12px;white-space:nowrap;{styles[status]}">
+<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 9px;border-radius:999px;font-size:11px;font-weight:500;white-space:nowrap;{styles[status]}">
   {@render children?.()}
 </span>

--- a/web/src/views/AgentsView.svelte
+++ b/web/src/views/AgentsView.svelte
@@ -142,21 +142,22 @@
 
 <style>
 /* ── layout ──────────────────────────────────────────────────────────────── */
-.page  { flex: 1; overflow-y: auto; min-height: 0; }
-.inner { max-width: 1080px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 24px; }
+.page  { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.inner { max-width: 1000px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
 
 /* ── page header ─────────────────────────────────────────────────────────── */
 .page-header  { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
-.title-block  { display: flex; flex-direction: column; gap: 4px; }
-h2 { margin: 0; font-size: 24px; font-weight: 600; color: var(--text-heading); }
-p  { margin: 0; font-size: 14px; color: var(--text-secondary); }
+.title-block  { display: flex; flex-direction: column; }
+h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+p  { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }
 .header-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 
 /* ── buttons (mirror McpView) ────────────────────────────────────────────── */
 .btn-primary {
   height: 32px; padding: 0 14px; border: none; background: var(--blue-6);
-  border-radius: 6px; font-size: 14px; color: #fff; cursor: pointer;
+  border-radius: 8px; font-size: 13px; font-weight: 600; color: #fff; cursor: pointer;
   font-family: inherit; display: flex; align-items: center; gap: 8px;
+  box-shadow: 0 1px 2px rgba(0,122,255,0.35);
 }
 .btn-primary:hover:not(:disabled) { background: var(--blue-5); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -165,7 +166,7 @@ p  { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .agent-list { display: flex; flex-direction: column; gap: 16px; }
 
 .agent-card {
-  background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow);
+  background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow);
   padding: 18px 24px; display: flex; align-items: center; gap: 16px;
   transition: opacity 0.2s;
 }
@@ -202,12 +203,12 @@ p  { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .agent-actions { display: flex; align-items: center; gap: 4px; flex: 0 0 auto; }
 
 .act-btn {
-  width: 30px; height: 30px; border: 1px solid var(--border-secondary); background: var(--bg-container);
-  border-radius: 6px; display: flex; align-items: center; justify-content: center;
-  cursor: pointer; color: var(--text-tertiary);
+  width: 28px; height: 28px; border: none; background: transparent;
+  border-radius: 7px; display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--text-secondary);
 }
-.act-btn:hover:not(:disabled)      { border-color: var(--blue-5); color: var(--blue-5); }
-.act-btn.del:hover:not(:disabled)  { border-color: var(--error); color: var(--error); }
+.act-btn:hover:not(:disabled)      { background: var(--hover-neutral); color: var(--text); }
+.act-btn.del:hover:not(:disabled)  { background: var(--error-bg); color: var(--error); }
 .act-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 
 /* ── empty state ─────────────────────────────────────────────────────────── */

--- a/web/src/views/SkillsView.svelte
+++ b/web/src/views/SkillsView.svelte
@@ -291,8 +291,8 @@
 {/if}
 
 <style>
-.page { flex: 1; overflow-y: auto; min-height: 0; }
-.inner { max-width: 1080px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 24px; }
+.page { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.inner { max-width: 1000px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
 
 /* ── import modal ─────────────────────────────────────────────────────────── */
 .modal-backdrop {
@@ -328,26 +328,26 @@
 .field-input:focus { border-color: var(--blue-6); box-shadow: 0 0 0 2px var(--focus-ring); }
 .field-hint { font-size: 12px; color: var(--text-tertiary); }
 .page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
-.title-block { display: flex; flex-direction: column; gap: 4px; }
-h2 { margin: 0; font-size: 24px; font-weight: 600; color: var(--text-heading); }
-p { margin: 0; font-size: 14px; color: var(--text-secondary); }
+.title-block { display: flex; flex-direction: column; }
+h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+p { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }
 .header-actions { display: flex; align-items: center; gap: 8px; }
-.btn-primary { height: 32px; padding: 0 14px; border: none; background: var(--blue-6); border-radius: 6px; font-size: 14px; color: #fff; cursor: pointer; font-family: inherit; }
+.btn-primary { height: 32px; padding: 0 14px; border: none; background: var(--blue-6); border-radius: 8px; font-size: 13px; font-weight: 600; color: #fff; cursor: pointer; font-family: inherit; box-shadow: 0 1px 2px rgba(0,122,255,0.35); }
 .btn-primary:hover { background: var(--blue-5); }
-.btn-secondary { height: 32px; padding: 0 14px; border: 1px solid var(--border); background: var(--bg-container); border-radius: 6px; font-size: 13px; color: var(--text-secondary); cursor: pointer; font-family: inherit; }
-.btn-secondary:hover { border-color: var(--blue-5); color: var(--blue-5); }
+.btn-secondary { height: 32px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container); border-radius: 8px; font-size: 13px; font-weight: 500; color: var(--text); cursor: pointer; font-family: inherit; }
+.btn-secondary:hover { background: var(--hover-neutral); border-color: var(--text-quaternary); }
 .toolbar-row { display: flex; align-items: center; justify-content: space-between; }
 .system-toggle { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); }
-.table-card { background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow); overflow-x: auto; }
+.table-card { background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow); overflow-x: auto; }
 .table-header, .table-row {
   display: grid;
   grid-template-columns: minmax(150px,2.2fr) minmax(120px,3fr) 96px 72px 100px;
-  column-gap: 12px; align-items: center; padding: 0 24px;
+  column-gap: 12px; align-items: center;
 }
-.table-header { height: 44px; background: var(--bg-table-header); font-size: 12px; font-weight: 600; color: var(--text-secondary); border-bottom: 1px solid var(--border-table); }
-.table-row { padding: 12px 24px; border-bottom: 1px solid var(--border-table); background: var(--bg-container); min-width: 680px; }
+.table-header { padding: 11px 18px; background: var(--bg-table-header); font-size: 11px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.03em; border-bottom: 1px solid var(--border); }
+.table-row { padding: 13px 18px; border-bottom: 1px solid var(--border-secondary); background: var(--bg-container); min-width: 680px; }
 .table-row:last-child { border-bottom: none; }
-.table-row:hover { background: var(--active-blue-bg); }
+.table-row:hover { background: var(--hover-neutral); }
 .skill-name-cell { display: flex; align-items: center; gap: 10px; min-width: 0; }
 .skill-icon {
   width: 28px; height: 28px; flex: 0 0 28px; border-radius: 9999px;
@@ -358,11 +358,12 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .desc { font-size: 13px; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding-right: 16px; }
 .row-actions { display: flex; align-items: center; justify-content: flex-end; gap: 4px; }
 .act-btn {
-  width: 28px; height: 28px; border: none; background: transparent; border-radius: 6px;
-  display: flex; align-items: center; justify-content: center; cursor: pointer; color: var(--text-tertiary);
+  width: 28px; height: 28px; border: none; background: transparent; border-radius: 7px;
+  display: flex; align-items: center; justify-content: center; cursor: pointer; color: var(--text-secondary);
 }
-.act-btn:hover { background: var(--hover-neutral); color: var(--blue-6); }
-.act-btn.del:hover { color: var(--error); }
+.act-btn:hover { background: var(--hover-neutral); color: var(--text); }
+.act-btn.del:hover { background: var(--error-bg); color: var(--error); }
+.act-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 .empty-state {
   display: flex; align-items: center; justify-content: center; gap: 10px;
   padding: 48px 24px; font-size: 14px; color: var(--text-tertiary);

--- a/web/src/views/TasksView.svelte
+++ b/web/src/views/TasksView.svelte
@@ -196,20 +196,21 @@
 
 <style>
 /* ── layout ─────────────────────────────────────────────────────────────────── */
-.page { flex: 1; overflow-y: auto; min-height: 0; }
-.inner { max-width: 1080px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 24px; }
+.page { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.inner { max-width: 1000px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
 
 /* ── page header ─────────────────────────────────────────────────────────────── */
 .page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
-.title-block { display: flex; flex-direction: column; gap: 4px; }
-h2 { margin: 0; font-size: 24px; font-weight: 600; color: var(--text-heading); }
-p { margin: 0; font-size: 14px; color: var(--text-secondary); }
+.title-block { display: flex; flex-direction: column; }
+h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+p { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }
 
 /* ── buttons ─────────────────────────────────────────────────────────────────── */
 .btn-primary {
   height: 32px; padding: 0 14px; border: none; background: var(--blue-6);
-  border-radius: 6px; font-size: 14px; color: #fff; cursor: pointer;
+  border-radius: 8px; font-size: 13px; font-weight: 600; color: #fff; cursor: pointer;
   font-family: inherit; display: inline-flex; align-items: center; gap: 6px;
+  box-shadow: 0 1px 2px rgba(0,122,255,0.35);
 }
 .btn-primary:hover:not(:disabled) { background: var(--blue-5); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -219,22 +220,23 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 
 /* ── table ───────────────────────────────────────────────────────────────────── */
 .table-card {
-  background: var(--bg-container); border-radius: 16px;
+  background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card);
   box-shadow: var(--card-shadow); overflow-x: auto;
 }
 .table-header, .table-row {
   display: grid;
   grid-template-columns: minmax(170px,2.4fr) 120px minmax(110px,1.2fr) 96px 120px;
-  column-gap: 12px; align-items: center; padding: 0 24px; min-width: 690px;
+  column-gap: 12px; align-items: center; min-width: 690px;
 }
 .table-header {
-  height: 44px; background: var(--bg-table-header);
-  font-size: 12px; font-weight: 600; color: var(--text-secondary);
-  border-bottom: 1px solid var(--border-table);
+  padding: 11px 18px; background: var(--bg-table-header);
+  font-size: 11px; font-weight: 600; color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: 0.03em;
+  border-bottom: 1px solid var(--border);
 }
-.table-row { padding: 12px 24px; border-bottom: 1px solid var(--border-table); background: var(--bg-container); }
+.table-row { padding: 13px 18px; border-bottom: 1px solid var(--border-secondary); background: var(--bg-container); }
 .table-row:last-child { border-bottom: none; }
-.table-row:hover { background: var(--active-blue-bg); }
+.table-row:hover { background: var(--hover-neutral); }
 .empty-row {
   padding: 36px 24px; text-align: center;
   font-size: 14px; color: var(--text-tertiary);
@@ -251,9 +253,10 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .row-actions { display: flex; align-items: center; justify-content: flex-end; gap: 4px; }
 .act-btn {
   width: 28px; height: 28px; border: none; background: transparent;
-  border-radius: 6px; display: flex; align-items: center; justify-content: center;
-  cursor: pointer; color: var(--text-tertiary);
+  border-radius: 7px; display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--text-secondary);
 }
-.act-btn:hover { background: var(--hover-neutral); color: var(--blue-6); }
-.act-btn.del:hover { color: var(--error); }
+.act-btn:hover { background: var(--hover-neutral); color: var(--text); }
+.act-btn.del:hover { background: var(--error-bg); color: var(--error); }
+.act-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 </style>

--- a/web/src/views/WorkflowsView.svelte
+++ b/web/src/views/WorkflowsView.svelte
@@ -199,8 +199,8 @@
 {/if}
 
 <style>
-.page { flex: 1; overflow-y: auto; min-height: 0; }
-.inner { max-width: 1080px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 24px; }
+.page { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.inner { max-width: 1000px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
 
 /* ── view-source modal ────────────────────────────────────────────────────── */
 .modal-backdrop {
@@ -233,26 +233,26 @@
   color: var(--text); white-space: pre-wrap; word-break: break-word;
 }
 .page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
-.title-block { display: flex; flex-direction: column; gap: 4px; }
-h2 { margin: 0; font-size: 24px; font-weight: 600; color: var(--text-heading); }
-p { margin: 0; font-size: 14px; color: var(--text-secondary); }
+.title-block { display: flex; flex-direction: column; }
+h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+p { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }
 .header-actions { display: flex; align-items: center; gap: 8px; }
-.btn-primary { height: 32px; padding: 0 14px; border: none; background: var(--blue-6); border-radius: 6px; font-size: 14px; color: #fff; cursor: pointer; font-family: inherit; }
+.btn-primary { height: 32px; padding: 0 14px; border: none; background: var(--blue-6); border-radius: 8px; font-size: 13px; font-weight: 600; color: #fff; cursor: pointer; font-family: inherit; box-shadow: 0 1px 2px rgba(0,122,255,0.35); }
 .btn-primary:hover { background: var(--blue-5); }
-.btn-secondary { height: 32px; padding: 0 14px; border: 1px solid var(--border); background: var(--bg-container); border-radius: 6px; font-size: 13px; color: var(--text-secondary); cursor: pointer; font-family: inherit; }
-.btn-secondary:hover { border-color: var(--blue-5); color: var(--blue-5); }
+.btn-secondary { height: 32px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container); border-radius: 8px; font-size: 13px; font-weight: 500; color: var(--text); cursor: pointer; font-family: inherit; }
+.btn-secondary:hover { background: var(--hover-neutral); border-color: var(--text-quaternary); }
 .toolbar-row { display: flex; align-items: center; justify-content: space-between; }
 .system-toggle { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); }
-.table-card { background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow); overflow-x: auto; }
+.table-card { background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow); overflow-x: auto; }
 .table-header, .table-row {
   display: grid;
   grid-template-columns: minmax(150px,2fr) minmax(120px,3fr) 96px 180px;
-  column-gap: 12px; align-items: center; padding: 0 24px;
+  column-gap: 12px; align-items: center;
 }
-.table-header { height: 44px; background: var(--bg-table-header); font-size: 12px; font-weight: 600; color: var(--text-secondary); border-bottom: 1px solid var(--border-table); }
-.table-row { padding: 12px 24px; border-bottom: 1px solid var(--border-table); background: var(--bg-container); min-width: 720px; }
+.table-header { padding: 11px 18px; background: var(--bg-table-header); font-size: 11px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.03em; border-bottom: 1px solid var(--border); }
+.table-row { padding: 13px 18px; border-bottom: 1px solid var(--border-secondary); background: var(--bg-container); min-width: 720px; }
 .table-row:last-child { border-bottom: none; }
-.table-row:hover { background: var(--active-blue-bg); }
+.table-row:hover { background: var(--hover-neutral); }
 .skill-name-cell { display: flex; align-items: center; gap: 10px; min-width: 0; }
 .skill-icon {
   width: 28px; height: 28px; flex: 0 0 28px; border-radius: 9999px;
@@ -263,13 +263,13 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .desc { font-size: 13px; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding-right: 16px; }
 .row-actions { display: flex; align-items: center; justify-content: flex-end; gap: 4px; }
 .act-btn {
-  width: 28px; height: 28px; border: none; background: transparent; border-radius: 6px;
-  display: flex; align-items: center; justify-content: center; cursor: pointer; color: var(--text-tertiary);
+  width: 28px; height: 28px; border: none; background: transparent; border-radius: 7px;
+  display: flex; align-items: center; justify-content: center; cursor: pointer; color: var(--text-secondary);
 }
-.act-btn:hover { background: var(--hover-neutral); color: var(--blue-6); }
-.act-btn.del:hover { color: var(--error); }
+.act-btn:hover { background: var(--hover-neutral); color: var(--text); }
+.act-btn.del:hover { background: var(--error-bg); color: var(--error); }
 .act-btn:disabled { opacity: 0.35; cursor: not-allowed; }
-.act-btn:disabled:hover { background: transparent; color: var(--text-tertiary); }
+.act-btn:disabled:hover { background: transparent; color: var(--text-secondary); }
 .empty-state {
   display: flex; align-items: center; justify-content: center; gap: 10px;
   padding: 48px 24px; font-size: 14px; color: var(--text-tertiary);


### PR DESCRIPTION
## Summary
- Restyle TasksView, AgentsView, SkillsView, WorkflowsView to match the Apple-style page primitives from the design mock (`dev-docs/design/desktop-redesign-mock.html`): card radius/border, table header/row spacing, action-button hover states, primary/secondary button styling.
- Restyle the shared `StatusTag` (badges) and `StatCard` (KPI tiles) components used across most secondary views.
- Pure reskin: no markup structure, behavior, or i18n changes.

Part of the phase 6 batch split (10 secondary views total, split across 2-3 PRs). Remaining: mcp / channels / browser / profile / files / lightapps.

## Test plan
- [x] `npx svelte-check` in `web/`: 0 errors (1 pre-existing unrelated warning)
- [x] Manual: Roy verified visually on local 8899 build

🤖 Generated with [Claude Code](https://claude.com/claude-code)