### PR TITLE
fix(agent): tighten session title prompt to avoid dialogue-style titles

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1424,7 +1424,9 @@ const titleContextMaxRunes = 500
 // handful of words. 8 words / 25 characters mirrors FirstUserSnippet's
 // truncation budget, so a model title and the snippet fallback land at the
 // same length.
-const titleInstruction = "Generate a very short title for this conversation — at most 8 words, or 25 characters for Chinese or Japanese. " +
+const titleInstruction = "Generate a very short title that summarizes the user's first message or task. " +
+	"Do not answer the user or continue the conversation — only output a concise title. " +
+	"At most 8 words, or 25 characters for Chinese or Japanese. " +
 	"Reply with the title text only — no preamble, no quotes, no trailing punctuation, no markdown."
 
 // GenerateTitle produces a short title for the conversation so far, for


### PR DESCRIPTION
## Summary

Tightens the throwaway prompt used for session title generation so that lite/cheap models are less likely to reply to the user's first message instead of summarizing it.

## Problem

The previous prompt asked the model to "Generate a very short title for this conversation". With only the user's first message as context, some models treated that message as a question and produced dialogue-style output (e.g. "好的，我来帮你...") rather than a concise title.

## Change

Updated `titleInstruction` in `internal/agent/agent.go` to:
- Explicitly request a title that **summarizes the user's first message or task**.
- Add a clear constraint: **do not answer the user or continue the conversation — only output a concise title**.

No logic changes; only the prompt text changed.

## Verification

- `go test ./internal/agent/ -run TestAgent_GenerateTitle`
- `go test ./internal/server/ -run TestDoAgentTurn`
- `gofmt -l internal/agent/agent.go`
- `go vet ./internal/agent/`

All passed.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>