### PR TITLE
feat(landing): reword safety feature title and add clean-UI feature card

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -508,8 +508,13 @@
         </div>
         <div class="feat reveal">
           <iconify-icon icon="ant-design:security-scan-outlined" width="26"></iconify-icon>
-          <h3 data-en="Won't kill itself, won't go rogue" data-zh="不会自挂，也不会发疯删数据"></h3>
+          <h3 data-en="Won't kill itself, won't nuke your data" data-zh="不自杀，不删库"></h3>
           <p data-en="Refuses kill commands aimed at its own process, requires explicit permission for restart, and hard-codes deny for catastrophic deletes like rm -rf / or ~." data-zh="拒绝任何指向自身进程的 kill 命令，重启必须显式授权，rm -rf / 或 ~ 这类毁灭性删除被硬编码拒绝。"></p>
+        </div>
+        <div class="feat reveal">
+          <iconify-icon icon="ant-design:layout-outlined" width="26"></iconify-icon>
+          <h3 data-en="Clean, uncluttered UI" data-zh="清爽的界面设计"></h3>
+          <p data-en="Terminal, web, desktop, and chat — every surface shares one restrained visual language. Right information density, zero clutter, nothing competing for your attention." data-zh="终端、Web、桌面、IM —— 每个界面共享同一套克制的视觉语言。信息密度刚刚好，没有多余的元素争抢你的注意力。"></p>
         </div>
       </div>
       <div class="chips reveal">


### PR DESCRIPTION
## What

Two copy/content tweaks to the landing page features grid:

1. **Reword the safety feature title** — `不会自挂，也不会发疯删数据` read awkwardly; replaced with the cleaner `不自杀，不删库` / `Won't kill itself, won't nuke your data`. Card body unchanged.
2. **Add a "清爽的界面设计" feature card** (`ant-design:layout-outlined` icon) highlighting the restrained visual language shared across terminal, web, desktop, and IM surfaces.

## Verification

- Served `landing/` locally and verified in a real browser: all 8 feature cards render correctly in the grid, zh copy shown below.

## Notes

Landing-page-only change, no Go code touched.
