### PR TITLE
feat(web): reskin mcp/channels/files views (redesign phase 6, batch 2)

### DIFF
--- a/web/src/views/ChannelsView.svelte
+++ b/web/src/views/ChannelsView.svelte
@@ -218,15 +218,15 @@
 </div>
 
 <style>
-.page { flex: 1; overflow-y: auto; min-height: 0; }
-.inner { max-width: 1080px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 24px; }
+.page { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.inner { max-width: 1000px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
 .page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
-.title-block { display: flex; flex-direction: column; gap: 4px; }
-h2 { margin: 0; font-size: 24px; font-weight: 600; color: var(--text-heading); }
-p { margin: 0; font-size: 14px; color: var(--text-secondary); }
+.title-block { display: flex; flex-direction: column; }
+h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+p { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }
 .grid { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 16px; }
 .channel-card {
-  background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow);
+  background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow);
   padding: 24px; display: flex; flex-direction: column; gap: 12px;
 }
 .channel-top { display: flex; align-items: center; gap: 10px; }
@@ -240,14 +240,14 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .ch-activity { font-size: 12px; color: var(--text-tertiary); }
 .ch-actions { display: flex; align-items: center; justify-content: flex-end; gap: 8px; padding-top: 4px; }
 .btn-outline {
-  height: 28px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container); border-radius: 6px;
-  display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary);
+  height: 28px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container); border-radius: 8px;
+  display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 500; color: var(--text);
   cursor: pointer; font-family: inherit;
 }
-.btn-outline:hover:not(:disabled) { border-color: var(--blue-5); color: var(--blue-5); }
+.btn-outline:hover:not(:disabled) { background: var(--hover-neutral); border-color: var(--text-quaternary); }
 .btn-outline:disabled { opacity: 0.5; cursor: not-allowed; }
-.btn-outline.del:hover:not(:disabled) { border-color: var(--error); color: var(--error); }
-.btn-primary-sm { height: 28px; padding: 0 12px; border: none; background: var(--blue-6); border-radius: 6px; display: flex; align-items: center; gap: 8px; font-size: 13px; color: #fff; cursor: pointer; font-family: inherit; }
+.btn-outline.del:hover:not(:disabled) { background: var(--error-bg); border-color: var(--error-border); color: var(--error); }
+.btn-primary-sm { height: 28px; padding: 0 12px; border: none; background: var(--blue-6); border-radius: 8px; display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600; color: #fff; cursor: pointer; font-family: inherit; box-shadow: 0 1px 2px rgba(0,122,255,0.35); }
 .btn-primary-sm:hover { background: var(--blue-5); }
 .empty-state { padding: 40px; text-align: center; color: var(--text-tertiary); font-size: 14px; }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }

--- a/web/src/views/FileRecallView.svelte
+++ b/web/src/views/FileRecallView.svelte
@@ -266,30 +266,30 @@
 </div>
 
 <style>
-.page { flex: 1; overflow-y: auto; min-height: 0; }
-.inner { max-width: 1080px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 24px; }
-.page-header { display: flex; flex-direction: column; gap: 4px; }
-h2 { margin: 0; font-size: 24px; font-weight: 600; color: var(--text-heading); }
-p { margin: 0; font-size: 14px; color: var(--text-secondary); }
+.page { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.inner { max-width: 1000px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
+.page-header { display: flex; flex-direction: column; }
+h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+p { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }
 .stats-bar {
-  background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow);
+  background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow);
   padding: 14px 20px; display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
 }
 .stats-text { font-size: 13px; color: var(--text-tertiary); flex: 1; min-width: 0; }
 .bar-actions { display: flex; align-items: center; gap: 8px; }
 .btn-outline {
-  height: 30px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container); border-radius: 6px;
-  display: flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-secondary);
+  height: 30px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container); border-radius: 8px;
+  display: flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 500; color: var(--text);
   cursor: pointer; font-family: inherit;
 }
-.btn-outline:hover:not(:disabled) { border-color: var(--blue-5); color: var(--blue-5); }
+.btn-outline:hover:not(:disabled) { background: var(--hover-neutral); border-color: var(--text-quaternary); }
 .btn-outline:disabled { opacity: 0.5; cursor: not-allowed; }
 .btn-danger-ghost {
-  height: 30px; padding: 0 12px; border: 1px solid var(--border-secondary); background: var(--bg-container); border-radius: 6px;
-  display: flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-tertiary);
+  height: 30px; padding: 0 12px; border: 1px solid var(--border-secondary); background: var(--bg-container); border-radius: 8px;
+  display: flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 500; color: var(--text-secondary);
   cursor: pointer; font-family: inherit;
 }
-.btn-danger-ghost:hover:not(:disabled) { border-color: var(--error); color: var(--error); }
+.btn-danger-ghost:hover:not(:disabled) { background: var(--error-bg); border-color: var(--error-border); color: var(--error); }
 .btn-danger-ghost:disabled { opacity: 0.4; cursor: not-allowed; }
 .empty-state {
   padding: 60px; display: flex; flex-direction: column; align-items: center; gap: 12px;
@@ -297,7 +297,7 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 }
 .file-list { display: flex; flex-direction: column; gap: 12px; }
 .file-card {
-  background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow);
+  background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow);
   padding: 16px 24px; display: flex; align-items: center; gap: 16px;
 }
 .file-icon {
@@ -313,11 +313,11 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .sep { width: 3px; height: 3px; border-radius: 9999px; background: var(--text-quaternary); }
 .file-actions { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
 .icon-btn {
-  width: 30px; height: 30px; border: 1px solid var(--border-secondary); background: var(--bg-container); border-radius: 6px;
+  width: 28px; height: 28px; border: none; background: transparent; border-radius: 7px;
   display: flex; align-items: center; justify-content: center; cursor: pointer;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
 }
 .icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.icon-btn.del:hover:not(:disabled) { border-color: var(--error); color: var(--error); }
+.icon-btn.del:hover:not(:disabled) { background: var(--error-bg); color: var(--error); }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 </style>

--- a/web/src/views/McpView.svelte
+++ b/web/src/views/McpView.svelte
@@ -431,36 +431,37 @@
 
 <style>
 /* ── layout ──────────────────────────────────────────────────────────────── */
-.page  { flex: 1; overflow-y: auto; min-height: 0; }
-.inner { max-width: 1080px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 24px; }
+.page  { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.inner { max-width: 1000px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
 
 /* ── page header ─────────────────────────────────────────────────────────── */
 .page-header  { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
-.title-block  { display: flex; flex-direction: column; gap: 4px; }
-h2 { margin: 0; font-size: 24px; font-weight: 600; color: var(--text-heading); }
-p  { margin: 0; font-size: 14px; color: var(--text-secondary); }
+.title-block  { display: flex; flex-direction: column; }
+h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+p  { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }
 .header-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 
 /* ── buttons ─────────────────────────────────────────────────────────────── */
 .btn-primary {
   height: 32px; padding: 0 14px; border: none; background: var(--blue-6);
-  border-radius: 6px; font-size: 14px; color: #fff; cursor: pointer;
+  border-radius: 8px; font-size: 13px; font-weight: 600; color: #fff; cursor: pointer;
   font-family: inherit; display: flex; align-items: center; gap: 8px;
+  box-shadow: 0 1px 2px rgba(0,122,255,0.35);
 }
 .btn-primary:hover:not(:disabled) { background: var(--blue-5); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .btn-secondary {
   height: 32px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container);
-  border-radius: 6px; font-size: 13px; color: var(--text-secondary); cursor: pointer;
+  border-radius: 8px; font-size: 13px; font-weight: 500; color: var(--text); cursor: pointer;
   font-family: inherit; display: flex; align-items: center; gap: 8px;
 }
-.btn-secondary:hover:not(:disabled) { border-color: var(--blue-5); color: var(--blue-5); }
+.btn-secondary:hover:not(:disabled) { background: var(--hover-neutral); border-color: var(--text-quaternary); }
 .btn-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* ── tool-search card ────────────────────────────────────────────────────── */
 .tool-search-card {
-  background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow);
+  background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow);
   padding: 20px 24px; display: flex; align-items: center; gap: 24px;
 }
 .ts-info  { display: flex; flex-direction: column; gap: 3px; flex: 1; min-width: 0; }
@@ -471,7 +472,7 @@ p  { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .server-list { display: flex; flex-direction: column; gap: 16px; }
 
 .server-card {
-  background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow);
+  background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow);
   padding: 18px 24px; display: flex; align-items: center; gap: 16px;
   transition: opacity 0.2s;
 }
@@ -507,12 +508,12 @@ p  { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .server-actions { display: flex; align-items: center; gap: 4px; flex: 0 0 auto; }
 
 .srv-btn {
-  width: 30px; height: 30px; border: 1px solid var(--border-secondary); background: var(--bg-container);
-  border-radius: 6px; display: flex; align-items: center; justify-content: center;
-  cursor: pointer; color: var(--text-tertiary);
+  width: 28px; height: 28px; border: none; background: transparent;
+  border-radius: 7px; display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--text-secondary);
 }
-.srv-btn:hover:not(:disabled)      { border-color: var(--blue-5); color: var(--blue-5); }
-.srv-btn.del:hover:not(:disabled)  { border-color: var(--error); color: var(--error); }
+.srv-btn:hover:not(:disabled)      { background: var(--hover-neutral); color: var(--text); }
+.srv-btn.del:hover:not(:disabled)  { background: var(--error-bg); color: var(--error); }
 .srv-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 
 /* ── empty state ─────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Restyle McpView, ChannelsView, FileRecallView to match the Apple-style page primitives from the design mock: card radius/border, action-button hover states, primary/secondary button styling.
- Same treatment as batch 1 (#1952): pure reskin, no markup structure, behavior, or i18n changes.

Part of the phase 6 batch split (10 secondary views total). Remaining: profile / lightapps / browser.

## Test plan
- [x] `npx svelte-check` in `web/`: 0 errors (1 pre-existing unrelated warning)
- [x] Manual: Roy verified visually on local 8899 build

🤖 Generated with [Claude Code](https://claude.com/claude-code)