### PR TITLE
chore: bump version to 1.15.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.0"
+var Version = "1.15.1"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
Patch release covering everything merged since v1.15.0:
- #1976 fix(desktop): pin macOS deployment target to 11.0 instead of the build machine's OS — desktop app was silently unlaunchable on macOS older than whatever GitHub's `macos-latest` runner happened to be
- #1977 fix(channels): make the enable toggle persist and reject enabling unconfigured channels
- #1978 feat(web): cap tool card bodies at ~10 lines with scroll instead of fold buttons
- #1981 feat(web): click a message attachment thumbnail to view it full-size
- #1982 fix(server): serve artifacts written via relative tool input paths

version.go only, no other version references in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)