### PR TITLE
fix(agent): stop title generation from greeting back on a bare greeting

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1424,10 +1424,19 @@ const titleContextMaxRunes = 500
 // handful of words. 8 words / 25 characters mirrors FirstUserSnippet's
 // truncation budget, so a model title and the snippet fallback land at the
 // same length.
-const titleInstruction = "Generate a very short title that summarizes the user's first message or task. " +
-	"Do not answer the user or continue the conversation — only output a concise title. " +
+//
+// It also spells out that the wrapped <message> is raw content to summarize,
+// not a turn addressed to the model. Without this, a bare greeting like "你好"
+// as the sole user turn reliably triggers the model's trained reflex to greet
+// back ("你好！有什么可以帮你的吗") instead of following the system instruction —
+// the instruction alone (even worded as "do not answer") wasn't enough to
+// override that reflex; wrapping the text in tags so it no longer reads as a
+// direct address is what actually stops it.
+const titleInstruction = "Generate a very short title that summarizes the user's message or task, given below wrapped in <message> tags. " +
+	"The wrapped text is raw content for you to summarize, not a message addressed to you — never greet back, answer it, or continue the conversation, even if it reads like a greeting or a question. " +
+	"Only output a concise title. " +
 	"At most 8 words, or 25 characters for Chinese or Japanese. " +
-	"Reply with the title text only — no preamble, no quotes, no trailing punctuation, no markdown."
+	"Reply with the title text only — no preamble, no quotes, no trailing punctuation, no markdown, no <message> tags."
 
 // GenerateTitle produces a short title for the conversation so far, for
 // display in the session list. It is a throwaway provider call: the request
@@ -1465,7 +1474,9 @@ func (a *Agent) GenerateTitleFrom(ctx context.Context, snap []Message) (string, 
 	if r := []rune(text); len(r) > titleContextMaxRunes {
 		text = string(r[:titleContextMaxRunes])
 	}
-	msgs := []Message{NewUserMessage(text)}
+	// Wrapped in <message> tags (see titleInstruction) so the text reads as
+	// content to summarize rather than a turn addressed to the model.
+	msgs := []Message{NewUserMessage("<message>" + text + "</message>")}
 
 	if nr, ok := sender.(NoReasoningSender); ok {
 		sender = nr.NoReasoning()
@@ -1513,6 +1524,11 @@ func cleanTitle(s string) string {
 	for _, line := range strings.Split(s, "\n") {
 		line = strings.TrimSpace(line)
 		line = strings.TrimPrefix(line, "# ")
+		// The model occasionally echoes the <message> wrapper from the prompt
+		// (see titleInstruction) despite being told not to.
+		line = strings.TrimPrefix(line, "<message>")
+		line = strings.TrimSuffix(line, "</message>")
+		line = strings.TrimSpace(line)
 		// The model sometimes wraps the title in quotes AND adds trailing
 		// punctuation (e.g. `"Fix the bug".`), so trim both sets repeatedly
 		// until the string stops shrinking — one pass leaves the outer quote

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1920,8 +1920,8 @@ func TestAgent_GenerateTitle(t *testing.T) {
 	if n := len(send.gotMessages); n != 1 {
 		t.Fatalf("sent %d messages, want 1 (first user message only)", n)
 	}
-	if send.gotMessages[0].Content != "the login page redirects in a loop" {
-		t.Errorf("first sent message = %q, want the first user message only", send.gotMessages[0].Content)
+	if want := "<message>the login page redirects in a loop</message>"; send.gotMessages[0].Content != want {
+		t.Errorf("first sent message = %q, want %q (wrapped in <message> tags)", send.gotMessages[0].Content, want)
 	}
 	if send.gotSystem != titleInstruction {
 		t.Errorf("system = %q, want the title instruction", send.gotSystem)
@@ -2118,14 +2118,15 @@ func TestAgent_GenerateTitle_LiteFailureSurfacesWithoutRetry(t *testing.T) {
 
 func TestCleanTitle(t *testing.T) {
 	cases := map[string]string{
-		"Refactor the parser":          "Refactor the parser",
-		"\"Quoted title\"":             "Quoted title",
-		"# Markdown heading":           "Markdown heading",
-		"trailing period.":             "trailing period",
-		"中文标题。":                        "中文标题",
-		"  \n  spaced out  \n ignored": "spaced out",
-		"":                             "",
-		"\n\n":                         "",
+		"Refactor the parser":            "Refactor the parser",
+		"\"Quoted title\"":               "Quoted title",
+		"# Markdown heading":             "Markdown heading",
+		"trailing period.":               "trailing period",
+		"中文标题。":                          "中文标题",
+		"  \n  spaced out  \n ignored":   "spaced out",
+		"<message>Fix the bug</message>": "Fix the bug",
+		"":                               "",
+		"\n\n":                           "",
 	}
 	for in, want := range cases {
 		if got := cleanTitle(in); got != want {


### PR DESCRIPTION
## Summary
- The session-title throwaway call sent the title instruction only as the system prompt, with the user's raw first message (e.g. "你好") as the sole user turn — this reliably triggers the model's trained reflex to respond conversationally to a greeting instead of following the system instruction, producing titles like "你好！有什么可以帮你的吗" instead of a real title.
- Wrap the text in `<message>` tags so it reads as content to summarize rather than a turn addressed to the model, and spell this out explicitly in `titleInstruction`.
- `cleanTitle` now strips a stray echoed `<message>` tag as a safety net.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/agent/... ./internal/server/...`
- [x] `make fmt-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)