### PR TITLE
fix(channels): make the enable toggle persist and reject enabling unconfigured channels

### DIFF
--- a/internal/channel/config.go
+++ b/internal/channel/config.go
@@ -171,7 +171,14 @@ func (c *Config) SetPlatform(name string, fields map[string]any) {
 	for k, v := range fields {
 		ic.Config[k] = v
 	}
-	ic.Enabled = true
+	// An explicit `enabled` key wins — a toggle-off save must persist.
+	// Absent means the caller is only merging credentials, which has always
+	// implied "configure ⇒ enable".
+	if _, ok := fields["enabled"]; ok {
+		ic.Enabled = isEnabled(fields)
+	} else {
+		ic.Enabled = true
+	}
 	delete(ic.Config, "enabled") // promoted to struct field, must not linger in map
 	c.Channels[name] = list
 }

--- a/internal/channel/config_test.go
+++ b/internal/channel/config_test.go
@@ -1,0 +1,34 @@
+package channel
+
+import "testing"
+
+// TestSetPlatform_EnabledKeyWins is the regression test for the UI toggle that
+// could never switch a channel off: SetPlatform used to force Enabled=true on
+// every call, discarding an explicit enabled:false.
+func TestSetPlatform_EnabledKeyWins(t *testing.T) {
+	var c Config
+
+	// Explicit enabled:false must persist.
+	c.SetPlatform("feishu", map[string]any{"enabled": false, "app_id": "a"})
+	if c.IsEnabled("feishu") {
+		t.Fatal("explicit enabled:false was overridden")
+	}
+
+	// Explicit enabled:true must persist.
+	c.SetPlatform("feishu", map[string]any{"enabled": true})
+	if !c.IsEnabled("feishu") {
+		t.Fatal("explicit enabled:true was not honored")
+	}
+
+	// Absent enabled key keeps the legacy "configure ⇒ enable" behavior.
+	c.SetPlatform("wecom", map[string]any{"bot_id": "b"})
+	if !c.IsEnabled("wecom") {
+		t.Fatal("credentials-only SetPlatform should auto-enable")
+	}
+
+	// The enabled key must be promoted to the struct field, never linger in
+	// the raw config map.
+	if _, ok := c.Channels["feishu"][0].Config["enabled"]; ok {
+		t.Fatal("enabled key leaked into the platform config map")
+	}
+}

--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/channel"
+	"github.com/open-octo/octo-agent/internal/channel/adapters/weixin/ilink"
 )
 
 // ─── Channels REST API ────────────────────────────────────────────────────
@@ -81,7 +82,9 @@ func (s *Server) handleGetChannel(w http.ResponseWriter, r *http.Request) {
 }
 
 type channelUpdateRequest struct {
-	Enabled bool              `json:"enabled"`
+	// Enabled is a pointer so "field absent" (a credentials-only save, which
+	// implies enable) is distinguishable from an explicit toggle-off.
+	Enabled *bool             `json:"enabled"`
 	Fields  map[string]string `json:"fields"`
 }
 
@@ -121,11 +124,23 @@ func (s *Server) handleSaveChannel(w http.ResponseWriter, r *http.Request) {
 	for k, v := range req.Fields {
 		fields[k] = v
 	}
-	if _, ok := fields["enabled"]; !ok {
-		fields["enabled"] = req.Enabled
+	if req.Enabled != nil {
+		fields["enabled"] = *req.Enabled
 	}
 
 	cfg.SetPlatform(platform, fields)
+
+	// Reject enabling a platform whose adapter can't start from the merged
+	// config — it would fail at startup and enter a crash-restart loop.
+	// Configure the channel first; a successful configuration enables it
+	// automatically.
+	if inst := cfg.Platform(platform); len(inst) > 0 && inst[0].Enabled {
+		if err := channelStartupCheck(platform, inst[0].Config); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("cannot enable %s: %v", platform, err))
+			return
+		}
+	}
+
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
@@ -320,6 +335,32 @@ func (s *Server) handleChannelSendFile(w http.ResponseWriter, r *http.Request) {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
+// channelStartupCheck reports whether a platform's adapter could start with
+// the given config: it must construct, pass ValidateConfig, and — for weixin,
+// whose credentials live outside channels.yml — have a readable credential
+// file (the check Start performs).
+func channelStartupCheck(platform string, cfg channel.PlatformConfig) error {
+	ctor, err := channel.Find(platform)
+	if err != nil {
+		return nil // unregistered platform: nothing to validate against
+	}
+	ad, err := ctor(cfg)
+	if err != nil {
+		return err
+	}
+	if errs := ad.ValidateConfig(cfg); len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	if platform == "weixin" {
+		credPath, _ := cfg["cred_path"].(string)
+		creds, err := ilink.LoadCredentials(credPath)
+		if err != nil || creds == nil {
+			return fmt.Errorf("no credentials — log in first (channel-manager setup weixin)")
+		}
+	}
+	return nil
+}
+
 func instanceToInfo(platform, adapterID string, ic channel.InstanceConfig) channelInfo {
 	fields := make(map[string]string)
 	for k, v := range ic.Config {
@@ -336,11 +377,20 @@ func instanceToInfo(platform, adapterID string, ic channel.InstanceConfig) chann
 		fields[k] = s
 	}
 
+	// Weixin keeps credentials in ~/.octo/weixin-credentials.json rather than
+	// channels.yml, so an empty field map can still mean "configured".
+	hasConfig := len(fields) > 0
+	if platform == "weixin" && !hasConfig {
+		if creds, err := ilink.LoadCredentials(fields["cred_path"]); err == nil && creds != nil {
+			hasConfig = true
+		}
+	}
+
 	return channelInfo{
 		Platform:  platform,
 		AdapterID: adapterID,
 		Enabled:   ic.Enabled,
-		HasConfig: len(fields) > 0,
+		HasConfig: hasConfig,
 		Fields:    fields,
 	}
 }

--- a/internal/server/channels_handler_toggle_test.go
+++ b/internal/server/channels_handler_toggle_test.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/channel"
+)
+
+// setupToggleTest registers togglefake (constructs cleanly) and togglebad
+// (fails construction, mirroring wecom without credentials), points HOME at a
+// temp dir, and returns the server plus the channels.yml path.
+func setupToggleTest(t *testing.T) (*Server, string) {
+	t.Helper()
+	channel.Register("togglefake", func(channel.PlatformConfig) (channel.Adapter, error) {
+		return &fullFakeAdapter{}, nil
+	})
+	channel.Register("togglebad", func(channel.PlatformConfig) (channel.Adapter, error) {
+		return nil, errors.New("togglebad: bot_token is required")
+	})
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	cfgDir := filepath.Join(tmp, ".octo")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	t.Cleanup(srv.stopChannels)
+	return srv, filepath.Join(cfgDir, "channels.yml")
+}
+
+func postChannelSave(t *testing.T, srv *Server, platform, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/channels/"+platform, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Access-Key", srv.AccessKey())
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	return w
+}
+
+// TestHandleSaveChannel_DisablePersists is the regression test for the toggle
+// that sprang back on: SetPlatform used to force Enabled=true on every save,
+// so a toggle-off never reached channels.yml.
+func TestHandleSaveChannel_DisablePersists(t *testing.T) {
+	srv, cfgPath := setupToggleTest(t)
+	if err := os.WriteFile(cfgPath,
+		[]byte("channels:\n  togglefake:\n    enabled: true\n    bot_token: real-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	w := postChannelSave(t, srv, "togglefake", `{"enabled": false}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	cfg, err := channel.LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.IsEnabled("togglefake") {
+		t.Fatal("platform should be disabled after toggle-off save")
+	}
+	// A flag-only save must not clobber existing credentials.
+	inst := cfg.Platform("togglefake")
+	if len(inst) == 0 || inst[0].Config["bot_token"] != "real-secret" {
+		t.Fatalf("credentials lost on flag-only save: %+v", inst)
+	}
+}
+
+// TestHandleSaveChannel_EnableWithoutCredentialsRejected: enabling a platform
+// whose adapter can't even construct must be refused, not saved — otherwise
+// the adapter enters a crash-restart loop and (before the fix) could never be
+// switched off again.
+func TestHandleSaveChannel_EnableWithoutCredentialsRejected(t *testing.T) {
+	srv, _ := setupToggleTest(t)
+
+	w := postChannelSave(t, srv, "togglebad", `{"enabled": true}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+
+	cfg, err := channel.LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Platform("togglebad")) != 0 {
+		t.Fatal("rejected enable must not persist a config entry")
+	}
+}
+
+// TestHandleSaveChannel_CredentialsOnlyAutoEnables preserves the
+// "configure ⇒ auto-enable" contract: a fields-only save (no enabled key)
+// enables the platform.
+func TestHandleSaveChannel_CredentialsOnlyAutoEnables(t *testing.T) {
+	srv, _ := setupToggleTest(t)
+
+	w := postChannelSave(t, srv, "togglefake", `{"fields": {"bot_token": "x"}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	cfg, err := channel.LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.IsEnabled("togglefake") {
+		t.Fatal("credentials-only save should auto-enable the platform")
+	}
+}
+
+// TestHandleSaveChannel_ReEnableAfterDisable: a configured channel can be
+// switched back on.
+func TestHandleSaveChannel_ReEnableAfterDisable(t *testing.T) {
+	srv, cfgPath := setupToggleTest(t)
+	if err := os.WriteFile(cfgPath,
+		[]byte("channels:\n  togglefake:\n    enabled: false\n    bot_token: real-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	w := postChannelSave(t, srv, "togglefake", `{"enabled": true}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	cfg, err := channel.LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.IsEnabled("togglefake") {
+		t.Fatal("platform should be enabled after toggle-on save")
+	}
+}

--- a/web/src/views/ChannelsView.svelte
+++ b/web/src/views/ChannelsView.svelte
@@ -68,11 +68,15 @@
     // Optimistic update
     rows = rows.map(r => r.platform === platform ? { ...r, enabled } : r)
     try {
-      await api.saveChannel(platform, { enabled, fields: row.fields })
+      // Send only the flag — the backend merges fields, and echoing row.fields
+      // back would overwrite real secrets with their masked display values.
+      // The backend rejects enabling a channel whose adapter can't start
+      // (no/invalid credentials); on failure we revert below.
+      await api.saveChannel(platform, { enabled })
     } catch (e: any) {
       // Revert
       rows = rows.map(r => r.platform === platform ? { ...r, enabled: !enabled } : r)
-      showToast(`Failed to save channel: ${e.message}`, 'error')
+      showToast(`${e.message}`, 'error')
     }
   }
 


### PR DESCRIPTION
## Problem

The Channels panel enable toggle was broken in both directions:

1. **Toggle-off never persisted.** `SetPlatform` forced `ic.Enabled = true` on every save and deleted the `enabled` key from the field map, so `POST /api/channels/:platform` with `{"enabled": false}` still saved the platform as enabled. Reopening the panel showed the switch back on.
2. **Toggle-on worked without any configuration.** Saving `{"enabled": true}` with empty fields created an enabled instance with zero credentials; the adapter then failed construction and entered a crash-restart loop (`restarting (2/10) after crash: ...`) that — per bug 1 — could never be switched off again.

## Fix

The intended semantics: a successful configuration auto-enables the channel (unchanged), and the user can then deliberately switch it off (now works).

- `internal/channel/config.go` — `SetPlatform` honors an explicit `enabled` key in the merged fields; absent keeps the legacy "configure ⇒ enable" behavior.
- `internal/server/channels_handler.go`
  - `channelUpdateRequest.Enabled` is now `*bool` so "field absent" (a credentials-only save, which implies enable) is distinguishable from an explicit toggle-off.
  - New `channelStartupCheck` runs before save when the result would be enabled: the adapter must construct and pass `ValidateConfig`, and for weixin — whose credentials live in `~/.octo/weixin-credentials.json`, checked at `Start`, not construction — the credential file must load. Failing platforms are rejected with 400 instead of being saved into a crash loop.
  - `instanceToInfo` reports `has_config=true` for weixin when the credential file exists, so a legitimately configured weixin no longer shows as "Not configured".
- `web/src/views/ChannelsView.svelte` — the toggle now sends only `{enabled}`. It previously echoed `row.fields` back, which would have **overwritten real secrets with their masked display values** on any toggle of a configured channel. On failure the switch reverts and the toast shows the backend's specific reason.

## Tests

- `internal/channel/config_test.go` — `SetPlatform` enabled-key semantics (explicit false/true honored, absent auto-enables, key never lingers in the raw map).
- `internal/server/channels_handler_toggle_test.go` — disable persists (and preserves credentials on a flag-only save), enabling an unconstructable platform is rejected without persisting, credentials-only save auto-enables, re-enable after disable works.

`make test` (`go test -race ./...`), `go vet ./...`, and the web build are green.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
