### PR TITLE
chore: bump version to 1.15.6

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.5"
+var Version = "1.15.6"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Bump `internal/version/version.go` for the next release.
- Includes since 1.15.5: desktop mac header padding fix (#2012), freezing the composed system prompt once per session on the server like the CLI (#2013), the new `/reload` slash command (#2014), refreshed WeChat group QR (#2015), session takeover notice surfaced to connected clients (#2016), and stopping session-title generation from greeting back on a bare greeting (#2017).

## Test plan
- [x] Version bump only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)