### PR TITLE
feat(agents): add terminal to resume-coach and skill tool to all curated experts

### DIFF
--- a/internal/agentprofile/defaults/copywriter.md
+++ b/internal/agentprofile/defaults/copywriter.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Write 3 viral-style headlines for a new coffee product launch"
   - "Rewrite this product description to sound more social-media-native"
   - "Suggest a few names for a new pet store"
-tools: [web_search, web_fetch, read_file, write_file]
+tools: [web_search, web_fetch, read_file, write_file, skill]
 ---
 
 You are a copywriting assistant. Help the user write marketing copy, social

--- a/internal/agentprofile/defaults/copywriter.md
+++ b/internal/agentprofile/defaults/copywriter.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Write 3 viral-style headlines for a new coffee product launch"
   - "Rewrite this product description to sound more social-media-native"
   - "Suggest a few names for a new pet store"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall]
+tools: [web_search, web_fetch, read_file, write_file]
 ---
 
 You are a copywriting assistant. Help the user write marketing copy, social

--- a/internal/agentprofile/defaults/learning-coach.md
+++ b/internal/agentprofile/defaults/learning-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have an IELTS exam in a month — help me build a study plan"
   - "Use the Feynman technique to explain compound interest to me"
   - "Give me 5 practice questions about photosynthesis"
-tools: [web_search, web_fetch, read_file, write_file]
+tools: [web_search, web_fetch, read_file, write_file, skill]
 ---
 
 You are a learning coach. When asked for a study plan, ask about the exam

--- a/internal/agentprofile/defaults/learning-coach.md
+++ b/internal/agentprofile/defaults/learning-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have an IELTS exam in a month — help me build a study plan"
   - "Use the Feynman technique to explain compound interest to me"
   - "Give me 5 practice questions about photosynthesis"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall]
+tools: [web_search, web_fetch, read_file, write_file]
 ---
 
 You are a learning coach. When asked for a study plan, ask about the exam

--- a/internal/agentprofile/defaults/legal-helper.md
+++ b/internal/agentprofile/defaults/legal-helper.md
@@ -27,3 +27,15 @@ anything with real financial or legal consequences (large sums, criminal
 matters, litigation strategy). Prefer citing the general principle over
 guessing at jurisdiction-specific statute numbers unless the user's
 jurisdiction is clear and you're confident in the citation.
+
+When a user's question goes beyond general concepts — case analysis, article
+retrieval, risk assessment, or argument construction — introduce the
+Legal-Skills-Chinese library (https://github.com/THUYRan/Legal-Skills-Chinese):
+38 lawyer-written skills covering retrieval → reasoning → argumentation →
+document drafting for PRC statutory law. Point them at installing the skills
+they need, e.g. `octo skills add THUYRan/Legal-Skills-Chinese/skills/legal-article-retrieval`
+(run `octo skills list` to see what's already installed). After installation,
+they must also enable the skill for you — Web UI → Agents → 法律知识助手 →
+Skills, or ask the Default Agent to do it — because expert agents only see
+skills explicitly enabled in their profile; installing alone doesn't make
+them loadable here.

--- a/internal/agentprofile/defaults/legal-helper.md
+++ b/internal/agentprofile/defaults/legal-helper.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "What does a '1 month deposit, 3 months rent upfront' lease term mean"
   - "I received a counterfeit item from an online order — how can I file a claim"
   - "Explain what an 'arbitration clause' means"
-tools: [web_search, web_fetch, read_file, write_file]
+tools: [web_search, web_fetch, read_file, write_file, skill]
 ---
 
 You are a legal-concepts helper, not a lawyer. Explain legal terms, common

--- a/internal/agentprofile/defaults/legal-helper.md
+++ b/internal/agentprofile/defaults/legal-helper.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "What does a '1 month deposit, 3 months rent upfront' lease term mean"
   - "I received a counterfeit item from an online order — how can I file a claim"
   - "Explain what an 'arbitration clause' means"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall]
+tools: [web_search, web_fetch, read_file, write_file]
 ---
 
 You are a legal-concepts helper, not a lawyer. Explain legal terms, common

--- a/internal/agentprofile/defaults/life-assistant.md
+++ b/internal/agentprofile/defaults/life-assistant.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have eggs, tomatoes, and noodles in the fridge — suggest a recipe"
   - "What's a good birthday gift idea for my mom"
   - "How do I quickly remove an oil stain from clothing"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall]
+tools: [web_search, web_fetch, read_file, write_file]
 ---
 
 You are a friendly everyday-life helper. Keep answers practical and quick to

--- a/internal/agentprofile/defaults/life-assistant.md
+++ b/internal/agentprofile/defaults/life-assistant.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have eggs, tomatoes, and noodles in the fridge — suggest a recipe"
   - "What's a good birthday gift idea for my mom"
   - "How do I quickly remove an oil stain from clothing"
-tools: [web_search, web_fetch, read_file, write_file]
+tools: [web_search, web_fetch, read_file, write_file, skill]
 ---
 
 You are a friendly everyday-life helper. Keep answers practical and quick to

--- a/internal/agentprofile/defaults/productivity-coach.md
+++ b/internal/agentprofile/defaults/productivity-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Break down 'finish the quarterly report' into actionable subtasks"
   - "I keep procrastinating — what methods can help"
   - "Use the SMART framework to help me set this month's goals"
-tools: [web_search, web_fetch, read_file, write_file]
+tools: [web_search, web_fetch, read_file, write_file, skill]
 ---
 
 You are a productivity coach. When asked to break down a task, produce a

--- a/internal/agentprofile/defaults/productivity-coach.md
+++ b/internal/agentprofile/defaults/productivity-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Break down 'finish the quarterly report' into actionable subtasks"
   - "I keep procrastinating — what methods can help"
   - "Use the SMART framework to help me set this month's goals"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall]
+tools: [web_search, web_fetch, read_file, write_file]
 ---
 
 You are a productivity coach. When asked to break down a task, produce a

--- a/internal/agentprofile/defaults/resume-coach.md
+++ b/internal/agentprofile/defaults/resume-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Review my resume and tell me what needs improvement"
   - "Simulate a few interview questions for a product manager role"
   - "I want to switch careers into data analytics — how should I plan for it"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall]
+tools: [web_search, web_fetch, read_file, write_file, terminal]
 ---
 
 You are a resume and career coach. Give specific, actionable feedback on
@@ -23,4 +23,7 @@ resumes and cover letters — call out weak bullet points, missing metrics, and
 formatting issues rather than vague encouragement. When asked to mock-
 interview, ask one question at a time, wait for the user's answer, then give
 feedback before the next question rather than dumping a whole question list
-at once.
+at once. Use the terminal only to extract text from documents the user
+uploaded (e.g. `pdftotext` for PDFs, `unzip -p … word/document.xml` or
+`textutil` for Word files) — never run arbitrary commands or modify files
+with it.

--- a/internal/agentprofile/defaults/resume-coach.md
+++ b/internal/agentprofile/defaults/resume-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Review my resume and tell me what needs improvement"
   - "Simulate a few interview questions for a product manager role"
   - "I want to switch careers into data analytics — how should I plan for it"
-tools: [web_search, web_fetch, read_file, write_file, terminal]
+tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
 ---
 
 You are a resume and career coach. Give specific, actionable feedback on

--- a/internal/agentprofile/defaults/trip-planner.md
+++ b/internal/agentprofile/defaults/trip-planner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Plan a 5-day independent trip to Osaka"
   - "What should I watch out for when traveling with young kids"
   - "Give me a packing list for an international trip"
-tools: [web_search, web_fetch, read_file, write_file]
+tools: [web_search, web_fetch, read_file, write_file, skill]
 ---
 
 You are a trip-planning assistant. Ask for budget, dates, and traveler

--- a/internal/agentprofile/defaults/trip-planner.md
+++ b/internal/agentprofile/defaults/trip-planner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Plan a 5-day independent trip to Osaka"
   - "What should I watch out for when traveling with young kids"
   - "Give me a packing list for an international trip"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall]
+tools: [web_search, web_fetch, read_file, write_file]
 ---
 
 You are a trip-planning assistant. Ask for budget, dates, and traveler

--- a/internal/agentprofile/defaults/writing-partner.md
+++ b/internal/agentprofile/defaults/writing-partner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Help me build an outline for an article about the pros and cons of remote work"
   - "Make this paragraph more concise and punchy"
   - "From a reader's perspective, where does this article's logic break down"
-tools: [web_search, web_fetch, read_file, write_file]
+tools: [web_search, web_fetch, read_file, write_file, skill]
 ---
 
 You are a writing partner for long-form content: essays, articles, reports,

--- a/internal/agentprofile/defaults/writing-partner.md
+++ b/internal/agentprofile/defaults/writing-partner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Help me build an outline for an article about the pros and cons of remote work"
   - "Make this paragraph more concise and punchy"
   - "From a reader's perspective, where does this article's logic break down"
-tools: [web_search, web_fetch, read_file, write_file, memory_recall]
+tools: [web_search, web_fetch, read_file, write_file]
 ---
 
 You are a writing partner for long-form content: essays, articles, reports,


### PR DESCRIPTION
## What

Tune the curated expert gallery (`internal/agentprofile/defaults/*.md`) in two directions:

### 1. resume-coach can actually read uploaded resumes

Its core scenario — "review my resume" — receives PDF/DOCX attachments, which `read_file` refuses (binary). The curated allowlist had no way to extract their text. Add `terminal` to resume-coach and constrain the persona to read-only document text extraction:

- `pdftotext` for PDFs
- `unzip -p … word/document.xml` / `textutil` for Word files
- never arbitrary commands or file modification

### 2. Skill channel opened for all 8 curated experts

Every curated expert now has the `skill` tool in its allowlist. Previously the tool was missing from all 8, so a `tool_skills` declaration (e.g. via the Web UI's per-agent skill checkboxes) could never actually be invoked — the manifest would name a skill the model had no way to load. `tool_skills` stays empty on all profiles: no skill is pre-bound, the UI opt-in is what activates one.

### 3. Drop `memory_recall` from all 8 curated experts

Expert agents have no memory-injection pipeline (no soul.md / octorules / MEMORY.md), so the tool was dead weight in their allowlists. Allowlists are now uniformly `[web_search, web_fetch, read_file, write_file, skill]` (+ `terminal` for resume-coach).

### 4. legal-helper guides users to the Legal-Skills-Chinese library

When a question goes beyond general legal concepts (case analysis, article retrieval, risk assessment, argument construction), legal-helper now introduces the 38-skill Legal-Skills-Chinese library for PRC statutory law (https://github.com/THUYRan/Legal-Skills-Chinese), with the exact install command (`octo skills add THUYRan/Legal-Skills-Chinese/skills/legal-article-retrieval`) and the follow-up enable step — expert agents only see skills explicitly enabled in their profile, so installing alone is not enough.

## Notes

- writing-partner has the same document-reading gap (long-form editing of uploaded docs) but its allowlist is left untouched per decision — a follow-up can extend the same `terminal` fix.
- Materialized defaults refresh on the next binary version bump (stamp-based); local testing can force with `octo agents update`.
- No Go code changed — profile .md content only. `go test ./internal/agentprofile/...` and profile-related `internal/tools` / `internal/server` tests pass.