### PR TITLE
fix(server): freeze the composed system prompt once per session, like the CLI

### DIFF
--- a/dev-docs/im-parity-design.md
+++ b/dev-docs/im-parity-design.md
@@ -32,15 +32,9 @@ config changes), every restart wiped every conversation.
   crash costs at most one turn, not a whole chain. Failures are logged to
   the server console and never eat the reply the user already received.
 
-## Per-turn memory freshness
+## Memory hooks parity
 
-`handleChannelMessage` recomposes the agent's system prompt (memory
-injection and the skills manifest included) at the start of every turn. Web
-turns always had this — `buildAgent` runs per turn — but the IM factory
-composed the prompt once at session creation, so memory written and skills
-imported mid-session were invisible to IM until a restart.
-
-IM turns also carry the L2 memory hooks, the same pair `buildAgent` wires
+IM turns carry the L2 memory hooks, the same pair `buildAgent` wires
 for web sessions: `UserInputHook` keyword reminders and the
 `ToolResultHook` save-nudge. The injector comes from the shared
 `injectorFor` store (keyed `im:<session key>`), is session-sticky — the
@@ -92,7 +86,7 @@ reply.
 |---|---|---|
 | Store | `internal/channel/persist.go` | deterministic ID, restore-or-init, `Persist`, store delete on /bind //unbind |
 | Steer intake | `internal/server/server.go` `routeChannelEvent` | command → ask → steer-if-running → turn |
-| Chained turns + persist + recompose | `internal/server/server.go` `handleChannelMessage` | leftover-inbox loop, per-turn `prompt.Compose`, post-turn `Persist` |
+| Chained turns + persist | `internal/server/server.go` `handleChannelMessage` | leftover-inbox loop, `prompt.Compose` frozen after the session's first turn (`Session.SetComposedSystem`), post-turn `Persist` |
 | Ctx asker | `internal/tools/ask_user_question.go` | `WithAsker` / `askerFrom`, global fallback |
 | Chat asker | `internal/server/channel_ask.go` | numbered options, reply parsing, timeout |
 
@@ -103,6 +97,8 @@ reply.
   `handleChannelMessage` with a stub sender.
 - Steer: blocking-sender test pins enqueue-while-running and the chained
   drain reaching the model.
-- Freshness: memory file written between two turns is visible to the second.
+- Freeze: the composed system prompt is set on the session's first turn and
+  a memory file written between two turns stays invisible to the second —
+  `TestHandleChannelMessage_FreezesSystemAfterFirstTurn`.
 - Asker: ctx-beats-global, global fallback, reply parsing table, numbered
   pick end-to-end, timeout cancel.

--- a/dev-docs/windows-onboarding-design.md
+++ b/dev-docs/windows-onboarding-design.md
@@ -70,9 +70,11 @@ on `PATH`:
 ```go
 // DetectToolchain reports which of a curated set of developer tools resolve on
 // the current PATH. Presence-only: it uses exec.LookPath (a filesystem lookup,
-// no subprocess), so it is safe to call on every context build — including the
-// server's per-turn recompose. Versions are deliberately not probed; the agent
-// runs `<tool> --version` on demand when it actually needs one.
+// no subprocess), so it is safe to call on every context build — once per
+// process for the CLI/TUI, once per session for the server (the composed
+// system prompt freezes after that — see Session.SetComposedSystem). Versions
+// are deliberately not probed; the agent runs `<tool> --version` on demand
+// when it actually needs one.
 func DetectToolchain() (present, missing []string)
 ```
 
@@ -93,9 +95,9 @@ block is injected in the same place, e.g.:
 Paired with the existing `ShellEnvNote()` install guidance, the agent now knows
 both *what is missing* and *how to install it* on this platform.
 
-Cost: `len(list)` filesystem lookups per context build, no subprocess. Cheap
-enough that the server's per-turn recompose is unaffected — the reason versions
-are excluded.
+Cost: `len(list)` filesystem lookups per context build, no subprocess — cheap
+even though a version probe (a real subprocess per tool) would not have been,
+which is the reason versions are excluded.
 
 ## Part B — Windows installer
 

--- a/docs/src/content/docs/guides/memory.md
+++ b/docs/src/content/docs/guides/memory.md
@@ -58,21 +58,20 @@ future sessions need to respect. It fires at most once per user turn, so a long 
 commands doesn't nag repeatedly; see it listed alongside every other configured hook via
 [`octo hooks list`](/docs/guides/hooks/).
 
-## Freshness differs by transport
+## When memory changes take effect
 
-- **Web and IM** recompose the system prompt fresh on every turn, so anything written to `MEMORY.md`
-  — by this session or another — is visible starting the very next turn. IM specifically drops and
-  rebuilds this state on `/bind`/`/unbind`, so a rebound chat picks up whatever the session's memory
-  currently contains. This matters there because a `octo serve` process, and the sessions it holds
-  open, routinely outlive any single task — across restarts, and across an IM chat being rebound to
-  a different underlying session entirely.
-- **The CLI composes once**, when the interactive session starts, and reuses that system prompt for
-  the rest of the process. This is deliberate, not an oversight: a CLI session is normally one
-  continuous conversation for one task, opened and closed around it, so anything you tell the agent
-  mid-session is already live in that conversation's own history — the agent doesn't need a fresh
-  read of `MEMORY.md` to know it. What the agent *writes* to memory during that session surfaces the
-  *next* time you run `octo` in that repo, which is exactly when a plain index file is supposed to
-  matter — for a session that hasn't lived through the conversation where it was learned.
+Every transport — CLI, web, and IM — composes the system prompt once, the first time a session
+takes a turn, and reuses that exact text for the rest of the session's life: resuming it later, or
+an IM chat being rebound to it, picks up the same frozen prompt rather than recomposing it. This is
+deliberate, not an oversight: recomposing on every turn would vary the text on anything that can
+change mid-session — the memory file included — and invalidate the provider's prompt-cache prefix on
+that turn and every one after.
+
+So what you tell the agent mid-session is already live in that conversation's own history — it
+doesn't need a fresh read of `MEMORY.md` to know it. What the agent *writes* to memory during a
+session surfaces starting the *next* session (over any transport), which is exactly when a plain
+index file is supposed to matter — for a conversation that hasn't lived through the one where it was
+learned.
 
 ## What ends up in it
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -37,8 +37,20 @@ type Session struct {
 	// and reused by every later turn — see SetComposedSystem's doc comment
 	// for why. Empty for a session that hasn't taken its first turn yet, and
 	// for every session predating this field (it freezes on its next turn).
+	//
+	// ComposedForModel is the model the freeze was composed against. The MCP
+	// tools manifest baked into the prompt (see tools.MCPManifestFor) depends
+	// on the model's context window — the same MCP tool set can render a
+	// manifest under a small-window model but not a large one, or vice versa.
+	// A mid-session model switch (session.SetModelConfig, IM's /model) would
+	// silently strand the frozen prompt's manifest out of sync with the
+	// per-turn tools array (which is always computed fresh for the current
+	// model — see registry.go's defaultToolsFor), so SetComposedSystem
+	// re-freezes instead of no-op-ing when the model at call time differs
+	// from this field.
 	ComposedSystem     string `json:"composed_system,omitempty"`
 	ComposedLeanSystem string `json:"composed_lean_system,omitempty"`
+	ComposedForModel   string `json:"composed_for_model,omitempty"`
 	Title              string `json:"title,omitempty"`
 	Source             string `json:"source,omitempty"` // how the session was created: "" (manual) | "cron" | "channel" | "setup"
 	// AgentID is the ID of the agent profile (agentprofile.Profile) that owns
@@ -529,6 +541,7 @@ type sessionRecord struct {
 	System             string    `json:"system,omitempty"`
 	ComposedSystem     string    `json:"composed_system,omitempty"`
 	ComposedLeanSystem string    `json:"composed_lean_system,omitempty"`
+	ComposedForModel   string    `json:"composed_for_model,omitempty"`
 	Title              string    `json:"title,omitempty"`
 	Source             string    `json:"source,omitempty"`
 	ModelConfig        string    `json:"model_config,omitempty"`
@@ -558,7 +571,7 @@ func (s *Session) metaRecord() sessionRecord {
 		goal = &g
 	}
 	s.mu.Unlock()
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, ComposedSystem: s.ComposedSystem, ComposedLeanSystem: s.ComposedLeanSystem, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, AgentID: s.AgentID, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, ComposedSystem: s.ComposedSystem, ComposedLeanSystem: s.ComposedLeanSystem, ComposedForModel: s.ComposedForModel, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, AgentID: s.AgentID, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
 }
 
 // MarkHookStarted records that SessionStart has fired for this session, so a
@@ -895,14 +908,20 @@ func (s *Session) SetPermissionMode(mode string) error {
 // invalidate the provider's prompt-cache prefix on that turn (and every turn
 // after, since the changed layer stays changed). This mirrors the CLI/TUI,
 // which compose once per process and never touch System again: a skill or
-// profile edit now takes effect in a new session, not a running one. A no-op
-// once already frozen — system is only ever empty before the first turn.
-// Same append-or-rewrite persistence mechanics as SetPermissionMode.
-func (s *Session) SetComposedSystem(system, lean string) error {
-	if s.ComposedSystem != "" {
+// profile edit now takes effect in a new session, not a running one.
+//
+// model is the model this compose ran against — see ComposedForModel's doc
+// comment for why it matters. A no-op only when already frozen for THIS
+// model; a call for a different model (a mid-session model switch) overwrites
+// the freeze instead, since the per-turn tools array is always computed fresh
+// for the current model and a stale MCP-manifest freeze would silently drift
+// out of sync with it. Same append-or-rewrite persistence mechanics as
+// SetPermissionMode.
+func (s *Session) SetComposedSystem(system, lean, model string) error {
+	if s.ComposedSystem != "" && s.ComposedForModel == model {
 		return nil
 	}
-	s.ComposedSystem, s.ComposedLeanSystem = system, lean
+	s.ComposedSystem, s.ComposedLeanSystem, s.ComposedForModel = system, lean, model
 	if s.persisted == 0 {
 		// See SetWorkingDir: a meta-only transcript must be rewritten now, since
 		// the load-modify-discard handler won't get a "next Save"; a session with
@@ -927,10 +946,19 @@ func (s *Session) SetComposedSystem(system, lean string) error {
 		return fmt.Errorf("session: open %s: %w", path, err)
 	}
 	defer f.Close()
-	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "composed_system", ComposedSystem: system, ComposedLeanSystem: lean}); err != nil {
+	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "composed_system", ComposedSystem: system, ComposedLeanSystem: lean, ComposedForModel: model}); err != nil {
 		return fmt.Errorf("session: append composed_system: %w", err)
 	}
 	return nil
+}
+
+// IsComposedFor reports whether the session's system prompt is already
+// frozen for model — the condition SetComposedSystem itself uses to decide
+// overwrite-vs-no-op, exposed so callers (buildAgent, runChannelTurns) can
+// skip the memory/skills/MCP recompute entirely when the freeze would just
+// be reused rather than replaced.
+func (s *Session) IsComposedFor(model string) bool {
+	return s.ComposedSystem != "" && s.ComposedForModel == model
 }
 
 // SetLastContextTokens records the context-window fill (real input-token count)
@@ -1270,8 +1298,8 @@ func LoadSession(id string) (*Session, error) {
 		switch rec.Type {
 		case "meta":
 			s.ID, s.CreatedAt, s.Model, s.System = rec.ID, rec.CreatedAt, rec.Model, rec.System
-			s.ComposedSystem, s.ComposedLeanSystem = rec.ComposedSystem, rec.ComposedLeanSystem // a rewritten file carries it in its meta header
-			s.Title = rec.Title                                                                 // a compacted file carries the title in its meta header
+			s.ComposedSystem, s.ComposedLeanSystem, s.ComposedForModel = rec.ComposedSystem, rec.ComposedLeanSystem, rec.ComposedForModel // a rewritten file carries it in its meta header
+			s.Title = rec.Title                                                                                                           // a compacted file carries the title in its meta header
 			s.Source = rec.Source
 			s.ModelConfig = rec.ModelConfig
 			s.AgentID = rec.AgentID
@@ -1300,7 +1328,7 @@ func LoadSession(id string) (*Session, error) {
 		case "context_tokens":
 			s.LastContextTokens = rec.LastContextTokens // last one wins, like title
 		case "composed_system":
-			s.ComposedSystem, s.ComposedLeanSystem = rec.ComposedSystem, rec.ComposedLeanSystem // frozen once, so first (and only) one wins
+			s.ComposedSystem, s.ComposedLeanSystem, s.ComposedForModel = rec.ComposedSystem, rec.ComposedLeanSystem, rec.ComposedForModel // last one wins — a mid-session model switch appends a second record
 		case "message":
 			if rec.Message != nil {
 				s.Messages = append(s.Messages, *rec.Message)

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -31,8 +31,16 @@ type Session struct {
 	CreatedAt time.Time `json:"created_at"`
 	Model     string    `json:"model"`
 	System    string    `json:"system,omitempty"`
-	Title     string    `json:"title,omitempty"`
-	Source    string    `json:"source,omitempty"` // how the session was created: "" (manual) | "cron" | "channel" | "setup"
+	// ComposedSystem/ComposedLeanSystem are the fully-composed system prompt
+	// (base + env + skills + mcp + memory + profile/user/project + System),
+	// frozen by SetComposedSystem the first time a turn builds this session
+	// and reused by every later turn — see SetComposedSystem's doc comment
+	// for why. Empty for a session that hasn't taken its first turn yet, and
+	// for every session predating this field (it freezes on its next turn).
+	ComposedSystem     string `json:"composed_system,omitempty"`
+	ComposedLeanSystem string `json:"composed_lean_system,omitempty"`
+	Title              string `json:"title,omitempty"`
+	Source             string `json:"source,omitempty"` // how the session was created: "" (manual) | "cron" | "channel" | "setup"
 	// AgentID is the ID of the agent profile (agentprofile.Profile) that owns
 	// this session. Empty means the default agent — also the value for every
 	// session predating multi-agent, so legacy files need no migration.
@@ -514,26 +522,28 @@ func (s *Session) ChunkDir() (string, error) {
 // type as authoritative; rewriteAll folds them back into the meta header when
 // compacting.
 type sessionRecord struct {
-	Type              string    `json:"type"` // "meta" | "message" | "title" | "model_config" | "agent_id" | "working_dir" | "permission_mode" | "context_tokens" | "lease" | "goal"
-	ID                string    `json:"id,omitempty"`
-	CreatedAt         time.Time `json:"created_at,omitempty"`
-	Model             string    `json:"model,omitempty"`
-	System            string    `json:"system,omitempty"`
-	Title             string    `json:"title,omitempty"`
-	Source            string    `json:"source,omitempty"`
-	ModelConfig       string    `json:"model_config,omitempty"`
-	AgentID           string    `json:"agent_id,omitempty"`
-	WorkingDir        string    `json:"working_dir,omitempty"`
-	PermissionMode    string    `json:"permission_mode,omitempty"`
-	BoundEntry        string    `json:"bound_entry,omitempty"`
-	BoundAt           time.Time `json:"bound_at,omitempty"`
-	LeaseEntry        string    `json:"lease_entry,omitempty"`
-	LeaseExpires      time.Time `json:"lease_expires,omitempty"`
-	HookStarted       bool      `json:"hook_started,omitempty"`
-	BranchedFrom      string    `json:"branched_from,omitempty"`
-	LastContextTokens int       `json:"last_context_tokens,omitempty"`
-	Message           *Message  `json:"message,omitempty"`
-	Goal              *Goal     `json:"goal,omitempty"`
+	Type               string    `json:"type"` // "meta" | "message" | "title" | "model_config" | "agent_id" | "working_dir" | "permission_mode" | "context_tokens" | "composed_system" | "lease" | "goal"
+	ID                 string    `json:"id,omitempty"`
+	CreatedAt          time.Time `json:"created_at,omitempty"`
+	Model              string    `json:"model,omitempty"`
+	System             string    `json:"system,omitempty"`
+	ComposedSystem     string    `json:"composed_system,omitempty"`
+	ComposedLeanSystem string    `json:"composed_lean_system,omitempty"`
+	Title              string    `json:"title,omitempty"`
+	Source             string    `json:"source,omitempty"`
+	ModelConfig        string    `json:"model_config,omitempty"`
+	AgentID            string    `json:"agent_id,omitempty"`
+	WorkingDir         string    `json:"working_dir,omitempty"`
+	PermissionMode     string    `json:"permission_mode,omitempty"`
+	BoundEntry         string    `json:"bound_entry,omitempty"`
+	BoundAt            time.Time `json:"bound_at,omitempty"`
+	LeaseEntry         string    `json:"lease_entry,omitempty"`
+	LeaseExpires       time.Time `json:"lease_expires,omitempty"`
+	HookStarted        bool      `json:"hook_started,omitempty"`
+	BranchedFrom       string    `json:"branched_from,omitempty"`
+	LastContextTokens  int       `json:"last_context_tokens,omitempty"`
+	Message            *Message  `json:"message,omitempty"`
+	Goal               *Goal     `json:"goal,omitempty"`
 }
 
 func (s *Session) metaRecord() sessionRecord {
@@ -548,7 +558,7 @@ func (s *Session) metaRecord() sessionRecord {
 		goal = &g
 	}
 	s.mu.Unlock()
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, AgentID: s.AgentID, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, ComposedSystem: s.ComposedSystem, ComposedLeanSystem: s.ComposedLeanSystem, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, AgentID: s.AgentID, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
 }
 
 // MarkHookStarted records that SessionStart has fired for this session, so a
@@ -872,6 +882,53 @@ func (s *Session) SetPermissionMode(mode string) error {
 	defer f.Close()
 	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "permission_mode", PermissionMode: mode}); err != nil {
 		return fmt.Errorf("session: append permission_mode: %w", err)
+	}
+	return nil
+}
+
+// SetComposedSystem freezes the fully-composed system prompt (base + env +
+// skills + mcp + memory + profile/user/project + System) the first time a
+// turn builds this session, so every later turn reuses the identical string
+// instead of recomposing it from layers that can legitimately change mid-
+// session — the live memory file an agent's own tools just wrote, a skill
+// toggle, a profile edit. Recomposing on any of those would vary the text and
+// invalidate the provider's prompt-cache prefix on that turn (and every turn
+// after, since the changed layer stays changed). This mirrors the CLI/TUI,
+// which compose once per process and never touch System again: a skill or
+// profile edit now takes effect in a new session, not a running one. A no-op
+// once already frozen — system is only ever empty before the first turn.
+// Same append-or-rewrite persistence mechanics as SetPermissionMode.
+func (s *Session) SetComposedSystem(system, lean string) error {
+	if s.ComposedSystem != "" {
+		return nil
+	}
+	s.ComposedSystem, s.ComposedLeanSystem = system, lean
+	if s.persisted == 0 {
+		// See SetWorkingDir: a meta-only transcript must be rewritten now, since
+		// the load-modify-discard handler won't get a "next Save"; a session with
+		// no file yet just carries the value until its first Save.
+		if path, perr := s.SavePath(); perr == nil {
+			if _, statErr := os.Stat(path); statErr == nil {
+				return s.rewriteAll()
+			}
+		}
+		return nil
+	}
+	if s.forceRewrite {
+		return s.rewriteAll()
+	}
+	path, err := s.SavePath()
+	if err != nil {
+		return err
+	}
+	// No O_CREATE — see SetTitle: never materialise an orphan transcript.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("session: open %s: %w", path, err)
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "composed_system", ComposedSystem: system, ComposedLeanSystem: lean}); err != nil {
+		return fmt.Errorf("session: append composed_system: %w", err)
 	}
 	return nil
 }
@@ -1213,7 +1270,8 @@ func LoadSession(id string) (*Session, error) {
 		switch rec.Type {
 		case "meta":
 			s.ID, s.CreatedAt, s.Model, s.System = rec.ID, rec.CreatedAt, rec.Model, rec.System
-			s.Title = rec.Title // a compacted file carries the title in its meta header
+			s.ComposedSystem, s.ComposedLeanSystem = rec.ComposedSystem, rec.ComposedLeanSystem // a rewritten file carries it in its meta header
+			s.Title = rec.Title                                                                 // a compacted file carries the title in its meta header
 			s.Source = rec.Source
 			s.ModelConfig = rec.ModelConfig
 			s.AgentID = rec.AgentID
@@ -1241,6 +1299,8 @@ func LoadSession(id string) (*Session, error) {
 			s.PermissionMode = rec.PermissionMode // last one wins, like title
 		case "context_tokens":
 			s.LastContextTokens = rec.LastContextTokens // last one wins, like title
+		case "composed_system":
+			s.ComposedSystem, s.ComposedLeanSystem = rec.ComposedSystem, rec.ComposedLeanSystem // frozen once, so first (and only) one wins
 		case "message":
 			if rec.Message != nil {
 				s.Messages = append(s.Messages, *rec.Message)

--- a/internal/agent/session_persist_test.go
+++ b/internal/agent/session_persist_test.go
@@ -276,10 +276,11 @@ func TestSetLastContextTokens_AppendsAndRoundTrips(t *testing.T) {
 }
 
 // TestSetComposedSystem_FreezesAppendsAndRoundTrips: the first call freezes
-// and appends a composed_system record; a later call (already frozen) is a
-// no-op that appends nothing; both an initial in-memory freeze and a fresh
-// LoadSession afterward (simulating a server restart) see the frozen value —
-// the actual cache-stability guarantee this mechanism exists to provide.
+// and appends a composed_system record; a later call for the SAME model
+// (already frozen) is a no-op that appends nothing; both an initial in-memory
+// freeze and a fresh LoadSession afterward (simulating a server restart) see
+// the frozen value — the actual cache-stability guarantee this mechanism
+// exists to provide.
 func TestSetComposedSystem_FreezesAppendsAndRoundTrips(t *testing.T) {
 	setTempHome(t)
 	s := NewSession("m", "")
@@ -288,11 +289,11 @@ func TestSetComposedSystem_FreezesAppendsAndRoundTrips(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	if err := s.SetComposedSystem("full prompt", "lean prompt"); err != nil {
+	if err := s.SetComposedSystem("full prompt", "lean prompt", "model-a"); err != nil {
 		t.Fatalf("SetComposedSystem: %v", err)
 	}
-	if s.ComposedSystem != "full prompt" || s.ComposedLeanSystem != "lean prompt" {
-		t.Fatalf("SetComposedSystem did not set fields: got %q / %q", s.ComposedSystem, s.ComposedLeanSystem)
+	if s.ComposedSystem != "full prompt" || s.ComposedLeanSystem != "lean prompt" || s.ComposedForModel != "model-a" {
+		t.Fatalf("SetComposedSystem did not set fields: got %q / %q / %q", s.ComposedSystem, s.ComposedLeanSystem, s.ComposedForModel)
 	}
 
 	path, err := s.SavePath()
@@ -307,9 +308,10 @@ func TestSetComposedSystem_FreezesAppendsAndRoundTrips(t *testing.T) {
 		t.Fatalf("expected an appended composed_system record; file was:\n%s", data)
 	}
 
-	// Already-frozen no-op: a second call must not overwrite or append.
+	// Already-frozen no-op: a second call for the SAME model must not
+	// overwrite or append.
 	before := len(data)
-	if err := s.SetComposedSystem("different prompt", "different lean"); err != nil {
+	if err := s.SetComposedSystem("different prompt", "different lean", "model-a"); err != nil {
 		t.Fatal(err)
 	}
 	if s.ComposedSystem != "full prompt" {
@@ -329,8 +331,49 @@ func TestSetComposedSystem_FreezesAppendsAndRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSession: %v", err)
 	}
-	if got.ComposedSystem != "full prompt" || got.ComposedLeanSystem != "lean prompt" {
-		t.Errorf("reloaded composed system = %q / %q, want %q / %q", got.ComposedSystem, got.ComposedLeanSystem, "full prompt", "lean prompt")
+	if got.ComposedSystem != "full prompt" || got.ComposedLeanSystem != "lean prompt" || got.ComposedForModel != "model-a" {
+		t.Errorf("reloaded composed system = %q / %q / %q, want %q / %q / %q", got.ComposedSystem, got.ComposedLeanSystem, got.ComposedForModel, "full prompt", "lean prompt", "model-a")
+	}
+}
+
+// TestSetComposedSystem_ModelSwitchForcesRefreeze: a call for a DIFFERENT
+// model than the one the session is frozen for must overwrite the freeze
+// (not no-op) and persist the new model — the fix for a mid-session model
+// switch (e.g. IM's /model) silently stranding the frozen prompt's MCP-tools
+// manifest out of sync with the per-turn tools array, which is always
+// computed fresh for the current model regardless of the freeze.
+func TestSetComposedSystem_ModelSwitchForcesRefreeze(t *testing.T) {
+	setTempHome(t)
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("hi"), NewAssistantMessage("hello")}
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := s.SetComposedSystem("prompt for model-a", "lean for model-a", "model-a"); err != nil {
+		t.Fatalf("SetComposedSystem: %v", err)
+	}
+	if !s.IsComposedFor("model-a") {
+		t.Fatal("expected IsComposedFor(\"model-a\") after freezing for model-a")
+	}
+	if s.IsComposedFor("model-b") {
+		t.Fatal("IsComposedFor(\"model-b\") must be false when frozen for model-a")
+	}
+
+	if err := s.SetComposedSystem("prompt for model-b", "lean for model-b", "model-b"); err != nil {
+		t.Fatalf("SetComposedSystem for model-b: %v", err)
+	}
+	if s.ComposedSystem != "prompt for model-b" || s.ComposedForModel != "model-b" {
+		t.Fatalf("model switch did not re-freeze: got %q / %q", s.ComposedSystem, s.ComposedForModel)
+	}
+
+	// Round-trips: the second composed_system record (for model-b) replays
+	// correctly rather than the first (for model-a) winning.
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got.ComposedSystem != "prompt for model-b" || got.ComposedLeanSystem != "lean for model-b" || got.ComposedForModel != "model-b" {
+		t.Errorf("reloaded composed system = %q / %q / %q, want %q / %q / %q", got.ComposedSystem, got.ComposedLeanSystem, got.ComposedForModel, "prompt for model-b", "lean for model-b", "model-b")
 	}
 }
 
@@ -355,7 +398,7 @@ func TestSetComposedSystem_PersistedZeroRewritesWhenFileExists(t *testing.T) {
 	shadow := NewSession(s.Model, s.System)
 	shadow.ID = s.ID
 
-	if err := shadow.SetComposedSystem("rewritten prompt", "rewritten lean"); err != nil {
+	if err := shadow.SetComposedSystem("rewritten prompt", "rewritten lean", "m"); err != nil {
 		t.Fatalf("SetComposedSystem: %v", err)
 	}
 

--- a/internal/agent/session_persist_test.go
+++ b/internal/agent/session_persist_test.go
@@ -275,6 +275,99 @@ func TestSetLastContextTokens_AppendsAndRoundTrips(t *testing.T) {
 	}
 }
 
+// TestSetComposedSystem_FreezesAppendsAndRoundTrips: the first call freezes
+// and appends a composed_system record; a later call (already frozen) is a
+// no-op that appends nothing; both an initial in-memory freeze and a fresh
+// LoadSession afterward (simulating a server restart) see the frozen value —
+// the actual cache-stability guarantee this mechanism exists to provide.
+func TestSetComposedSystem_FreezesAppendsAndRoundTrips(t *testing.T) {
+	setTempHome(t)
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("hi"), NewAssistantMessage("hello")}
+	if err := s.Save(); err != nil { // persisted > 0, transcript on disk
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := s.SetComposedSystem("full prompt", "lean prompt"); err != nil {
+		t.Fatalf("SetComposedSystem: %v", err)
+	}
+	if s.ComposedSystem != "full prompt" || s.ComposedLeanSystem != "lean prompt" {
+		t.Fatalf("SetComposedSystem did not set fields: got %q / %q", s.ComposedSystem, s.ComposedLeanSystem)
+	}
+
+	path, err := s.SavePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"type":"composed_system"`) {
+		t.Fatalf("expected an appended composed_system record; file was:\n%s", data)
+	}
+
+	// Already-frozen no-op: a second call must not overwrite or append.
+	before := len(data)
+	if err := s.SetComposedSystem("different prompt", "different lean"); err != nil {
+		t.Fatal(err)
+	}
+	if s.ComposedSystem != "full prompt" {
+		t.Errorf("already-frozen SetComposedSystem overwrote the value: got %q", s.ComposedSystem)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != before {
+		t.Errorf("no-op SetComposedSystem must not append: file grew %d -> %d bytes", before, len(after))
+	}
+
+	// Round-trips through a reload — simulates a server restart reloading the
+	// session from disk rather than reusing the in-memory Session.
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got.ComposedSystem != "full prompt" || got.ComposedLeanSystem != "lean prompt" {
+		t.Errorf("reloaded composed system = %q / %q, want %q / %q", got.ComposedSystem, got.ComposedLeanSystem, "full prompt", "lean prompt")
+	}
+}
+
+// TestSetComposedSystem_PersistedZeroRewritesWhenFileExists: a session with no
+// prior Save (persisted == 0) that already has a transcript file on disk (the
+// load-modify-discard case SetWorkingDir's sibling comment describes) must
+// rewrite the file with the frozen value rather than silently dropping it.
+func TestSetComposedSystem_PersistedZeroRewritesWhenFileExists(t *testing.T) {
+	setTempHome(t)
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("hi")}
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// A second Session value pointed at the same on-disk file via a shared ID,
+	// but never itself Save()d — persisted is its zero value, 0, even though
+	// a transcript already exists at its path. Mirrors a handler that
+	// constructs/loads a Session without going through the normal Save path
+	// (LoadSession itself sets persisted = len(Messages), so it can't produce
+	// this state — see SetWorkingDir's sibling comment for the scenario).
+	shadow := NewSession(s.Model, s.System)
+	shadow.ID = s.ID
+
+	if err := shadow.SetComposedSystem("rewritten prompt", "rewritten lean"); err != nil {
+		t.Fatalf("SetComposedSystem: %v", err)
+	}
+
+	again, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatalf("LoadSession after SetComposedSystem: %v", err)
+	}
+	if again.ComposedSystem != "rewritten prompt" || again.ComposedLeanSystem != "rewritten lean" {
+		t.Errorf("reloaded composed system = %q / %q, want %q / %q", again.ComposedSystem, again.ComposedLeanSystem, "rewritten prompt", "rewritten lean")
+	}
+}
+
 // PersistContextUsage records the agent's current context-token count on the
 // session and round-trips it, and is a safe no-op with a nil session or no
 // count. Every transport (web, IM, CLI, scheduled) calls it at turn end so a

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -551,9 +551,12 @@ func TestHandleChannelMessage_PersistsTurn(t *testing.T) {
 	}
 }
 
-// TestHandleChannelMessage_RefreshesSystemPerTurn: memory written after the
-// session was created must be visible on the next turn without a restart.
-func TestHandleChannelMessage_RefreshesSystemPerTurn(t *testing.T) {
+// TestHandleChannelMessage_FreezesSystemAfterFirstTurn: the composed system
+// prompt is frozen on the session's first turn (Session.SetComposedSystem)
+// and reused as-is afterward — memory written mid-session must NOT change an
+// already-open IM session's prompt, so the provider's prompt-cache prefix
+// stays stable turn over turn. Mirrors buildAgent's web-path behavior.
+func TestHandleChannelMessage_FreezesSystemAfterFirstTurn(t *testing.T) {
 	srv := chanServer(t)
 	srv.memDir = t.TempDir()
 	ad := &fullFakeAdapter{}
@@ -563,13 +566,20 @@ func TestHandleChannelMessage_RefreshesSystemPerTurn(t *testing.T) {
 	if strings.Contains(sess.Agent.System, "fresh-fact-9000") {
 		t.Fatal("memory marker present before it was written")
 	}
+	frozen := sess.Agent.System
+	if sess.Store.ComposedSystem != frozen {
+		t.Fatal("first turn did not freeze ComposedSystem on the session")
+	}
 
 	if err := os.WriteFile(srv.memDir+"/MEMORY.md", []byte("- fresh-fact-9000"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	srv.handleChannelMessage(context.Background(), ad, evFor("turn two"), nil)
-	if !strings.Contains(sess.Agent.System, "fresh-fact-9000") {
-		t.Error("system prompt not recomposed: memory written mid-session is invisible to IM turns")
+	if strings.Contains(sess.Agent.System, "fresh-fact-9000") {
+		t.Error("system prompt recomposed: memory written mid-session should stay invisible until a new session")
+	}
+	if sess.Agent.System != frozen {
+		t.Error("second turn's system prompt drifted from the frozen one")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1272,28 +1272,46 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	// MemoryBackendGuidance()/registering its hooks below — both need this
 	// turn's config, not whatever the last turn (of any kind) left set. See
 	// app.RefreshMemoryBackend's doc comment for why prepareToolTurn alone
-	// (which runs after this function returns) is one turn too late.
+	// (which runs after this function returns) is one turn too late. Runs
+	// every turn regardless of the freeze below: RegisterMemoryBackendHooks
+	// further down needs a fresh backend even on a turn that reuses the
+	// session's already-composed system prompt.
 	app.RefreshMemoryBackend()
 
-	// L1: project memory embedded in the system prompt (stable across turns).
-	var memInjection string
-	if s.memDir != "" {
-		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
+	// The composed system prompt is frozen the first time a turn builds this
+	// session (see Session.SetComposedSystem) — every later turn reuses the
+	// identical string instead of recomposing it, so the provider's prompt-
+	// cache prefix survives turn over turn. Recomposing would otherwise vary
+	// the text on things that legitimately change mid-session (the live
+	// memory file, a skill/profile edit landing elsewhere) and bust the cache
+	// on literally every turn. This mirrors the CLI/TUI, which compose once
+	// per process: a profile/skill edit now takes effect in a new session,
+	// not a running one.
+	if sess.ComposedSystem != "" {
+		a.System, a.LeanSystem = sess.ComposedSystem, sess.ComposedLeanSystem
+	} else {
+		// L1: project memory embedded in the system prompt, snapshotted once.
+		var memInjection string
+		if s.memDir != "" {
+			memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
+		}
+		if g := tools.MemoryBackendGuidance(); g != "" {
+			memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
+		}
+		// A profile with its own system prompt replaces the server's base
+		// prompt (default agent: unchanged, s.system).
+		profile := s.profileForAgent(sess.EffectiveAgentID())
+		base := s.system
+		expertMode := false
+		if profile.SystemPrompt != "" {
+			base = profile.SystemPrompt
+			expertMode = true
+		}
+		a.System, a.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
+		if err := sess.SetComposedSystem(a.System, a.LeanSystem); err != nil {
+			slog.Warn("freeze composed system prompt", "session", sess.ID, "err", err)
+		}
 	}
-	if g := tools.MemoryBackendGuidance(); g != "" {
-		memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
-	}
-	// A profile with its own system prompt replaces the server's base prompt
-	// (default agent: unchanged, s.system). Resolved fresh per turn so profile
-	// edits land on the next message; a deleted profile falls back to default.
-	profile := s.profileForAgent(sess.EffectiveAgentID())
-	base := s.system
-	expertMode := false
-	if profile.SystemPrompt != "" {
-		base = profile.SystemPrompt
-		expertMode = true
-	}
-	a.System, a.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
 
 	// L2: attention-layer rules (triggered keywords) + save-nudge on milestone
 	// tool results, plus any shell hooks (env/hooks.yml), unified on the agent's
@@ -3156,18 +3174,6 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	ctx = tools.WithProfileStore(ctx, s.agentStore)
 	ctx = tools.WithSessionAgentID(ctx, sess.AgentID)
 
-	// Recompose the system prompt every turn so memory written and skills
-	// imported/toggled since server start are visible — web turns get this
-	// for free from buildAgent; the IM factory's compose-once snapshot went
-	// stale until restart. Unconditional: the skills manifest changes at
-	// runtime even when memory is disabled.
-	var memInjection string
-	if s.memDir != "" {
-		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
-	}
-	if g := tools.MemoryBackendGuidance(); g != "" {
-		memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
-	}
 	cwd, envCtx := s.sessionCwdEnv(sess.Store)
 	sess.Agent.CWD = cwd          // keep tool cwd aligned with the per-session dir the prompt/hooks use
 	cfg, _ := config.LoadCached() // zero value on error (no last-good yet) still resolves correctly via EffectiveCoauthor
@@ -3179,16 +3185,36 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	if cfg.CompactAutoPct > 0 {
 		sess.Agent.CompactAutoFraction = float64(cfg.CompactAutoPct) / 100.0
 	}
-	// A profile with its own system prompt replaces the server's base prompt
-	// (default agent: unchanged, s.system). Resolved fresh per turn so profile
-	// edits land on the next message; a deleted profile falls back to default.
-	base := s.system
-	expertMode := false
-	if profile.SystemPrompt != "" {
-		base = profile.SystemPrompt
-		expertMode = true
+	// The composed system prompt is frozen the first time a turn builds this
+	// channel session (see Session.SetComposedSystem) — every later turn
+	// reuses the identical string instead of recomposing it, matching the web
+	// path (buildAgent) and the CLI/TUI. This used to recompose every turn so
+	// memory writes and skill/profile edits landed without a restart; that
+	// traded prompt-cache stability for immediacy. A profile/skill edit now
+	// takes effect in a new session, not a running one.
+	if sess.Store.ComposedSystem != "" {
+		sess.Agent.System, sess.Agent.LeanSystem = sess.Store.ComposedSystem, sess.Store.ComposedLeanSystem
+	} else {
+		var memInjection string
+		if s.memDir != "" {
+			memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
+		}
+		if g := tools.MemoryBackendGuidance(); g != "" {
+			memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
+		}
+		// A profile with its own system prompt replaces the server's base
+		// prompt (default agent: unchanged, s.system).
+		base := s.system
+		expertMode := false
+		if profile.SystemPrompt != "" {
+			base = profile.SystemPrompt
+			expertMode = true
+		}
+		sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(sess.Agent.Model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
+		if err := sess.Store.SetComposedSystem(sess.Agent.System, sess.Agent.LeanSystem); err != nil {
+			slog.Warn("freeze composed system prompt", "session", string(sess.Key), "err", err)
+		}
 	}
-	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(sess.Agent.Model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
 
 	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,
 	// rebuilt per IM turn. The injector is session-sticky (recall latch) and

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2202,9 +2202,10 @@ func (s *Server) initChannels() {
 // same shape prepareToolTurn gives web turns. A factory-time gate would freeze
 // one policy snapshot for the session's whole life.
 // System/LeanSystem and CWD are deliberately NOT set here (unlike buildAgent):
-// runChannelTurns unconditionally recomposes both on every IM turn before the
-// first LLM call ever happens, so baking them here once at session-creation
-// time only produced a value nothing would ever read. MaxTokens and the
+// runChannelTurns sets both on the session's first turn (freezing them
+// thereafter — see Session.SetComposedSystem) before the first LLM call ever
+// happens, so baking them here once at session-creation time only produced a
+// value nothing would ever read. MaxTokens and the
 // LiteSender/LiteModel resolved below have no such per-turn refresh anywhere
 // in the IM path, so they stay — this is genuinely the only place they're set
 // for the session's whole lifetime.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1286,8 +1286,13 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	// memory file, a skill/profile edit landing elsewhere) and bust the cache
 	// on literally every turn. This mirrors the CLI/TUI, which compose once
 	// per process: a profile/skill edit now takes effect in a new session,
-	// not a running one.
-	if sess.ComposedSystem != "" {
+	// not a running one. A model switch is the one exception that DOES force
+	// a re-freeze (IsComposedFor checks the model, not just emptiness) — the
+	// MCP tools manifest baked into the prompt depends on the model's context
+	// window, and the per-turn tools array is always computed fresh for the
+	// current model regardless of the freeze, so a stale manifest would drift
+	// out of sync with what's actually offered.
+	if sess.IsComposedFor(model) {
 		a.System, a.LeanSystem = sess.ComposedSystem, sess.ComposedLeanSystem
 	} else {
 		// L1: project memory embedded in the system prompt, snapshotted once.
@@ -1308,7 +1313,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 			expertMode = true
 		}
 		a.System, a.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
-		if err := sess.SetComposedSystem(a.System, a.LeanSystem); err != nil {
+		if err := sess.SetComposedSystem(a.System, a.LeanSystem, model); err != nil {
 			slog.Warn("freeze composed system prompt", "session", sess.ID, "err", err)
 		}
 	}
@@ -3192,8 +3197,11 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// path (buildAgent) and the CLI/TUI. This used to recompose every turn so
 	// memory writes and skill/profile edits landed without a restart; that
 	// traded prompt-cache stability for immediacy. A profile/skill edit now
-	// takes effect in a new session, not a running one.
-	if sess.Store.ComposedSystem != "" {
+	// takes effect in a new session, not a running one. A model switch (IM's
+	// /model, applied above via applyChannelModel) DOES force a re-freeze —
+	// see IsComposedFor's doc comment for why a stale MCP manifest can't just
+	// be left frozen under the old model.
+	if sess.Store.IsComposedFor(sess.Agent.Model) {
 		sess.Agent.System, sess.Agent.LeanSystem = sess.Store.ComposedSystem, sess.Store.ComposedLeanSystem
 	} else {
 		var memInjection string
@@ -3212,7 +3220,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 			expertMode = true
 		}
 		sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(sess.Agent.Model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
-		if err := sess.Store.SetComposedSystem(sess.Agent.System, sess.Agent.LeanSystem); err != nil {
+		if err := sess.Store.SetComposedSystem(sess.Agent.System, sess.Agent.LeanSystem, sess.Agent.Model); err != nil {
 			slog.Warn("freeze composed system prompt", "session", string(sess.Key), "err", err)
 		}
 	}

--- a/internal/server/subagent_test.go
+++ b/internal/server/subagent_test.go
@@ -103,7 +103,9 @@ func (s *systemRecordingSender) StreamMessagesWithTools(_ context.Context, _, sy
 // tools.MemoryBackendGuidance() into the sub-agent template's System prompt
 // ONCE — at server startup, and again after onboarding — and spawned
 // sub-agents reuse that baked template rather than recomposing per spawn
-// (unlike buildAgent/runChannelTurns, which do recompose every turn). Without
+// (unlike buildAgent/runChannelTurns, which each compose once per session and
+// freeze — see Session.SetComposedSystem — rather than reusing one shared
+// template). Without
 // refreshing the memory-backend globals first, a server that starts with
 // memory_backend already configured would still bake an empty guidance
 // block, because nothing had ever called the refresh before this function's

--- a/internal/tools/toolchain.go
+++ b/internal/tools/toolchain.go
@@ -40,10 +40,11 @@ var toolchainProbes = []struct {
 // DetectToolchain reports which curated developer tools resolve on the current
 // PATH, plus (for uv) octo's own bundled ~/.octo/bin fallback. The PATH
 // check is via exec.LookPath — a filesystem lookup, not a subprocess — so it
-// stays cheap enough to call on every context build, including the server's
-// per-turn recompose. Versions are deliberately not probed; the agent runs
-// `<tool> --version` on demand when it actually needs one. On Windows
-// LookPath honours PATHEXT, so npm.cmd / npx.cmd resolve as expected.
+// stays cheap enough to call on every context build (once per process for the
+// CLI/TUI, once per session for the server — see Session.SetComposedSystem).
+// Versions are deliberately not probed; the agent runs `<tool> --version` on
+// demand when it actually needs one. On Windows LookPath honours PATHEXT, so
+// npm.cmd / npx.cmd resolve as expected.
 //
 // The bundled-dir check matters because withBundledBinPath (sandbox.go)
 // already makes a bundled uv resolvable inside every child process octo


### PR DESCRIPTION
## Summary
- Web (`buildAgent`) and IM (`runChannelTurns`) sessions recomposed the entire system prompt from scratch on every turn — unlike the CLI/TUI, which compose once per process and freeze (`internal/prompt/prompt.go`'s own doc comment says as much). Two of the recomposed layers actually change mid-session in normal use: the live memory file (an agent's own tools write to it) and the env layer's per-day date line. Either changing invalidates the provider's prompt-cache prefix for that turn and every one after.
- `agent.Session` gains `ComposedSystem`/`ComposedLeanSystem`, persisted with the same append-or-rewrite mechanics as `Title`/`WorkingDir`/`PermissionMode` (`SetComposedSystem`).
- `buildAgent` and `runChannelTurns` now check the session's frozen fields first; only a session's first turn pays for `ComposePair` (and the memory/skills/MCP inputs that feed it) and persists the result.

## Trade-off (confirmed with the user before implementing)
A profile's system-prompt edit, or a skill/MCP toggle, now only takes effect in a **new** session — not one already open — same as editing those files under a running CLI process. Previously the server deliberately recomposed every turn so such edits landed immediately; this trades that immediacy for prompt-cache stability.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test -race ./...` (full suite green)
- [x] Updated `TestHandleChannelMessage_RefreshesSystemPerTurn` → `TestHandleChannelMessage_FreezesSystemAfterFirstTurn`, which asserted the old (now intentionally reversed) per-turn-recompose behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)