### PR TITLE
fix(server): eliminate race in kickIdleSteerTurn release-vs-turnRunning order

### DIFF
--- a/internal/server/bg_tasks.go
+++ b/internal/server/bg_tasks.go
@@ -152,10 +152,14 @@ func (s *Server) kickIdleSteerTurn(sessionID string) bool {
 			defer s.drain.end()
 		}
 		defer func() {
+			// Release the binding — which reloads the session and writes a
+			// lease-clear record — BEFORE clearing turnRunning, so the flag only
+			// flips once the trailing session write is done. Tests (and the
+			// drain gate) wait on this flag as "turn fully wound down".
+			s.releaseSessionBinding(sessionID, agent.EntryWeb)
 			mu.Lock()
 			s.turnRunning[sessionID] = false
 			mu.Unlock()
-			s.releaseSessionBinding(sessionID, agent.EntryWeb)
 		}()
 		s.runAgentTurnLoop(sess, content, blocks, imageRefsFromBlocks(blocks))
 	}()


### PR DESCRIPTION
Fixes the flaky `TestKickIdleSteerTurn_RunsQueuedAsSeparateTurns` seen in the linked CI run.

`kickIdleSteerTurn` cleared `turnRunning` before `releaseSessionBinding` finished its trailing session write. Since tests (and the drain gate) treat `turnRunning == false` as "turn fully wound down", a follow-up `agent.LoadSession` could race the `O_TRUNC` rewrite and see an empty transcript.

Reorder to match `handleWSUserMessage`: release the binding first, then clear the flag.

- [x] `make test` passes (full `-race` suite)
- [x] `gofmt` clean