### PR TITLE
feat(tools): add enable_own_skill so experts can self-enable installed skills

### DIFF
--- a/internal/agentprofile/defaults/copywriter.md
+++ b/internal/agentprofile/defaults/copywriter.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Write 3 viral-style headlines for a new coffee product launch"
   - "Rewrite this product description to sound more social-media-native"
   - "Suggest a few names for a new pet store"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, skill, enable_own_skill]
 ---
 
 You are a copywriting assistant. Help the user write marketing copy, social

--- a/internal/agentprofile/defaults/learning-coach.md
+++ b/internal/agentprofile/defaults/learning-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have an IELTS exam in a month — help me build a study plan"
   - "Use the Feynman technique to explain compound interest to me"
   - "Give me 5 practice questions about photosynthesis"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, skill, enable_own_skill]
 ---
 
 You are a learning coach. When asked for a study plan, ask about the exam

--- a/internal/agentprofile/defaults/legal-helper.md
+++ b/internal/agentprofile/defaults/legal-helper.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "What does a '1 month deposit, 3 months rent upfront' lease term mean"
   - "I received a counterfeit item from an online order — how can I file a claim"
   - "Explain what an 'arbitration clause' means"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, skill, enable_own_skill]
 ---
 
 You are a legal-concepts helper, not a lawyer. Explain legal terms, common

--- a/internal/agentprofile/defaults/life-assistant.md
+++ b/internal/agentprofile/defaults/life-assistant.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "I have eggs, tomatoes, and noodles in the fridge — suggest a recipe"
   - "What's a good birthday gift idea for my mom"
   - "How do I quickly remove an oil stain from clothing"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, skill, enable_own_skill]
 ---
 
 You are a friendly everyday-life helper. Keep answers practical and quick to

--- a/internal/agentprofile/defaults/productivity-coach.md
+++ b/internal/agentprofile/defaults/productivity-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Break down 'finish the quarterly report' into actionable subtasks"
   - "I keep procrastinating — what methods can help"
   - "Use the SMART framework to help me set this month's goals"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, skill, enable_own_skill]
 ---
 
 You are a productivity coach. When asked to break down a task, produce a

--- a/internal/agentprofile/defaults/resume-coach.md
+++ b/internal/agentprofile/defaults/resume-coach.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Review my resume and tell me what needs improvement"
   - "Simulate a few interview questions for a product manager role"
   - "I want to switch careers into data analytics — how should I plan for it"
-tools: [web_search, web_fetch, read_file, write_file, terminal, skill]
+tools: [web_search, web_fetch, read_file, write_file, terminal, skill, enable_own_skill]
 ---
 
 You are a resume and career coach. Give specific, actionable feedback on

--- a/internal/agentprofile/defaults/trip-planner.md
+++ b/internal/agentprofile/defaults/trip-planner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Plan a 5-day independent trip to Osaka"
   - "What should I watch out for when traveling with young kids"
   - "Give me a packing list for an international trip"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, skill, enable_own_skill]
 ---
 
 You are a trip-planning assistant. Ask for budget, dates, and traveler

--- a/internal/agentprofile/defaults/writing-partner.md
+++ b/internal/agentprofile/defaults/writing-partner.md
@@ -15,7 +15,7 @@ example_prompts_en:
   - "Help me build an outline for an article about the pros and cons of remote work"
   - "Make this paragraph more concise and punchy"
   - "From a reader's perspective, where does this article's logic break down"
-tools: [web_search, web_fetch, read_file, write_file, skill]
+tools: [web_search, web_fetch, read_file, write_file, skill, enable_own_skill]
 ---
 
 You are a writing partner for long-form content: essays, articles, reports,

--- a/internal/tools/enable_own_skill.go
+++ b/internal/tools/enable_own_skill.go
@@ -1,0 +1,96 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
+)
+
+// EnableOwnSkillTool lets a non-builtin expert agent opt an installed skill
+// into its own profile, closing the install → use loop without waiting for
+// the Web UI or the Default Agent: the expert installs a skill via the
+// terminal tool (`octo skills add ...`), then calls this to add it to its
+// profile's tool_skills. The write goes through agentprofile.Store.Update, so
+// a curated expert is forked into a ~/.octo/agents/<id>.md override (the same
+// semantics as editing it from the gallery UI), and the per-turn profile
+// re-resolution makes the skill visible from the expert's next message.
+//
+// Advertised only when the turn's context resolves to a non-builtin profile
+// (enableOwnSkillOn in registry.go) — builtin profiles and context-less CLI
+// sessions already see every installed skill, so the tool would be a no-op
+// slot for them. It must additionally be in the profile's tools allowlist,
+// like any other tool.
+type EnableOwnSkillTool struct{}
+
+func (EnableOwnSkillTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "enable_own_skill",
+		Description: "Enable an already-installed skill for yourself (this agent). Adds the skill " +
+			"to your profile's tool_skills so it appears in your Available skills list from your " +
+			"next message — load it with the skill tool after that. The skill must be installed " +
+			"first: if the result says it is missing, install it (e.g. via the terminal tool: " +
+			"`octo skills add <owner/repo[/path]>`) and retry. Enabling an already-enabled skill " +
+			"is a no-op.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "The installed skill's name (its directory name, as `octo skills list` shows it).",
+				},
+			},
+			"required": []string{"name"},
+		},
+	}
+}
+
+func (EnableOwnSkillTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	name, _ := input["name"].(string)
+	if name == "" {
+		return agent.ToolResult{}, fmt.Errorf("enable_own_skill: name is required")
+	}
+	store := profileStoreFromContext(ctx)
+	agentID := sessionAgentIDFromContext(ctx)
+	if store == nil || agentID == "" {
+		return agent.ToolResult{}, fmt.Errorf("enable_own_skill: this session has no agent profile context")
+	}
+	profile, ok := store.Get(agentID)
+	if !ok {
+		return agent.ToolResult{}, fmt.Errorf("enable_own_skill: profile %q not found", agentID)
+	}
+	if profile.Source == agentprofile.SourceBuiltin {
+		return agent.ToolResult{}, fmt.Errorf("enable_own_skill: builtin agents already see every installed skill")
+	}
+	for _, s := range profile.ToolSkills {
+		if s == name {
+			return agent.ToolResult{Text: fmt.Sprintf("Skill %q is already enabled for your profile — load it with the skill tool.", name)}, nil
+		}
+	}
+	if !skillsEnabled() {
+		return agent.ToolResult{}, fmt.Errorf("enable_own_skill: no skills are installed — install one first (e.g. via the terminal tool: `octo skills add <owner/repo[/path]>`)")
+	}
+	skill, ok := activeSkills.Get(name)
+	if !ok {
+		// The skill may have been installed after this registry was built —
+		// same rescan-on-miss fast path as the skill tool.
+		activeSkills.Reload()
+		skill, ok = activeSkills.Get(name)
+	}
+	if !ok {
+		return agent.ToolResult{}, fmt.Errorf("enable_own_skill: skill %q is not installed (or is disabled) — install it first (e.g. via the terminal tool: `octo skills add <owner/repo[/path]>`), then retry", name)
+	}
+	if skill.System {
+		return agent.ToolResult{}, fmt.Errorf("enable_own_skill: skill %q is a system skill reserved for the Default agent and cannot be enabled for an expert", name)
+	}
+	profile.ToolSkills = append(profile.ToolSkills, name)
+	if err := store.Update(profile); err != nil {
+		return agent.ToolResult{}, fmt.Errorf("enable_own_skill: %v", err)
+	}
+	msg := fmt.Sprintf("Enabled skill %q for your profile (%s). It appears in your Available skills list from your next message — load it with the skill tool then.", name, agentID)
+	if profile.Source == agentprofile.SourceDefault {
+		msg += " Note: your curated profile was forked into a personal override, so future official content updates to this expert no longer apply to you."
+	}
+	return agent.ToolResult{Text: msg}, nil
+}

--- a/internal/tools/enable_own_skill_test.go
+++ b/internal/tools/enable_own_skill_test.go
@@ -1,0 +1,173 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
+	"github.com/open-octo/octo-agent/internal/skills"
+)
+
+// setupTestSkills points skill discovery at a temp HOME holding one skill per
+// map entry (name → system flag) and registers it as the active registry.
+func setupTestSkills(t *testing.T, specs map[string]bool) {
+	t.Helper()
+	home := t.TempDir()
+	for name, system := range specs {
+		dir := filepath.Join(home, ".octo", "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		fm := fmt.Sprintf("---\nname: %s\ndescription: test skill %s\n", name, name)
+		if system {
+			fm += "system: true\n"
+		}
+		fm += "---\nbody\n"
+		if err := os.WriteFile(filepath.Join(dir, skills.SkillFile), []byte(fm), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", home)
+	SetSkills(skills.Discover())
+	t.Cleanup(func() { SetSkills(nil) })
+}
+
+func newExpertStore(t *testing.T, id string, toolNames []string) *agentprofile.Store {
+	t.Helper()
+	store := agentprofile.New(t.TempDir())
+	if err := store.Create(&agentprofile.Profile{
+		ID:          id,
+		Description: "test expert",
+		CapabilitySpec: agentprofile.CapabilitySpec{
+			Tools: toolNames,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func enableOwnCtx(store *agentprofile.Store, agentID string) context.Context {
+	return WithSessionAgentID(WithProfileStore(context.Background(), store), agentID)
+}
+
+func TestEnableOwnSkill_EnablesInstalledSkill(t *testing.T) {
+	setupTestSkills(t, map[string]bool{"test-skill": false})
+	store := newExpertStore(t, "expert", []string{"skill", "enable_own_skill"})
+	tool := EnableOwnSkillTool{}
+
+	res, err := tool.Execute(enableOwnCtx(store, "expert"), "enable_own_skill", map[string]any{"name": "test-skill"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "Enabled skill") || !strings.Contains(res.Text, "next message") {
+		t.Fatalf("unexpected result text: %q", res.Text)
+	}
+	p, ok := store.Get("expert")
+	if !ok || len(p.ToolSkills) != 1 || p.ToolSkills[0] != "test-skill" {
+		t.Fatalf("profile ToolSkills = %v, ok = %v", p.ToolSkills, ok)
+	}
+}
+
+func TestEnableOwnSkill_AlreadyEnabledIsNoOp(t *testing.T) {
+	setupTestSkills(t, map[string]bool{"test-skill": false})
+	store := newExpertStore(t, "expert", []string{"skill", "enable_own_skill"})
+	tool := EnableOwnSkillTool{}
+	ctx := enableOwnCtx(store, "expert")
+
+	if _, err := tool.Execute(ctx, "enable_own_skill", map[string]any{"name": "test-skill"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := tool.Execute(ctx, "enable_own_skill", map[string]any{"name": "test-skill"})
+	if err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "already enabled") {
+		t.Fatalf("expected already-enabled no-op, got %q", res.Text)
+	}
+	p, _ := store.Get("expert")
+	if len(p.ToolSkills) != 1 {
+		t.Fatalf("no-op duplicated the skill: ToolSkills = %v", p.ToolSkills)
+	}
+}
+
+func TestEnableOwnSkill_UnknownSkill(t *testing.T) {
+	setupTestSkills(t, map[string]bool{"test-skill": false})
+	store := newExpertStore(t, "expert", []string{"skill", "enable_own_skill"})
+
+	_, err := EnableOwnSkillTool{}.Execute(enableOwnCtx(store, "expert"), "enable_own_skill", map[string]any{"name": "ghost-skill"})
+	if err == nil || !strings.Contains(err.Error(), "not installed") {
+		t.Fatalf("expected not-installed error, got %v", err)
+	}
+}
+
+func TestEnableOwnSkill_SystemSkillRejected(t *testing.T) {
+	setupTestSkills(t, map[string]bool{"sys-skill": true})
+	store := newExpertStore(t, "expert", []string{"skill", "enable_own_skill"})
+
+	_, err := EnableOwnSkillTool{}.Execute(enableOwnCtx(store, "expert"), "enable_own_skill", map[string]any{"name": "sys-skill"})
+	if err == nil || !strings.Contains(err.Error(), "system skill") {
+		t.Fatalf("expected system-skill rejection, got %v", err)
+	}
+}
+
+func TestEnableOwnSkill_BuiltinRejected(t *testing.T) {
+	setupTestSkills(t, map[string]bool{"test-skill": false})
+	store := agentprofile.New(t.TempDir())
+
+	_, err := EnableOwnSkillTool{}.Execute(enableOwnCtx(store, agentprofile.DefaultID), "enable_own_skill", map[string]any{"name": "test-skill"})
+	if err == nil || !strings.Contains(err.Error(), "builtin") {
+		t.Fatalf("expected builtin rejection, got %v", err)
+	}
+}
+
+func TestEnableOwnSkill_NoProfileContext(t *testing.T) {
+	setupTestSkills(t, map[string]bool{"test-skill": false})
+
+	_, err := EnableOwnSkillTool{}.Execute(context.Background(), "enable_own_skill", map[string]any{"name": "test-skill"})
+	if err == nil || !strings.Contains(err.Error(), "no agent profile context") {
+		t.Fatalf("expected missing-context error, got %v", err)
+	}
+}
+
+func TestEnableOwnSkill_Advertising(t *testing.T) {
+	has := func(defs []agent.ToolDefinition, name string) bool {
+		for _, d := range defs {
+			if d.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Expert with the tool in its allowlist: advertised.
+	store := newExpertStore(t, "expert", []string{"read_file", "enable_own_skill"})
+	defs := DefaultToolsForProfile(enableOwnCtx(store, "expert"), "test-model")
+	if !has(defs, "enable_own_skill") {
+		t.Fatal("enable_own_skill should be advertised for an expert whose allowlist includes it")
+	}
+
+	// Expert without it in the allowlist: filtered out by the allowlist.
+	other := newExpertStore(t, "expert-no-tool", []string{"read_file"})
+	defs = DefaultToolsForProfile(enableOwnCtx(other, "expert-no-tool"), "test-model")
+	if has(defs, "enable_own_skill") {
+		t.Fatal("enable_own_skill should be filtered out when absent from the profile's allowlist")
+	}
+
+	// Builtin profile: gated off — builtins already see every installed skill.
+	defs = DefaultToolsForProfile(enableOwnCtx(store, agentprofile.DefaultID), "test-model")
+	if has(defs, "enable_own_skill") {
+		t.Fatal("enable_own_skill should be hidden from builtin profiles")
+	}
+
+	// No profile context (CLI/TUI): gated off.
+	defs = DefaultToolsForProfile(context.Background(), "test-model")
+	if has(defs, "enable_own_skill") {
+		t.Fatal("enable_own_skill should be hidden without a profile context")
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -40,6 +40,7 @@ var allTools = []tool{
 	WebFetchTool{},
 	WebSearchTool{},
 	SkillTool{},
+	EnableOwnSkillTool{},
 	AgentTool{},
 	AgentSendTool{},
 	AgentStatusTool{},
@@ -621,6 +622,20 @@ func KnownToolNames() []string {
 	return names
 }
 
+// enableOwnSkillOn reports whether this turn runs as a non-builtin expert
+// profile. Only experts need to opt skills into their profile; builtin
+// profiles already see every installed skill, and CLI/TUI sessions carry no
+// profile context at all — for both the tool would be a dead slot.
+func enableOwnSkillOn(ctx context.Context) bool {
+	store := profileStoreFromContext(ctx)
+	agentID := sessionAgentIDFromContext(ctx)
+	if store == nil || agentID == "" {
+		return false
+	}
+	p, ok := store.Get(agentID)
+	return ok && p.Source != agentprofile.SourceBuiltin
+}
+
 func defaultToolsFor(ctx context.Context, model string) []agent.ToolDefinition {
 	skillsOn := skillsEnabled()
 	mgrOn := subAgentManagerEnabled()
@@ -651,6 +666,9 @@ func defaultToolsFor(ctx context.Context, model string) []agent.ToolDefinition {
 			continue
 		}
 		if _, isSkill := t.(SkillTool); isSkill && !skillsOn {
+			continue
+		}
+		if _, isEnableOwn := t.(EnableOwnSkillTool); isEnableOwn && !enableOwnSkillOn(ctx) {
 			continue
 		}
 		if _, isAgent := t.(AgentTool); isAgent && !mgrOn {


### PR DESCRIPTION
## Motivation

Follow-up to #1995 (which gave every curated expert `terminal`). An expert could then *install* a skill itself via `octo skills add`, but installing never made the skill *visible* to it: a non-builtin profile only sees skills explicitly listed in its `tool_skills` (`skills.ManifestForProfile`, `internal/skills/skills.go:339`). The enable step still required the Web UI or the Default Agent — the install → use loop wasn't closed.

## Change

New built-in tool **`enable_own_skill`** (`internal/tools/enable_own_skill.go`):

1. Resolves the current profile from the ctx-stamped profile store + session agent ID (the same `WithProfileStore`/`WithSessionAgentID` plumbing `DefaultToolsForProfile` uses — stamped per turn by the web/IM/cron handlers).
2. Validates the skill is installed via the active skills registry, with rescan-on-miss (same fast path as the `skill` tool) so a skill installed seconds ago resolves.
3. Rejects **system skills** (stripped from expert manifests anyway — enabling one would be a silent no-op).
4. Appends the name to the profile's `tool_skills` and persists via `Store.Update`, which gives the curated-fork semantics for free: a curated expert is forked into `~/.octo/agents/<id>.md`, and per-turn profile re-resolution (`server.go:1289`) makes the skill visible from the expert's **next message** — no restart.
5. Already-enabled → no-op success; builtin profile or missing profile context → clean error (builtins already see every installed skill).

The result text tells the expert when the skill becomes visible and, for curated experts, notes the fork trade-off.

## Advertising & allowlist

- Gated in `defaultToolsFor` via `enableOwnSkillOn(ctx)`: advertised **only** when the turn resolves to a non-builtin profile. Builtin profiles and context-less CLI/TUI sessions never see the slot.
- Still subject to the profile's `tools` allowlist like any other tool — all 8 curated experts gain `enable_own_skill` in their allowlist here. User-created experts opt in by adding it to their allowlist.

## Merge note

This branch and #1995 both edit the `tools:` line of the same 7 defaults files — whichever merges second gets a trivial one-line conflict (`terminal` and `enable_own_skill` both belong in the final list).

## Testing

- 7 new tests in `internal/tools/enable_own_skill_test.go` (hermetic — temp-HOME skill discovery): enable, idempotent no-op, unknown skill, system-skill rejection, builtin rejection, missing context, advertising gate (expert with/without allowlist entry, builtin, no-context).
- `go test -race ./internal/tools/ ./internal/agentprofile/ ./internal/server/` — pass
- `go vet ./internal/...` + `gofmt -l` — clean