### PR TITLE
fix(web): fix white background on Sidebar popovers in dark mode

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -733,12 +733,12 @@
 .agent-picker-menu {
   position: absolute; top: 100%; left: 12px; right: 12px; z-index: 30;
   margin-top: 2px; padding: 4px;
-  background: var(--bg-elevated, #fff); border: 1px solid var(--border-secondary);
+  background: var(--bg-container); border: 1px solid var(--border-secondary);
   border-radius: 8px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);
 }
 .ap-item {
   display: flex; align-items: center; gap: 8px; width: 100%; padding: 8px 12px; border: none;
-  background: transparent; color: var(--text-primary); font-size: 13px;
+  background: transparent; color: var(--text); font-size: 13px;
   text-align: left; cursor: pointer; border-radius: 6px;
 }
 .ap-item:hover { background: var(--hover-neutral); }
@@ -749,7 +749,7 @@
 .more-popover {
   position: fixed; z-index: 30;
   padding: 4px;
-  background: var(--bg-elevated, #fff); border: 1px solid var(--border-secondary);
+  background: var(--bg-container); border: 1px solid var(--border-secondary);
   border-radius: 8px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);
 }
 .ap-sep { height: 1px; margin: 4px 8px; background: var(--border-secondary); }
@@ -802,7 +802,7 @@
   position: absolute; top: 100%; right: 8px; z-index: 30;
   min-width: 160px; max-width: 220px; max-height: 260px; overflow-y: auto;
   margin-top: 2px; padding: 4px;
-  background: var(--bg-elevated, #fff); border: 1px solid var(--border-secondary);
+  background: var(--bg-container); border: 1px solid var(--border-secondary);
   border-radius: 8px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);
 }
 .grp-opt {

--- a/web/src/components/layout/VersionBadge.svelte
+++ b/web/src/components/layout/VersionBadge.svelte
@@ -254,13 +254,13 @@
 .vb-title.warn { color: var(--warning-text, #d46b08); }
 .vb-ok { color: var(--success); }
 .vb-desc { margin: 0 0 8px; font-size: 12px; line-height: 1.6; color: var(--text-secondary); }
-.vb-versions { margin: 0 0 12px; font-size: 13px; color: var(--text-primary); font-variant-numeric: tabular-nums; }
+.vb-versions { margin: 0 0 12px; font-size: 13px; color: var(--text); font-variant-numeric: tabular-nums; }
 .vb-arrow { color: var(--text-tertiary); margin: 0 4px; }
 .vb-list { margin: 0 0 12px; padding-left: 18px; font-size: 12px; line-height: 1.7; color: var(--text-secondary); }
 .vb-cmd {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px; padding: 1px 5px; border-radius: 4px;
-  background: var(--hover-neutral); color: var(--text-primary);
+  background: var(--hover-neutral); color: var(--text);
 }
 .vb-actions { display: flex; gap: 8px; }
 .vb-btn-primary {

--- a/web/src/components/overlays/AuthGate.svelte
+++ b/web/src/components/overlays/AuthGate.svelte
@@ -104,7 +104,7 @@
   height: 36px; padding: 0 12px;
   border: 1px solid var(--border); background: var(--bg-base);
   border-radius: 6px;
-  font-size: 13px; color: var(--text-primary);
+  font-size: 13px; color: var(--text);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 .key-input:focus {

--- a/web/src/components/overlays/ConfirmDialog.svelte
+++ b/web/src/components/overlays/ConfirmDialog.svelte
@@ -54,7 +54,7 @@
 .modal:focus { outline: none; }
 .msg {
   margin: 0; padding: 20px 20px 4px;
-  font-size: 14px; line-height: 1.6; color: var(--text-primary);
+  font-size: 14px; line-height: 1.6; color: var(--text);
   white-space: pre-wrap; word-break: break-word;
 }
 .footer {

--- a/web/src/components/overlays/FolderPickerModal.svelte
+++ b/web/src/components/overlays/FolderPickerModal.svelte
@@ -231,7 +231,7 @@
   text-align: left;
 }
 .entry.dir {
-  border: none; background: none; cursor: pointer; color: var(--text-primary);
+  border: none; background: none; cursor: pointer; color: var(--text);
   font-family: inherit;
 }
 .entry.dir:hover { background: var(--bg-hover, var(--bg-layout)); }


### PR DESCRIPTION
## Summary
- `.more-popover` (更多配置 dropdown: 专家/技能/MCP 服务器/工作流/渠道), `.agent-picker-menu`, and `.grp-popover` in `Sidebar.svelte` referenced `--bg-elevated` and `--text-primary` — neither variable is defined anywhere in `app.css` (only `--bg-container`/`--text` exist).
- The background silently fell back to the hardcoded `#fff` fallback; the text color relied on an invalid `var()` inheriting body's `--text` rather than referencing it directly. This happened to look fine in light mode (white-on-dark-text) but produced a white popover with near-white text once dark mode's `--text` flips to near-white — reported by a user as "深色模式有问题" with a screenshot of the 更多配置 submenu.
- Switched all three to the actual semantic vars (`--bg-container` / `--text`), matching how `CommandPalette.svelte` already does it correctly.
- Follow-up commit: swept the rest of the codebase for the same `--text-primary` ghost variable and fixed the remaining four spots — `AuthGate.svelte` (API key input), `ConfirmDialog.svelte` (message text), `FolderPickerModal.svelte` (directory row), `VersionBadge.svelte` (version line + command chip). These weren't visibly broken (the invalid `var()` happened to inherit the correct `--text` from `body`), but now reference the real variable directly instead of relying on that fallback-inheritance accident. Confirmed `--bg-elevated`/`--text-primary` have zero remaining code references (one leftover hit is a comment in `ChatView.svelte`, not live code).

## Test plan
- [x] `npx svelte-check` in `web/` — 0 errors (2 pre-existing unrelated warnings), before and after the follow-up commit
- [x] Reviewed all affected selectors' rendered light/dark colors against `app.css`'s var definitions
- [x] `grep -rn "bg-elevated\|text-primary" web/src/` returns no remaining code usages
- [ ] Manual visual check in the running app (light + dark) — reporter can confirm once this ships

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>