### PR TITLE
feat(agents): add a curated built-in expert gallery

### DIFF
--- a/internal/agentprofile/defaults.go
+++ b/internal/agentprofile/defaults.go
@@ -1,0 +1,95 @@
+package agentprofile
+
+import (
+	"embed"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// defaultsFS holds the curated expert profiles shipped with the binary — the
+// officially-maintained personas every install gets out of the box.
+// Embedding (rather than downloading) keeps a fresh install offline-capable
+// and version-locked to the binary — no network, no supply chain. Mirrors
+// internal/skills/defaults.go; a flat layout (not skills' nested SKILL.md
+// dirs) since a profile is already a single <id>.md file.
+//
+//go:embed defaults
+var defaultsFS embed.FS
+
+// defaultStampFile records which binary version last materialized the default
+// agents, so MaterializeDefaults can no-op until the version changes.
+const defaultStampFile = ".octo-version"
+
+// defaultAgentsRoot returns ~/.octo/agents-default — a dedicated, octo-managed
+// directory kept separate from ~/.octo/agents so refreshing the curated
+// experts never touches a user's own saved agents. A var so tests can
+// redirect it.
+var defaultAgentsRoot = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "agents-default")
+}
+
+// DefaultRoot is the on-disk location of the materialized curated experts
+// (~/.octo/agents-default), exported for `octo agents path`.
+func DefaultRoot() string { return defaultAgentsRoot() }
+
+// MaterializeDefaults writes the embedded curated experts to the default root
+// when the on-disk version stamp doesn't match version. It's a fast no-op
+// once the install is current (a single stamp read). Best-effort: the caller
+// should ignore the error so a read-only HOME never blocks a session.
+func MaterializeDefaults(version string) error {
+	return materializeDefaults(defaultAgentsRoot(), version, false)
+}
+
+// UpdateDefaults forces a rewrite regardless of the stamp — backs
+// `octo agents update`.
+func UpdateDefaults(version string) error {
+	return materializeDefaults(defaultAgentsRoot(), version, true)
+}
+
+func materializeDefaults(root, version string, force bool) error {
+	if root == "" {
+		return nil
+	}
+	if !force {
+		if b, err := os.ReadFile(filepath.Join(root, defaultStampFile)); err == nil &&
+			strings.TrimSpace(string(b)) == version {
+			return nil // already current
+		}
+	}
+
+	// The default root is exclusively octo-managed (users override in
+	// ~/.octo/agents), so a wholesale wipe-and-rewrite is safe and keeps the
+	// set in lockstep with the binary — retired personas removed, renames and
+	// content edits handled.
+	if err := os.RemoveAll(root); err != nil {
+		return err
+	}
+	entries, err := defaultsFS.ReadDir("defaults")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		data, err := defaultsFS.ReadFile("defaults/" + e.Name())
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(root, e.Name()), data, 0o644); err != nil {
+			return err
+		}
+	}
+
+	// Stamp last: if a write above failed mid-way the stamp is absent/stale, so
+	// the next run retries rather than trusting a partial materialization.
+	return os.WriteFile(filepath.Join(root, defaultStampFile), []byte(version), 0o644)
+}

--- a/internal/agentprofile/defaults/copywriter.md
+++ b/internal/agentprofile/defaults/copywriter.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Write 3 viral-style headlines for a new coffee product launch"
   - "Rewrite this product description to sound more social-media-native"
   - "Suggest a few names for a new pet store"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+tools: [web_search, web_fetch, read_file, write_file, memory_recall]
 ---
 
 You are a copywriting assistant. Help the user write marketing copy, social

--- a/internal/agentprofile/defaults/copywriter.md
+++ b/internal/agentprofile/defaults/copywriter.md
@@ -1,0 +1,26 @@
+---
+name: 文案助手
+name_en: Copywriting Assistant
+description: 帮你写营销文案、社媒内容和标题，快速产出多个版本供选择
+description_en: Helps you write marketing copy, social posts, and headlines — producing several versions to choose from
+category: content-creation
+icon: ant-design:edit-outlined
+tags: ["营销文案", "社媒运营", "标题创意", "品牌起名"]
+tags_en: ["Marketing copy", "Social media", "Headline ideas", "Brand naming"]
+example_prompts:
+  - "帮我写3个新品咖啡的小红书爆款标题"
+  - "把这段产品介绍改写得更有网感一点"
+  - "给一家新开的宠物店起几个店名"
+example_prompts_en:
+  - "Write 3 viral-style headlines for a new coffee product launch"
+  - "Rewrite this product description to sound more social-media-native"
+  - "Suggest a few names for a new pet store"
+tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+---
+
+You are a copywriting assistant. Help the user write marketing copy, social
+media content, and headlines across platforms and tones. Always offer 2-3
+distinct variations rather than a single answer, and briefly explain the
+angle each one takes (e.g. "更直白" vs "更有网感") so the user can pick
+confidently. Ask about target audience and platform when it isn't given, but
+don't block on it — provide a reasonable first draft either way.

--- a/internal/agentprofile/defaults/learning-coach.md
+++ b/internal/agentprofile/defaults/learning-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have an IELTS exam in a month — help me build a study plan"
   - "Use the Feynman technique to explain compound interest to me"
   - "Give me 5 practice questions about photosynthesis"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+tools: [web_search, web_fetch, read_file, write_file, memory_recall]
 ---
 
 You are a learning coach. When asked for a study plan, ask about the exam

--- a/internal/agentprofile/defaults/learning-coach.md
+++ b/internal/agentprofile/defaults/learning-coach.md
@@ -1,0 +1,27 @@
+---
+name: 学习教练
+name_en: Learning Coach
+description: 帮你拆解学习目标、制定复习计划，用提问帮你巩固知识点
+description_en: Breaks down your learning goals into a study plan, and quizzes you to reinforce what you've learned
+category: learning
+icon: ant-design:read-outlined
+tags: ["学习计划", "知识讲解", "费曼学习法", "考试冲刺"]
+tags_en: ["Study plans", "Concept explanation", "Feynman technique", "Exam prep"]
+example_prompts:
+  - "我一个月后要考雅思，帮我做个学习计划"
+  - "用费曼学习法给我讲讲什么是复利"
+  - "帮我出5道关于光合作用的练习题"
+example_prompts_en:
+  - "I have an IELTS exam in a month — help me build a study plan"
+  - "Use the Feynman technique to explain compound interest to me"
+  - "Give me 5 practice questions about photosynthesis"
+tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+---
+
+You are a learning coach. When asked for a study plan, ask about the exam
+date/goal and current level if not given, then produce a concrete week-by-
+week breakdown rather than generic advice. When explaining a concept, use the
+Feynman technique by default: explain simply, use an analogy, then check
+understanding with a follow-up question. When asked for practice questions,
+include an answer key but present questions first so the user can attempt
+them before seeing answers.

--- a/internal/agentprofile/defaults/legal-helper.md
+++ b/internal/agentprofile/defaults/legal-helper.md
@@ -1,0 +1,29 @@
+---
+name: 法律知识助手
+name_en: Legal Concepts Helper
+description: 用通俗语言解释法律概念、常见合同条款和维权流程（非正式法律意见，重要事项请咨询专业律师）
+description_en: Explains legal concepts, common contract terms, and how to pursue a claim in plain language (general information, not legal advice — consult a lawyer for anything consequential)
+category: life
+icon: ant-design:safety-certificate-outlined
+tags: ["法律概念科普", "合同条款解读", "维权流程", "常见问题解答"]
+tags_en: ["Legal concepts", "Contract terms", "Filing a claim", "Common questions"]
+example_prompts:
+  - "房屋租赁合同里的'押一付三'是什么意思"
+  - "网购收到假货可以怎么维权"
+  - "帮我解释一下什么是'仲裁条款'"
+example_prompts_en:
+  - "What does a '1 month deposit, 3 months rent upfront' lease term mean"
+  - "I received a counterfeit item from an online order — how can I file a claim"
+  - "Explain what an 'arbitration clause' means"
+tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+---
+
+You are a legal-concepts helper, not a lawyer. Explain legal terms, common
+contract clauses, and general dispute-resolution/claim-filing processes in
+plain, accessible language. Always frame answers as general information, not
+case-specific legal advice: don't tell the user whether they will win a
+specific dispute, and explicitly recommend consulting a licensed lawyer for
+anything with real financial or legal consequences (large sums, criminal
+matters, litigation strategy). Prefer citing the general principle over
+guessing at jurisdiction-specific statute numbers unless the user's
+jurisdiction is clear and you're confident in the citation.

--- a/internal/agentprofile/defaults/legal-helper.md
+++ b/internal/agentprofile/defaults/legal-helper.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "What does a '1 month deposit, 3 months rent upfront' lease term mean"
   - "I received a counterfeit item from an online order — how can I file a claim"
   - "Explain what an 'arbitration clause' means"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+tools: [web_search, web_fetch, read_file, write_file, memory_recall]
 ---
 
 You are a legal-concepts helper, not a lawyer. Explain legal terms, common

--- a/internal/agentprofile/defaults/life-assistant.md
+++ b/internal/agentprofile/defaults/life-assistant.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have eggs, tomatoes, and noodles in the fridge — suggest a recipe"
   - "What's a good birthday gift idea for my mom"
   - "How do I quickly remove an oil stain from clothing"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+tools: [web_search, web_fetch, read_file, write_file, memory_recall]
 ---
 
 You are a friendly everyday-life helper. Keep answers practical and quick to

--- a/internal/agentprofile/defaults/life-assistant.md
+++ b/internal/agentprofile/defaults/life-assistant.md
@@ -1,0 +1,24 @@
+---
+name: 生活小管家
+name_en: Home & Life Helper
+description: 日常琐事的贴心帮手：菜谱、家务技巧、礼物建议、生活小妙招
+description_en: A handy helper for everyday things — recipes, household tips, gift ideas, and life hacks
+category: life
+icon: ant-design:home-outlined
+tags: ["菜谱推荐", "家务技巧", "礼物建议", "生活妙招"]
+tags_en: ["Recipe ideas", "Household tips", "Gift suggestions", "Life hacks"]
+example_prompts:
+  - "冰箱里有鸡蛋、番茄和面条，帮我出个菜谱"
+  - "给妈妈的生日礼物有什么好建议"
+  - "怎么快速去除衣服上的油渍"
+example_prompts_en:
+  - "I have eggs, tomatoes, and noodles in the fridge — suggest a recipe"
+  - "What's a good birthday gift idea for my mom"
+  - "How do I quickly remove an oil stain from clothing"
+tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+---
+
+You are a friendly everyday-life helper. Keep answers practical and quick to
+act on — a recipe should list what's actually on hand first, a gift
+suggestion should ask about the recipient's interests/budget if unclear, a
+household tip should be a concrete step-by-step, not a wall of caveats.

--- a/internal/agentprofile/defaults/productivity-coach.md
+++ b/internal/agentprofile/defaults/productivity-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Break down 'finish the quarterly report' into actionable subtasks"
   - "I keep procrastinating — what methods can help"
   - "Use the SMART framework to help me set this month's goals"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+tools: [web_search, web_fetch, read_file, write_file, memory_recall]
 ---
 
 You are a productivity coach. When asked to break down a task, produce a

--- a/internal/agentprofile/defaults/productivity-coach.md
+++ b/internal/agentprofile/defaults/productivity-coach.md
@@ -1,0 +1,26 @@
+---
+name: 效率教练
+name_en: Productivity Coach
+description: 帮你梳理任务优先级、拆解目标，给出可执行的时间管理方法
+description_en: Helps you prioritize tasks, break down goals, and apply actionable time-management methods
+category: productivity
+icon: ant-design:schedule-outlined
+tags: ["任务拆解", "时间管理", "目标设定", "习惯养成"]
+tags_en: ["Task breakdown", "Time management", "Goal setting", "Habit building"]
+example_prompts:
+  - "帮我把'完成季度报告'拆成可执行的小任务"
+  - "我总是拖延，有什么方法可以改善"
+  - "用SMART原则帮我设定这个月的目标"
+example_prompts_en:
+  - "Break down 'finish the quarterly report' into actionable subtasks"
+  - "I keep procrastinating — what methods can help"
+  - "Use the SMART framework to help me set this month's goals"
+tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+---
+
+You are a productivity coach. When asked to break down a task, produce a
+concrete, ordered subtask list with rough time estimates rather than
+high-level categories. When asked about procrastination or habits, recommend
+specific, well-known techniques (time-boxing, the two-minute rule, habit
+stacking) matched to the situation described, and explain briefly why that
+one fits rather than listing every technique you know.

--- a/internal/agentprofile/defaults/resume-coach.md
+++ b/internal/agentprofile/defaults/resume-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Review my resume and tell me what needs improvement"
   - "Simulate a few interview questions for a product manager role"
   - "I want to switch careers into data analytics — how should I plan for it"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+tools: [web_search, web_fetch, read_file, write_file, memory_recall]
 ---
 
 You are a resume and career coach. Give specific, actionable feedback on

--- a/internal/agentprofile/defaults/resume-coach.md
+++ b/internal/agentprofile/defaults/resume-coach.md
@@ -1,0 +1,26 @@
+---
+name: 简历教练
+name_en: Resume Coach
+description: 帮你打磨简历和求职信，模拟面试问题，给出针对性反馈
+description_en: Helps you polish your resume and cover letter, and runs mock interview questions with targeted feedback
+category: career
+icon: ant-design:solution-outlined
+tags: ["简历润色", "求职信", "模拟面试", "职业规划"]
+tags_en: ["Resume polish", "Cover letters", "Mock interviews", "Career planning"]
+example_prompts:
+  - "帮我看看这份简历哪里需要改进"
+  - "针对产品经理岗位模拟几个面试问题考我"
+  - "我想转行做数据分析，该怎么规划"
+example_prompts_en:
+  - "Review my resume and tell me what needs improvement"
+  - "Simulate a few interview questions for a product manager role"
+  - "I want to switch careers into data analytics — how should I plan for it"
+tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+---
+
+You are a resume and career coach. Give specific, actionable feedback on
+resumes and cover letters — call out weak bullet points, missing metrics, and
+formatting issues rather than vague encouragement. When asked to mock-
+interview, ask one question at a time, wait for the user's answer, then give
+feedback before the next question rather than dumping a whole question list
+at once.

--- a/internal/agentprofile/defaults/trip-planner.md
+++ b/internal/agentprofile/defaults/trip-planner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Plan a 5-day independent trip to Osaka"
   - "What should I watch out for when traveling with young kids"
   - "Give me a packing list for an international trip"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+tools: [web_search, web_fetch, read_file, write_file, memory_recall]
 ---
 
 You are a trip-planning assistant. Ask for budget, dates, and traveler

--- a/internal/agentprofile/defaults/trip-planner.md
+++ b/internal/agentprofile/defaults/trip-planner.md
@@ -1,0 +1,25 @@
+---
+name: 旅行规划师
+name_en: Trip Planner
+description: 根据预算和时间帮你规划旅行路线、行程和注意事项
+description_en: Plans your route, itinerary, and practical tips based on your budget and time
+category: life
+icon: ant-design:compass-outlined
+tags: ["行程规划", "预算控制", "当地攻略", "打包清单"]
+tags_en: ["Itinerary planning", "Budgeting", "Local tips", "Packing lists"]
+example_prompts:
+  - "帮我规划一个5天4夜的大阪自由行"
+  - "带娃出行有什么需要特别注意的"
+  - "给我一份出国旅行的行李打包清单"
+example_prompts_en:
+  - "Plan a 5-day independent trip to Osaka"
+  - "What should I watch out for when traveling with young kids"
+  - "Give me a packing list for an international trip"
+tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+---
+
+You are a trip-planning assistant. Ask for budget, dates, and traveler
+composition (solo/family/etc.) if not given, then produce a day-by-day
+itinerary with rough costs and practical notes (transit, booking lead time,
+local customs). Use web search for anything time-sensitive (prices, opening
+hours, visa rules) rather than relying on memorized facts that may be stale.

--- a/internal/agentprofile/defaults/writing-partner.md
+++ b/internal/agentprofile/defaults/writing-partner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Help me build an outline for an article about the pros and cons of remote work"
   - "Make this paragraph more concise and punchy"
   - "From a reader's perspective, where does this article's logic break down"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+tools: [web_search, web_fetch, read_file, write_file, memory_recall]
 ---
 
 You are a writing partner for long-form content: essays, articles, reports,

--- a/internal/agentprofile/defaults/writing-partner.md
+++ b/internal/agentprofile/defaults/writing-partner.md
@@ -1,0 +1,26 @@
+---
+name: 写作伙伴
+name_en: Writing Partner
+description: 陪你打磨长文写作，从大纲到润色，帮你把想法写清楚、写通顺
+description_en: Helps you develop long-form writing end to end — from outline to polish — so your ideas read clearly
+category: content-creation
+icon: ant-design:file-text-outlined
+tags: ["大纲梳理", "逐段润色", "语气调整", "读者视角反馈"]
+tags_en: ["Outlining", "Paragraph polish", "Tone adjustment", "Reader feedback"]
+example_prompts:
+  - "帮我搭一个关于'远程办公利弊'的文章大纲"
+  - "把这段话改得更简洁有力"
+  - "从读者角度看，这篇文章哪里逻辑不通"
+example_prompts_en:
+  - "Help me build an outline for an article about the pros and cons of remote work"
+  - "Make this paragraph more concise and punchy"
+  - "From a reader's perspective, where does this article's logic break down"
+tools: [web_search, web_fetch, read_file, write_file, memory_recall, skill]
+---
+
+You are a writing partner for long-form content: essays, articles, reports,
+personal writing. Work with the user iteratively — outline first if none
+exists, then paragraph-by-paragraph polish on request. When giving feedback,
+be concrete: point at the specific sentence or structural issue rather than
+generic praise/criticism. Read the whole piece before commenting on any part
+of it if it's supplied in full.

--- a/internal/agentprofile/defaults_test.go
+++ b/internal/agentprofile/defaults_test.go
@@ -1,0 +1,172 @@
+package agentprofile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain neutralizes the default-agents root for the whole package so tests
+// never read the real ~/.octo/agents-default (which an installed binary
+// populates). Tests that exercise defaults opt in via useDefaultAgentsRoot.
+func TestMain(m *testing.M) {
+	tmp, _ := os.MkdirTemp("", "octo-agents-default-empty")
+	defaultAgentsRoot = func() string { return tmp }
+	code := m.Run()
+	if tmp != "" {
+		_ = os.RemoveAll(tmp)
+	}
+	os.Exit(code)
+}
+
+// useDefaultAgentsRoot points defaultAgentsRoot at dir for the test's duration.
+func useDefaultAgentsRoot(t *testing.T, dir string) {
+	t.Helper()
+	orig := defaultAgentsRoot
+	defaultAgentsRoot = func() string { return dir }
+	t.Cleanup(func() { defaultAgentsRoot = orig })
+}
+
+func TestMaterializeDefaults_WritesEmbeddedAndStamps(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "agents-default")
+	useDefaultAgentsRoot(t, root)
+
+	if err := MaterializeDefaults("v1"); err != nil {
+		t.Fatalf("MaterializeDefaults: %v", err)
+	}
+	for _, id := range []string{"copywriter", "trip-planner", "legal-helper"} {
+		if _, err := os.Stat(filepath.Join(root, id+".md")); err != nil {
+			t.Fatalf("expected %s.md materialized: %v", id, err)
+		}
+	}
+	b, err := os.ReadFile(filepath.Join(root, defaultStampFile))
+	if err != nil || string(b) != "v1" {
+		t.Fatalf("stamp = %q, %v; want v1", string(b), err)
+	}
+}
+
+func TestMaterializeDefaults_NoOpWhenCurrent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "agents-default")
+	useDefaultAgentsRoot(t, root)
+	if err := MaterializeDefaults("v1"); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(root, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeDefaults("v1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("same-version call should be a no-op, but the dir was rewritten")
+	}
+
+	if err := MaterializeDefaults("v2"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Errorf("version bump should wipe-and-rewrite the default root")
+	}
+}
+
+func TestStore_DefaultLayerSurfacesAndIsOverridable(t *testing.T) {
+	defaultRoot := filepath.Join(t.TempDir(), "agents-default")
+	useDefaultAgentsRoot(t, defaultRoot)
+	writeMD(t, defaultRoot, "copywriter.md", "---\ndescription: curated copywriter\ntools: [read_file]\ncategory: content-creation\ntags: [writing]\n---\npersona body\n")
+
+	s, userDir := newTestStore(t)
+
+	// Default-only: shows up in List() with Source == SourceDefault, unlike
+	// builtins which List() always excludes.
+	got := s.List()
+	if len(got) != 1 || got[0].ID != "copywriter" || got[0].Source != SourceDefault {
+		t.Fatalf("List() = %+v, want one SourceDefault copywriter", got)
+	}
+	if got[0].Category != "content-creation" || len(got[0].Tags) != 1 {
+		t.Fatalf("gallery metadata not threaded through: %+v", got[0])
+	}
+
+	// A user file of the same ID overrides the curated default (same
+	// precedence rule as builtin overriding, one layer up).
+	writeMD(t, userDir, "copywriter.md", "---\ndescription: my override\n---\nuser body\n")
+	p, ok := s.Get("copywriter")
+	if !ok || p.Source != SourceUser || p.Description != "my override" {
+		t.Fatalf("user file should override curated default: %+v, %v", p, ok)
+	}
+}
+
+func TestStore_UpdateForksDefaultIntoUserOverride(t *testing.T) {
+	defaultRoot := filepath.Join(t.TempDir(), "agents-default")
+	useDefaultAgentsRoot(t, defaultRoot)
+	writeMD(t, defaultRoot, "copywriter.md", "---\ndescription: curated copywriter\ntools: [read_file]\ncategory: content-creation\n---\npersona body\n")
+
+	s, userDir := newTestStore(t)
+
+	existing, ok := s.Get("copywriter")
+	if !ok {
+		t.Fatal("copywriter not found")
+	}
+	existing.Description = "edited copywriter"
+	if err := s.Update(existing); err != nil {
+		t.Fatalf("Update() on a curated default should fork it, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(userDir, "copywriter.md")); err != nil {
+		t.Fatalf("expected fork written to user dir: %v", err)
+	}
+	p, ok := s.Get("copywriter")
+	if !ok || p.Source != SourceUser || p.Description != "edited copywriter" {
+		t.Fatalf("after fork: %+v, %v", p, ok)
+	}
+	// The fork must keep the persona's gallery metadata (category etc.), not
+	// silently drop it — the plan requires the API layer preserve unspecified
+	// fields, but the Store itself must simply persist whatever Profile it's
+	// handed.
+	if p.Category != "content-creation" {
+		t.Fatalf("fork lost gallery metadata: %+v", p)
+	}
+}
+
+func TestStore_DeleteBlockedForCuratedDefault(t *testing.T) {
+	defaultRoot := filepath.Join(t.TempDir(), "agents-default")
+	useDefaultAgentsRoot(t, defaultRoot)
+	writeMD(t, defaultRoot, "copywriter.md", "---\ndescription: curated copywriter\ntools: [read_file]\n---\npersona body\n")
+
+	s, _ := newTestStore(t)
+	if err := s.Delete("copywriter"); err == nil {
+		t.Fatal("Delete of a curated default should fail")
+	}
+}
+
+func TestStore_SetDisabledDefaults(t *testing.T) {
+	defaultRoot := filepath.Join(t.TempDir(), "agents-default")
+	useDefaultAgentsRoot(t, defaultRoot)
+	writeMD(t, defaultRoot, "copywriter.md", "---\ndescription: curated copywriter\ntools: [read_file]\n---\npersona body\n")
+
+	s, _ := newTestStore(t)
+	if _, ok := s.Get("copywriter"); !ok {
+		t.Fatal("copywriter should be visible before disabling")
+	}
+
+	s.SetDisabledDefaults([]string{"copywriter"})
+	if _, ok := s.Get("copywriter"); ok {
+		t.Fatal("disabled default should be hidden from Get")
+	}
+	found := false
+	for _, p := range s.List() {
+		if p.ID == "copywriter" {
+			found = true
+		}
+	}
+	if found {
+		t.Fatal("disabled default should be hidden from List")
+	}
+	if _, ok := s.LookupAny("copywriter"); !ok {
+		t.Fatal("LookupAny should still see a disabled default")
+	}
+
+	s.SetDisabledDefaults(nil)
+	if _, ok := s.Get("copywriter"); !ok {
+		t.Fatal("re-enabled default should be visible again")
+	}
+}

--- a/internal/agentprofile/defaults_test.go
+++ b/internal/agentprofile/defaults_test.go
@@ -165,6 +165,17 @@ func TestStore_SetDisabledDefaults(t *testing.T) {
 		t.Fatal("LookupAny should still see a disabled default")
 	}
 
+	// All() is the management-surface view: unlike List(), it must still
+	// include the hidden default (with IsEnabled reporting false) so a
+	// caller (the gallery UI) can offer a way to re-show it.
+	all := s.All()
+	if len(all) != 1 || all[0].ID != "copywriter" {
+		t.Fatalf("All() should still include the hidden default: %+v", all)
+	}
+	if s.IsEnabled(all[0]) {
+		t.Fatal("IsEnabled should report false for a hidden default")
+	}
+
 	s.SetDisabledDefaults(nil)
 	if _, ok := s.Get("copywriter"); !ok {
 		t.Fatal("re-enabled default should be visible again")

--- a/internal/agentprofile/parse.go
+++ b/internal/agentprofile/parse.go
@@ -22,6 +22,17 @@ type frontmatter struct {
 	LeanContext     bool             `yaml:"lean_context,omitempty"`
 	WorkingDir      string           `yaml:"working_dir,omitempty"`
 	ChannelBindings []ChannelBinding `yaml:"channel_bindings,omitempty"`
+
+	// Gallery display metadata — only meaningful for curated (SourceDefault)
+	// experts; ordinary user profiles simply omit these.
+	Category         string   `yaml:"category,omitempty"`
+	Tags             []string `yaml:"tags,omitempty"`
+	TagsEN           []string `yaml:"tags_en,omitempty"`
+	ExamplePrompts   []string `yaml:"example_prompts,omitempty"`
+	ExamplePromptsEN []string `yaml:"example_prompts_en,omitempty"`
+	Icon             string   `yaml:"icon,omitempty"`
+	NameEN           string   `yaml:"name_en,omitempty"`
+	DescriptionEN    string   `yaml:"description_en,omitempty"`
 }
 
 // parseFile reads one profile .md file. The profile ID is the file name
@@ -65,6 +76,15 @@ func parseFile(path string) (*Profile, error) {
 		},
 		WorkingDir:      fm.WorkingDir,
 		ChannelBindings: fm.ChannelBindings,
+
+		Category:         fm.Category,
+		Tags:             fm.Tags,
+		TagsEN:           fm.TagsEN,
+		ExamplePrompts:   fm.ExamplePrompts,
+		ExamplePromptsEN: fm.ExamplePromptsEN,
+		Icon:             fm.Icon,
+		NameEN:           fm.NameEN,
+		DescriptionEN:    fm.DescriptionEN,
 	}
 	if info, err := os.Stat(path); err == nil {
 		p.CreatedAt = info.ModTime()
@@ -88,6 +108,15 @@ func serialize(p *Profile) ([]byte, error) {
 		LeanContext:     p.LeanContext,
 		WorkingDir:      p.WorkingDir,
 		ChannelBindings: p.ChannelBindings,
+
+		Category:         p.Category,
+		Tags:             p.Tags,
+		TagsEN:           p.TagsEN,
+		ExamplePrompts:   p.ExamplePrompts,
+		ExamplePromptsEN: p.ExamplePromptsEN,
+		Icon:             p.Icon,
+		NameEN:           p.NameEN,
+		DescriptionEN:    p.DescriptionEN,
 	}
 	head, err := yaml.Marshal(&fm)
 	if err != nil {

--- a/internal/agentprofile/profile.go
+++ b/internal/agentprofile/profile.go
@@ -3,9 +3,10 @@
 // skills) plus the platform slice (mention aliases, channel bindings) used
 // when a profile is addressed directly by users.
 //
-// Profiles come from two sources, in increasing precedence:
+// Profiles come from three sources, in increasing precedence:
 //
 //   - builtin: code-defined (default, explore, general, code-review)
+//   - default: ~/.octo/agents-default/<id>.md (curated experts, officially shipped)
 //   - user:    ~/.octo/agents/<id>.md       (conversation + delegation modes)
 //
 // A profile is consumed in two modes:
@@ -36,6 +37,12 @@ const (
 	// SourceBuiltin profiles are code-defined (default, explore, general,
 	// code-review) and have no .md file.
 	SourceBuiltin Source = "builtin"
+	// SourceDefault profiles are officially-curated expert personas shipped in
+	// the binary and materialized to ~/.octo/agents-default (mirrors
+	// internal/skills' "default" source). Unlike SourceBuiltin they ARE
+	// surfaced through Store.List()/the REST API — they're user-facing
+	// content, not internal capability tiers.
+	SourceDefault Source = "default"
 	// SourceUser profiles live in ~/.octo/agents/*.md and support both
 	// conversation and delegation modes.
 	SourceUser Source = "user"
@@ -79,6 +86,20 @@ type Profile struct {
 
 	WorkingDir      string
 	ChannelBindings []ChannelBinding // conversation mode only
+
+	// Gallery display metadata for SourceDefault (curated) profiles — kept
+	// outside CapabilitySpec so it can never leak into the sub_agent
+	// delegation path. Empty/zero for ordinary user profiles, which the
+	// gallery UI renders with graceful fallbacks (initials avatar, no
+	// tags/example-prompt sections).
+	Category         string   // slug, e.g. "content-creation" — frontend maps to a localized chip label
+	Tags             []string // 擅长领域 chips (zh)
+	TagsEN           []string // en variant
+	ExamplePrompts   []string // 试试这样问我 (zh)
+	ExamplePromptsEN []string // en variant
+	Icon             string   // iconify icon name; empty → initials+hash-color fallback
+	NameEN           string   // en display name
+	DescriptionEN    string   // en description
 
 	Source Source
 

--- a/internal/agentprofile/store.go
+++ b/internal/agentprofile/store.go
@@ -130,7 +130,9 @@ func (s *Store) LookupAny(id string) (*Profile, bool) {
 }
 
 // List returns every user-level and curated-default profile (excluding
-// builtins and hidden curated experts), sorted by ID for stable output.
+// builtins and hidden curated experts), sorted by ID for stable output. This
+// is the "resolvable" view — what Get() would find — used wherever a hidden
+// expert should behave as if it doesn't exist (e.g. delegation contexts).
 func (s *Store) List() []*Profile {
 	var out []*Profile
 	for _, p := range s.load() {
@@ -144,6 +146,30 @@ func (s *Store) List() []*Profile {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
+}
+
+// All returns every user-level and curated-default profile, INCLUDING hidden
+// curated experts (excluding only builtins), sorted by ID. Mirrors
+// skills.Registry.All() — the management-surface view (the gallery UI needs
+// to see a hidden expert to offer a way to re-show it, unlike List()/Get()
+// which treat it as gone).
+func (s *Store) All() []*Profile {
+	var out []*Profile
+	for _, p := range s.load() {
+		if p.Source == SourceBuiltin {
+			continue
+		}
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// IsEnabled reports whether p is currently visible/resolvable — always true
+// except for a hidden (toggled-off) curated expert. Mirrors
+// skills.Registry.IsEnabled.
+func (s *Store) IsEnabled(p *Profile) bool {
+	return !s.isDisabledDefault(p)
 }
 
 // Create validates p and writes it as <userDir>/<id>.md.

--- a/internal/agentprofile/store.go
+++ b/internal/agentprofile/store.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // Store loads profiles from the user-level agent directory plus the
@@ -16,6 +17,9 @@ import (
 // a handful of small files, so a rescan is cheap.
 type Store struct {
 	userDir string
+
+	mu               sync.RWMutex
+	disabledDefaults map[string]bool // curated-expert IDs hidden by the user; mirrors skills.Registry's disabled set
 }
 
 // New builds a Store over the user-level directory (~/.octo/agents).
@@ -23,13 +27,38 @@ func New(userDir string) *Store {
 	return &Store{userDir: userDir}
 }
 
-// load scans user profiles and returns the id → profile map, with builtins as
-// the base layer. Files that fail to parse are skipped.
+// SetDisabledDefaults replaces the set of curated-expert IDs hidden from
+// Get/List. Called once at startup with the persisted config value, and again
+// whenever the toggle endpoint flips one. Hidden, not deleted — the
+// underlying ~/.octo/agents-default/<id>.md is untouched and can be re-shown.
+func (s *Store) SetDisabledDefaults(ids []string) {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	s.mu.Lock()
+	s.disabledDefaults = m
+	s.mu.Unlock()
+}
+
+func (s *Store) isDisabledDefault(p *Profile) bool {
+	if p == nil || p.Source != SourceDefault {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.disabledDefaults[p.ID]
+}
+
+// load scans default (curated) and user profiles and returns the id →
+// profile map, with builtins as the base layer and user files taking highest
+// precedence. Files that fail to parse are skipped.
 func (s *Store) load() map[string]*Profile {
 	profiles := make(map[string]*Profile)
 	for _, p := range builtinProfiles() {
 		profiles[p.ID] = p
 	}
+	s.scanDir(defaultAgentsRoot(), SourceDefault, profiles)
 	s.scanDir(s.userDir, SourceUser, profiles)
 	return profiles
 }
@@ -78,20 +107,37 @@ func (s *Store) Load() error {
 }
 
 // Get returns the profile with the given id. The default profile is
-// code-defined and always available.
+// code-defined and always available. A hidden (toggled-off) curated expert is
+// treated as not found, matching skills.Registry's "disabled == non-existent"
+// semantics — use LookupAny to see it regardless.
 func (s *Store) Get(id string) (*Profile, bool) {
 	if id == DefaultID {
 		return DefaultProfile(), true
 	}
 	p, ok := s.load()[id]
+	if ok && s.isDisabledDefault(p) {
+		return nil, false
+	}
 	return p, ok
 }
 
-// List returns every user-level profile, sorted by ID for stable output.
+// LookupAny returns the profile with the given id regardless of whether it's
+// a currently-hidden curated expert — used by the toggle handler, which must
+// find a disabled default to re-enable it.
+func (s *Store) LookupAny(id string) (*Profile, bool) {
+	p, ok := s.load()[id]
+	return p, ok
+}
+
+// List returns every user-level and curated-default profile (excluding
+// builtins and hidden curated experts), sorted by ID for stable output.
 func (s *Store) List() []*Profile {
 	var out []*Profile
 	for _, p := range s.load() {
 		if p.Source == SourceBuiltin {
+			continue
+		}
+		if s.isDisabledDefault(p) {
 			continue
 		}
 		out = append(out, p)
@@ -112,15 +158,24 @@ func (s *Store) Create(p *Profile) error {
 	return s.writeFile(path, p)
 }
 
-// Update rewrites an existing user-level profile.
+// Update rewrites a profile. For a user profile this rewrites its existing
+// file; for a curated (SourceDefault) expert with no user-dir file yet, this
+// forks it into a permanent ~/.octo/agents/<id>.md override — same semantics
+// as a skill override, and the intended way "edit this expert" works from the
+// gallery UI. Once forked, that ID stops receiving future curated-content
+// refreshes (accepted trade-off, mirrors skill overrides).
 func (s *Store) Update(p *Profile) error {
 	if err := s.validateForStoreWrite(p); err != nil {
 		return err
 	}
-	path := filepath.Join(s.userDir, p.ID+".md")
-	if _, err := os.Stat(path); err != nil {
+	existing, ok := s.LookupAny(p.ID)
+	if !ok {
 		return fmt.Errorf("profile %q not found", p.ID)
 	}
+	if existing.Source == SourceBuiltin {
+		return fmt.Errorf("profile %q is builtin and cannot be modified", p.ID)
+	}
+	path := filepath.Join(s.userDir, p.ID+".md")
 	return s.writeFile(path, p)
 }
 
@@ -134,15 +189,19 @@ func (s *Store) validateForStoreWrite(p *Profile) error {
 	return nil
 }
 
-// Delete removes a profile. Builtin profiles are protected. A profile with
-// channel bindings must be unbound first.
+// Delete removes a profile. Builtin and curated-default profiles are
+// protected (curated experts can only be hidden via SetDisabledDefaults, not
+// deleted — same as skills.Registry refusing to delete Source=="default"). A
+// profile with channel bindings must be unbound first. Deleting a user
+// override of a curated expert works as usual and correctly falls back to the
+// shipped default on the next load.
 func (s *Store) Delete(id string) error {
-	p, ok := s.Get(id)
+	p, ok := s.LookupAny(id)
 	if !ok {
 		return fmt.Errorf("profile %q not found", id)
 	}
-	if p.Source == SourceBuiltin {
-		return fmt.Errorf("profile %q is builtin and cannot be deleted", id)
+	if p.Source == SourceBuiltin || p.Source == SourceDefault {
+		return fmt.Errorf("profile %q is %s and cannot be deleted", id, p.Source)
 	}
 	if len(p.ChannelBindings) > 0 {
 		return fmt.Errorf("profile %q still has %d channel binding(s): unbind them first", id, len(p.ChannelBindings))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,16 @@ type Config struct {
 	// so installs that recorded it in config.yml before the marker file existed
 	// still count as attempted; nothing writes it anymore.
 	OnboardAttempted bool `yaml:"onboard_attempted,omitempty"`
+	// Agents groups agent-profile-related settings (curated expert visibility).
+	Agents AgentsConfig `yaml:"agents,omitempty"`
+}
+
+// AgentsConfig groups agent-profile-related settings under the `agents:` block.
+type AgentsConfig struct {
+	// DisabledDefaults lists curated expert-agent IDs the user has hidden from
+	// the gallery. Hidden, not deleted — the underlying
+	// ~/.octo/agents-default/<id>.md is untouched and can be re-shown.
+	DisabledDefaults []string `yaml:"disabled_defaults,omitempty"`
 }
 
 // TrashConfig configures the file recycle bin.

--- a/internal/server/agent_toggle_handler.go
+++ b/internal/server/agent_toggle_handler.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/open-octo/octo-agent/internal/agentprofile"
+	"github.com/open-octo/octo-agent/internal/config"
+)
+
+// ─── PATCH /api/agents/{id}/toggle ──────────────────────────────────────────
+
+// handleToggleAgent hides or re-shows a curated (SourceDefault) expert in the
+// gallery. Mirrors handleToggleSkill: only curated experts can be toggled —
+// user-created agents have no visibility switch (they're just deleted), and
+// builtins never reach the store's public surface at all.
+func (s *Server) handleToggleAgent(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing agent id")
+		return
+	}
+
+	store, ok := s.agentStoreIfReady()
+	if !ok {
+		_ = s.agentRouter()
+		store = s.agentStore
+	}
+
+	p, ok := store.LookupAny(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	if p.Source != agentprofile.SourceDefault {
+		writeError(w, http.StatusBadRequest, "only curated default experts can be hidden/shown")
+		return
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load config")
+		return
+	}
+
+	currentlyDisabled := false
+	for _, n := range cfg.Agents.DisabledDefaults {
+		if n == id {
+			currentlyDisabled = true
+			break
+		}
+	}
+
+	if currentlyDisabled {
+		newDisabled := make([]string, 0, len(cfg.Agents.DisabledDefaults)-1)
+		for _, n := range cfg.Agents.DisabledDefaults {
+			if n != id {
+				newDisabled = append(newDisabled, n)
+			}
+		}
+		cfg.Agents.DisabledDefaults = newDisabled
+	} else {
+		cfg.Agents.DisabledDefaults = append(cfg.Agents.DisabledDefaults, id)
+	}
+
+	if err := cfg.Save(); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save config")
+		return
+	}
+
+	store.SetDisabledDefaults(cfg.Agents.DisabledDefaults)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id":      id,
+		"enabled": currentlyDisabled, // toggle: disabled → enabled, enabled → disabled
+	})
+}

--- a/internal/server/agent_toggle_handler_test.go
+++ b/internal/server/agent_toggle_handler_test.go
@@ -63,8 +63,19 @@ func TestHandleAgents_ToggleHidesAndReshowsCuratedDefault(t *testing.T) {
 	if resp["enabled"] != false {
 		t.Fatalf("first toggle should disable: %+v", resp)
 	}
-	if list := doAgents(t, srv); len(list) != 0 {
-		t.Fatalf("expected 0 agents after hiding, got %d", len(list))
+	// The hidden expert must still be LISTED (with enabled: false) — GET
+	// /api/agents uses Store.All(), not List(), specifically so the gallery
+	// UI has a way to find and re-show it. It just must not be resolvable
+	// via Get() (checked separately below).
+	list := doAgents(t, srv)
+	if len(list) != 1 || list[0].Enabled {
+		t.Fatalf("expected 1 agent listed with enabled=false after hiding, got %+v", list)
+	}
+	// GET /api/agents/:id (single-item) goes through Store.Get(), which still
+	// treats a hidden default as not-found — only the list endpoint (Store.All())
+	// exposes it, since that's the only place the gallery UI needs to see it.
+	if w := doJSON(t, srv, http.MethodGet, "/api/agents/test-expert", ""); w.Code != http.StatusNotFound {
+		t.Fatalf("GET /api/agents/test-expert on a hidden default = %d, want 404: %s", w.Code, w.Body.String())
 	}
 
 	// Re-show it.
@@ -78,8 +89,9 @@ func TestHandleAgents_ToggleHidesAndReshowsCuratedDefault(t *testing.T) {
 	if resp["enabled"] != true {
 		t.Fatalf("second toggle should re-enable: %+v", resp)
 	}
-	if list := doAgents(t, srv); len(list) != 1 {
-		t.Fatalf("expected 1 agent after re-showing, got %d", len(list))
+	list = doAgents(t, srv)
+	if len(list) != 1 || !list[0].Enabled {
+		t.Fatalf("expected 1 agent listed with enabled=true after re-showing, got %+v", list)
 	}
 }
 

--- a/internal/server/agent_toggle_handler_test.go
+++ b/internal/server/agent_toggle_handler_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// curatedTestServer returns a server with an isolated ~/.octo/agents dir and
+// one hand-placed curated (SourceDefault) expert in ~/.octo/agents-default —
+// mustServer never calls agentprofile.MaterializeDefaults, so the curated
+// content is planted directly rather than relying on the embedded set.
+func curatedTestServer(t *testing.T) *Server {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	_ = os.MkdirAll(filepath.Join(tmp, ".octo", "agents"), 0o755)
+	defaultDir := filepath.Join(tmp, ".octo", "agents-default")
+	if err := os.MkdirAll(defaultDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	md := "---\ndescription: curated test expert\ntools: [read_file]\ncategory: content-creation\ntags: [writing]\nexample_prompts: [\"hi\"]\nicon: ant-design:edit-outlined\nname_en: Test Expert\n---\npersona body\n"
+	if err := os.WriteFile(filepath.Join(defaultDir, "test-expert.md"), []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+}
+
+func TestHandleAgents_ListIncludesCuratedDefaultWithSource(t *testing.T) {
+	srv := curatedTestServer(t)
+
+	list := doAgents(t, srv)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 curated agent, got %d: %+v", len(list), list)
+	}
+	got := list[0]
+	if got.ID != "test-expert" || got.Source != "default" {
+		t.Fatalf("unexpected profile: %+v", got)
+	}
+	if got.Category != "content-creation" || len(got.Tags) != 1 || got.Tags[0] != "writing" {
+		t.Fatalf("gallery metadata not surfaced: %+v", got)
+	}
+	if len(got.ExamplePrompts) != 1 || got.Icon != "ant-design:edit-outlined" || got.NameEN != "Test Expert" {
+		t.Fatalf("gallery metadata not surfaced: %+v", got)
+	}
+}
+
+func TestHandleAgents_ToggleHidesAndReshowsCuratedDefault(t *testing.T) {
+	srv := curatedTestServer(t)
+
+	// Hide it.
+	w := doJSON(t, srv, http.MethodPatch, "/api/agents/test-expert/toggle", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("toggle = %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["enabled"] != false {
+		t.Fatalf("first toggle should disable: %+v", resp)
+	}
+	if list := doAgents(t, srv); len(list) != 0 {
+		t.Fatalf("expected 0 agents after hiding, got %d", len(list))
+	}
+
+	// Re-show it.
+	w = doJSON(t, srv, http.MethodPatch, "/api/agents/test-expert/toggle", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("toggle = %d: %s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["enabled"] != true {
+		t.Fatalf("second toggle should re-enable: %+v", resp)
+	}
+	if list := doAgents(t, srv); len(list) != 1 {
+		t.Fatalf("expected 1 agent after re-showing, got %d", len(list))
+	}
+}
+
+func TestHandleAgents_ToggleRejectsUserAgent(t *testing.T) {
+	srv := agentsTestServer(t)
+
+	w := doJSON(t, srv, http.MethodPost, "/api/agents", `{"name": "My Agent", "description": "d"}`)
+	var created agentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	w = doJSON(t, srv, http.MethodPatch, "/api/agents/"+created.ID+"/toggle", "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("toggle of a user agent = %d, want 400: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleAgents_ToggleNotFound(t *testing.T) {
+	srv := agentsTestServer(t)
+
+	w := doJSON(t, srv, http.MethodPatch, "/api/agents/ghost/toggle", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("toggle of unknown agent = %d, want 404: %s", w.Code, w.Body.String())
+	}
+}
+
+// DeleteBlockedForCuratedDefault verifies the API surface, not just the Store
+// layer (store_test.go's TestStore_DeleteBlockedForCuratedDefault) — the
+// handler must translate the Store's error into a 409, not a 500.
+func TestHandleAgents_DeleteBlockedForCuratedDefault(t *testing.T) {
+	srv := curatedTestServer(t)
+
+	w := doJSON(t, srv, http.MethodDelete, "/api/agents/test-expert", "")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("delete curated default = %d, want 409: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/agents_handlers.go
+++ b/internal/server/agents_handlers.go
@@ -22,6 +22,17 @@ type agentRequest struct {
 	ToolSkills      []string                      `json:"tool_skills,omitempty"`
 	SystemPrompt    string                        `json:"system_prompt,omitempty"`
 	ChannelBindings []agentprofile.ChannelBinding `json:"channel_bindings,omitempty"`
+
+	// Gallery display metadata — optional, lets any agent (curated or
+	// user-authored) carry them.
+	Category         string   `json:"category,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
+	TagsEN           []string `json:"tags_en,omitempty"`
+	ExamplePrompts   []string `json:"example_prompts,omitempty"`
+	ExamplePromptsEN []string `json:"example_prompts_en,omitempty"`
+	Icon             string   `json:"icon,omitempty"`
+	NameEN           string   `json:"name_en,omitempty"`
+	DescriptionEN    string   `json:"description_en,omitempty"`
 }
 
 type agentBindRequest struct {
@@ -45,18 +56,42 @@ type agentResponse struct {
 	ToolSkills      []string                      `json:"tool_skills,omitempty"`
 	SystemPrompt    string                        `json:"system_prompt,omitempty"`
 	ChannelBindings []agentprofile.ChannelBinding `json:"channel_bindings,omitempty"`
+
+	// Gallery display metadata (see agentRequest).
+	Category         string   `json:"category,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
+	TagsEN           []string `json:"tags_en,omitempty"`
+	ExamplePrompts   []string `json:"example_prompts,omitempty"`
+	ExamplePromptsEN []string `json:"example_prompts_en,omitempty"`
+	Icon             string   `json:"icon,omitempty"`
+	NameEN           string   `json:"name_en,omitempty"`
+	DescriptionEN    string   `json:"description_en,omitempty"`
+
+	// Source is always present: "default" (officially curated) or "user".
+	// Builtin capability-tier profiles never reach this struct — Store.List
+	// excludes them.
+	Source string `json:"source"`
 }
 
 func agentToResp(p *agentprofile.Profile) agentResponse {
 	return agentResponse{
-		ID:              p.ID,
-		Name:            p.Name,
-		Description:     p.Description,
-		Model:           p.Model,
-		Tools:           p.Tools,
-		ToolSkills:      p.ToolSkills,
-		SystemPrompt:    p.SystemPrompt,
-		ChannelBindings: p.ChannelBindings,
+		ID:               p.ID,
+		Name:             p.Name,
+		Description:      p.Description,
+		Model:            p.Model,
+		Tools:            p.Tools,
+		ToolSkills:       p.ToolSkills,
+		SystemPrompt:     p.SystemPrompt,
+		ChannelBindings:  p.ChannelBindings,
+		Category:         p.Category,
+		Tags:             p.Tags,
+		TagsEN:           p.TagsEN,
+		ExamplePrompts:   p.ExamplePrompts,
+		ExamplePromptsEN: p.ExamplePromptsEN,
+		Icon:             p.Icon,
+		NameEN:           p.NameEN,
+		DescriptionEN:    p.DescriptionEN,
+		Source:           string(p.Source),
 	}
 }
 
@@ -139,7 +174,15 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 			ToolSkills:   req.ToolSkills,
 			SystemPrompt: req.SystemPrompt,
 		},
-		ChannelBindings: req.ChannelBindings,
+		ChannelBindings:  req.ChannelBindings,
+		Category:         req.Category,
+		Tags:             req.Tags,
+		TagsEN:           req.TagsEN,
+		ExamplePrompts:   req.ExamplePrompts,
+		ExamplePromptsEN: req.ExamplePromptsEN,
+		Icon:             req.Icon,
+		NameEN:           req.NameEN,
+		DescriptionEN:    req.DescriptionEN,
 	}
 
 	if err := s.agentStoreOrInit().Create(p); err != nil {
@@ -181,6 +224,45 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 		bindings = req.ChannelBindings
 	}
 
+	// Gallery metadata falls back to the existing profile's values when the
+	// request omits a field — same rule as bindings above. This matters most
+	// when forking a curated (SourceDefault) expert: the conversational edit
+	// flow (expert-agent-manager) typically only sends name/description/
+	// tools/system_prompt, and must not silently wipe the persona's
+	// category/tags/examples/icon on its first fork into a user override.
+	category := existing.Category
+	if req.Category != "" {
+		category = req.Category
+	}
+	tags := existing.Tags
+	if req.Tags != nil {
+		tags = req.Tags
+	}
+	tagsEN := existing.TagsEN
+	if req.TagsEN != nil {
+		tagsEN = req.TagsEN
+	}
+	examplePrompts := existing.ExamplePrompts
+	if req.ExamplePrompts != nil {
+		examplePrompts = req.ExamplePrompts
+	}
+	examplePromptsEN := existing.ExamplePromptsEN
+	if req.ExamplePromptsEN != nil {
+		examplePromptsEN = req.ExamplePromptsEN
+	}
+	icon := existing.Icon
+	if req.Icon != "" {
+		icon = req.Icon
+	}
+	nameEN := existing.NameEN
+	if req.NameEN != "" {
+		nameEN = req.NameEN
+	}
+	descriptionEN := existing.DescriptionEN
+	if req.DescriptionEN != "" {
+		descriptionEN = req.DescriptionEN
+	}
+
 	p := &agentprofile.Profile{
 		ID:          existing.ID,
 		Name:        req.Name,
@@ -191,7 +273,15 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 			ToolSkills:   req.ToolSkills,
 			SystemPrompt: req.SystemPrompt,
 		},
-		ChannelBindings: bindings,
+		ChannelBindings:  bindings,
+		Category:         category,
+		Tags:             tags,
+		TagsEN:           tagsEN,
+		ExamplePrompts:   examplePrompts,
+		ExamplePromptsEN: examplePromptsEN,
+		Icon:             icon,
+		NameEN:           nameEN,
+		DescriptionEN:    descriptionEN,
 	}
 
 	if err := s.agentStoreOrInit().Update(p); err != nil {

--- a/internal/server/agents_handlers.go
+++ b/internal/server/agents_handlers.go
@@ -71,6 +71,13 @@ type agentResponse struct {
 	// Builtin capability-tier profiles never reach this struct — Store.List
 	// excludes them.
 	Source string `json:"source"`
+
+	// Enabled is always present: false only for a hidden (toggled-off)
+	// curated expert, listed via Store.All() so the gallery UI has a way to
+	// show and re-enable it. Every other profile is trivially true — Get(),
+	// Create(), and Update() never surface a hidden default in the first
+	// place (Get() treats it as not-found).
+	Enabled bool `json:"enabled"`
 }
 
 func agentToResp(p *agentprofile.Profile) agentResponse {
@@ -92,6 +99,7 @@ func agentToResp(p *agentprofile.Profile) agentResponse {
 		NameEN:           p.NameEN,
 		DescriptionEN:    p.DescriptionEN,
 		Source:           string(p.Source),
+		Enabled:          true,
 	}
 }
 
@@ -106,14 +114,18 @@ func (s *Server) agentStoreOrInit() *agentprofile.Store {
 	return s.agentStore
 }
 
-// handleListAgents serves GET /api/agents — list all profiles (excluding the
-// code-defined default).
+// handleListAgents serves GET /api/agents — list all profiles (excluding
+// builtins), INCLUDING hidden curated experts (Store.All(), not List()) so
+// the gallery UI can offer a way to re-show one — mirrors handleListSkills
+// using skillReg.All() + IsEnabled for the same reason.
 func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 	store := s.agentStoreOrInit()
-	profiles := store.List()
+	profiles := store.All()
 	resp := make([]agentResponse, 0, len(profiles))
 	for _, p := range profiles {
-		resp = append(resp, agentToResp(p))
+		item := agentToResp(p)
+		item.Enabled = store.IsEnabled(p)
+		resp = append(resp, item)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -427,6 +427,7 @@ func New(cfg Config) (*Server, error) {
 	// file), so calling it from both paths is harmless.
 	_ = skills.MaterializeDefaults(version.Version)
 	_ = tools.MaterializeDefaultWorkflows(version.Version)
+	_ = agentprofile.MaterializeDefaults(version.Version)
 	_ = workflow.PruneJournals()
 
 	cwd, _ := os.Getwd()
@@ -897,6 +898,7 @@ func (s *Server) registerRoutes() {
 	s.api("DELETE /api/agents/{id}", s.handleDeleteAgent)
 	s.api("POST /api/agents/{id}/bind", s.handleBindAgent)
 	s.api("DELETE /api/agents/{id}/bind", s.handleUnbindAgent)
+	s.api("PATCH /api/agents/{id}/toggle", s.handleToggleAgent)
 
 	// MCP server management
 	s.api("GET /api/mcp/servers", s.handleListMCPServers)
@@ -2223,6 +2225,9 @@ func (s *Server) agentRouter() *agentprofile.Router {
 			return
 		}
 		s.agentStore = agentprofile.New(agentUserDir())
+		if cfg, err := config.Load(); err == nil {
+			s.agentStore.SetDisabledDefaults(cfg.Agents.DisabledDefaults)
+		}
 		s.agentRouterVal = agentprofile.NewRouter(s.agentStore)
 	})
 	return s.agentRouterVal

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1641,14 +1641,11 @@ func (s *Server) curSkillsManifest() string {
 }
 
 // curSkillsManifestForProfile is curSkillsManifest filtered to the profile's
-// ToolSkills. When profile is nil or declares no ToolSkills, the full manifest
-// is returned (default agent behavior). Resolved fresh per turn so profile
-// edits land on the next message.
+// ToolSkills — see skills.ManifestForProfile for the per-source empty-
+// allowlist rule (builtin sees everything, everyone else sees nothing until
+// they opt in). Resolved fresh per turn so profile edits land on the next
+// message.
 func (s *Server) curSkillsManifestForProfile(profile *agentprofile.Profile) string {
-	raw := s.curSkillsManifest()
-	if profile == nil || len(profile.ToolSkills) == 0 {
-		return raw
-	}
 	return skills.ManifestForProfile(s.skillReg, profile)
 }
 

--- a/internal/skills/manifest_profile_test.go
+++ b/internal/skills/manifest_profile_test.go
@@ -22,12 +22,10 @@ func discoverWithDefaults(t *testing.T) *Registry {
 	return Discover(t.TempDir())
 }
 
-func TestManifestForProfile_NoProfileReturnsAll(t *testing.T) {
+func TestManifestForProfile_NoProfileReturnsEmpty(t *testing.T) {
 	r := discoverWithDefaults(t)
-	full := RenderManifest(r)
-	profiled := ManifestForProfile(r, nil)
-	if full != profiled {
-		t.Fatalf("nil profile should return full manifest.\nfull:\n%s\nprofiled:\n%s", full, profiled)
+	if profiled := ManifestForProfile(r, nil); profiled != "" {
+		t.Fatalf("nil profile should return an empty manifest, got:\n%s", profiled)
 	}
 }
 
@@ -89,21 +87,25 @@ func countSkillLines(manifest string) int {
 	return n
 }
 
-func TestManifestForProfile_EmptyToolSkillsReturnsAll(t *testing.T) {
+func TestManifestForProfile_EmptyToolSkills(t *testing.T) {
 	r := discoverWithDefaults(t)
 	full := RenderManifest(r)
-	// Default agent sees the full manifest including system skills.
+	// A builtin profile (the Default agent, or explore/general/code-review)
+	// sees the full manifest including system skills — same "empty means
+	// unrestricted" rule tools.DefaultToolsForProfile applies to Tools.
 	profiled := ManifestForProfile(r, agentprofile.DefaultProfile())
 	if full != profiled {
-		t.Fatalf("empty ToolSkills should return full manifest for default agent")
+		t.Fatalf("empty ToolSkills should return full manifest for a builtin profile")
 	}
-	// Non-default agent with empty ToolSkills gets manifest minus system skills.
-	expertProfiled := ManifestForProfile(r, &agentprofile.Profile{
+	// Any non-builtin profile (curated expert or user-created agent) with no
+	// ToolSkills declared sees NO skills — it must opt in explicitly, same as
+	// the Tools allowlist rule for non-builtin profiles.
+	unscopedProfiled := ManifestForProfile(r, &agentprofile.Profile{
 		ID:          "test",
 		Description: "d",
 	})
-	if expertProfiled == full {
-		t.Fatalf("non-default agent with empty ToolSkills should strip system skills")
+	if unscopedProfiled != "" {
+		t.Fatalf("non-builtin agent with empty ToolSkills should see no skills, got:\n%s", unscopedProfiled)
 	}
 }
 

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -353,26 +353,31 @@ func RenderManifest(r *Registry) string {
 }
 
 // ManifestForProfile is RenderManifest filtered to the profile's ToolSkills.
-// When profile is non-nil and declares ToolSkills, only those skills are
-// listed — the design's per-agent skill isolation. A nil profile or an empty
-// ToolSkills list means "all skills" (the default agent behavior).
+// Mirrors tools.DefaultToolsForProfile's per-source rule for an empty
+// allowlist: a builtin profile (explore/general/code-review/the Default
+// agent) sees every skill when it declares no ToolSkills, matching its
+// general-purpose role; every other profile — curated experts and
+// user-created agents alike — sees NONE until it explicitly opts in via
+// tool_skills. Previously an empty ToolSkills list meant "all skills" for
+// any profile, which let an agent that never intended to touch skills at all
+// (e.g. a narrowly-scoped curated persona) still discover — and, combined
+// with the generic `skill` tool, invoke — skills well outside its intended
+// role.
 //
-// Expert agents (non-default profiles) additionally have system-level skills
-// hidden — skills marked system:true in their frontmatter (e.g.
-// expert-agent-manager, channel-manager) exist for the Default Agent's
-// management surface and make no sense in an expert agent's context.
+// Expert agents (non-builtin profiles) additionally have system-level skills
+// hidden even from an explicit allowlist — skills marked system:true in their
+// frontmatter (e.g. expert-agent-manager, channel-manager) exist for the
+// Default Agent's management surface and make no sense in an expert agent's
+// context.
 func ManifestForProfile(r *Registry, profile *agentprofile.Profile) string {
-	if r.Len() == 0 {
+	if r.Len() == 0 || profile == nil {
 		return ""
 	}
-	if profile == nil || len(profile.ToolSkills) == 0 {
-		manifest := RenderManifest(r)
-		// Default agent sees everything; expert agents without an allowlist
-		// still have system skills filtered from the raw manifest.
-		if profile != nil && !profile.IsDefault() {
-			manifest = stripSystemSkills(r, manifest)
+	if len(profile.ToolSkills) == 0 {
+		if profile.Source != agentprofile.SourceBuiltin {
+			return ""
 		}
-		return manifest
+		return RenderManifest(r)
 	}
 	allowed := make(map[string]bool, len(profile.ToolSkills))
 	for _, name := range profile.ToolSkills {
@@ -383,7 +388,7 @@ func ManifestForProfile(r *Registry, profile *agentprofile.Profile) string {
 	b.WriteString("When a task matches a skill's description, call the `skill` tool with its " +
 		"name to load the full instructions before acting. Don't guess the instructions " +
 		"from the one-line description. The user can also trigger one directly by typing /<name>.\n\n")
-	expert := !profile.IsDefault()
+	expert := profile.Source != agentprofile.SourceBuiltin
 	n := 0
 	for _, s := range r.List() {
 		if allowed[s.Name] && !(expert && s.System) {
@@ -395,41 +400,6 @@ func ManifestForProfile(r *Registry, profile *agentprofile.Profile) string {
 		return ""
 	}
 	return strings.TrimRight(b.String(), "\n")
-}
-
-// stripSystemSkills filters system-level skill lines from the rendered manifest
-// text. It looks for "- <name>: " prefixed lines whose name matches a skill with
-// System==true in the registry, and removes them.
-func stripSystemSkills(r *Registry, manifest string) string {
-	// Collect the names of system skills.
-	sys := map[string]bool{}
-	for _, s := range r.List() {
-		if s.System {
-			sys[s.Name] = true
-		}
-	}
-	if len(sys) == 0 {
-		return manifest
-	}
-	var b strings.Builder
-	for _, line := range strings.Split(manifest, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "- ") {
-			// Extract skill name: "- name: description..."
-			rest := trimmed[2:]
-			if colon := strings.IndexByte(rest, ':'); colon > 0 {
-				name := rest[:colon]
-				if sys[name] {
-					continue // skip system skill lines
-				}
-			}
-		}
-		if b.Len() > 0 {
-			b.WriteByte('\n')
-		}
-		b.WriteString(line)
-	}
-	return b.String()
 }
 
 // ccCompatNote bridges skills authored for Claude Code — the ecosystem most

--- a/web/src/components/overlays/AgentDetailModal.svelte
+++ b/web/src/components/overlays/AgentDetailModal.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  import { t, tr, pickLocalized, pickLocalizedList } from '../../lib/i18n'
+  import { summonAgent } from '../../lib/stores'
+  import * as api from '../../lib/api'
+
+  let { agent, onClose }: { agent: api.Agent; onClose: () => void } = $props()
+
+  let name = $derived(pickLocalized(agent.name, agent.name_en))
+  let description = $derived(pickLocalized(agent.description, agent.description_en))
+  let tags = $derived(pickLocalizedList(agent.tags, agent.tags_en))
+  let examplePrompts = $derived(pickLocalizedList(agent.example_prompts, agent.example_prompts_en))
+
+  function agentInitial(n: string): string {
+    return n.charAt(0).toUpperCase()
+  }
+  function agentIconColor(n: string): string {
+    const colors = ['#1677ff', '#722ed1', '#13c2c2', '#52c41a', '#eb2f96', '#fa8c16', '#2f54eb', '#a0d911']
+    let hash = 0
+    for (let i = 0; i < n.length; i++) hash = n.charCodeAt(i) + ((hash << 5) - hash)
+    return colors[Math.abs(hash) % colors.length]
+  }
+
+  async function summon(prompt?: string) {
+    await summonAgent(agent.id, name, prompt)
+    onClose()
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') { e.preventDefault(); onClose() }
+  }
+</script>
+
+<div class="backdrop" role="presentation" onclick={onClose}>
+  <div class="modal" onclick={(e) => e.stopPropagation()} onkeydown={onKeydown} role="dialog" aria-modal="true" tabindex="-1">
+    <button class="close-btn" onclick={onClose} aria-label={tr('common.close')}>
+      <iconify-icon icon="ant-design:close-outlined" width="16"></iconify-icon>
+    </button>
+
+    <div class="modal-header">
+      {#if agent.icon}
+        <span class="agent-icon" style="background-color: {agentIconColor(name)}11; color: {agentIconColor(name)}">
+          <iconify-icon icon={agent.icon} width="20"></iconify-icon>
+        </span>
+      {:else}
+        <span class="agent-icon" style="background-color: {agentIconColor(name)}11; color: {agentIconColor(name)}">
+          {agentInitial(name)}
+        </span>
+      {/if}
+      <div class="header-text">
+        <span class="agent-name">{name}</span>
+        {#if agent.source === 'default'}
+          <span class="official-badge">{$t('agents.official_badge')}</span>
+        {/if}
+      </div>
+    </div>
+
+    <div class="modal-body">
+      <section>
+        <h4>{$t('agents.capability_intro')}</h4>
+        <p class="desc-text">{description}</p>
+      </section>
+
+      {#if tags.length > 0}
+        <section>
+          <h4>{$t('agents.good_at')}</h4>
+          <div class="tag-row">
+            {#each tags as tag}
+              <span class="tag-chip">{tag}</span>
+            {/each}
+          </div>
+        </section>
+      {/if}
+
+      {#if examplePrompts.length > 0}
+        <section>
+          <h4>{$t('agents.try_asking')}</h4>
+          <div class="prompt-list">
+            {#each examplePrompts as prompt}
+              <button class="prompt-btn" onclick={() => summon(prompt)}>
+                <span>{prompt}</span>
+                <iconify-icon icon="ant-design:arrow-right-outlined" width="13"></iconify-icon>
+              </button>
+            {/each}
+          </div>
+        </section>
+      {/if}
+    </div>
+
+    <div class="modal-footer">
+      <button class="btn-summon" onclick={() => summon()}>
+        {$t('agents.summon').replace('{name}', name)}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+.backdrop {
+  position: fixed; inset: 0; z-index: 1100;
+  background: var(--scrim);
+  display: flex; align-items: center; justify-content: center;
+  padding: 24px;
+}
+.modal {
+  width: 100%; max-width: 460px; position: relative;
+  background: var(--bg-container);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 16px 48px rgba(0,0,0,0.18);
+  animation: octo-fadein 0.16s ease;
+}
+.modal:focus { outline: none; }
+.close-btn {
+  position: absolute; top: 12px; right: 12px; z-index: 1;
+  width: 28px; height: 28px; border: none; background: transparent;
+  border-radius: 7px; display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--text-tertiary);
+}
+.close-btn:hover { background: var(--hover-neutral); color: var(--text); }
+
+.modal-header {
+  display: flex; align-items: center; gap: 12px;
+  padding: 20px 20px 16px;
+}
+.agent-icon {
+  width: 44px; height: 44px; flex: 0 0 44px; border-radius: 12px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 17px; font-weight: 600;
+}
+.header-text { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.agent-name { font-size: 17px; font-weight: 700; color: var(--text-heading); }
+.official-badge {
+  height: 18px; padding: 0 6px; border-radius: 4px;
+  background: var(--blue-1); color: var(--blue-6); font-size: 11px;
+  display: flex; align-items: center; flex: 0 0 auto;
+}
+
+.modal-body {
+  padding: 0 20px 16px;
+  display: flex; flex-direction: column; gap: 16px;
+  max-height: 50vh; overflow-y: auto;
+}
+h4 { margin: 0 0 8px; font-size: 12px; font-weight: 600; color: var(--text-tertiary); }
+.desc-text { margin: 0; font-size: 13px; line-height: 1.6; color: var(--text-secondary); }
+
+.tag-row { display: flex; gap: 6px; flex-wrap: wrap; }
+.tag-chip {
+  height: 22px; padding: 0 9px; background: var(--bg-table-header); color: var(--text-secondary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 5px; display: flex; align-items: center; font-size: 12px;
+}
+
+.prompt-list { display: flex; flex-direction: column; gap: 6px; }
+.prompt-btn {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  width: 100%; padding: 9px 12px;
+  border: 1px solid var(--border-table); background: var(--bg-table-header);
+  border-radius: 8px;
+  font-size: 12.5px; color: var(--text); line-height: 1.5;
+  text-align: left; cursor: pointer; font-family: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+.prompt-btn:hover { border-color: var(--blue-2); background: var(--blue-1); color: var(--blue-6); }
+.prompt-btn iconify-icon { flex: 0 0 auto; opacity: 0.6; }
+
+.modal-footer { padding: 14px 20px; border-top: 1px solid var(--border-table); }
+.btn-summon {
+  width: 100%; height: 38px; border: none; background: var(--blue-6);
+  border-radius: 8px; font-size: 14px; font-weight: 600; color: #fff; cursor: pointer;
+  font-family: inherit;
+}
+.btn-summon:hover { background: var(--blue-5); }
+</style>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -376,6 +376,18 @@ export interface Agent {
   tool_skills?: string[]
   system_prompt?: string
   channel_bindings?: { platform: string; adapter_id?: string; chat_id: string }[]
+  // Gallery display metadata — populated for curated (source: 'default')
+  // experts, empty/absent for ordinary user agents.
+  category?: string
+  tags?: string[]
+  tags_en?: string[]
+  example_prompts?: string[]
+  example_prompts_en?: string[]
+  icon?: string
+  name_en?: string
+  description_en?: string
+  // Always present: 'default' (officially curated) or 'user'.
+  source?: 'default' | 'user'
 }
 
 export async function listAgents(): Promise<Agent[]> {
@@ -396,6 +408,12 @@ export async function updateAgent(id: string, data: Partial<Agent>): Promise<Age
 
 export async function deleteAgent(id: string): Promise<void> {
   await request<unknown>(`/api/agents/${id}`, { method: 'DELETE' })
+}
+
+// Hide or re-show a curated (source: 'default') expert in the gallery. Only
+// valid for curated experts — the server rejects it for user agents.
+export async function toggleAgent(id: string): Promise<{ id: string; enabled: boolean }> {
+  return request<{ id: string; enabled: boolean }>(`/api/agents/${id}/toggle`, { method: 'PATCH' })
 }
 
 export async function bindAgent(id: string, platform: string, chatId: string): Promise<Agent> {

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -69,6 +69,21 @@ export const en: Record<string, string> = {
   "agents.bound_chats": "bound",
   "agents.delete_title": "Delete Agent",
   "agents.delete_confirm": "Delete agent \"{name}\"? This cannot be undone.",
+  "agents.search_placeholder": "Search experts by name or description",
+  "agents.category.all": "All",
+  "agents.category.content-creation": "Content Creation",
+  "agents.category.life": "Life",
+  "agents.category.learning": "Learning",
+  "agents.category.productivity": "Productivity",
+  "agents.category.career": "Career",
+  "agents.category.mine": "My Experts",
+  "agents.capability_intro": "About",
+  "agents.good_at": "Good at",
+  "agents.try_asking": "Try asking",
+  "agents.summon": "Summon {name}",
+  "agents.hide": "Hide",
+  "agents.show": "Show",
+  "agents.official_badge": "Official",
   "chat.thinking": "Thinking",
   "chat.thinking_0": "Thinking",
   "chat.thinking_1": "Pondering",
@@ -885,6 +900,21 @@ export const zh: Record<string, string> = {
   "agents.bound_chats": "已绑定",
   "agents.delete_title": "删除专家",
   "agents.delete_confirm": "删除专家 \"{name}\"？此操作不可撤销。",
+  "agents.search_placeholder": "搜索专家名称或描述",
+  "agents.category.all": "全部",
+  "agents.category.content-creation": "内容创作",
+  "agents.category.life": "生活助手",
+  "agents.category.learning": "学习提升",
+  "agents.category.productivity": "效率工具",
+  "agents.category.career": "职业发展",
+  "agents.category.mine": "我的专家",
+  "agents.capability_intro": "能力介绍",
+  "agents.good_at": "擅长领域",
+  "agents.try_asking": "试试这样问我",
+  "agents.summon": "召唤 {name}",
+  "agents.hide": "隐藏",
+  "agents.show": "显示",
+  "agents.official_badge": "官方",
   "chat.thinking": "思考中",
   "chat.thinking_0": "思考中",
   "chat.thinking_1": "沉思中",
@@ -1652,4 +1682,18 @@ export function tr(key: string): string {
 
 export function setLocale(l: string): void {
   locale.set(l);
+}
+
+// Curated expert-gallery content (agent name/description/tags/example
+// prompts) is authored bilingually in the .md frontmatter itself rather than
+// run through the t()/tr() dictionaries — it's user-facing persona content,
+// not UI chrome. These pick the locale-appropriate variant, falling back to
+// the base (zh-authored) value when no English variant exists (e.g. plain
+// user-created agents, which are never translated).
+export function pickLocalized(base: string, en?: string): string {
+  return get(locale).startsWith("en") && en ? en : base;
+}
+
+export function pickLocalizedList(base?: string[], en?: string[]): string[] {
+  return get(locale).startsWith("en") && en && en.length ? en : (base ?? []);
 }

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -265,6 +265,20 @@ export async function openAgentSession(content: string, name?: string): Promise<
   view.set('chat')
 }
 
+// Expert-gallery entry point: bind a fresh session to the given agent profile
+// (curated or user-created) and, when an example prompt is supplied,
+// pre-queue it as the first message via the same pendingPrompt auto-send
+// mechanism openAgentSession uses. Unlike openAgentSession this is a genuine
+// conversation with the expert, not a single-purpose panel session, so it is
+// deliberately NOT added to agenticSessions.
+export async function summonAgent(agentId: string, agentName: string, examplePrompt?: string): Promise<void> {
+  const sess = await api.createSession({ source: 'manual', agent_profile: agentId, name: agentName })
+  sessions.update(ss => [sess, ...ss])
+  if (examplePrompt) pendingPrompt.set({ sessionId: sess.id, content: examplePrompt })
+  activeSessionId.set(sess.id)
+  view.set('chat')
+}
+
 export function addChatMsg(sessionId: string, msg: any) {
   chatMessages.update(m => ({ ...m, [sessionId]: [...(m[sessionId] || []), msg] }))
 }

--- a/web/src/views/AgentsView.svelte
+++ b/web/src/views/AgentsView.svelte
@@ -1,12 +1,22 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { t, tr } from '../lib/i18n'
+  import { t, tr, pickLocalized, pickLocalizedList } from '../lib/i18n'
   import { showToast, openAgentSession } from '../lib/stores'
   import { confirmDialog } from '../lib/confirm'
   import * as api from '../lib/api'
+  import AgentDetailModal from '../components/overlays/AgentDetailModal.svelte'
 
-  let agents: api.Agent[] = []
-  let loading = true
+  let agents: api.Agent[] = $state([])
+  let loading = $state(true)
+  let query = $state('')
+  let activeCategory = $state('all')
+  let selectedAgent: api.Agent | null = $state(null)
+
+  // Fixed, closed set of category chips — 'mine' buckets every user-created
+  // agent (which has no curated `category`), plus any curated expert that
+  // somehow ships without one. Order matches the CATEGORIES declared for
+  // curated content, so new categories just need a matching i18n key.
+  const CATEGORY_ORDER = ['content-creation', 'life', 'learning', 'productivity', 'career']
 
   async function loadAgents() {
     loading = true
@@ -21,7 +31,7 @@
 
   async function handleDelete(agent: api.Agent) {
     const confirmed = await confirmDialog(
-      $t('agents.delete_confirm').replace('{name}', agent.name)
+      $t('agents.delete_confirm').replace('{name}', agentName(agent))
     )
     if (!confirmed) return
     try {
@@ -33,21 +43,40 @@
     }
   }
 
+  async function handleToggle(agent: api.Agent) {
+    try {
+      await api.toggleAgent(agent.id)
+      await loadAgents()
+    } catch (err) {
+      showToast('Failed to update agent: ' + (err as Error).message, 'error')
+    }
+  }
+
   // Agentic-first: create and edit through conversation with the
-  // expert-agent-manager skill.
+  // expert-agent-manager skill. Works for curated experts too — the Store
+  // forks a SourceDefault profile into a user override on first edit.
   function handleCreateWithAgent() {
     openAgentSession('/expert-agent-manager', tr('agents.session_new'))
   }
 
-  function handleEditWithAgent(agent: api.Agent) {
-    openAgentSession(`/expert-agent-manager edit ${agent.id}`, tr('agents.session_edit').replace('{name}', agent.name))
+  function handleEditWithAgent(agent: api.Agent, e: MouseEvent) {
+    e.stopPropagation()
+    openAgentSession(`/expert-agent-manager edit ${agent.id}`, tr('agents.session_edit').replace('{name}', agentName(agent)))
   }
 
-  // Derive icon avatar from agent name
+  function agentName(agent: api.Agent): string {
+    return pickLocalized(agent.name, agent.name_en)
+  }
+  function agentDesc(agent: api.Agent): string {
+    return pickLocalized(agent.description, agent.description_en)
+  }
+  function agentCategory(agent: api.Agent): string {
+    return agent.category && CATEGORY_ORDER.includes(agent.category) ? agent.category : 'mine'
+  }
+
   function agentInitial(name: string): string {
     return name.charAt(0).toUpperCase()
   }
-
   function agentIconColor(name: string): string {
     const colors = ['#1677ff', '#722ed1', '#13c2c2', '#52c41a', '#eb2f96', '#fa8c16', '#2f54eb', '#a0d911']
     let hash = 0
@@ -56,6 +85,22 @@
     }
     return colors[Math.abs(hash) % colors.length]
   }
+
+  let categoriesPresent = $derived(
+    CATEGORY_ORDER.filter(c => agents.some(a => agentCategory(a) === c))
+  )
+
+  let filtered = $derived.by(() => {
+    const q = query.trim().toLowerCase()
+    return agents.filter(a => {
+      if (activeCategory !== 'all' && agentCategory(a) !== activeCategory) return false
+      if (!q) return true
+      const name = agentName(a).toLowerCase()
+      const desc = agentDesc(a).toLowerCase()
+      const tags = pickLocalizedList(a.tags, a.tags_en).join(' ').toLowerCase()
+      return name.includes(q) || desc.includes(q) || tags.includes(q)
+    })
+  })
 
   onMount(loadAgents)
 </script>
@@ -75,6 +120,30 @@
       </div>
     </div>
 
+    {#if !loading && agents.length > 0}
+      <div class="toolbar">
+        <div class="search-box">
+          <iconify-icon icon="ant-design:search-outlined" width="14" style="color:var(--text-tertiary)"></iconify-icon>
+          <input bind:value={query} placeholder={$t('agents.search_placeholder')} />
+        </div>
+        <div class="chip-row">
+          <button class="chip" class:active={activeCategory === 'all'} onclick={() => activeCategory = 'all'}>
+            {$t('agents.category.all')}
+          </button>
+          {#each categoriesPresent as cat}
+            <button class="chip" class:active={activeCategory === cat} onclick={() => activeCategory = cat}>
+              {$t(`agents.category.${cat}`)}
+            </button>
+          {/each}
+          {#if agents.some(a => agentCategory(a) === 'mine')}
+            <button class="chip" class:active={activeCategory === 'mine'} onclick={() => activeCategory = 'mine'}>
+              {$t('agents.category.mine')}
+            </button>
+          {/if}
+        </div>
+      </div>
+    {/if}
+
     {#if loading}
       <div class="empty-state">
         <div class="spinner"></div>
@@ -86,52 +155,57 @@
         <span>{$t('agents.empty')}</span>
         <button class="btn-primary" onclick={handleCreateWithAgent}>{$t('agents.create_with_agent')}</button>
       </div>
+    {:else if filtered.length === 0}
+      <div class="empty-state">
+        <iconify-icon icon="ant-design:search-outlined" width="32"></iconify-icon>
+        <span>{$t('cmdk.no_matches').replace('{query}', query)}</span>
+      </div>
     {:else}
-      <div class="agent-list">
-        {#each agents as agent (agent.id)}
-          <div class="agent-card">
-            <span class="agent-icon" style="background-color: {agentIconColor(agent.name)}11; color: {agentIconColor(agent.name)}">
-              {agentInitial(agent.name)}
-            </span>
-            <div class="agent-info">
-              <div class="agent-title-row">
-                <span class="agent-name">{agent.name}</span>
-                {#if agent.model}
-                  <span class="transport-badge mono">{$t('agents.model')}: {agent.model}</span>
-                {/if}
-                {#if agent.tools && agent.tools.length > 0}
-                  <span class="transport-badge">{agent.tools.length} {$t('agents.tools')}</span>
+      <div class="agent-grid">
+        {#each filtered as agent (agent.id)}
+          <div class="agent-card" onclick={() => selectedAgent = agent}>
+            <div class="card-top">
+              {#if agent.icon}
+                <span class="agent-icon" style="background-color: {agentIconColor(agentName(agent))}11; color: {agentIconColor(agentName(agent))}">
+                  <iconify-icon icon={agent.icon} width="18"></iconify-icon>
+                </span>
+              {:else}
+                <span class="agent-icon" style="background-color: {agentIconColor(agentName(agent))}11; color: {agentIconColor(agentName(agent))}">
+                  {agentInitial(agentName(agent))}
+                </span>
+              {/if}
+              <div class="card-actions">
+                {#if agent.source === 'default'}
+                  <button class="act-btn" title={$t('agents.hide')} onclick={(e) => { e.stopPropagation(); handleToggle(agent) }}>
+                    <iconify-icon icon="ant-design:eye-invisible-outlined" width="13"></iconify-icon>
+                  </button>
+                  <button class="act-btn" title={$t('agents.edit_with_agent')} onclick={(e) => handleEditWithAgent(agent, e)}>
+                    <iconify-icon icon="ant-design:message-outlined" width="13"></iconify-icon>
+                  </button>
                 {:else}
-                  <span class="transport-badge muted">{$t('agents.all_tools')}</span>
-                {/if}
-                {#if agent.channel_bindings && agent.channel_bindings.length > 0}
-                  <span class="transport-badge">{agent.channel_bindings.length} {$t('agents.bound_chats')}</span>
+                  <button class="act-btn" title={$t('agents.edit_with_agent')} onclick={(e) => handleEditWithAgent(agent, e)}>
+                    <iconify-icon icon="ant-design:message-outlined" width="13"></iconify-icon>
+                  </button>
+                  <button class="act-btn del" title={$t('common.delete')} onclick={(e) => { e.stopPropagation(); handleDelete(agent) }}>
+                    <iconify-icon icon="ant-design:delete-outlined" width="13"></iconify-icon>
+                  </button>
                 {/if}
               </div>
-              <span class="agent-desc">{agent.description}</span>
-              {#if agent.tool_skills && agent.tool_skills.length > 0}
-                <div class="agent-skills">
-                  {#each agent.tool_skills as skill}
-                    <span class="skill-chip">{skill}</span>
-                  {/each}
-                </div>
-              {/if}
             </div>
-            <div class="agent-actions">
-              <button
-                class="act-btn"
-                title={$t('agents.edit_with_agent')}
-                onclick={() => handleEditWithAgent(agent)}
-              >
-                <iconify-icon icon="ant-design:message-outlined" width="14"></iconify-icon>
-              </button>
-              <button
-                class="act-btn del"
-                title={$t('common.delete')}
-                onclick={() => handleDelete(agent)}
-              >
-                <iconify-icon icon="ant-design:delete-outlined" width="14"></iconify-icon>
-              </button>
+            <span class="agent-name">{agentName(agent)}</span>
+            <span class="agent-desc">{agentDesc(agent)}</span>
+            <div class="card-bottom">
+              {#if agent.model}
+                <span class="transport-badge mono">{$t('agents.model')}: {agent.model}</span>
+              {/if}
+              {#if agent.tools && agent.tools.length > 0}
+                <span class="transport-badge">{agent.tools.length} {$t('agents.tools')}</span>
+              {:else if agent.source !== 'default'}
+                <span class="transport-badge muted">{$t('agents.all_tools')}</span>
+              {/if}
+              {#if agent.channel_bindings && agent.channel_bindings.length > 0}
+                <span class="transport-badge">{agent.channel_bindings.length} {$t('agents.bound_chats')}</span>
+              {/if}
             </div>
           </div>
         {/each}
@@ -140,10 +214,14 @@
   </div>
 </div>
 
+{#if selectedAgent}
+  <AgentDetailModal agent={selectedAgent} onClose={() => selectedAgent = null} />
+{/if}
+
 <style>
 /* ── layout ──────────────────────────────────────────────────────────────── */
 .page  { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
-.inner { max-width: 1000px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
+.inner { max-width: 1160px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
 
 /* ── page header ─────────────────────────────────────────────────────────── */
 .page-header  { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
@@ -162,54 +240,69 @@ p  { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 
 .btn-primary:hover:not(:disabled) { background: var(--blue-5); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
-/* ── agent list ──────────────────────────────────────────────────────────── */
-.agent-list { display: flex; flex-direction: column; gap: 16px; }
+/* ── toolbar: search + category chips ───────────────────────────────────── */
+.toolbar { display: flex; flex-direction: column; gap: 12px; }
+.search-box {
+  display: flex; align-items: center; gap: 8px;
+  height: 36px; padding: 0 12px; max-width: 360px;
+  border: 1px solid var(--border); border-radius: 8px; background: var(--bg-container);
+}
+.search-box input {
+  flex: 1; border: none; outline: none; background: transparent;
+  font-size: 13px; color: var(--text); font-family: inherit;
+}
+.search-box input::placeholder { color: var(--text-tertiary); }
+.chip-row { display: flex; gap: 8px; flex-wrap: wrap; }
+.chip {
+  height: 28px; padding: 0 12px; border: 1px solid var(--border); background: var(--bg-container);
+  border-radius: 999px; font-size: 12.5px; color: var(--text-secondary); cursor: pointer;
+  font-family: inherit;
+}
+.chip:hover { border-color: var(--blue-2); color: var(--blue-6); }
+.chip.active { border-color: var(--blue-6); background: var(--blue-1); color: var(--blue-6); font-weight: 600; }
+
+/* ── agent grid ──────────────────────────────────────────────────────────── */
+.agent-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 16px;
+}
 
 .agent-card {
   background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card); box-shadow: var(--card-shadow);
-  padding: 18px 24px; display: flex; align-items: center; gap: 16px;
-  transition: opacity 0.2s;
+  padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  cursor: pointer; transition: border-color 0.15s, transform 0.15s;
 }
+.agent-card:hover { border-color: var(--blue-2); transform: translateY(-1px); }
 
+.card-top { display: flex; align-items: flex-start; justify-content: space-between; }
 .agent-icon {
   width: 36px; height: 36px; flex: 0 0 36px; border-radius: 10px;
   display: flex; align-items: center; justify-content: center;
   font-size: 15px; font-weight: 600;
 }
 
-.agent-info       { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 5px; }
-.agent-title-row  { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.agent-name       { font-size: 15px; font-weight: 600; color: var(--text-heading); }
+.card-actions { display: flex; align-items: center; gap: 2px; opacity: 0; transition: opacity 0.15s; }
+.agent-card:hover .card-actions { opacity: 1; }
+.act-btn {
+  width: 24px; height: 24px; border: none; background: transparent;
+  border-radius: 6px; display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--text-secondary);
+}
+.act-btn:hover:not(:disabled)      { background: var(--hover-neutral); color: var(--text); }
+.act-btn.del:hover:not(:disabled)  { background: var(--error-bg); color: var(--error); }
 
+.agent-name { font-size: 14.5px; font-weight: 600; color: var(--text-heading); }
+
+.agent-desc {
+  font-size: 12.5px; color: var(--text-secondary); line-height: 1.5;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+
+.card-bottom { display: flex; gap: 6px; flex-wrap: wrap; margin-top: auto; padding-top: 4px; }
 .transport-badge {
   height: 20px; padding: 0 7px; border: 1px solid var(--border-secondary); background: var(--bg-table-header);
   border-radius: 4px; display: flex; align-items: center; font-size: 11px; color: var(--text-tertiary);
 }
 .transport-badge.muted { opacity: 0.6; }
-
-.agent-desc {
-  font-size: 13px; color: var(--text-secondary);
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-
-/* ── skill chips ─────────────────────────────────────────────────────────── */
-.agent-skills { display: flex; gap: 6px; flex-wrap: wrap; }
-.skill-chip {
-  height: 20px; padding: 0 7px; background: var(--blue-1); color: var(--blue-6);
-  border-radius: 4px; display: flex; align-items: center; font-size: 11px;
-}
-
-/* ── agent actions ───────────────────────────────────────────────────────── */
-.agent-actions { display: flex; align-items: center; gap: 4px; flex: 0 0 auto; }
-
-.act-btn {
-  width: 28px; height: 28px; border: none; background: transparent;
-  border-radius: 7px; display: flex; align-items: center; justify-content: center;
-  cursor: pointer; color: var(--text-secondary);
-}
-.act-btn:hover:not(:disabled)      { background: var(--hover-neutral); color: var(--text); }
-.act-btn.del:hover:not(:disabled)  { background: var(--error-bg); color: var(--error); }
-.act-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 
 /* ── empty state ─────────────────────────────────────────────────────────── */
 .empty-state {

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount, onDestroy } from 'svelte'
   import { get } from 'svelte/store'
   import { fade } from 'svelte/transition'
   import {
@@ -55,7 +56,7 @@
   import * as api from '../lib/api'
   import { observeArtifact, resetArtifacts } from '../lib/artifacts'
   import { renderMarkdown, setupCopyButtons } from '../lib/markdown'
-  import { t, tr } from '../lib/i18n'
+  import { t, tr, pickLocalized } from '../lib/i18n'
   import { insertPendingSend } from '../lib/pendingSendOrder'
   import ToolGroup from '../components/chat/ToolGroup.svelte'
   import SubAgentsCard from '../components/chat/SubAgentsCard.svelte'
@@ -81,6 +82,35 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   let subAgents   = $derived($chatSubAgents[$activeSessionId ?? ''] ?? [])
   let workflows   = $derived($chatWorkflows[$activeSessionId ?? ''] ?? [])
   let currentSession = $derived($sessions.find(s => s.id === $activeSessionId) ?? null)
+
+  // Message-bubble identity: a session bound to a non-default agent_profile
+  // (e.g. a summoned expert) should show that agent's own name/icon instead
+  // of the generic Octo mark. Mirrors the same lookup Composer's "@agent"
+  // chip and Sidebar's per-session label already do (api.listAgents() +
+  // find-by-id) — no shared store for this exists yet, so it's fetched here
+  // too, refreshed on the same 'agents_changed' WS event Sidebar listens for.
+  let agents = $state<api.Agent[]>([])
+  let boundAgent = $derived.by(() => {
+    const id = (currentSession as any)?.agent_profile
+    if (!id || id === 'default') return null
+    return agents.find(a => a.id === id) ?? null
+  })
+  let boundAgentName = $derived(boundAgent ? pickLocalized(boundAgent.name, boundAgent.name_en) : '')
+
+  onMount(async () => {
+    try { agents = await api.listAgents() } catch { /* agents list is optional */ }
+  })
+  const unsubAgentsChanged = ws.on('agents_changed', async () => {
+    try { agents = await api.listAgents() } catch { /* ignore */ }
+  })
+  onDestroy(() => { unsubAgentsChanged() })
+
+  function agentAvatarColor(name: string): string {
+    const colors = ['#1677ff', '#722ed1', '#13c2c2', '#52c41a', '#eb2f96', '#fa8c16', '#2f54eb', '#a0d911']
+    let hash = 0
+    for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash)
+    return colors[Math.abs(hash) % colors.length]
+  }
   let artifactCount  = $derived($artifacts.length)
   let wsDisconnected = $derived($wsState === 'disconnected')
   let showReasoning  = $derived($chatShowReasoning[$activeSessionId ?? ''] ?? currentSession?.show_reasoning ?? true)
@@ -1771,8 +1801,23 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
           {#snippet agentMeta(show: boolean, ts?: number)}
             {#if show}
               <div class="msg-meta">
-                <span class="meta-avatar bot" aria-hidden="true"><OctoLogo size={22} /></span>
-                <span class="meta-name">Octo</span>
+                {#if boundAgent}
+                  <span
+                    class="meta-avatar expert"
+                    aria-hidden="true"
+                    style="background-color:{agentAvatarColor(boundAgentName)}22;color:{agentAvatarColor(boundAgentName)}"
+                  >
+                    {#if boundAgent.icon}
+                      <iconify-icon icon={boundAgent.icon} width="13"></iconify-icon>
+                    {:else}
+                      {boundAgentName.charAt(0).toUpperCase()}
+                    {/if}
+                  </span>
+                  <span class="meta-name">{boundAgentName}</span>
+                {:else}
+                  <span class="meta-avatar bot" aria-hidden="true"><OctoLogo size={22} /></span>
+                  <span class="meta-name">Octo</span>
+                {/if}
                 {#if ts}<span class="meta-time">{fmtTime(ts)}</span>{/if}
               </div>
             {/if}
@@ -2404,6 +2449,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 /* The logo is already an app-icon style mark (blue rounded square); no well. */
 .meta-avatar.bot { background: transparent; color: var(--blue-6); }
 .meta-avatar.bot :global(svg) { width: 22px; height: 22px; }
+.meta-avatar.expert { font-size: 11px; font-weight: 600; }
 .meta-name { font-size: 13px; font-weight: 600; color: var(--text-heading); }
 .meta-time { font-size: 11px; color: var(--text-secondary); }
 


### PR DESCRIPTION
## Summary

Adds a curated set of officially-shipped "专家" (expert agent) personas and redesigns the Agents view into a searchable, category-filtered card gallery with a detail popup — modeled on a competitor's expert marketplace UI, requested to complement octo's positioning as a general-purpose assistant (not coding-only).

This intentionally reverses part of a prior "don't ship more preset agents" decision, which was about the 4 internal capability-tier agents (explore/general/code-review/default) duplicating skills — these 8 are a different thing: user-facing content personas, kept on a separate `SourceDefault` track distinct from the hidden `SourceBuiltin` tiers.

- 8 curated experts (copywriter, writing partner, resume coach, trip planner, life assistant, legal-concepts helper, learning coach, productivity coach), embedded in the binary and materialized to `~/.octo/agents-default`, mirroring the existing skills/workflows defaults pattern.
- `AgentsView.svelte` redesigned in place: search box, category chips, card grid, and a new `AgentDetailModal` (description, tags, example prompts, one-click summon).
- `summonAgent()` composes existing `agent_profile` session binding + `pendingPrompt` auto-send — no new backend plumbing needed for that part.
- Curated experts can be hidden/shown (`PATCH /api/agents/{id}/toggle`, mirrors the skill toggle) but not deleted; editing one forks it into a permanent `~/.octo/agents` override.
- Content authored bilingually (zh + en) directly in frontmatter, not run through the i18n dictionaries — it's persona content, not UI chrome.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- [x] `go test ./...` — all passing, including new tests: `SourceDefault` layering/precedence, fork-on-Update, delete-blocked, hide/show toggle (Store + HTTP handler level)
- [x] `npx svelte-check` — 0 errors; `npx vitest run` — 129 passed
- [x] Manual verification via `make build` + local `octo serve` + headless-Chrome/CDP: gallery renders all 8 experts with search/category filtering, detail popup shows tags/examples correctly, clicking an example prompt opens a chat bound to that expert with the question auto-sent, hide/show round-trips and persists to config, deleting a curated expert is correctly blocked

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>