### PR TITLE
fix(agentprofile): use legal skills directly when already enabled in legal-helper

### DIFF
--- a/internal/agentprofile/defaults/legal-helper.md
+++ b/internal/agentprofile/defaults/legal-helper.md
@@ -29,11 +29,17 @@ guessing at jurisdiction-specific statute numbers unless the user's
 jurisdiction is clear and you're confident in the citation.
 
 When a user's question goes beyond general concepts — case analysis, article
-retrieval, risk assessment, or argument construction — introduce the
-Legal-Skills-Chinese library (https://github.com/THUYRan/Legal-Skills-Chinese):
-38 lawyer-written skills covering retrieval → reasoning → argumentation →
-document drafting for PRC statutory law. Point them at installing the skills
-they need, e.g. `octo skills add THUYRan/Legal-Skills-Chinese/skills/legal-article-retrieval`
+retrieval, risk assessment, or argument construction — first check your
+available skills list for a matching legal skill (e.g. legal-article-retrieval,
+legal-element-extraction, legal-risk-assessment, dispute-and-performance-risk).
+If one is available, load it with the skill tool and follow its instructions
+directly — do not tell the user to install anything.
+
+Only if no such skill is available to you, introduce the Legal-Skills-Chinese
+library (https://github.com/THUYRan/Legal-Skills-Chinese): 38 lawyer-written
+skills covering retrieval → reasoning → argumentation → document drafting for
+PRC statutory law. Point them at installing the skills they need, e.g.
+`octo skills add THUYRan/Legal-Skills-Chinese/skills/legal-article-retrieval`
 (run `octo skills list` to see what's already installed). After installation,
 they must also enable the skill for you — Web UI → Agents → 法律知识助手 →
 Skills, or ask the Default Agent to do it — because expert agents only see


### PR DESCRIPTION
## Problem

The curated `legal-helper` expert's system prompt unconditionally told it to guide the user through installing and enabling the Legal-Skills-Chinese skill library whenever a question went beyond general legal concepts — even when those skills were already installed **and enabled** for the expert. In that case the correct behavior is to simply load the skill via the `skill` tool and follow it, not send the user off to install anything.

## Change

Prompt-only edit in `internal/agentprofile/defaults/legal-helper.md`:

1. **Check first** — when a question goes beyond general concepts (case analysis, article retrieval, risk assessment, argument construction), check the expert's available skills list for a matching legal skill (`legal-article-retrieval`, `legal-element-extraction`, `legal-risk-assessment`, `dispute-and-performance-risk`). If one is available, load it with the skill tool and follow it directly — explicitly instructed *not* to tell the user to install anything.
2. **Guide only when missing** — the install + enable guidance (Legal-Skills-Chinese library, `octo skills add ...`, enable via Web UI / Default Agent) is now the fallback for when no such skill is available.

## Testing

- `go test -race ./internal/agentprofile/...` — pass
- `go vet ./internal/agentprofile/...` — clean

Prompt-only change to an embedded curated expert definition; `defaults_test.go` asserts materialization, not content, so no test updates needed. Users with an existing fork (`~/.octo/agents/legal-helper.md`) keep their override, per the documented curated-fork semantics.