### PR TITLE
fix(desktop): align mac header content with native traffic lights

### DIFF
--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -164,8 +164,11 @@ header {
   z-index: 100;
 }
 /* Mac's native hidden-inset title bar floats the real traffic-light buttons
-   over the top-left of the content area, so inset the header past them. */
-header.native-inset { padding-left: 82px; }
+   over the top-left of the content area, so inset the header past them.
+   Their vertical position is fixed by macOS (not by our header height), and
+   it sits a few px below this row's flex-centered line, so nudge the whole
+   row down by the same amount — measured against a live build, not guessed. */
+header.native-inset { padding-left: 82px; padding-top: 6px; }
 /* The header is a window drag handle. Every interactive control on it opts
    back to no-drag so it stays clickable — the blank strips between controls
    drag the window. Applied for all platforms (frameless window now), not just


### PR DESCRIPTION
## Summary
- The window-shell redesign (#1944) shrank the header from 56px to 48px but never re-checked macOS's native hidden-inset title bar, whose traffic-light vertical position is fixed by the OS, not by our header height.
- Measured against a live build (pixel centroid of the traffic lights vs. the header's logo icon): the lights sat ~3px below the header's flex-centered content.
- Added `padding-top: 6px` to `header.native-inset` (mac only) to close the gap.

## Verification
Built `cmd/octo-desktop` before/after with a temporary isolated port + single-instance ID (never committed), screenshotted the live window, and measured pixel centroids:
- Before: traffic-light center y=119.5 vs logo center y=114 (physical px) — 5.5px off
- After: traffic-light center y=243.5 vs logo center y=243.5 — exact match

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] Visual pixel measurement against a live desktop build (see above)