### PR TITLE
feat(web): reskin profile/lightapps/browser views (redesign phase 6, batch 3)

### DIFF
--- a/web/src/views/BrowserView.svelte
+++ b/web/src/views/BrowserView.svelte
@@ -199,32 +199,33 @@
 {/if}
 
 <style>
-  .view { padding: 24px; max-width: 880px; margin: 0 auto; overflow-y: auto; }
-  .view-head h1 { margin: 0; font-size: 20px; }
-  .sub { color: var(--text-muted); margin: 4px 0 20px; font-size: 13px; }
-  .card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 18px; margin-bottom: 18px; }
+  .view { padding: 26px 28px 40px; max-width: 880px; margin: 0 auto; overflow-y: auto; background: var(--bg-layout); }
+  .view-head h1 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+  .sub { color: var(--text-secondary); margin: 4px 0 20px; font-size: 13px; }
+  .card { background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow); padding: 18px; margin-bottom: 18px; }
   .sec-head { display: flex; align-items: center; justify-content: space-between; }
   .sec-title { margin: 0 0 12px; font-size: 15px; }
   .conn-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
   .conn-info { display: flex; flex-direction: column; gap: 4px; }
   .conn-info .sec-title { margin: 0; }
-  .conn-desc { font-size: 12px; color: var(--text-muted); }
+  .conn-desc { font-size: 12px; color: var(--text-secondary); }
   .conn-right { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
   .conn-note { display: flex; align-items: center; gap: 8px; margin-top: 12px; padding: 10px 12px; border-radius: 8px; font-size: 12px; color: var(--warning); background: var(--warning-bg); }
   .mono { font-family: ui-monospace, monospace; }
-  .hint { color: var(--text-muted); font-size: 12px; margin: 0 0 14px; }
-  .muted { color: var(--text-muted); font-size: 13px; }
+  .hint { color: var(--text-secondary); font-size: 12px; margin: 0 0 14px; }
+  .muted { color: var(--text-secondary); font-size: 13px; }
   .rec-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
-  .rec { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 14px; border: 1px solid var(--border); border-radius: 8px; }
+  .rec { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 14px; border: 1px solid var(--border-secondary); border-radius: 8px; }
   .rec-name { font-weight: 600; font-size: 14px; }
-  .rec-desc { color: var(--text-muted); font-size: 12px; margin-top: 2px; }
-  .rec-meta { color: var(--text-muted); font-size: 11px; margin-top: 4px; }
+  .rec-desc { color: var(--text-secondary); font-size: 12px; margin-top: 2px; }
+  .rec-meta { color: var(--text-tertiary); font-size: 11px; margin-top: 4px; }
   .rec-actions { display: flex; gap: 6px; flex-shrink: 0; }
-  .ghost-btn { background: transparent; border: 1px solid var(--border); border-radius: 6px; padding: 5px 10px; font-size: 12px; cursor: pointer; color: var(--text); }
-  .ghost-btn:hover { background: var(--surface-hover); }
-  .ghost-btn.danger { color: var(--danger, #d4380d); }
+  .ghost-btn { background: transparent; border: 1px solid var(--border); border-radius: 8px; padding: 5px 10px; font-size: 12px; font-weight: 500; cursor: pointer; color: var(--text); }
+  .ghost-btn:hover { background: var(--hover-neutral); border-color: var(--text-quaternary); }
+  .ghost-btn.danger { color: var(--error); }
+  .ghost-btn.danger:hover { background: var(--error-bg); border-color: var(--error-border); }
   .rec-head-actions { display: flex; align-items: center; gap: 8px; }
-  .primary-btn { display: inline-flex; align-items: center; gap: 5px; background: var(--blue-6); color: #fff; border: none; border-radius: 6px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+  .primary-btn { display: inline-flex; align-items: center; gap: 5px; background: var(--blue-6); color: #fff; border: none; border-radius: 8px; padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; box-shadow: 0 1px 2px rgba(0,122,255,0.35); }
   .primary-btn:hover:not(:disabled) { background: var(--blue-5); }
   .primary-btn:disabled { opacity: 0.6; cursor: default; }
   .modal-overlay {

--- a/web/src/views/LightAppsView.svelte
+++ b/web/src/views/LightAppsView.svelte
@@ -128,17 +128,18 @@
 </div>
 
 <style>
-.page { flex: 1; overflow-y: auto; min-height: 0; }
-.inner { max-width: 1080px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 24px; }
-.page-header { display: flex; flex-direction: column; gap: 4px; }
+.page { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.inner { max-width: 1000px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
+.page-header { display: flex; flex-direction: column; }
 .header-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
-h2 { margin: 0; font-size: 24px; font-weight: 600; color: var(--text-heading); }
-p { margin: 0; font-size: 14px; color: var(--text-secondary); }
+h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+p { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }
 .btn-primary {
-  height: 32px; padding: 0 16px; border: none; border-radius: 6px;
-  background: var(--blue-6); color: #fff; font-size: 13px;
+  height: 32px; padding: 0 14px; border: none; border-radius: 8px;
+  background: var(--blue-6); color: #fff; font-size: 13px; font-weight: 600;
   display: flex; align-items: center; gap: 6px;
   cursor: pointer; font-family: inherit; flex-shrink: 0;
+  box-shadow: 0 1px 2px rgba(0,122,255,0.35);
 }
 .btn-primary:hover { background: var(--blue-5); }
 .empty-state {
@@ -151,7 +152,7 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
   gap: 16px;
 }
 .app-card {
-  background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow);
+  background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow);
   padding: 24px; display: flex; flex-direction: column; gap: 16px;
   transition: box-shadow 0.15s;
 }
@@ -171,12 +172,12 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 }
 .btn-action {
   height: 28px; padding: 0 10px; border: 1px solid var(--border);
-  background: var(--bg-container); border-radius: 6px;
+  background: var(--bg-container); border-radius: 8px;
   display: flex; align-items: center; gap: 4px;
-  font-size: 12px; color: var(--text-secondary);
+  font-size: 12px; font-weight: 500; color: var(--text);
   cursor: pointer; font-family: inherit;
 }
-.btn-action:hover:not(:disabled) { border-color: var(--blue-5); color: var(--blue-5); }
+.btn-action:hover:not(:disabled) { background: var(--hover-neutral); border-color: var(--text-quaternary); }
 .btn-action:disabled { opacity: 0.5; cursor: not-allowed; }
-.btn-action.danger:hover:not(:disabled) { border-color: var(--error); color: var(--error); }
+.btn-action.danger:hover:not(:disabled) { background: var(--error-bg); border-color: var(--error-border); color: var(--error); }
 </style>

--- a/web/src/views/ProfileView.svelte
+++ b/web/src/views/ProfileView.svelte
@@ -247,11 +247,11 @@
 </div>
 
 <style>
-.page { flex: 1; overflow-y: auto; min-height: 0; }
-.inner { max-width: 800px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 20px; }
-.page-header { display: flex; flex-direction: column; gap: 4px; }
-h2 { margin: 0; font-size: 24px; font-weight: 600; color: var(--text-heading); }
-p { margin: 0; font-size: 14px; color: var(--text-secondary); }
+.page { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.inner { max-width: 780px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
+.page-header { display: flex; flex-direction: column; }
+h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
+p { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }
 .tabs { display: flex; align-items: center; gap: 24px; border-bottom: 1px solid var(--border-secondary); }
 .tab {
   padding: 0 2px 10px; margin-bottom: -1px; cursor: pointer;
@@ -260,7 +260,7 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 }
 .tab.active { font-weight: 600; color: var(--blue-6); border-bottom-color: var(--blue-6); }
 .tab:hover:not(.active) { color: var(--text); }
-.section-card { background: var(--bg-container); border-radius: 16px; box-shadow: var(--card-shadow); overflow: hidden; }
+.section-card { background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow); overflow: hidden; }
 .card-header {
   display: flex; align-items: center; gap: 12px;
   padding: 16px 24px; border-bottom: 1px solid var(--border-table);
@@ -293,7 +293,7 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
   padding: 16px 24px; border-top: 1px dashed var(--border-secondary);
 }
 .footer-hint { font-size: 13px; color: var(--text-tertiary); flex: 1; min-width: 0; }
-.btn-primary { height: 32px; padding: 0 14px; border: none; background: var(--blue-6); border-radius: 6px; font-size: 13px; color: #fff; cursor: pointer; font-family: inherit; white-space: nowrap; }
+.btn-primary { height: 32px; padding: 0 14px; border: none; background: var(--blue-6); border-radius: 8px; font-size: 13px; font-weight: 600; color: #fff; cursor: pointer; font-family: inherit; white-space: nowrap; box-shadow: 0 1px 2px rgba(0,122,255,0.35); }
 .btn-primary:hover { background: var(--blue-5); }
 .mem-count { font-size: 12px; color: var(--text-tertiary); }
 .auto-badge { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-tertiary); margin-left: auto; }
@@ -318,10 +318,10 @@ p { margin: 0; font-size: 14px; color: var(--text-secondary); }
 .mem-meta { font-size: 12px; color: var(--text-tertiary); }
 .forget-btn {
   flex: 0 0 auto; margin-top: 1px; height: 28px; padding: 0 10px;
-  border: 1px solid var(--border-secondary); background: var(--bg-container); border-radius: 6px;
+  border: none; background: transparent; border-radius: 7px;
   display: flex; align-items: center; gap: 6px; font-size: 12px;
-  color: var(--text-tertiary); cursor: pointer; font-family: inherit;
+  color: var(--text-secondary); cursor: pointer; font-family: inherit;
 }
-.forget-btn:hover { border-color: var(--error); color: var(--error); }
+.forget-btn:hover { background: var(--error-bg); color: var(--error); }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 </style>


### PR DESCRIPTION
## Summary
- Restyle ProfileView, LightAppsView, BrowserView to match the Apple-style page primitives from the design mock: card radius/border, action-button hover states, primary/secondary button styling.
- Same treatment as batches 1-2 (#1952, #1953): pure reskin, no markup structure, behavior, or i18n changes.
- BrowserView had drifted from the phase 0 token rename (#1943) — it still referenced removed `--text-muted`/`--surface`/`--surface-hover` vars with no CSS fallback, so those rules were rendering with an invalid/inherited color. Migrated it to the current token set as part of this pass so the reskin has something valid to build on.

This completes phase 6 — all 10 secondary views (tasks/agents/skills/workflows/mcp/channels/files/profile/lightapps/browser) now match the redesign's visual language. Remaining phases per the plan: phase 7 (settings modal + onboarding redesign).

## Test plan
- [x] `npx svelte-check` in `web/`: 0 errors (1 pre-existing unrelated warning)
- [x] Manual: Roy verified visually on local 8899 build

🤖 Generated with [Claude Code](https://claude.com/claude-code)