### PR TITLE
fix(web): auto-scroll slash-command menu to keep active item visible

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { get } from 'svelte/store'
-  import { onMount, untrack } from 'svelte'
+  import { onMount, untrack, tick } from 'svelte'
   import {
     running, activeSessionId, chatStreaming, sessions,
     chatContextUsage, chatWorkingDir, chatPermMode, chatReasoningEffort, chatShowReasoning, showToast, chatGoal, chatModel,
@@ -44,6 +44,7 @@
   let attachmentsBySession: Record<string, Attachment[]> = {}
   let draftSid = ''
   let textareaEl = $state<HTMLTextAreaElement | null>(null)
+  let skillMenuEl = $state<HTMLDivElement | null>(null)
   let attachments = $state<Attachment[]>([])
   let dragOver = $state(false)
 
@@ -517,6 +518,11 @@
     const items = filteredItems()
     if (!slashMenu || items.length === 0) return
     slashActiveIndex = (slashActiveIndex + delta + items.length) % items.length
+    // Keyboard nav can move the active item outside the menu's scroll
+    // viewport (max-height: 240px); scroll it back into view.
+    tick().then(() => {
+      skillMenuEl?.querySelector('.skill-menu-item.active')?.scrollIntoView({ block: 'nearest' })
+    })
   }
 
 
@@ -1052,7 +1058,7 @@
         </button>
       </div>
       {#if slashMenu}
-        <div class="skill-menu">
+        <div class="skill-menu" bind:this={skillMenuEl}>
           {#each filteredItems() as item, i (item.kind + ':' + (item.kind === 'builtin' ? item.name : item.kind === 'skill' ? item.skill.name : item.kind === 'workflow' ? item.workflow.name : item.kind === 'mcp-server' ? item.name : item.kind === 'agent' ? item.id : item.kind === 'agent-create' ? '' : item.server + '/' + item.tool.name))}
             <button
               class="skill-menu-item"


### PR DESCRIPTION
## Summary
- `moveSlashActive()` updated `slashActiveIndex` on `ArrowUp`/`ArrowDown` but never scrolled the `.skill-menu` container (`max-height: 240px; overflow-y: auto`), so once the suggestion list overflowed, keyboard navigation could push the highlighted item outside the visible viewport with no way to see it short of scrolling manually.
- Scrolls the active item into view (`scrollIntoView({ block: 'nearest' })`) after each keyboard move.

## Test plan
- [x] Built the binary and ran an isolated `octo serve` instance (separate port + throwaway `OCTO_HOME`, no real session data touched).
- [x] Playwright: opened the slash menu (25 candidates, scrollHeight 1133 vs 238px viewport), pressed `ArrowDown` to the last item. Before the fix, `scrollTop` stayed at 0 and the active item was fully outside the viewport; after the fix, the container scrolls and the active item stays fully visible.
- [x] `svelte-check` — 398 files, 0 errors (2 pre-existing unrelated warnings).

Fixes #2007

🤖 Generated with [Claude Code](https://claude.com/claude-code)