### PR TITLE
chore: bump version to 1.15.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.14.8"
+var Version = "1.15.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Minor version bump per user request, covering this batch of merged fixes (#1966, #1969, #1970, #1971).

🤖 Generated with [Claude Code](https://claude.com/claude-code)