### PR TITLE
fix(web): let the conversation pane scroll to recover a clipped composer

### DIFF
--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -2355,6 +2355,13 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
      that the composer's status chips (model · reasoning · cwd · context · mode)
      sit on one row without wrapping. */
   --chat-content-max-width: 960px;
+  /* Safety net: on short viewports the header/banners/plan-card/composer
+     (all flex: 0 0 auto) can together exceed the available height even after
+     .messages shrinks to 0. Without this, the excess silently overflows past
+     every ancestor up to .app's `overflow: hidden` and clips the composer
+     with no way to recover it. This lets the conversation column itself
+     scroll into view when that happens. */
+  overflow-y: auto;
 }
 .workflows-bar {
   flex: 0 0 auto;


### PR DESCRIPTION
## Summary
- On short browser windows, the fixed-height rows around the message list (chat-header, ws/bind banner, session-tasks plan card, workflows-bar, composer) can together exceed the available height even after `.messages` shrinks to 0. No ancestor between `.conversation` and `.app` declared its own `overflow`, so the excess silently bled through and got clipped at `.app`'s `overflow: hidden` — the composer became unreachable, and scrolling the message list didn't help because `.messages` sets `overscroll-behavior-y: contain`, which blocks the wheel event from chaining up to any ancestor.
- Adds `overflow-y: auto` to `.conversation` (`web/src/views/ChatView.svelte`) as a fallback so this excess becomes a real scrollable region instead of a silent clip.

## Test plan
- [x] Built the binary and ran an isolated `octo serve` instance (separate port + throwaway `OCTO_HOME`, not touching any real session data).
- [x] Used Playwright to shrink the viewport to 130px height and confirmed: before the fix, `.conversation`'s `scrollTop` stayed at 0 and the composer was permanently clipped out of view; after the fix, `.conversation` scrolls and the composer becomes reachable.
- [x] `svelte-check` — 398 files, 0 errors (2 pre-existing unrelated warnings).

Fixes #2005

🤖 Generated with [Claude Code](https://claude.com/claude-code)