### PR TITLE
fix(mcp): don't decode a body for notification responses

### DIFF
--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -202,6 +202,16 @@ func (t *HTTPTransport) doRequest(ctx context.Context, msg *Message, forceFreshT
 		return false, fmt.Errorf("mcp: http %d: %s", resp.StatusCode, bytes.TrimSpace(b))
 	}
 
+	if msg.IsNotification() {
+		// The spec has servers accept a notification with 202 and no body,
+		// but 204 is handled above and some servers instead answer 200 with
+		// an empty (or non-JSON-RPC) body. Notify never registers a pending
+		// response, so there's nothing to decode or queue either way —
+		// drain the small ack body so the connection can be reused.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return false, nil
+	}
+
 	ct := resp.Header.Get("Content-Type")
 	switch {
 	case ct == "" || isJSONContentType(ct):

--- a/internal/mcp/http_test.go
+++ b/internal/mcp/http_test.go
@@ -361,6 +361,27 @@ func TestHTTPTransport_NotificationGet204(t *testing.T) {
 	}
 }
 
+// TestHTTPTransport_NotificationEmptyBody200 covers a server that
+// acknowledges a notification with 200 (not the spec-preferred 202, and not
+// the 204 the previous test covers) and an empty body: since Notify never
+// expects a response frame, this must not be treated as a JSON decode
+// failure (an empty body isn't valid JSON).
+func TestHTTPTransport_NotificationEmptyBody200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+
+	notif := &Message{JSONRPC: "2.0", Method: "notifications/initialized"}
+	if err := tx.Send(context.Background(), notif); err != nil {
+		t.Errorf("notification Send returned error: %v", err)
+	}
+}
+
 func TestNewHTTPTransport_EmptyURLRejected(t *testing.T) {
 	_, err := NewHTTPTransport(HTTPConfig{})
 	if err == nil {


### PR DESCRIPTION
## Summary
- Follow-up to #2019. The HTTP transport treated any non-204 2xx response as carrying a JSON-RPC frame to decode, but some MCP servers acknowledge a notification (e.g. `notifications/initialized`) with 200/202 and an empty body instead of 204 — this hit `mcp: decode response: EOF`.
- A notification is fire-and-forget (`Notify` never registers a pending response), so `doRequest` now skips the decode/queue step entirely once it knows the outbound message was a notification (`msg.IsNotification()`), regardless of the status code or Content-Type used to acknowledge it.

## Test plan
- [x] `go test -race ./internal/mcp/...`
- [x] `make vet` / `make fmt-check`
- [x] New test: notification acknowledged with 200 + empty `application/json` body