### PR TITLE
feat(web): right-align user messages with avatar on the right

### DIFF
--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -2454,8 +2454,10 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 .meta-time { font-size: 11px; color: var(--text-secondary); }
 
 /* ── User message ────────────────────────────────────────────────────────── */
-.msg-user { display: flex; flex-direction: column; gap: 9px; }
-.user-card-wrap { display: flex; flex-direction: column; gap: 4px; }
+.msg-user { display: flex; flex-direction: column; gap: 9px; align-items: flex-end; }
+/* Right-side chat layout: meta row reads "time · name · avatar" left→right. */
+.msg-user .msg-meta { flex-direction: row-reverse; }
+.user-card-wrap { display: flex; flex-direction: column; gap: 4px; max-width: 80%; }
 .user-card {
   background: var(--bg-container); border: 1px solid var(--border);
   border-radius: 12px; padding: 14px 16px; box-shadow: var(--card-shadow);


### PR DESCRIPTION
## What

User messages in the chat view are now right-aligned like a typical chat UI, with the user avatar on the far right. Agent messages stay on the left with their avatar on the left — unchanged.

## Changes

All in `web/src/views/ChatView.svelte` (styles only, no markup changes):

- `.msg-user` gets `align-items: flex-end` — the whole user message block (meta row, card, action buttons) hugs the right edge
- `.msg-user .msg-meta` gets `flex-direction: row-reverse` — meta row reads `time · name · avatar` left-to-right, avatar on the far right
- `.user-card-wrap` gets `max-width: 80%` — long messages don't span the full row, so the bubble reads as a bubble

## Test

- `npm run build` passes
- Manual: send a message in the web UI — user bubble sits right with avatar rightmost; agent replies stay left

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
