### PR TITLE
chore: bump version to 1.15.5

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.4"
+var Version = "1.15.5"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
Includes today's fixes:
- #2008 — web chat: conversation pane now scrolls to recover a composer clipped off-screen on short windows (#2005)
- #2009 — web chat: slash-command suggestion menu auto-scrolls to keep the keyboard-active item visible (#2007)
- #2010 — upload/attachment file retention (age-out sweep for `~/.octo/uploads` and IM-channel temp files), including desktop-hub housekeeping coverage found in review (#2004)

(#2006's Windows folder-picker drive-navigation fix already shipped in 1.15.4 via #2001.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)