### PR TITLE
fix(web): give the Settings modal a fixed height

### DIFF
--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -469,7 +469,10 @@
   display: flex; align-items: center; justify-content: center; padding: 24px;
 }
 .modal {
-  width: 100%; max-width: 760px; max-height: 78vh;
+  /* Fixed height (not max-height) so switching between categories with very
+     different content lengths (关于 vs 端点) never resizes the modal itself
+     — each pane scrolls internally instead. */
+  width: 100%; max-width: 760px; height: 78vh;
   background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card);
   box-shadow: 0 24px 48px rgba(15,23,42,0.18);
   display: flex; flex-direction: column; overflow: hidden;


### PR DESCRIPTION
## Summary

The Settings modal used `max-height: 78vh` with no explicit `height`, so it shrank to fit whichever category's content was shortest (关于, 手机) and only grew up to the cap for longer ones (端点) — switching between categories visibly resized the whole modal.

Changed `max-height` to a real `height: 78vh`. The category rail and content pane already flex to fill the modal's height with their own internal scroll (`.pane { overflow-y: auto }`), so this just makes that container size fixed instead of content-driven — every category now renders at the same height, with only the pane's content scrolling.

## Test plan
- [x] `npx svelte-check` — 0 errors, `npx vitest run` — 129 passed
- [x] Manual verification via `make build` + local `octo serve` + headless-Chrome: measured `.modal`'s `getBoundingClientRect().height` across 关于/端点/手机/常规 tabs — all four now render at the identical 634.125px, vs. previously varying per tab's content length

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>