### PR TITLE
docs: polish README and landing page value propositions

### DIFF
--- a/.octorules
+++ b/.octorules
@@ -4,7 +4,7 @@ The canonical project guidance for contributors and AI coding agents. Keep this 
 
 ## Project
 
-`octo-agent` is a Go AI agent CLI (Go 1.22+, single binary). Module path `github.com/open-octo/octo-agent`. Ships as CLI + embedded Web UI + IM bridges (see `octo serve`).
+`octo-agent` is a Go AI agent CLI (Go 1.25+, single binary). Module path `github.com/open-octo/octo-agent`. Ships as CLI + embedded Web UI + IM bridges (see `octo serve`).
 
 ## Commands
 
@@ -42,7 +42,7 @@ Dependency direction is one-way: `provider → agent`, `tools → agent`, never 
 
 ## Code style
 
-- Go 1.22 syntax. `gofmt -w` is the formatter; `go vet ./...` must pass.
+- Go 1.25 syntax. `gofmt -w` is the formatter; `go vet ./...` must pass.
 - Tests live next to code (`foo.go` + `foo_test.go`). Use `httptest.NewServer` for HTTP-mocked tests; do not hit live APIs in `go test ./...`.
 - Comments in English. Prefer self-documenting names over comments. Only comment the **why**, never the **what**.
 - No new third-party dependencies without justification in the PR description.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 <p align="center">觉得有用的话，给 octo 点个 ⭐ 吧！</p>
 
-> **开源、单二进制、自托管的 AI Agent。** coding 能力对标 Claude Code，个人助手
-> 比 OpenClaw 更轻量 —— 一个 MIT 开源的 Go 二进制，无需 Node / Python / Ruby，
-> 接**任意模型**（DeepSeek、Kimi、Anthropic、OpenAI 或任何兼容端点），服务和
-> 数据都留在你自己的机器上。
+> **开源、单二进制、自托管的 AI Agent。** coding agent 能力对标 Claude Code；作为
+> 个人助手，它比 OpenClaw 更轻量 —— 一个 MIT 开源的 Go 二进制，无需 Node / Python /
+> Ruby，接入**任意模型**（DeepSeek、Kimi、Anthropic、OpenAI 或任何兼容端点），服务
+> 和数据都留在你自己的机器上。
 
 ```bash
 curl -fsSL https://octo-agent.dev/install.sh | sh     # 单二进制，无需 Node / Ruby / Python 环境
@@ -60,106 +60,78 @@ octo serve -d              # Web UI + IM 桥接，http://127.0.0.1:8088
 
 ## 为什么用 octo
 
-octo 不打算在功能上卷赢大厂 agent；它是同一个想法的**开源、可自托管、不绑厂商**
-版本 —— 而且是有主张的那种，Rails 风格：约定优于配置，omakase 默认值优于无限选项。
+octo 不是又一个需要“养”的 agent 框架。它的定位更接近 Codex / WorkBuddy：
+**下载即用、用户友好**，同时把模型选择权、数据所有权和运行环境牢牢留在你手里。
 
-|  | **octo-agent** | Claude Code |
-|---|---|---|
-| 授权 / 成本 | **MIT 开源，免费，自托管** | 专有，多数场景需 Claude 订阅 |
-| 运行时 | **单个自包含 Go 二进制** | 原生安装，绑定 Anthropic 账户 |
-| 模型 | **双协议原生 + 任意兼容端点**（DeepSeek/Kimi/百炼/OpenRouter/vLLM） | 以 Anthropic 为主 |
-| 部署 / 数据 | **完全自托管，服务与数据都在你手里** | 多数场景由 Anthropic 托管 |
-| 技能 | SKILL.md 格式相同，复用 Claude Code 技能 | 原生（skills 的发源地） |
+### 1. 开箱即用，不用“养”
 
-在个人助手这条线上，[OpenClaw](https://github.com/openclaw/openclaw) 是最接近的
-同类。octo 覆盖同一块地盘 —— 自托管、MIT、在你已经在用的聊天 App 里找到你 ——
-但它是单个静态二进制而不是带依赖树的 Node.js 应用，且自带完整的 coding agent 核心。
+OpenClaw、Hermes 这类项目往往需要你调环境、写规则、配技能才能让 agent 跑顺。
+octo 默认就把 shell、文件读写改、搜索、MCP、skills、子代理等能力全部打开，
+装完一条消息就能真正开始干活。
 
-## 作者的心里话
+### 2. 原生支持所有主流模型，缓存不劣化
 
-上面讲的是 octo「是什么」，这一节讲「为什么」—— 为什么我觉得它值得你花十分钟
-装一个，特别是如果你在国内。
+DeepSeek、Kimi、Qwen、Anthropic、OpenAI，或任何兼容 OpenAI / Anthropic 协议的
+端点，octo 都是原生支持。针对国产模型逐家做了提示词缓存优化，Kimi、DeepSeek、
+Qwen 的缓存命中率都能到 **95% 以上**；不会像某些方案把 Claude Code 接在国产模型
+前面时，因缓存配置不当导致命中率崩塌、token 账单暴涨。
 
-**好的 agent 体验不该被环境挡住。** 我自己是 Claude Code 的重度用户，它是目前
-最好的 coding agent。但在国内想用上它，要先跨过三道和技术无关的坎：订阅费
-（每月 $20 到 $200）、支付方式（需要一张外币卡）、网络。很多人被挡在这三道坎
-外面，而不是败在「会不会用 agent」上。octo 做的事说穿了就一件：把同样的工作
-方式，带给跨不过这三道坎的人。
+### 3. 八种界面，随处可用
 
-**国产模型真的够用了。** DeepSeek、Kimi、Qwen 这两年的进步是实打实的。而模型
-只是一半，另一半是 harness —— 工具循环、权限门控、skills、记忆、子代理。把国产
-模型接进一个认真做的 harness 里，日常编码任务的完成度和订阅制大厂 agent 已经
-没有体感上的鸿沟，但价格便宜一到两个数量级，人民币直接充值。octo 对这些模型是
-一等公民支持：Anthropic 和 OpenAI 双协议都是原生实现，不是「兼容模式」凑合。
-
-**已经在用 cc-switch 接国产模型？** 这是个流行的路子，但有两个绕不开的短板：
-Claude Code 的提示词缓存是围绕 Anthropic 官方端点调的，第三方模型接进去命中率
-并不理想 —— 而缓存命中率直接决定你的 token 账单；web_search、tool_search 这类
-依赖 Anthropic 服务端的能力，切到第三方端点后就用不了了。octo 把这两件事都在
-自己这一侧做实了：针对几大国产模型逐家做了缓存优化，实测 Kimi、DeepSeek、Qwen
-的缓存命中率都能到 95% 以上，实打实地省钱；web_search 和 tool_search 是 octo
-内置实现，开箱即用，不挑模型。
-
-**你的数据只经过你自己的机器。** octo 没有云端、没有账号体系，代码里没有任何
-遥测埋点 —— 对外的网络请求只有两类：你自己配置的模型 API，和检查更新时访问
-GitHub。对在公司内网干活、代码不能离开内网的人，这不是加分项，是先决条件。
-
-**微信、飞书、钉钉里的 agent。** 海外的 agent 产品永远不会认真支持国内的 IM
-生态。octo 把 IM 桥接当核心功能做：微信 iLink、飞书、钉钉、企业微信开箱即用。
-在工位上布置任务，通勤路上用手机跟进，到家活已经干完了。
-
-**在外面聊得好好的，agent 把自己整没了。** 这是我以前玩 OpenClaw 和 Hermes 时
-最破防的场景：人在外面，用微信跟 agent 聊一个功能怎么实现，聊得正顺，它突然
-自作主张改了代码、顺手重启服务 —— 然后，就没有然后了。它把自己搞挂了，我只能
-干等到晚上回家把它救活。octo 对这个场景做了专门设防：terminal 工具直接拒绝
-任何打向 octo 自身进程的 kill / pkill / killall（连 `kill $(pgrep octo)` 这种
-拐弯的变体也认得）；重启只有一条路 —— 专门的 restart_server 工具，而它在默认
-权限规则里被写死为「必须询问」，网页上弹确认框、IM 里要你明确回复同意才执行；
-即便你同意了，重启也是优雅的：先把当前这轮跑完、回复送到你手上，supervisor
-再拉起新进程，客户端自动重连。你在外面，永远不会再对着一个突然沉默的聊天窗口
-干瞪眼。
-
-**你见过 agent 发疯吗？** 模型越来越强，但本质仍是概率模型。也许你也遇到过
-这样的失控现场：它突然认定「环境坏了」「刚才写的全错了」「系统被入侵了」
-「这个文件是病毒」—— 然后它真的动手了，`rm` 下去，你一整天的工作成果没了，
-再也找不回来。octo 不会让这一幕发生：所有经 octo 发出的删除命令都要过校验，
-`rm -rf /`、`rm -rf ~` 这类毁灭性命令被硬编码拒绝 —— 硬到连你自己改权限规则
-都放不开；删普通文件，先把目标备份进回收站再执行；write_file / edit_file
-覆盖旧文件，同样先存底。回收站默认保留 14 天、上限 10 GiB，在这个范围内，
-被误删的文件永远找得回来。
-
-**单二进制在国内的含金量。** 不需要 Node / Python / Ruby 环境，意味着 npm 镜像、
-node-gyp 编译失败、依赖版本冲突这些事从根上就不存在。一个二进制文件，拷到任何
-机器上就能跑 —— 包括不能上外网的内网机器。
-
-**紧跟前沿，但不照单全收。** 开源平替常见的宿命是慢半拍，octo 不是。今年 6 月
-Claude Code 推出 dynamic workflows（模型自己写编排脚本、扇出子代理协同干活），
-Codex 推出 record & replay（演示一遍操作、录成可复用的技能），这两个高阶能力
-octo 都有，而且结合自己的内置工具做了取舍：dynamic workflow 的官方玩法动辄
-几十上百个并行子代理，跑起来壮观，token 账单也壮观 —— octo 把单个 workflow
-的并行扇出限制在 8 个，多出来的排队等空位，任务照样全部跑完，账单不会失控；
-Codex 的 record & replay 只在 macOS 应用里提供，octo 的浏览器录制回放（带页面
-改版后的自愈）对 Windows 和 Linux 一视同仁。
-
-最后一句实话：如果你已经有 Claude 订阅而且用得顺手，请继续用 Claude Code，它
-配得上它的价格。octo 适合的是另外一群人 —— 订阅对你太贵、支付和网络够不着、
-数据不能出机器，或者单纯想把整套工具攥在自己手里。两边的 SKILL.md 格式互通，
-你甚至可以白天用 Claude Code 干重活，日常杂事交给跑着 DeepSeek 的 octo。
-
-## 界面
-
-**稳定版（1.0）。** 规划了八个界面 —— 正好对上章鱼的八条腕 —— 其中七个已上线：
-
-- **CLI** —— 终端里是交互式 TUI，其余场景是 headless 单发
-- **Web UI** —— `octo serve`，基于 REST + WebSocket 的本地仪表盘
-- **桌面应用** —— 原生窗口 + 系统托盘（macOS / Windows / Linux）
-- **IM 桥接** —— 微信 iLink、飞书、钉钉、企微、Discord、Telegram，随 `octo serve` 运行
+- **CLI / TUI** —— 终端交互与 headless 单发
+- **Web UI** —— `octo serve` 本地仪表盘
+- **桌面应用** —— macOS / Windows / Linux 原生窗口 + 托盘
+- **IM 桥接** —— 微信 iLink、飞书、钉钉、企业微信、Discord、Telegram
 - **VS Code 插件** —— [`open-octo/octo-vscode`](https://github.com/open-octo/octo-vscode)
 - **Obsidian 插件** —— [`open-octo/octo-obsidian`](https://github.com/open-octo/octo-obsidian)
 - **Go SDK** —— [`pkg/octoagent`](pkg/octoagent)，把 agent 循环嵌进你自己的程序
+- **移动端** —— iOS + Android 开发者预览（[`mobile/`](mobile/)）
 
+很少有其他 agent 项目能同时覆盖这么多入口。
+
+### 4. 极简内核：单个 ~40 MB 的 Go 二进制
+
+一条命令下载，拷到任何服务器都能立即运行。没有 Node / Python / Ruby 依赖树，
+没有 npm 镜像、node-gyp 编译失败、依赖版本冲突的烦恼。
+
+### 5. 零遥测
+
+除了你自己配置的模型 API 调用，octo 自身不会向外发送任何请求。不收集 IP、
+机型、模型选择、使用行为——没有任何遥测埋点。
+
+### 6. 桌面安装包也只有 100 MB 左右
+
+基于“单二进制 + 零遥测”这两点，octo 的桌面安装包约为 **100 MB**。相比之下，
+Codex 桌面版和 WorkBuddy 动辄 **1 GB 上下**。一个薄薄的 agent harness，没必要占用
+那么大的空间。
+
+### 7. 稳定且安全：不会把自己改挂，也不会发疯删数据
+
+- **terminal** 工具直接拒绝任何打向 octo 自身进程的 `kill` / `pkill` / `killall`
+  （连 `kill $(pgrep octo)` 这种拐弯变体也认得）。
+- **restart_server** 在默认权限规则里被写死为“必须询问”，网页弹确认框、IM 里
+  要你明确回复同意才执行；即便同意，也是优雅热重启——先把当前这轮跑完、回复送
+  到你手上，supervisor 再拉起新进程，客户端自动重连。
+- 所有删除命令都过校验，`rm -rf /`、`rm -rf ~` 这类毁灭性命令被**硬编码拒绝**，
+  连自定义权限规则也放不开；普通文件删除和 `write_file` / `edit_file` 覆盖前
+  会先备份到回收站（默认保留 14 天、上限 10 GiB），误删永远找得回来。
+
+### 8. 同时做到以上所有的，只有 octo
+
+单看每一点，或许都有其他产品能覆盖其中一两项。但能同时满足“开箱即用 + 原生多模型
++ 八界面 + 单二进制 + 零遥测 + 小体积 + 高稳定性 + 强安全”的，只有 octo。
+
+### 9. 最后的建议
+
+如果你能合法稳定地使用 Codex / Claude 订阅，请继续用它们——它们依旧是这个星球上
+最顶级的 agent harness。否则，octo 值得你认真看一看。
+
+## 界面
+
+**稳定版（1.0）** 已覆盖 CLI、Web UI、桌面端、IM 桥接、VS Code / Obsidian 插件、Go SDK；
 第八个界面——移动端 App（iOS + Android）——已实现，目前是**开发者预览**：现在即可从源码
 自建、配合自托管 relay 使用（见 [`mobile/`](mobile/)），托管 relay 与应用商店版本在路上。
+
 哪些接口可以放心依赖见 [COMPATIBILITY.md](COMPATIBILITY.md)；安全边界见
 [SECURITY.md](SECURITY.md)。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,7 +14,7 @@
 <p align="center">If you find octo useful, give it a ⭐ on GitHub!</p>
 
 > **An open-source, single-binary, self-hosted AI agent.** A coding agent on par
-> with Claude Code and a personal assistant lighter than OpenClaw — one MIT-licensed
+> with Claude Code; as a personal assistant, lighter than OpenClaw — one MIT-licensed
 > Go binary, no Node / Python / Ruby, running on **any model** (DeepSeek, Kimi,
 > Anthropic, OpenAI, or anything compatible), with the server and your data staying
 > on your own machine.
@@ -62,99 +62,90 @@ default, so a single message can actually do work. Next steps:
 
 ## Why octo
 
-octo isn't trying to out-feature the big agents; it's the **open, self-hostable,
-vendor-neutral** take on the same idea — an opinionated one, in the Rails spirit:
-convention over configuration, omakase defaults over infinite choice.
+octo isn't another agent framework you have to "raise." It sits closer to Codex
+or WorkBuddy: **download and use, user-friendly**, while keeping model choice,
+data ownership, and the runtime firmly in your hands.
 
-|  | **octo-agent** | Claude Code |
-|---|---|---|
-| License / cost | **MIT, free, self-hosted** | proprietary; most surfaces need a Claude subscription |
-| Runtime | **one self-contained Go binary** | native install tied to an Anthropic account |
-| Models | **both protocols + any compatible endpoint** (DeepSeek/Kimi/Bailian/OpenRouter/vLLM) | Anthropic-first |
-| Deployment / data | **fully self-hosted — server and data stay yours** | Anthropic-managed for most surfaces |
-| Skills | same SKILL.md format — reuse your Claude Code skills | native (the format's origin) |
+### 1. Works out of the box — no "raising" required
 
-On the personal-assistant side, [OpenClaw](https://github.com/openclaw/openclaw)
-is the closest kin. octo covers the same ground — self-hosted, MIT, reaches you on
-the chat apps you already use — but as one static binary instead of a Node.js app
-with a dependency tree, and with a full coding-agent core built in.
+Projects like OpenClaw or Hermes often need environment tuning, rule writing, and
+skill configuration before the agent runs smoothly. octo enables shell, file
+read/write/edit, search, MCP servers, skills, and sub-agents by default, so one
+message after install is enough for it to actually do work.
 
-## A note from the author
+### 2. Native model support, without cache degradation
 
-I'm a heavy Claude Code user myself, and I think it's the best coding agent there
-is. octo exists because a great agent experience shouldn't depend on things that
-have nothing to do with your skills: whether you can afford a $20–200/month
-subscription, whether your credit card and network can reach the vendor at all
-(for many users — in China especially — they can't), and whether your code is
-allowed to leave your machine.
+DeepSeek, Kimi, Qwen, Anthropic, OpenAI, or any OpenAI / Anthropic-compatible
+endpoint — octo supports them natively. Prompt caching is tuned per provider;
+measured hit rates for Kimi, DeepSeek, and Qwen are all **95%+**. Unlike setups
+that front Claude Code with a third-party model and see cache hit rates collapse
+from misconfiguration, octo keeps your token bill predictable.
 
-Three beliefs drive the project:
+### 3. Eight interfaces, everywhere you are
 
-- **Open models are good enough now.** DeepSeek, Kimi, and Qwen have closed most
-  of the day-to-day gap — what's usually missing is the harness around them: the
-  tool loop, permission gating, skills, memory, sub-agents. octo gives them the
-  same harness at one to two orders of magnitude lower cost, with both wire
-  protocols implemented natively rather than through a compatibility shim.
-- **The harness shouldn't degrade off-Anthropic.** A popular route is plugging
-  third-party models into Claude Code through a router (cc-switch and kin), but
-  two things quietly break: prompt caching is tuned for Anthropic's own endpoint,
-  so hit rates — and your token bill — suffer; and server-side capabilities like
-  web search and tool search simply stop working. octo does both on its own side:
-  caching is tuned per provider (measured 95%+ hit rates on Kimi, DeepSeek, and
-  Qwen), and web search / tool search are built into the harness, working the
-  same on every model.
-- **Your data should only pass through your own machine.** No cloud, no accounts,
-  no telemetry in the codebase — the only outbound traffic is the model API you
-  configure and GitHub for update checks. For people working inside a corporate
-  network where code cannot leave, this is a precondition, not a nice-to-have.
-- **The agent should live where you already are.** IM bridges (WeChat iLink,
-  Feishu, DingTalk, WeCom, Discord, Telegram) are core features, not
-  afterthoughts — assign a task at your desk, follow up from your phone.
-- **The agent must not saw off the branch it's sitting on.** My most infuriating
-  OpenClaw/Hermes memory: chatting with the agent from my phone, mid-discussion
-  it decides to edit code and restart itself — then silence until I got home to
-  revive it. octo defends this scenario specifically: the terminal tool refuses
-  any kill aimed at octo's own process (including `kill $(pgrep octo)`-style
-  detours); the only restart path is a dedicated `restart_server` tool,
-  hard-wired to ask permission first (browser modal on web, explicit reply on
-  IM); and even an approved restart drains the current turn so the reply
-  reaches you before the supervisor respawns the server and clients reconnect.
-- **A probabilistic model will eventually go insane on you.** One day the agent
-  decides "the environment is broken", "everything I wrote is wrong", "this
-  file is a virus" — and really deletes a day of your work. On octo every
-  delete is checked: catastrophic commands (`rm -rf /`, `rm -rf ~`) are
-  hard-coded denies that even your own permission rules cannot re-allow;
-  ordinary deletes are copied to a recycle bin before they run, and file
-  overwrites are backed up the same way. Within the default 14-day / 10 GiB
-  window, nothing the agent deletes is ever truly gone.
-- **Frontier features, without the gates.** In June 2026 Claude Code shipped
-  dynamic workflows and Codex shipped record & replay (macOS only). octo has
-  both, on its own terms: a workflow fans out at most 8 concurrent sub-agents
-  (the rest queue — every task still completes, the token bill stays bounded),
-  and browser record / replay, self-healing included, treats Windows and Linux
-  as first-class.
-
-And one honest word: if you have a Claude subscription and you're happy with it,
-keep using Claude Code — it earns its price. octo is for everyone the
-subscription doesn't reach. The SKILL.md format is shared, so you can even run
-both: Claude Code for the heavy lifting, octo on DeepSeek for everything else.
-
-## Interfaces
-
-**Stable (1.0).** Eight interfaces are planned — one per arm of the octopus — and seven are live:
-
-- **CLI** — interactive TUI in a terminal, headless one-shot everywhere else
-- **Web UI** — `octo serve`, a local dashboard over REST + WebSocket
-- **Desktop app** — native window + system tray (macOS / Windows / Linux)
-- **IM bridge** — WeChat iLink, Feishu, DingTalk, WeCom, Discord, Telegram, inside `octo serve`
+- **CLI / TUI** — terminal interaction and headless one-shots
+- **Web UI** — `octo serve` local dashboard
+- **Desktop app** — native window + system tray on macOS / Windows / Linux
+- **IM bridge** — WeChat iLink, Feishu, DingTalk, WeCom, Discord, Telegram
 - **VS Code extension** — [`open-octo/octo-vscode`](https://github.com/open-octo/octo-vscode)
 - **Obsidian plugin** — [`open-octo/octo-obsidian`](https://github.com/open-octo/octo-obsidian)
 - **Go SDK** — [`pkg/octoagent`](pkg/octoagent), embed the agent loop in your own programs
+- **Mobile** — iOS + Android developer preview ([`mobile/`](mobile/))
 
-The eighth — a mobile app (iOS + Android) — is implemented and in **developer
-preview**: buildable from source today against a self-hosted relay (see
-[`mobile/`](mobile/)), with a hosted relay and app-store builds next. What you
-can build on is declared in [COMPATIBILITY.md](COMPATIBILITY.md); the security
+Few other agent projects cover this many entry points at once.
+
+### 4. Minimal core: a single ~40 MB Go binary
+
+One command to download, copy to any server, and run. No Node / Python / Ruby
+dependency tree; no npm mirror, node-gyp build failure, or version conflict
+headaches.
+
+### 5. Zero telemetry
+
+Except for the model API calls you configure, octo sends no outbound traffic on
+its own. It collects no IP, device model, model choice, or usage behavior.
+
+### 6. Desktop installer is only about 100 MB
+
+Because of the single-binary + zero-telemetry design, the desktop installer
+is around **100 MB**. Compare that to Codex desktop and WorkBuddy, which
+often weigh in around **1 GB**. A thin agent harness shouldn't need that much
+space.
+
+### 7. Stable and safe — won't edit itself dead, won't go rogue
+
+- The **terminal** tool refuses any `kill` / `pkill` / `killall` aimed at octo's
+  own process, including detours like `kill $(pgrep octo)`.
+- **restart_server** is hard-wired to ask permission first — a browser modal on
+  the web, an explicit reply on IM. Even after approval, the restart is graceful:
+  the current turn drains so your reply reaches you before the supervisor
+  respawns the server and clients reconnect.
+- Every delete is validated. Catastrophic commands like `rm -rf /` and `rm -rf ~`
+  are **hard-coded denies** that custom permission rules cannot override. Ordinary
+  file deletes and `write_file` / `edit_file` overwrites are first backed up to a
+  recycle bin (default 14 days / 10 GiB), so nothing is ever truly gone.
+
+### 8. Only octo does all of the above
+
+Any one of these points might be covered by some other product. But only octo
+combines out-of-the-box usability, native multi-model support, eight interfaces,
+a single binary, zero telemetry, a small footprint, high stability, and strong
+safety.
+
+### 9. One last word
+
+If you already have reliable access to a Codex or Claude subscription, keep using
+it — they remain the best agent harnesses on the planet. Otherwise, octo is worth
+a serious look.
+
+## Interfaces
+
+**Stable (1.0)** already covers CLI, Web UI, Desktop, IM bridge, VS Code / Obsidian
+extensions, and Go SDK. The eighth — a mobile app (iOS + Android) — is implemented
+and in **developer preview**: buildable from source today against a self-hosted
+relay (see [`mobile/`](mobile/)), with a hosted relay and app-store builds next.
+
+What you can build on is declared in [COMPATIBILITY.md](COMPATIBILITY.md); the security
 boundary in [SECURITY.md](SECURITY.md).
 
 ## Learn more

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,26 +3,26 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Octo — private, self-hosted AI agent · one brain, eight arms</title>
-  <meta name="description" content="A private, self-hosted AI agent: one brain — a single fast Go binary — with eight arms, like an octopus, reaching your terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile. Any model, zero telemetry; your data never leaves your machine.">
+  <title>Octo — private, self-hosted AI agent · one brain, eight legs</title>
+  <meta name="description" content="A private, self-hosted AI agent: one brain — a single fast Go binary — with eight legs, like an octopus, reaching your terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile. Any model, zero telemetry; your data never leaves your machine.">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='22' fill='%231677FF'/%3E%3Cpath fill='%23ffffff' d='M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z'/%3E%3Ccircle cx='40' cy='42' r='5' fill='%231677FF'/%3E%3Ccircle cx='60' cy='42' r='5' fill='%231677FF'/%3E%3C/svg%3E">
   <link rel="canonical" href="https://octo-agent.dev/">
-  <meta property="og:title" content="Octo — private, self-hosted AI agent · one brain, eight arms">
-  <meta property="og:description" content="A private, self-hosted AI agent: one brain — a single fast Go binary — with eight arms, like an octopus, reaching your terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile. Any model, zero telemetry; your data never leaves your machine.">
+  <meta property="og:title" content="Octo — private, self-hosted AI agent · one brain, eight legs">
+  <meta property="og:description" content="A private, self-hosted AI agent: one brain — a single fast Go binary — with eight legs, like an octopus, reaching your terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile. Any model, zero telemetry; your data never leaves your machine.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://octo-agent.dev/">
   <meta property="og:image" content="https://octo-agent.dev/og-image.png">
   <meta property="og:site_name" content="Octo">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Octo — private, self-hosted AI agent · one brain, eight arms">
-  <meta name="twitter:description" content="A private, self-hosted AI agent: one brain — a single fast Go binary — with eight arms, like an octopus, reaching your terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile. Any model, zero telemetry; your data never leaves your machine.">
+  <meta name="twitter:title" content="Octo — private, self-hosted AI agent · one brain, eight legs">
+  <meta name="twitter:description" content="A private, self-hosted AI agent: one brain — a single fast Go binary — with eight legs, like an octopus, reaching your terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile. Any model, zero telemetry; your data never leaves your machine.">
   <meta name="twitter:image" content="https://octo-agent.dev/og-image.png">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "Octo",
-    "description": "A private, self-hosted AI agent: one brain — a single fast Go binary — with eight arms, like an octopus, reaching your terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile. Any model; your data never leaves your machine.",
+    "description": "A private, self-hosted AI agent: one brain — a single fast Go binary — with eight legs, like an octopus, reaching your terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile. Any model; your data never leaves your machine.",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux, Windows",
     "license": "https://github.com/open-octo/octo-agent/blob/main/LICENSE.txt",
@@ -164,6 +164,13 @@
     .arm-title{display:flex;align-items:center;gap:8px;margin-bottom:6px;}
     .arm-title h3{margin:0;}
 
+    /* why octo */
+    .why{background:#fff;border-top:1px solid var(--line);}
+    .why-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:16px;}
+    .why-card{background:var(--canvas);border:1px solid var(--line2);border-radius:12px;padding:20px;}
+    .why-card h3{font-size:15px;font-weight:600;margin-bottom:8px;color:var(--ink);}
+    .why-card p{margin:0;font-size:13.5px;line-height:1.6;color:var(--t65);}
+
     /* features */
     .feat-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px;}
     .feat{background:#fff;border:1px solid var(--line2);border-radius:16px;padding:28px;}
@@ -221,7 +228,7 @@
       .nav{gap:12px;padding:0 16px;}
       .nav-cta{white-space:nowrap;margin-left:auto;}
       .lang{display:none;}
-      .hero h1{font-size:42px;} .grid3,.grid4,.feat-grid,.grid2,.foot-grid{grid-template-columns:1fr;}
+      .hero h1{font-size:42px;} .grid3,.grid4,.feat-grid,.grid2,.foot-grid,.why-grid{grid-template-columns:1fr;}
       .feat.hero-feat{grid-column:auto;} section{padding:56px 20px;} .hero{padding:100px 20px 0;}
     }
   </style>
@@ -261,10 +268,10 @@
         <iconify-icon icon="ant-design:safety-outlined" width="14"></iconify-icon>
         <span data-en="Open source · MIT · Self-hosted · Zero telemetry" data-zh="开源 · MIT · 自托管 · 零遥测"></span>
       </div>
-      <h1><span data-en="One brain, " data-zh="一个脑，"></span><span class="accent" data-en="eight arms." data-zh="八条腕。"></span></h1>
+      <h1><span data-en="One brain, " data-zh="一个脑，"></span><span class="accent" data-en="eight legs." data-zh="八条腿。"></span></h1>
       <p class="tagline"
-         data-en="Octo is a private, self-hosted AI agent — a single fast Go binary that reaches your terminal, VS Code, Obsidian, web, desktop, IM, SDK, and mobile. Any model. Your data never leaves your machine."
-         data-zh="Octo 是一个私密、自托管的 AI Agent —— 一个够快的 Go 二进制，伸进你的终端、VS Code、Obsidian、网页、桌面、IM、SDK 和移动端。任意模型，你的数据从不离开你的机器。"></p>
+         data-en="The self-hosted AI agent that just works. One Go binary, zero dependencies, any model — reaching your terminal, editor, notes, browser, desktop, chat apps, SDK, and phone. Your data never leaves your machine."
+         data-zh="开箱即用的自托管 AI Agent。一个零依赖的 Go 二进制，任意模型 —— 伸进终端、编辑器、笔记、浏览器、桌面、聊天应用、SDK 和手机。你的数据从不离开你的机器。"></p>
       <div class="cta-row">
         <a id="get-started" class="btn-primary" href="https://github.com/open-octo/octo-agent/releases/latest">
           <iconify-icon id="dl-icon" icon="ant-design:download-outlined" width="18"></iconify-icon>
@@ -355,7 +362,7 @@
         </div>
         <div class="step reveal">
           <div class="step-head"><span class="num">3</span><h3 data-en="Ship" data-zh="交付"></h3></div>
-          <p data-en="One prompt, full tool loop — in the TUI, headless in CI, or from any of the eight arms." data-zh="一句 prompt，完整工具循环 —— 在 TUI、CI 无界面运行，或从八条腕中任意一条发起。"></p>
+          <p data-en="One prompt, full tool loop — in the TUI, headless in CI, or from any of the eight legs." data-zh="一句 prompt，完整工具循环 —— 在 TUI、CI 无界面运行，或从八条腿中任意一条发起。"></p>
           <div class="path"><span class="tag" data-en="Desktop" data-zh="桌面版"></span><span class="txt" data-en="Type your first prompt in the workbench — sessions, skills, and MCP all in one window." data-zh="在 Workbench 里发出第一句 prompt —— 会话、skills、MCP 都在同一个窗口。"></span></div>
           <div class="path"><span class="tag">CLI</span><code>octo "Add a --json flag to config show"</code></div>
         </div>
@@ -367,10 +374,10 @@
     <div class="wrap">
       <div class="sec-head reveal">
         <h2 data-en="Reach it from wherever you work" data-zh="你在哪干活，就从哪够到它"></h2>
-        <p data-en="One brain — the Go harness plus the model you chose — and eight arms. Same memory, same ~/.octo, from every interface." data-zh="一个大脑 —— Go harness 加上你选的模型 —— 和八条腕。同一份记忆、同一个 ~/.octo，来自每一个界面。"></p>
+        <p data-en="One brain — the Go harness plus the model you chose — and eight legs. Same memory, same ~/.octo, from every interface." data-zh="一个大脑 —— Go harness 加上你选的模型 —— 和八条腿。同一份记忆、同一个 ~/.octo，来自每一个界面。"></p>
       </div>
       <figure class="octo reveal">
-        <svg font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif" xmlns="http://www.w3.org/2000/svg" viewBox="0 64 720 356" role="img" aria-label="One brain, eight arms — one local octopus agent whose eight tentacles reach eight interfaces: terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile (coming soon)">
+        <svg font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif" xmlns="http://www.w3.org/2000/svg" viewBox="0 64 720 356" role="img" aria-label="One brain, eight legs — one local octopus agent whose eight legs reach eight interfaces: terminal, VS Code, Obsidian, SDK, web, desktop, IM, and mobile (coming soon)">
           <g>
           <path fill="#1677FF" d="M 330.11 206.96 L 324.02 202.37 L 317.87 197.81 L 311.65 193.27 L 305.37 188.75 L 299.02 184.26 L 292.61 179.80 L 286.13 175.35 L 279.58 170.93 L 272.97 166.54 L 266.29 162.17 L 259.54 157.82 L 252.73 153.49 L 245.85 149.19 L 238.91 144.90 L 231.90 140.64 L 224.83 136.41 L 217.69 132.19 L 210.48 127.99 L 203.21 123.82 L 195.88 119.66 L 188.47 115.52 L 181.01 111.40 L 173.48 107.29 L 165.88 103.20 L 158.23 99.12 L 150.52 95.03 L 149.48 96.97 L 157.08 101.21 L 164.60 105.51 L 172.04 109.84 L 179.40 114.21 L 186.67 118.61 L 193.88 123.04 L 201.00 127.50 L 208.05 131.98 L 215.02 136.50 L 221.92 141.04 L 228.74 145.60 L 235.48 150.20 L 242.15 154.81 L 248.74 159.46 L 255.25 164.12 L 261.69 168.82 L 268.05 173.53 L 274.34 178.27 L 280.55 183.04 L 286.68 187.83 L 292.74 192.64 L 298.72 197.47 L 304.63 202.33 L 310.46 207.21 L 316.21 212.11 L 321.89 217.04 Z"/>
           <path fill="#1677FF" d="M 316.03 229.83 L 309.84 228.07 L 303.63 226.35 L 297.41 224.64 L 291.17 222.95 L 284.92 221.29 L 278.65 219.65 L 272.37 218.03 L 266.08 216.43 L 259.77 214.85 L 253.44 213.29 L 247.10 211.76 L 240.74 210.24 L 234.37 208.74 L 227.99 207.27 L 221.59 205.81 L 215.17 204.38 L 208.74 202.96 L 202.30 201.56 L 195.84 200.19 L 189.36 198.82 L 182.88 197.48 L 176.37 196.15 L 169.86 194.83 L 163.33 193.53 L 156.78 192.23 L 150.23 190.92 L 149.77 193.08 L 156.28 194.56 L 162.76 196.10 L 169.22 197.69 L 175.65 199.31 L 182.06 200.96 L 188.46 202.64 L 194.83 204.36 L 201.18 206.10 L 207.51 207.88 L 213.82 209.68 L 220.11 211.51 L 226.38 213.37 L 232.63 215.26 L 238.85 217.17 L 245.06 219.11 L 251.25 221.07 L 257.41 223.07 L 263.56 225.09 L 269.68 227.13 L 275.78 229.21 L 281.87 231.30 L 287.93 233.43 L 293.97 235.57 L 299.99 237.75 L 305.99 239.95 L 311.97 242.17 Z"/>
@@ -456,7 +463,7 @@
             <h3 data-en="Mobile" data-zh="移动端"></h3>
             <span class="soon-tag" data-en="Developer preview" data-zh="开发者预览"></span>
           </div>
-          <p data-en="A thin native client (iOS + Android) over an end-to-end encrypted link to your machine. The eighth arm — buildable today from source with a self-hosted relay; hosted relay and app-store builds are next." data-zh="通过端到端加密链路连回你机器的轻量原生客户端（iOS + Android）。第八条腕 —— 现在即可从源码自建并配合自托管 relay 使用；托管 relay 与应用商店版本在路上。"></p>
+          <p data-en="A thin native client (iOS + Android) over an end-to-end encrypted link to your machine. The eighth leg — buildable today from source with a self-hosted relay; hosted relay and app-store builds are next." data-zh="通过端到端加密链路连回你机器的轻量原生客户端（iOS + Android）。第八条腿 —— 现在即可从源码自建并配合自托管 relay 使用；托管 relay 与应用商店版本在路上。"></p>
         </div>
       </div>
     </div>
@@ -494,6 +501,16 @@
           <h3 data-en="Workflows &amp; sub-agents" data-zh="工作流 &amp; 子代理"></h3>
           <p data-en="Parallel sub-agents with git worktree isolation, detached background runs, progress reported to every interface." data-zh="并行子代理，带 git worktree 隔离，可后台分离运行，并向每个界面回报进度。"></p>
         </div>
+        <div class="feat reveal">
+          <iconify-icon icon="ant-design:global-outlined" width="26"></iconify-icon>
+          <h3 data-en="Any model, tuned caching" data-zh="任意模型，缓存逐家优化"></h3>
+          <p data-en="DeepSeek, Kimi, Qwen, Anthropic, OpenAI, or any compatible endpoint. Caching is tuned per provider, with 95%+ measured hit rates on major domestic models." data-zh="DeepSeek、Kimi、Qwen、Anthropic、OpenAI，或任何兼容端点。缓存按供应商逐家优化，主流国产模型实测命中率 95%+。"></p>
+        </div>
+        <div class="feat reveal">
+          <iconify-icon icon="ant-design:security-scan-outlined" width="26"></iconify-icon>
+          <h3 data-en="Won't kill itself, won't go rogue" data-zh="不会自挂，也不会发疯删数据"></h3>
+          <p data-en="Refuses kill commands aimed at its own process, requires explicit permission for restart, and hard-codes deny for catastrophic deletes like rm -rf / or ~." data-zh="拒绝任何指向自身进程的 kill 命令，重启必须显式授权，rm -rf / 或 ~ 这类毁灭性删除被硬编码拒绝。"></p>
+        </div>
       </div>
       <div class="chips reveal">
         <span class="chip" data-en="Browser automation via CDP" data-zh="通过 CDP 的浏览器自动化"></span>
@@ -526,6 +543,33 @@
         <div class="term reveal">
           <div class="term-bar"><span class="d" style="background:#FF5F57"></span><span class="d" style="background:#FEBC2E"></span><span class="d" style="background:#28C840"></span><span data-en="Configuration layers" data-zh="配置分层"></span></div>
           <pre><div class="cmt" data-en="# Octo learns who you are and how you work" data-zh="# Octo 学习你是谁、你怎么工作"></div><div>~/.octo/soul.md      <span class="cmt" data-en="# agent persona" data-zh="# agent 人格"></span></div><div>~/.octo/user.md      <span class="cmt" data-en="# your profile" data-zh="# 你的个人画像"></span></div><div>~/.octo/octorules.md <span class="cmt" data-en="# global rules" data-zh="# 全局规则"></span></div><div>.octorules           <span class="cmt" data-en="# project conventions" data-zh="# 项目约定"></span></div></pre>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="why" class="why">
+    <div class="wrap">
+      <div class="sec-head reveal">
+        <h2 data-en="Why Octo" data-zh="为什么用 Octo"></h2>
+        <p data-en="Everything that matters, without the gates." data-zh="重要的事一件不落，门槛一点不加。"></p>
+      </div>
+      <div class="why-grid">
+        <div class="why-card reveal">
+          <h3 data-en="Works out of the box" data-zh="开箱即用"></h3>
+          <p data-en="No tuning, no custom rules, no &quot;raising&quot; required. Shell, files, search, MCP, skills, and sub-agents are enabled by default." data-zh="无需调环境、写规则、精心“喂养”。shell、文件、搜索、MCP、skills、子代理全部默认开启。"></p>
+        </div>
+        <div class="why-card reveal">
+          <h3 data-en="Model choice, no lock-in" data-zh="模型任选，不被绑定"></h3>
+          <p data-en="Use DeepSeek, Kimi, Qwen, Anthropic, OpenAI, or any compatible endpoint. Tuned caching keeps hit rates high and bills low." data-zh="DeepSeek、Kimi、Qwen、Anthropic、OpenAI 或任意兼容端点。逐家优化的缓存保证高命中率、低账单。"></p>
+        </div>
+        <div class="why-card reveal">
+          <h3 data-en="One binary, eight legs" data-zh="一个二进制，八条腿"></h3>
+          <p data-en="A single ~40 MB Go executable with zero telemetry. The desktop installer is ~100 MB, not 1 GB." data-zh="单个约 40 MB 的 Go 可执行文件，零遥测。桌面安装包约 100 MB，而非 1 GB。"></p>
+        </div>
+        <div class="why-card reveal">
+          <h3 data-en="Stable and safe" data-zh="稳定且安全"></h3>
+          <p data-en="Won't kill itself, won't restart without permission, and won't nuke your files. Deletes go through a recycle bin first." data-zh="不会自杀、不会擅自重启、不会删除你的文件。删除先过回收站，误删可恢复。"></p>
         </div>
       </div>
     </div>
@@ -584,7 +628,7 @@
           <svg width="24" height="24" viewBox="0 0 100 100"><rect width="100" height="100" rx="22" fill="#1677FF"/><path fill="#fff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/><circle cx="40" cy="42" r="5" fill="#1677FF"/><circle cx="60" cy="42" r="5" fill="#1677FF"/></svg>
           Octo
         </div>
-        <p data-en="A private, self-hosted AI agent. One brain, eight arms. MIT licensed." data-zh="私密、自托管的 AI Agent。一个脑，八条腕。MIT 许可。"></p>
+        <p data-en="A private, self-hosted AI agent. One brain, eight legs. MIT licensed." data-zh="私密、自托管的 AI Agent。一个脑，八条腿。MIT 许可。"></p>
       </div>
       <div class="foot-col">
         <span class="h" data-en="Product" data-zh="产品"></span>


### PR DESCRIPTION
## Summary

Polish the README, English README, and landing page to better communicate octo's core value propositions, and keep `.octorules` in sync with the actual Go version.

## Changes

- **README.md / README_EN.md**: rewrite the "Why octo" section around the nine core value propositions (out-of-the-box, native multi-model support with tuned caching, eight interfaces, single binary, zero telemetry, small footprint, stability/safety, uniqueness, and the final recommendation to keep using Codex/Claude if it works for you). Remove the old comparison table and the lengthy "author's note".
- **landing/index.html**:
  - sharpen the hero tagline to emphasize "just works / 开箱即用";
  - add two new feature cards ("Any model, tuned caching" and "Won't kill itself, won't go rogue");
  - add a new "Why Octo" section between the demo and FAQ;
  - replace "eight arms" with "eight legs" across all copy and meta tags.
- **.octorules**: update Go version requirement from `1.22` to `1.25` to match `go.mod`.

No functional code changes; docs and marketing site only.