### PR TITLE
fix(server): surface real error behind "invalid JSON body" 400s

### DIFF
--- a/internal/server/browser_recordings_handlers.go
+++ b/internal/server/browser_recordings_handlers.go
@@ -108,7 +108,7 @@ func (s *Server) handleSaveBrowserRecording(w http.ResponseWriter, r *http.Reque
 		YAML string `json:"yaml"`
 	}
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	sk, err := browser.ParseRecording([]byte(req.YAML))

--- a/internal/server/browser_recordings_handlers.go
+++ b/internal/server/browser_recordings_handlers.go
@@ -108,7 +108,7 @@ func (s *Server) handleSaveBrowserRecording(w http.ResponseWriter, r *http.Reque
 		YAML string `json:"yaml"`
 	}
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	sk, err := browser.ParseRecording([]byte(req.YAML))

--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -109,7 +109,7 @@ func (s *Server) handleSaveChannel(w http.ResponseWriter, r *http.Request) {
 
 	var req channelUpdateRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -294,7 +294,7 @@ func (s *Server) handleChannelSendText(w http.ResponseWriter, r *http.Request) {
 		Text   string `json:"text"`
 	}
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if strings.TrimSpace(req.ChatID) == "" || strings.TrimSpace(req.Text) == "" {
@@ -319,7 +319,7 @@ func (s *Server) handleChannelSendFile(w http.ResponseWriter, r *http.Request) {
 		Name   string `json:"name"`
 	}
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if strings.TrimSpace(req.ChatID) == "" || strings.TrimSpace(req.Path) == "" {

--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -109,7 +109,7 @@ func (s *Server) handleSaveChannel(w http.ResponseWriter, r *http.Request) {
 
 	var req channelUpdateRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -294,7 +294,7 @@ func (s *Server) handleChannelSendText(w http.ResponseWriter, r *http.Request) {
 		Text   string `json:"text"`
 	}
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if strings.TrimSpace(req.ChatID) == "" || strings.TrimSpace(req.Text) == "" {
@@ -319,7 +319,7 @@ func (s *Server) handleChannelSendFile(w http.ResponseWriter, r *http.Request) {
 		Name   string `json:"name"`
 	}
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if strings.TrimSpace(req.ChatID) == "" || strings.TrimSpace(req.Path) == "" {

--- a/internal/server/goal.go
+++ b/internal/server/goal.go
@@ -116,7 +116,7 @@ func (s *Server) handleUpdateSessionGoal(w http.ResponseWriter, r *http.Request)
 		Replace     bool   `json:"replace"`
 	}
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 

--- a/internal/server/goal.go
+++ b/internal/server/goal.go
@@ -116,7 +116,7 @@ func (s *Server) handleUpdateSessionGoal(w http.ResponseWriter, r *http.Request)
 		Replace     bool   `json:"replace"`
 	}
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -265,7 +265,7 @@ func (s *Server) handleCreateChat(w http.ResponseWriter, r *http.Request) {
 
 	var req createChatRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if strings.TrimSpace(req.Message) == "" {
@@ -329,7 +329,7 @@ func (s *Server) handleTurn(w http.ResponseWriter, r *http.Request) {
 
 	var req turnRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if strings.TrimSpace(req.Message) == "" {
@@ -426,7 +426,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	var req sessionCreateRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -741,7 +741,7 @@ type deleteSessionsRequest struct {
 func (s *Server) handleDeleteSessions(w http.ResponseWriter, r *http.Request) {
 	var req deleteSessionsRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if len(req.IDs) == 0 {
@@ -791,7 +791,7 @@ func (s *Server) handleBranchSession(w http.ResponseWriter, r *http.Request) {
 	}
 	var req branchSessionRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	src, err := agent.LoadSession(id)
@@ -844,7 +844,7 @@ func (s *Server) handleEditMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	var req editMessageRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if strings.TrimSpace(req.NewContent) == "" {
@@ -1069,7 +1069,7 @@ type fileActionRequest struct {
 func (s *Server) handleFileAction(w http.ResponseWriter, r *http.Request) {
 	var req fileActionRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.Path == "" {
@@ -1156,7 +1156,7 @@ func (s *Server) handleUpdateSession(w http.ResponseWriter, r *http.Request) {
 	}
 	var req updateSessionRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	name := strings.TrimSpace(req.Name)
@@ -1198,7 +1198,7 @@ func (s *Server) handleUpdateSessionModel(w http.ResponseWriter, r *http.Request
 
 	var req updateSessionModelRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.ModelID == "" {
@@ -1276,7 +1276,7 @@ func (s *Server) handleUpdateSessionReasoningEffort(w http.ResponseWriter, r *ht
 
 	var req updateSessionReasoningEffortRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -1375,7 +1375,7 @@ func (s *Server) handleUpdateSessionPermissionMode(w http.ResponseWriter, r *htt
 
 	var req updateSessionPermissionModeRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -1449,7 +1449,7 @@ func (s *Server) handleUpdateSessionShowReasoning(w http.ResponseWriter, r *http
 
 	var req updateSessionShowReasoningRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -1524,7 +1524,7 @@ func (s *Server) handleUpdateSessionWorkingDir(w http.ResponseWriter, r *http.Re
 
 	var req updateSessionWorkingDirRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.WorkingDir == "" {
@@ -1611,7 +1611,7 @@ func (s *Server) handleUpdateSessionAgentProfile(w http.ResponseWriter, r *http.
 
 	var req updateSessionAgentProfileRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	agentProfile := req.AgentProfile

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -265,7 +265,7 @@ func (s *Server) handleCreateChat(w http.ResponseWriter, r *http.Request) {
 
 	var req createChatRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if strings.TrimSpace(req.Message) == "" {
@@ -329,7 +329,7 @@ func (s *Server) handleTurn(w http.ResponseWriter, r *http.Request) {
 
 	var req turnRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if strings.TrimSpace(req.Message) == "" {
@@ -426,7 +426,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	var req sessionCreateRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -741,7 +741,7 @@ type deleteSessionsRequest struct {
 func (s *Server) handleDeleteSessions(w http.ResponseWriter, r *http.Request) {
 	var req deleteSessionsRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if len(req.IDs) == 0 {
@@ -791,7 +791,7 @@ func (s *Server) handleBranchSession(w http.ResponseWriter, r *http.Request) {
 	}
 	var req branchSessionRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	src, err := agent.LoadSession(id)
@@ -844,7 +844,7 @@ func (s *Server) handleEditMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	var req editMessageRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if strings.TrimSpace(req.NewContent) == "" {
@@ -1069,7 +1069,7 @@ type fileActionRequest struct {
 func (s *Server) handleFileAction(w http.ResponseWriter, r *http.Request) {
 	var req fileActionRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.Path == "" {
@@ -1156,7 +1156,7 @@ func (s *Server) handleUpdateSession(w http.ResponseWriter, r *http.Request) {
 	}
 	var req updateSessionRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	name := strings.TrimSpace(req.Name)
@@ -1198,7 +1198,7 @@ func (s *Server) handleUpdateSessionModel(w http.ResponseWriter, r *http.Request
 
 	var req updateSessionModelRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.ModelID == "" {
@@ -1276,7 +1276,7 @@ func (s *Server) handleUpdateSessionReasoningEffort(w http.ResponseWriter, r *ht
 
 	var req updateSessionReasoningEffortRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -1375,7 +1375,7 @@ func (s *Server) handleUpdateSessionPermissionMode(w http.ResponseWriter, r *htt
 
 	var req updateSessionPermissionModeRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -1449,7 +1449,7 @@ func (s *Server) handleUpdateSessionShowReasoning(w http.ResponseWriter, r *http
 
 	var req updateSessionShowReasoningRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -1524,7 +1524,7 @@ func (s *Server) handleUpdateSessionWorkingDir(w http.ResponseWriter, r *http.Re
 
 	var req updateSessionWorkingDirRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.WorkingDir == "" {
@@ -1611,7 +1611,7 @@ func (s *Server) handleUpdateSessionAgentProfile(w http.ResponseWriter, r *http.
 
 	var req updateSessionAgentProfileRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	agentProfile := req.AgentProfile

--- a/internal/server/mcp_handlers.go
+++ b/internal/server/mcp_handlers.go
@@ -289,7 +289,7 @@ func (s *Server) handleCreateMCPServer(w http.ResponseWriter, r *http.Request) {
 		Servers map[string]mcp.ServerEntry `json:"mcpServers"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if len(req.Servers) == 0 {
@@ -506,7 +506,7 @@ func (s *Server) handlePutToolSearch(w http.ResponseWriter, r *http.Request) {
 		Enabled string `json:"enabled"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	switch req.Enabled {

--- a/internal/server/mcp_handlers.go
+++ b/internal/server/mcp_handlers.go
@@ -289,7 +289,7 @@ func (s *Server) handleCreateMCPServer(w http.ResponseWriter, r *http.Request) {
 		Servers map[string]mcp.ServerEntry `json:"mcpServers"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if len(req.Servers) == 0 {
@@ -506,7 +506,7 @@ func (s *Server) handlePutToolSearch(w http.ResponseWriter, r *http.Request) {
 		Enabled string `json:"enabled"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	switch req.Enabled {

--- a/internal/server/native_handlers.go
+++ b/internal/server/native_handlers.go
@@ -168,7 +168,7 @@ func (s *Server) handleNativeNotify(w http.ResponseWriter, r *http.Request) {
 	}
 	var req nativeNotifyRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.SessionID != "" {
@@ -213,7 +213,7 @@ func (s *Server) handleNativeAutostartSet(w http.ResponseWriter, r *http.Request
 	}
 	var req nativeAutostartRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if err := s.cfg.Native.SetAutostart(req.Enabled); err != nil {
@@ -319,7 +319,7 @@ func (s *Server) handleNativeOpenExternal(w http.ResponseWriter, r *http.Request
 	}
 	var req nativeOpenExternalRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	u, err := url.Parse(req.URL)
@@ -381,7 +381,7 @@ func (s *Server) handleNativeSaveFile(w http.ResponseWriter, r *http.Request) {
 	}
 	var req nativeSaveFileRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	content := req.Content

--- a/internal/server/native_handlers.go
+++ b/internal/server/native_handlers.go
@@ -168,7 +168,7 @@ func (s *Server) handleNativeNotify(w http.ResponseWriter, r *http.Request) {
 	}
 	var req nativeNotifyRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.SessionID != "" {
@@ -213,7 +213,7 @@ func (s *Server) handleNativeAutostartSet(w http.ResponseWriter, r *http.Request
 	}
 	var req nativeAutostartRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if err := s.cfg.Native.SetAutostart(req.Enabled); err != nil {
@@ -319,7 +319,7 @@ func (s *Server) handleNativeOpenExternal(w http.ResponseWriter, r *http.Request
 	}
 	var req nativeOpenExternalRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	u, err := url.Parse(req.URL)
@@ -381,7 +381,7 @@ func (s *Server) handleNativeSaveFile(w http.ResponseWriter, r *http.Request) {
 	}
 	var req nativeSaveFileRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	content := req.Content

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -324,7 +324,7 @@ type putShowReasoningRequest struct {
 func (s *Server) handlePutShowReasoning(w http.ResponseWriter, r *http.Request) {
 	var req putShowReasoningRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -390,7 +390,7 @@ type putCoauthorRequest struct {
 func (s *Server) handlePutCoauthor(w http.ResponseWriter, r *http.Request) {
 	var req putCoauthorRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -418,7 +418,7 @@ type putLanguageRequest struct {
 func (s *Server) handlePutLanguage(w http.ResponseWriter, r *http.Request) {
 	var req putLanguageRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.Language != "en" && req.Language != "zh" {
@@ -456,7 +456,7 @@ type putWorkspaceDirRequest struct {
 func (s *Server) handlePutWorkspaceDir(w http.ResponseWriter, r *http.Request) {
 	var req putWorkspaceDirRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -499,7 +499,7 @@ type putReasoningEffortRequest struct {
 func (s *Server) handlePutReasoningEffort(w http.ResponseWriter, r *http.Request) {
 	var req putReasoningEffortRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -574,7 +574,7 @@ type putPermissionModeRequest struct {
 func (s *Server) handlePutPermissionMode(w http.ResponseWriter, r *http.Request) {
 	var req putPermissionModeRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -667,7 +667,7 @@ func storedAPIKey(cfg config.Config, provider, baseURL string) string {
 func (s *Server) handleTestConfig(w http.ResponseWriter, r *http.Request) {
 	var req testConfigRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.Model == "" || req.BaseURL == "" {
@@ -793,7 +793,7 @@ func endpointToJSON(ep config.Endpoint) endpointJSONOut {
 func (s *Server) handleCreateEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req createEndpointRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.ID == "" {
@@ -852,7 +852,7 @@ func (s *Server) handleUpdateEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 	var req updateEndpointRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -982,7 +982,7 @@ func (s *Server) handleAddEndpointModel(w http.ResponseWriter, r *http.Request) 
 	}
 	var req endpointModelIn
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.Model == "" {

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -324,7 +324,7 @@ type putShowReasoningRequest struct {
 func (s *Server) handlePutShowReasoning(w http.ResponseWriter, r *http.Request) {
 	var req putShowReasoningRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -390,7 +390,7 @@ type putCoauthorRequest struct {
 func (s *Server) handlePutCoauthor(w http.ResponseWriter, r *http.Request) {
 	var req putCoauthorRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -418,7 +418,7 @@ type putLanguageRequest struct {
 func (s *Server) handlePutLanguage(w http.ResponseWriter, r *http.Request) {
 	var req putLanguageRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.Language != "en" && req.Language != "zh" {
@@ -456,7 +456,7 @@ type putWorkspaceDirRequest struct {
 func (s *Server) handlePutWorkspaceDir(w http.ResponseWriter, r *http.Request) {
 	var req putWorkspaceDirRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -499,7 +499,7 @@ type putReasoningEffortRequest struct {
 func (s *Server) handlePutReasoningEffort(w http.ResponseWriter, r *http.Request) {
 	var req putReasoningEffortRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -574,7 +574,7 @@ type putPermissionModeRequest struct {
 func (s *Server) handlePutPermissionMode(w http.ResponseWriter, r *http.Request) {
 	var req putPermissionModeRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -667,7 +667,7 @@ func storedAPIKey(cfg config.Config, provider, baseURL string) string {
 func (s *Server) handleTestConfig(w http.ResponseWriter, r *http.Request) {
 	var req testConfigRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.Model == "" || req.BaseURL == "" {
@@ -793,7 +793,7 @@ func endpointToJSON(ep config.Endpoint) endpointJSONOut {
 func (s *Server) handleCreateEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req createEndpointRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.ID == "" {
@@ -852,7 +852,7 @@ func (s *Server) handleUpdateEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 	var req updateEndpointRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -982,7 +982,7 @@ func (s *Server) handleAddEndpointModel(w http.ResponseWriter, r *http.Request) 
 	}
 	var req endpointModelIn
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.Model == "" {

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -716,6 +716,56 @@ func TestPutPermissionMode_InvalidMode_Rejects(t *testing.T) {
 	}
 }
 
+// TestCreateEndpoint_DocumentedModelsShape sends the exact request body
+// documented in config-setup/SKILL.md's "Create an Endpoint" example — a
+// models array of {"model": ..., "vision": ...} objects, matching
+// createEndpointRequest.Models []endpointModelIn. Regression guard for #1941,
+// where the doc and the wire format had drifted apart.
+func TestCreateEndpoint_DocumentedModelsShape(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	body := `{
+		"id": "my-relay",
+		"name": "My Relay",
+		"provider": "custom",
+		"api_key": "sk-test",
+		"base_url": "https://api.example.com",
+		"protocol": "openai",
+		"models": [{"model": "gpt-4o", "vision": false}]
+	}`
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints", body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("POST /api/config/endpoints = %d, want %d: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	var resp endpointJSONOut
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body: %s)", err, w.Body.String())
+	}
+	if len(resp.Models) != 1 || resp.Models[0].Model != "gpt-4o" {
+		t.Fatalf("models = %+v, want one gpt-4o entry", resp.Models)
+	}
+}
+
+// TestCreateEndpoint_StringModelsRejectedWithDetail covers the failure mode
+// #1941 actually hit: a plain string models array (the shape SKILL.md wrongly
+// documented before this fix) doesn't unmarshal into []endpointModelIn. The
+// 400 must explain why instead of the old bare "invalid JSON body".
+func TestCreateEndpoint_StringModelsRejectedWithDetail(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	body := `{"id": "my-relay", "provider": "custom", "models": ["gpt-4o"]}`
+	w := doJSON(t, srv, http.MethodPost, "/api/config/endpoints", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("POST /api/config/endpoints with string models = %d, want %d: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cannot unmarshal") {
+		t.Errorf("error body = %q, want the underlying decode error, not a bare message", w.Body.String())
+	}
+}
+
 func TestSetEndpointDefault_WithModelQuery_SetsSpecificModel(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1366,6 +1366,13 @@ func readBodyJSON(r *http.Request, v any) error {
 	return json.NewDecoder(r.Body).Decode(v)
 }
 
+// writeInvalidJSONBody writes the standard 400 response for a readBodyJSON
+// failure, including the decode error so callers can tell a body-shape
+// mismatch from a syntax error instead of guessing.
+func writeInvalidJSONBody(w http.ResponseWriter, err error) {
+	writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+}
+
 // ─── Provider resolution ────────────────────────────────────────────────────
 //
 // The server resolves provider/model/key/base-URL exactly as before, then hands

--- a/internal/server/session_groups.go
+++ b/internal/server/session_groups.go
@@ -305,7 +305,7 @@ type createSessionGroupRequest struct {
 func (s *Server) handleCreateSessionGroup(w http.ResponseWriter, r *http.Request) {
 	var req createSessionGroupRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	name := strings.TrimSpace(req.Name)
@@ -348,7 +348,7 @@ func (s *Server) handleUpdateSessionGroup(w http.ResponseWriter, r *http.Request
 	}
 	var req updateSessionGroupRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.Name == nil && req.Collapsed == nil {
@@ -448,7 +448,7 @@ type reorderSessionGroupsRequest struct {
 func (s *Server) handleReorderSessionGroups(w http.ResponseWriter, r *http.Request) {
 	var req reorderSessionGroupsRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -505,7 +505,7 @@ func (s *Server) handleSetSessionGroup(w http.ResponseWriter, r *http.Request) {
 	}
 	var req setSessionGroupRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 
@@ -569,7 +569,7 @@ func (s *Server) handleSetSessionPin(w http.ResponseWriter, r *http.Request) {
 	}
 	var req setSessionPinRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 

--- a/internal/server/session_groups.go
+++ b/internal/server/session_groups.go
@@ -305,7 +305,7 @@ type createSessionGroupRequest struct {
 func (s *Server) handleCreateSessionGroup(w http.ResponseWriter, r *http.Request) {
 	var req createSessionGroupRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	name := strings.TrimSpace(req.Name)
@@ -348,7 +348,7 @@ func (s *Server) handleUpdateSessionGroup(w http.ResponseWriter, r *http.Request
 	}
 	var req updateSessionGroupRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.Name == nil && req.Collapsed == nil {
@@ -448,7 +448,7 @@ type reorderSessionGroupsRequest struct {
 func (s *Server) handleReorderSessionGroups(w http.ResponseWriter, r *http.Request) {
 	var req reorderSessionGroupsRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -505,7 +505,7 @@ func (s *Server) handleSetSessionGroup(w http.ResponseWriter, r *http.Request) {
 	}
 	var req setSessionGroupRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -569,7 +569,7 @@ func (s *Server) handleSetSessionPin(w http.ResponseWriter, r *http.Request) {
 	}
 	var req setSessionPinRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 

--- a/internal/server/skill_import_handler.go
+++ b/internal/server/skill_import_handler.go
@@ -28,7 +28,7 @@ func (s *Server) handleImportSkill(w http.ResponseWriter, r *http.Request) {
 		Force  bool   `json:"force"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	source := strings.TrimSpace(req.Source)

--- a/internal/server/skill_import_handler.go
+++ b/internal/server/skill_import_handler.go
@@ -28,7 +28,7 @@ func (s *Server) handleImportSkill(w http.ResponseWriter, r *http.Request) {
 		Force  bool   `json:"force"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	source := strings.TrimSpace(req.Source)

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -494,7 +494,7 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 	}
 	var req taskRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.Name == "" || req.Cron == "" || req.Prompt == "" {
@@ -592,7 +592,7 @@ func (s *Server) handleTransferTask(w http.ResponseWriter, r *http.Request) {
 	}
 	var req agentTransferRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.AgentID == "" {
@@ -649,7 +649,7 @@ func (s *Server) handlePatchTask(w http.ResponseWriter, r *http.Request) {
 	}
 	var req patchTaskRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	task, err := s.scheduler.Get(id)

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -494,7 +494,7 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 	}
 	var req taskRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.Name == "" || req.Cron == "" || req.Prompt == "" {
@@ -592,7 +592,7 @@ func (s *Server) handleTransferTask(w http.ResponseWriter, r *http.Request) {
 	}
 	var req agentTransferRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	if req.AgentID == "" {
@@ -649,7 +649,7 @@ func (s *Server) handlePatchTask(w http.ResponseWriter, r *http.Request) {
 	}
 	var req patchTaskRequest
 	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeInvalidJSONBody(w, err)
 		return
 	}
 	task, err := s.scheduler.Get(id)

--- a/internal/skills/defaults/config-setup/SKILL.md
+++ b/internal/skills/defaults/config-setup/SKILL.md
@@ -174,7 +174,7 @@ POST /api/config/endpoints
   "api_key": "sk-…",
   "base_url": "https://api.example.com",
   "protocol": "openai",
-  "models": ["gpt-4o"]
+  "models": [{"model": "gpt-4o", "vision": false}]
 }
 ```
 
@@ -186,7 +186,7 @@ POST /api/config/endpoints
 | `api_key` | no | The API key (never echo it back to the user after saving) |
 | `base_url` | no | Override for API base URL; only for `"custom"` provider — named providers use their registry URL |
 | `protocol` | no | `"anthropic"` or `"openai"` — only needed for `"custom"` provider |
-| `models` | no | Initial model names to register |
+| `models` | no | Initial models to register — array of `{"model": "...", "vision": bool}`, **not** plain strings |
 
 ### Update an Endpoint
 


### PR DESCRIPTION
## Summary
- `config-setup` skill's `POST /api/config/endpoints` example documented `"models": ["gpt-4o"]` (string array), but the endpoint decodes into `[]endpointModelIn` (`{"model": "...", "vision": bool}` objects) — sending the documented shape triggers a JSON unmarshal type error.
- Every `readBodyJSON` call site (44 across 10 files) swallowed the actual decode error into an identical, detail-free `400 "invalid JSON body"`, so there was no way to tell a body-shape mismatch from a syntax error without guessing/retrying.
- Fixed the skill doc example to the correct object-array shape, and appended the real `err.Error()` to every `"invalid JSON body"` response so future mismatches are self-diagnosable.

Fixes #1941.

## Test plan
- [x] `go build ./...`
- [x] `make fmt-check`
- [x] `make vet`
- [x] `go test ./internal/server/...` (no test asserted the old literal string)