### PR TITLE
fix(desktop): pin macOS deployment target to 11.0, not the build machine's OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,12 @@ build-full: build
 # WebView2). Embeds the web UI first (the in-process server go:embeds webdist).
 # Produces a bare binary; use `wails3 build` inside cmd/octo-desktop for a
 # packaged .app / installer.
-DESKTOP_MACOS_VERSION ?= $(shell sw_vers -productVersion 2>/dev/null | cut -d. -f1 || echo 11)
+# Fixed at 11.0 (matches cmd/octo-desktop's Info.plist LSMinimumSystemVersion
+# and Go's own linker default) rather than derived from the build machine's
+# live macOS version — deriving it from `sw_vers` bakes whatever OS the
+# builder happens to run into the binary's LC_VERSION_MIN, silently raising
+# the real minimum macOS required to launch it.
+DESKTOP_MACOS_VERSION ?= 11.0
 desktop: web-build
 	cd cmd/octo-desktop && CGO_ENABLED=1 \
 		CGO_CFLAGS="-mmacosx-version-min=$(DESKTOP_MACOS_VERSION)" \

--- a/scripts/package-desktop-macos.sh
+++ b/scripts/package-desktop-macos.sh
@@ -44,7 +44,16 @@ for arch in amd64 arm64; do
 
 	echo "==> building octo-desktop (darwin/$arch)"
 	out="$ROOT/octo-desktop-$arch"
-	macos_ver="$(sw_vers -productVersion | cut -d. -f1)"
+	# Fixed, not derived from the build machine's own macOS version (a prior
+	# version of this script used `sw_vers -productVersion` here, which baked
+	# the CI runner's live OS version into the binary's LC_VERSION_MIN load
+	# command — on a runner newer than a user's Mac, launching failed with
+	# "You can't use this version of the application... with this version of
+	# macOS", unrelated to the LSMinimumSystemVersion=11.0 in Info.plist).
+	# 11.0 matches that Info.plist value and Go's own linker default, so it
+	# also fully eliminates the SDK-vs-link-target warning this flag was
+	# added for in the first place.
+	macos_ver="11.0"
 	( cd "$MOD_DIR" && \
 		GOOS=darwin GOARCH="$arch" CGO_ENABLED=1 CC="clang -arch $cc_arch" \
 		CGO_CFLAGS="-mmacosx-version-min=$macos_ver" \


### PR DESCRIPTION
## Summary
- `scripts/package-desktop-macos.sh` and the `Makefile` `desktop` target derived `-mmacosx-version-min` from `sw_vers -productVersion` on whichever machine ran the build.
- On the `macos-latest` GitHub Actions runner (currently macOS 26.x), this bakes that OS version into the released Octo.app's Mach-O `LC_BUILD_VERSION`/`minos`, independent of the `LSMinimumSystemVersion=11.0` declared in `Info.plist`.
- Result: users on an older macOS than whatever the CI runner happens to be get "You can't use this version of the application 'Octo' with this version of macOS" and cannot launch the app at all — reported by a user on an M1 MacBook Air running macOS 14.6.
- This regressed in #1785 (2026-07-25), which introduced the `sw_vers`-derived value to silence a benign linker warning.

## Fix
Pin the deployment target to a fixed `11.0` in both places, matching `Info.plist` and Go's own linker default — this still eliminates the original SDK-vs-link-target warning `#1785` targeted, without raising the real minimum OS requirement.

Verified locally: built `cmd/octo-desktop` with `CGO_CFLAGS/CGO_LDFLAGS` pinned to 11.0 and confirmed via `otool -l` that the resulting binary's `LC_BUILD_VERSION` reports `minos 11.0` (previously would have been `26` on this machine).

## Test plan
- [x] `bash -n scripts/package-desktop-macos.sh`
- [x] Local CGO build of `cmd/octo-desktop` with the pinned flags succeeds
- [x] `otool -l` on the resulting binary shows `minos 11.0`
- [ ] Next tagged release should be verified to launch on macOS 14.x (can't verify in CI, no old-macOS runner available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)