### PR TITLE
fix(web): restore the search pill's label text

### DIFF
--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -111,8 +111,9 @@
     </button>
   {/if}
 
-  <button class="search-btn" title={$t('header.search_sessions')} onclick={() => cmdkOpen.set(true)}>
+  <button class="search-btn" onclick={() => cmdkOpen.set(true)}>
     <iconify-icon icon="ant-design:search-outlined" width="15"></iconify-icon>
+    <span>{$t('header.search_sessions')}</span>
     <kbd>⌘K</kbd>
   </button>
 


### PR DESCRIPTION
## Summary
- The header's search button had shrunk to icon + `⌘K` only, with no visible label — looking cramped/unlabeled compared to the prior wide-pill design (which showed the label but with a large dead gap before the shortcut badge).
- Restored the `header.search_sessions` label between the icon and the shortcut badge. The button already sizes to its own content (no fixed width in this design), so it now hugs icon + label + kbd snugly instead of either hiding the label or reintroducing a large gap.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run` — 129/129 passed
- [x] `make build` succeeds
- [x] Verified visually against a running `octo serve` with real config: label now shows, pill sized to content

🤖 Generated with [Claude Code](https://claude.com/claude-code)