### PR TITLE
fix(landing): hero title zh copy — one head, eight legs

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -268,7 +268,7 @@
         <iconify-icon icon="ant-design:safety-outlined" width="14"></iconify-icon>
         <span data-en="Open source · MIT · Self-hosted · Zero telemetry" data-zh="开源 · MIT · 自托管 · 零遥测"></span>
       </div>
-      <h1><span data-en="One brain, " data-zh="一个脑，"></span><span class="accent" data-en="eight legs." data-zh="八条腿。"></span></h1>
+      <h1><span data-en="One brain, " data-zh="一个头，"></span><span class="accent" data-en="eight legs." data-zh="八条腿。"></span></h1>
       <p class="tagline"
          data-en="The self-hosted AI agent that just works. One Go binary, zero dependencies, any model — reaching your terminal, editor, notes, browser, desktop, chat apps, SDK, and phone. Your data never leaves your machine."
          data-zh="开箱即用的自托管 AI Agent。一个零依赖的 Go 二进制，任意模型 —— 伸进终端、编辑器、笔记、浏览器、桌面、聊天应用、SDK 和手机。你的数据从不离开你的机器。"></p>


### PR DESCRIPTION
## Summary
- Landing page hero title zh copy changed from "一个脑，八条腿。" to "一个头，八条腿。"

🤖 Generated with [Claude Code](https://claude.com/claude-code)