### PR TITLE
chore: bump version to 1.15.3

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.2"
+var Version = "1.15.3"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## What

Bump `internal/version/version.go` 1.15.2 → 1.15.3 to ship the curated expert gallery adjustments from #1990:

- resume-coach gains `terminal` for read-only document text extraction (PDF/DOCX resumes)
- all 8 curated experts drop `memory_recall` and gain the `skill` tool
- legal-helper now guides users to the Legal-Skills-Chinese library

The version stamp also drives materialization of the curated experts to `~/.octo/agents-default/`, so this release refreshes them on installed machines.

## Verify

- `go build ./cmd/octo` ✅
- `go test ./internal/version/...` ✅
- `octo version` → `octo 1.15.3` ✅

After merge: tag `v1.15.3` to trigger the goreleaser release workflow.