### PR TITLE
chore: bump version to 1.15.4

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.3"
+var Version = "1.15.4"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Includes today's three bugfixes: macOS desktop updater's stale `$TMPDIR` fix (#1999), the Sidebar dark-mode popover fix (#2000), and the Windows folder picker's drive navigation fix (#2001).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>