### PR TITLE
fix(desktop): align mac header content with traffic lights via padding-bottom

### DIFF
--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -166,9 +166,13 @@ header {
 /* Mac's native hidden-inset title bar floats the real traffic-light buttons
    over the top-left of the content area, so inset the header past them.
    Their vertical position is fixed by macOS (not by our header height), and
-   it sits a few px below this row's flex-centered line, so nudge the whole
-   row down by the same amount — measured against a live build, not guessed. */
-header.native-inset { padding-left: 82px; padding-top: 6px; }
+   it sits above this row's flex-centered line — padding-top would only push
+   the content further down, away from the lights, so pull the centering axis
+   up instead via padding-bottom (shrinks the box from the bottom, which
+   raises the align-items:center midpoint without moving the header's own
+   background/border box). Value confirmed by pixel-measuring a live build's
+   traffic-light center against the content center, not eyeballed. */
+header.native-inset { padding-left: 82px; padding-bottom: 8px; }
 /* The header is a window drag handle. Every interactive control on it opts
    back to no-drag so it stays clickable — the blank strips between controls
    drag the window. Applied for all platforms (frameless window now), not just


### PR DESCRIPTION
## Summary
- The previous fix (#1973) added `padding-top: 6px` to nudge the mac header's content row down to meet the native traffic lights, but that pushed it the wrong way — the traffic lights actually sit *above* the header's flex-centered line, so `padding-top` only widened the gap.
- Verified against a live build with pixel-measurements (not eyeballed): swapping to `padding-bottom: 8px` pulls the `align-items: center` midpoint up instead of pushing it down, without changing the header's own background/border box.
- Result: traffic-light center vs. content center (sidebar toggle icon, Octo logo, wordmark, subtitle) all measured within 1px, verified on both a small (700×500) and a large window — the native traffic-light offset is fixed to the window's top-left corner and doesn't move with content layout or window size.
- Windows/Linux are unaffected: this rule lives under `header.native-inset`, which is only applied when `$nativeShell && isMac` — those platforms use the Frameless window with the frontend's own right-side window controls, a separate code path.

## Test plan
- [x] `make desktop` builds cleanly
- [x] Launched the built app, captured the real titlebar via `screencapture -l<windowID>`, and pixel-measured the vertical center of the traffic lights vs. the sidebar icon / Octo logo / text — all within 1px
- [x] Re-measured after resizing the window to 700×500 and to near-fullscreen — identical alignment in both cases
- [x] Confirmed via source read that `header.native-inset` (and thus this change) never applies when `isMac` is false, so Windows/Linux title bars are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)