### PR TITLE
fix(desktop): tray "Settings" opens the settings modal again

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -391,7 +391,8 @@ func (b *nativeBridge) WindowState() bool {
 // showWindow brings the hub window to the foreground on the current view.
 func (b *nativeBridge) showWindow() { b.showWindowAt("") }
 
-// openSettings brings the window up on the Settings view (tray "Settings").
+// openSettings brings the window up and opens the Settings modal (tray
+// "Settings"). The frontend maps the "settings" hash route to the modal.
 func (b *nativeBridge) openSettings() { b.showWindowAt("settings") }
 
 // showWindowAt brings the hub window to the foreground, re-creating it if it was

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, sessions, sessionGroups, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell, panelContent, cmdkOpen } from './lib/stores'
+  import { view, sessions, sessionGroups, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell, panelContent, cmdkOpen, settingsModalOpen } from './lib/stores'
   import MobileApp from './mobile/MobileApp.svelte'
   import { ws, wsState } from './lib/ws'
   import { notificationsEnabled } from './lib/notifications'
@@ -49,6 +49,17 @@
     const h = location.hash.replace(/^#\/?/, '')
     if (!h) return
     const [v, ...rest] = h.split('/')
+    // The desktop shell's tray "Settings" item navigates to #settings; the
+    // full-page view became a modal (settings modal redesign, PR #1955), so
+    // route the hash to the modal instead of a VALID_VIEWS entry. Normalize
+    // the hash back to the current view so a reload doesn't re-open the modal.
+    if (v === 'settings') {
+      settingsModalOpen.set(true)
+      const cv = get(view) || 'chat'
+      const hash = cv === 'chat' ? '#/chat' : `#/${cv}`
+      history.replaceState(null, '', location.pathname + location.search + hash)
+      return
+    }
     if (!VALID_VIEWS.includes(v)) return
     if (get(view) !== v) view.set(v)
     if (v === 'chat' && rest[0]) {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -9,6 +9,7 @@
   import { get } from 'svelte/store'
   import * as api from './lib/api'
   import { installExternalLinkInterceptor } from './lib/externalLinks'
+  import { normalizeHash } from './lib/hashRouting'
   import AuthGate from './components/overlays/AuthGate.svelte'
   import FirstRunSetup from './components/overlays/FirstRunSetup.svelte'
   import Header from './components/layout/Header.svelte'
@@ -55,8 +56,7 @@
     // the hash back to the current view so a reload doesn't re-open the modal.
     if (v === 'settings') {
       settingsModalOpen.set(true)
-      const cv = get(view) || 'chat'
-      const hash = cv === 'chat' ? '#/chat' : `#/${cv}`
+      const hash = normalizeHash(get(view), get(activeSessionId))
       history.replaceState(null, '', location.pathname + location.search + hash)
       return
     }
@@ -111,7 +111,7 @@
   $effect(() => {
     const v = $view, sid = $activeSessionId, phase = $onboardPhase
     if (!routeReady || phase === 'unknown' || phase === 'key_setup') return
-    const hash = v === 'chat' ? (sid ? `#/chat/${encodeURIComponent(sid)}` : '#/chat') : `#/${v}`
+    const hash = normalizeHash(v, sid)
     if (location.hash !== hash) location.hash = hash
   })
 

--- a/web/src/lib/hashRouting.test.ts
+++ b/web/src/lib/hashRouting.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeHash } from './hashRouting'
+
+describe('normalizeHash', () => {
+  it('keeps the active session id on the chat view', () => {
+    expect(normalizeHash('chat', 'sess-42')).toBe('#/chat/sess-42')
+  })
+
+  it('falls back to bare #/chat without a session', () => {
+    expect(normalizeHash('chat', null)).toBe('#/chat')
+  })
+
+  it('uses the bare view hash for non-chat views', () => {
+    expect(normalizeHash('agents', null)).toBe('#/agents')
+    expect(normalizeHash('agents', 'sess-42')).toBe('#/agents')
+  })
+
+  it('percent-encodes session ids for the URL', () => {
+    expect(normalizeHash('chat', 'a/b c?d')).toBe('#/chat/a%2Fb%20c%3Fd')
+  })
+})

--- a/web/src/lib/hashRouting.ts
+++ b/web/src/lib/hashRouting.ts
@@ -1,0 +1,7 @@
+// Hash-route helpers shared by App.svelte's routing. The desktop shell
+// (cmd/octo-desktop) navigates the frontend via location.hash, and the app
+// reflects its current view there so a refresh lands back where the user was —
+// both directions must agree on the exact hash shape.
+export function normalizeHash(view: string, sid: string | null): string {
+  return view === 'chat' ? (sid ? `#/chat/${encodeURIComponent(sid)}` : '#/chat') : `#/${view}`
+}


### PR DESCRIPTION
## Problem

点击系统托盘的「设置」菜单项没有任何反应——设置弹窗没有打开。

## Root cause

PR #1955（settings modal redesign，phase 7）把设置从全页 view 改成了弹窗（`settingsModalOpen` store 驱动），并做了两处配套删除：

- `VALID_VIEWS` 里移除了 `'settings'`（`web/src/App.svelte`）
- 删除了 `#settings` 的 view 渲染分支

但那次重构只覆盖了前端的四个触发点（sidebar footer、sidebar rail、header gear、composer manage models、command palette），**漏掉了第五个：桌面端系统托盘的「设置」**。Go 侧的 `openSettings()`（`cmd/octo-desktop/bridge.go`）仍然导航到 `#settings` hash 路由，而前端 `applyHash()` 对未知 view 静默 return——于是点击托盘「设置」什么都不会发生（如果窗口之前关到托盘，只会重新打开窗口，但弹窗不弹出）。

## Fix

在 `applyHash()` 中特判 `settings` hash：打开设置弹窗，并用 `history.replaceState` 把 hash 规范化回当前 view（否则刷新页面会再次自动弹窗）。这样两条路径都覆盖：

- 窗口已存在 → SetURL 触发 `hashchange` → 打开弹窗
- 窗口已关到托盘 → 重建窗口初始加载 → 打开弹窗

Go 侧行为无需改动，仅同步更新了 `openSettings` 的过时注释。

## Verification

- `cd web && npm run build` ✅
- `npm test`：10 个测试文件 129 个用例全部通过 ✅
- Go 侧仅注释改动，`gofmt` 干净 ✅


---

## Review follow-up (d7d46190)

Independent code review found one Important issue, now fixed:

- **丢 session id**：打开弹窗后的 hash 规范化只保留 view，丢了 chat session id —— 用户在 chat 视图（`#/chat/<sid>`）点托盘设置后 URL 变 `#/chat`，刷新会落到默认 session。修复方式：把 hash 形状抽成 `web/src/lib/hashRouting.ts#normalizeHash`，让 hash 写入 `$effect` 和 settings 规范化共用同一函数（单一事实来源），并新增 4 个单测（含 session id 的百分号编码）。
