### PR TITLE
fix(web): render i18n 'View' label in cross-session question notice

### DIFF
--- a/web/src/components/overlays/QuestionModal.svelte
+++ b/web/src/components/overlays/QuestionModal.svelte
@@ -89,7 +89,7 @@
         <iconify-icon icon="ant-design:form-outlined" width="14" style="color:var(--blue-6);flex-shrink:0"></iconify-icon>
         <span class="qnote-label">{sessionLabel(sid)}</span>
         <span class="qnote-q">{entry.question}</span>
-        <span class="qnote-go">$t('m.view')} ›</span>
+        <span class="qnote-go">{$t('m.view')} ›</span>
       </button>
     {/each}
   </div>


### PR DESCRIPTION
## 问题

当处于某个会话页面时，另一个会话的 `ask_user_question` 会在当前会话页底部弹出一个紧凑通知条。通知后半段直接渲染出了代码文本：

```
$t('m.view')} ›
```

## 根因

`web/src/components/overlays/QuestionModal.svelte` 的通知条里 Svelte 表达式缺了开头的 `{`：

```svelte
<span class="qnote-go">$t('m.view')} ›</span>
```

Svelte 没把它当表达式求值，原样当纯文本渲染。对比同仓库的正确用法（`web/src/mobile/QuestionOverlay.svelte`、`web/src/mobile/ChatDetail.svelte`）均为 `{$t('m.view')} ›`。

## 修复

补上 `{`：

```svelte
<span class="qnote-go">{$t('m.view')} ›</span>
```

## 验证

- `npm run build`（vite）通过

Co-authored-by: octo-agent <no-reply@octo-agent.dev>