### PR TITLE
feat(agentprofile): give every curated expert the terminal tool

### DIFF
--- a/internal/agentprofile/defaults/copywriter.md
+++ b/internal/agentprofile/defaults/copywriter.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Write 3 viral-style headlines for a new coffee product launch"
   - "Rewrite this product description to sound more social-media-native"
   - "Suggest a few names for a new pet store"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
 ---
 
 You are a copywriting assistant. Help the user write marketing copy, social

--- a/internal/agentprofile/defaults/learning-coach.md
+++ b/internal/agentprofile/defaults/learning-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have an IELTS exam in a month — help me build a study plan"
   - "Use the Feynman technique to explain compound interest to me"
   - "Give me 5 practice questions about photosynthesis"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
 ---
 
 You are a learning coach. When asked for a study plan, ask about the exam

--- a/internal/agentprofile/defaults/legal-helper.md
+++ b/internal/agentprofile/defaults/legal-helper.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "What does a '1 month deposit, 3 months rent upfront' lease term mean"
   - "I received a counterfeit item from an online order — how can I file a claim"
   - "Explain what an 'arbitration clause' means"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
 ---
 
 You are a legal-concepts helper, not a lawyer. Explain legal terms, common

--- a/internal/agentprofile/defaults/life-assistant.md
+++ b/internal/agentprofile/defaults/life-assistant.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have eggs, tomatoes, and noodles in the fridge — suggest a recipe"
   - "What's a good birthday gift idea for my mom"
   - "How do I quickly remove an oil stain from clothing"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
 ---
 
 You are a friendly everyday-life helper. Keep answers practical and quick to

--- a/internal/agentprofile/defaults/productivity-coach.md
+++ b/internal/agentprofile/defaults/productivity-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Break down 'finish the quarterly report' into actionable subtasks"
   - "I keep procrastinating — what methods can help"
   - "Use the SMART framework to help me set this month's goals"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
 ---
 
 You are a productivity coach. When asked to break down a task, produce a

--- a/internal/agentprofile/defaults/trip-planner.md
+++ b/internal/agentprofile/defaults/trip-planner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Plan a 5-day independent trip to Osaka"
   - "What should I watch out for when traveling with young kids"
   - "Give me a packing list for an international trip"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
 ---
 
 You are a trip-planning assistant. Ask for budget, dates, and traveler

--- a/internal/agentprofile/defaults/writing-partner.md
+++ b/internal/agentprofile/defaults/writing-partner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Help me build an outline for an article about the pros and cons of remote work"
   - "Make this paragraph more concise and punchy"
   - "From a reader's perspective, where does this article's logic break down"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
 ---
 
 You are a writing partner for long-form content: essays, articles, reports,


### PR DESCRIPTION
## Motivation

Curated experts can recommend skills (e.g. legal-helper points users at the Legal-Skills-Chinese library), but without `terminal` they can't act on that recommendation — the user has to leave the conversation and run `octo skills add` themselves. With `terminal`, an expert can offer to run the install in place.

## Change

One-line frontmatter change in 7 of the 8 curated defaults under `internal/agentprofile/defaults/`:

```
tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
```

`resume-coach` already had this exact allowlist (its `terminal` is prompt-scoped to document text extraction — that prompt constraint is unchanged). The other 7 gain `terminal` **unconstrained**, inserted in the same position for a uniform allowlist across all 8 experts.

This intentionally widens the permission surface decided in #1990 (which gave `terminal` only to resume-coach) — discussed and confirmed with the requester.

## Known remaining gap (not addressed here)

Installing a skill does **not** make it visible to the expert: a non-builtin profile only sees skills explicitly listed in its `tool_skills` (`skills.ManifestForProfile`). Enabling still requires the Web UI or the Default Agent (`PUT /api/agents/:id`). Closing that loop (e.g. letting an expert fork-enable its own profile) is left as a separate decision.

## Testing

- `go test -race ./internal/agentprofile/...` — pass
- `go vet ./internal/agentprofile/...` — clean

Metadata-only change to embedded curated definitions; no test asserts the tools allowlist content.