### PR TITLE
chore(agentprofile): drop stale `octo agents` references from comments

### DIFF
--- a/internal/agentprofile/defaults.go
+++ b/internal/agentprofile/defaults.go
@@ -34,7 +34,7 @@ var defaultAgentsRoot = func() string {
 }
 
 // DefaultRoot is the on-disk location of the materialized curated experts
-// (~/.octo/agents-default), exported for `octo agents path`.
+// (~/.octo/agents-default).
 func DefaultRoot() string { return defaultAgentsRoot() }
 
 // MaterializeDefaults writes the embedded curated experts to the default root
@@ -45,8 +45,7 @@ func MaterializeDefaults(version string) error {
 	return materializeDefaults(defaultAgentsRoot(), version, false)
 }
 
-// UpdateDefaults forces a rewrite regardless of the stamp — backs
-// `octo agents update`.
+// UpdateDefaults forces a rewrite regardless of the stamp.
 func UpdateDefaults(version string) error {
 	return materializeDefaults(defaultAgentsRoot(), version, true)
 }


### PR DESCRIPTION
## What

`internal/agentprofile/defaults.go` had two comments citing CLI commands that don't exist:

- `DefaultRoot` — "exported for \`octo agents path\`"
- `UpdateDefaults` — "backs \`octo agents update\`"

There is no `agents` subcommand in `cmd/octo` (or desktop/server); `octo agents …` falls through to the chat fallback in `main.go` and runs a headless agentic turn, which looks like a hang. The functions stay (symmetric with the skills package API) — only the stale references are removed.

## Verify

- `go build ./internal/agentprofile/` ✅
- `go test ./internal/agentprofile/...` ✅

Note: if a real `octo agents` CLI command (path / update) is planned, that's a separate feature PR — this one only removes the misleading comments.