### PR TITLE
fix(server): serve artifacts written via relative tool input paths

### DIFF
--- a/internal/server/artifact_handler.go
+++ b/internal/server/artifact_handler.go
@@ -90,12 +90,26 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 }
 
 // sessionWrotePath looks for a write_file, edit_file, or show_artifact tool_use
-// in the transcript whose path input matches reqPath (after Clean on both
-// sides — the payloads carry absolute paths, so no base-dir join is needed) and
+// in the transcript whose path matches reqPath (after Clean on both sides) and
 // which actually ran. show_artifact is how script-produced files (built rather
 // than written through the file tools) enter the whitelist. On a match it
 // returns the transcript's own copy of the path so callers serve a value sourced
 // from what the agent recorded rather than from the raw request.
+//
+// A call's path is matched in two places, because the two record different
+// forms of it:
+//
+//   - The tool_use input is the model's *raw* path — frequently relative or
+//     ~/-prefixed, since the file tools accept those and resolve them against
+//     the session working dir. It matches only when the model happened to
+//     pass an absolute path.
+//   - The answering tool_result's ui payload carries the path as the tool
+//     *resolved* it (always absolute; see write_file/edit_file/show_artifact),
+//     persisted with the transcript and invisible to the model. This is the
+//     same value the panel lists, and the only form that matches for the
+//     common relative-input case. The payload lives on the result block, so
+//     this form exists only once the call has finished — an in-flight write
+//     is still matched by its raw input alone.
 //
 // The "actually ran" half matters: the agent records a tool_use before the
 // permission gate rules on it, so a write the user *denied* sits in the
@@ -113,10 +127,44 @@ func sessionWrotePath(sess *agent.Session, reqPath string) (string, bool) {
 			if !ok {
 				continue
 			}
-			clean := filepath.Clean(p)
-			if clean != want || !callAuthorized(sess.Messages, i, b.ID) {
+			served := ""
+			if clean := filepath.Clean(p); clean == want {
+				served = clean
+			} else if resolved, ok := resultUIPath(sess.Messages, i, b.ID, want); ok {
+				served = resolved
+			}
+			if served == "" || !callAuthorized(sess.Messages, i, b.ID) {
 				continue
 			}
+			return served, true
+		}
+	}
+	return "", false
+}
+
+// resultUIPath returns the tool-resolved path from the ui payload of the
+// result answering the tool_use with the given id in messages[i], when that
+// path matches want. Scoping mirrors callAuthorized: tool-call ids come from
+// the model, so only the next message's blocks answer this call, and an error
+// result (a denial, a failed write) has no resolved path to vouch for. After
+// the transcript's JSON round-trip the payload decodes as map[string]any.
+func resultUIPath(msgs []agent.Message, i int, id, want string) (string, bool) {
+	if id == "" || i+1 >= len(msgs) {
+		return "", false
+	}
+	for _, rb := range msgs[i+1].Blocks {
+		if rb.Type != "tool_result" || rb.ToolUseID != id || rb.IsError {
+			continue
+		}
+		ui, ok := rb.UI.(map[string]any)
+		if !ok {
+			continue
+		}
+		p, ok := ui["path"].(string)
+		if !ok {
+			continue
+		}
+		if clean := filepath.Clean(p); clean == want {
 			return clean, true
 		}
 	}

--- a/internal/server/artifact_handler_test.go
+++ b/internal/server/artifact_handler_test.go
@@ -182,6 +182,76 @@ func TestHandleGetArtifact_SizeCap(t *testing.T) {
 	}
 }
 
+// Models routinely pass relative paths (or ~/…) to write_file/edit_file; the
+// tools resolve them against the session working dir and record the absolute
+// result in the ui payload, which is also what the panel lists. The whitelist
+// must serve from that resolved path — matching only the raw tool_use input
+// 404s every relative-path write in the panel, which is most code edits.
+func TestHandleGetArtifact_RelativeInputPath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	artDir := t.TempDir()
+	abs := filepath.Join(artDir, "main.go")
+	if err := os.WriteFile(abs, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exactly what the transcript records when the model passes a relative
+	// path: the raw relative input on the tool_use, the tool-resolved absolute
+	// path on the answering result's ui payload.
+	sess := agent.NewSession("stub-model", "")
+	sess.Messages = append(sess.Messages, agent.Message{
+		Role: agent.RoleAssistant,
+		Blocks: []agent.ContentBlock{{
+			Type: "tool_use", ID: "t1", Name: "write_file",
+			Input: map[string]any{"path": "main.go", "content": "package main"},
+		}},
+	})
+	res := agent.NewToolResultBlock("t1", "wrote main.go", false)
+	res.UI = map[string]any{"type": "write", "path": abs, "size_bytes": 12}
+	sess.Messages = append(sess.Messages, agent.Message{
+		Role:   agent.RoleUser,
+		Blocks: []agent.ContentBlock{res},
+	})
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := getArtifact(t, srv, sess.ID, abs)
+	if w.Code != http.StatusOK {
+		t.Fatalf("relative-input write: status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "package main" {
+		t.Errorf("body = %q", w.Body.String())
+	}
+
+	// The resolved path must still come from an *authorized* call: a ui
+	// payload on an error result (e.g. a denied write) proves nothing ran.
+	denied := agent.NewSession("stub-model", "")
+	denied.Messages = append(denied.Messages, agent.Message{
+		Role: agent.RoleAssistant,
+		Blocks: []agent.ContentBlock{{
+			Type: "tool_use", ID: "t1", Name: "write_file",
+			Input: map[string]any{"path": "main.go", "content": "x"},
+		}},
+	})
+	deniedRes := agent.NewToolResultBlock("t1", "permission_denied: user declined to run write_file", true)
+	deniedRes.UI = map[string]any{"type": "write", "path": abs}
+	denied.Messages = append(denied.Messages, agent.Message{
+		Role:   agent.RoleUser,
+		Blocks: []agent.ContentBlock{deniedRes},
+	})
+	if err := denied.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if w := getArtifact(t, srv, denied.ID, abs); w.Code != http.StatusNotFound {
+		t.Errorf("ui path on a denied write: status = %d, want 404", w.Code)
+	}
+}
+
 func TestHandleGetArtifact_ShowArtifactCountsAsWrite(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)


### PR DESCRIPTION
## Problem

The web Artifacts panel listed files but failed to preview them with "⚠️ This file could not be loaded for preview. It may have been deleted or moved." — most visibly for source files (e.g. `.go`) written during a coding session.

Root cause: the artifact endpoint's whitelist (`sessionWrotePath` in `internal/server/artifact_handler.go`) matched the request path only against the **raw `tool_use` input path** recorded in the transcript. Models routinely pass relative or `~/`-prefixed paths to `write_file`/`edit_file`; the tools resolve those against the session working dir and record the resolved absolute path in the persisted `tool_result` ui payload — the same value the panel lists. The endpoint compared the request's absolute path against the transcript's relative input, never matched, and returned 404. Report-style artifacts (HTML/MD) are usually written with absolute paths, which is why the failure showed up mostly on code files.

## Fix

`sessionWrotePath` now also consults the answering `tool_result`'s ui payload (`resultUIPath`) for the tool-resolved absolute path:

- Scoped exactly like `callAuthorized`: next message only, matching tool-call id, non-error result — so a denied or failed write still proves nothing ran and stays 404.
- The ui payload is runtime-generated and invisible to the model, so it can't be forged by prompt output.
- In-flight writes (no result persisted yet) keep matching on the raw input, unchanged.

## Tests

- New `TestHandleGetArtifact_RelativeInputPath`: transcript with relative input + absolute ui path serves 200 (reproduced the 404 before the fix); a ui path on a **denied** write's error result still 404s.
- All existing `TestHandleGetArtifact*` security regressions pass (denied-write, forged-success, stale-unanswered, in-flight).
- `go build ./...`, `go vet`, and the full `internal/server` package pass.

## Known boundary

A live write fetched in the sub-second window before its result is persisted still 404s if the model used a relative path; the panel hydrates on first user selection, so this is effectively unreachable, and re-writing the path retries.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>