### PR TITLE
fix(desktop): clear stale $TMPDIR inherited from installer sandbox

### DIFF
--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -113,7 +113,30 @@ func ensureWorkingDir() {
 	}
 }
 
+// ensureValidTempDir unsets $TMPDIR when it points at a directory that no
+// longer exists, so Go's os.TempDir() (and the Wails updater's
+// os.MkdirTemp("", ...) on top of it) falls back to the platform default
+// instead of failing outright.
+func ensureValidTempDir() {
+	dir := os.Getenv("TMPDIR")
+	if dir == "" {
+		return
+	}
+	if _, err := os.Stat(dir); err != nil {
+		os.Unsetenv("TMPDIR")
+	}
+}
+
 func main() {
+	// macOS's postinstall script launches the app with `open` from inside
+	// installd's ephemeral PKInstallSandbox.*; the launched process can inherit
+	// that sandbox's $TMPDIR. The desktop app then runs for days as a tray
+	// resident, long after the sandbox is torn down, so a later update check's
+	// os.MkdirTemp fails with "no such file or directory" against a $TMPDIR
+	// that hasn't existed since install. Clear it before anything (including
+	// the updater helper below) can use it.
+	ensureValidTempDir()
+
 	// When spawned as the updater's helper child (sentinel env vars set), swap
 	// the staged update over the installed app and exit — before any of the
 	// launch side effects below (chdir, CLI/uv seeding, settings) run in a

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -113,16 +113,16 @@ func ensureWorkingDir() {
 	}
 }
 
-// ensureValidTempDir unsets $TMPDIR when it points at a directory that no
-// longer exists, so Go's os.TempDir() (and the Wails updater's
-// os.MkdirTemp("", ...) on top of it) falls back to the platform default
-// instead of failing outright.
+// ensureValidTempDir unsets $TMPDIR when it doesn't point at a usable
+// directory (missing, or a file rather than a directory), so Go's
+// os.TempDir() (and the Wails updater's os.MkdirTemp("", ...) on top of it)
+// falls back to the platform default instead of failing outright.
 func ensureValidTempDir() {
 	dir := os.Getenv("TMPDIR")
 	if dir == "" {
 		return
 	}
-	if _, err := os.Stat(dir); err != nil {
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 		os.Unsetenv("TMPDIR")
 	}
 }

--- a/cmd/octo-desktop/tempdir_test.go
+++ b/cmd/octo-desktop/tempdir_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnsureValidTempDir(t *testing.T) {
+	t.Run("stale dir is unset", func(t *testing.T) {
+		t.Setenv("TMPDIR", t.TempDir()+"/PKInstallSandbox.gone/tmp")
+		ensureValidTempDir()
+		if v, ok := os.LookupEnv("TMPDIR"); ok {
+			t.Errorf("TMPDIR = %q, want unset", v)
+		}
+	})
+
+	t.Run("existing dir is left alone", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("TMPDIR", dir)
+		ensureValidTempDir()
+		if got := os.Getenv("TMPDIR"); got != dir {
+			t.Errorf("TMPDIR = %q, want %q", got, dir)
+		}
+	})
+
+	t.Run("unset TMPDIR is a no-op", func(t *testing.T) {
+		os.Unsetenv("TMPDIR")
+		ensureValidTempDir()
+		if _, ok := os.LookupEnv("TMPDIR"); ok {
+			t.Error("TMPDIR became set")
+		}
+	})
+}

--- a/cmd/octo-desktop/tempdir_test.go
+++ b/cmd/octo-desktop/tempdir_test.go
@@ -2,12 +2,35 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
+
+// unsetenvForTest clears an env var for the test and restores its prior
+// state (set or unset) afterwards — t.Setenv can't express "was unset".
+func unsetenvForTest(t *testing.T, key string) {
+	t.Helper()
+	if orig, ok := os.LookupEnv(key); ok {
+		t.Cleanup(func() { os.Setenv(key, orig) })
+	}
+	os.Unsetenv(key)
+}
 
 func TestEnsureValidTempDir(t *testing.T) {
 	t.Run("stale dir is unset", func(t *testing.T) {
 		t.Setenv("TMPDIR", t.TempDir()+"/PKInstallSandbox.gone/tmp")
+		ensureValidTempDir()
+		if v, ok := os.LookupEnv("TMPDIR"); ok {
+			t.Errorf("TMPDIR = %q, want unset", v)
+		}
+	})
+
+	t.Run("dir that is actually a file is unset", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "not-a-dir")
+		if err := os.WriteFile(file, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("TMPDIR", file)
 		ensureValidTempDir()
 		if v, ok := os.LookupEnv("TMPDIR"); ok {
 			t.Errorf("TMPDIR = %q, want unset", v)
@@ -24,7 +47,7 @@ func TestEnsureValidTempDir(t *testing.T) {
 	})
 
 	t.Run("unset TMPDIR is a no-op", func(t *testing.T) {
-		os.Unsetenv("TMPDIR")
+		unsetenvForTest(t, "TMPDIR")
 		ensureValidTempDir()
 		if _, ok := os.LookupEnv("TMPDIR"); ok {
 			t.Error("TMPDIR became set")


### PR DESCRIPTION
## Summary
- macOS's `postinstall` script (`packaging/macos/scripts/postinstall`) launches Octo.app with `open` from inside installd's ephemeral `PKInstallSandbox.*`. The launched process can inherit that sandbox's `$TMPDIR`.
- The desktop app runs for a long time as a tray resident, well past the point the sandbox is torn down. When the in-place updater later calls `os.MkdirTemp("", ...)`, it fails against a `$TMPDIR` that no longer exists: `updater: temp dir: stat /private/tmp/PKInstallSandbox.xxxxx/tmp: no such file or directory`.
- Added `ensureValidTempDir()` in `cmd/octo-desktop/main.go`, called at the very start of `main()` (before `updater.HandleHelperMode()`): if `$TMPDIR` is set but no longer exists, unset it so `os.TempDir()` falls back to the platform default (`/tmp`).

## Test plan
- [x] `go test ./...` in `cmd/octo-desktop` passes, including new `TestEnsureValidTempDir`
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on changed files
- [ ] Manual verification on a machine with the actual stale-`$TMPDIR` app instance (reported by a user hitting this exact error) after upgrading past this fix

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>