### PR TITLE
fix(web): stop the header search button collapsing in narrow windows

### DIFF
--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -111,9 +111,9 @@
     </button>
   {/if}
 
-  <button class="search-btn" onclick={() => cmdkOpen.set(true)}>
+  <button class="search-btn" title={$t('header.search_sessions')} onclick={() => cmdkOpen.set(true)}>
     <iconify-icon icon="ant-design:search-outlined" width="15"></iconify-icon>
-    <span>{$t('header.search_sessions')}</span>
+    <span class="label">{$t('header.search_sessions')}</span>
     <kbd>⌘K</kbd>
   </button>
 
@@ -195,9 +195,28 @@ header .window-controls { --wails-draggable: no-drag; }
   height: 30px; padding: 0 9px;
   background: transparent; border: none; border-radius: var(--radius-sm);
   color: var(--text-secondary); cursor: pointer; font-family: inherit;
+  /* The header can't wrap (fixed 48px) and every other control is
+     fixed-width, so the label was the only thing that could give: it wrapped
+     to several lines inside the 30px-tall button and spilled over the
+     header's edge into the view below. */
+  flex: 0 0 auto; white-space: nowrap;
 }
 .search-btn:hover { background: var(--hover-neutral); color: var(--text); }
 kbd { font-size: 11px; font-family: var(--font-mono); }
+
+/* Narrow windows: nothing here shrinks, so shed the label-only decoration
+   instead of letting controls collide. Steps reuse the widths the sidebar
+   already switches on (Sidebar.svelte: rail below 860, hidden below 640). */
+@media (max-width: 860px) {
+  .sub, .brand-divider { display: none; }
+  .search-btn kbd { display: none; }
+}
+@media (max-width: 640px) {
+  /* Icon-only from here — the title attribute carries the meaning, the same
+     way ChatView's header buttons drop their labels below 680px. */
+  .search-btn .label { display: none; }
+  .search-btn { padding: 0 7px; }
+}
 
 .ptoggle-group {
   display: inline-flex; gap: 2px; padding: 2px;


### PR DESCRIPTION
## Problem

At narrow window widths the header's search button label wrapped to several vertical lines inside its 30px-tall box and spilled past the header's edge, colliding with the panel toggle and the row below.

The header is a fixed-48px, `nowrap` flex row in which every other control has a fixed width (`.icon-btn` 30px, `.ptoggle` 30px, `.sub` already `nowrap`), so `.search-btn` was the only shrinkable item and absorbed the entire deficit. `Header.svelte` had no `@media`/`@container` rules at all.

## Fix

- `.search-btn` gets `flex: 0 0 auto` + `white-space: nowrap` so it can no longer be crushed.
- Two degradation steps, reusing the widths the sidebar already switches on (`Sidebar.svelte`: rail below 860, hidden below 640) rather than inventing new breakpoints:
  - **≤860px** — hide the `nav.workbench` subtitle, its divider, and the `⌘K` hint.
  - **≤640px** — hide the search label too, leaving an icon-only button; a new `title` attribute carries the meaning, matching how ChatView's header buttons already drop their labels below 680px.

## Verification

`svelte-check` clean (0 errors; the 2 remaining `line-clamp` warnings are pre-existing in AgentsView/LightAppsView). Production `make web-build` succeeds.

Rendered the built bundle against a throwaway static server (no backend) and measured over CDP with an explicit `Emulation.setDeviceMetricsOverride`, checking `scrollWidth` vs `clientWidth` plus every element extending past the viewport:

| CSS width | Result |
|---|---|
| 360 | header complete on one line, `scrollWidth == 360`, zero overflowing elements |
| 500 | same, zero overflowing elements |
| 800 | subtitle + `⌘K` hidden, search label retained, sidebar in rail mode |
| 1200 | unchanged from before — full subtitle, `Search sessions… ⌘K`, all controls |

The worst case is covered: with no reachable backend the reconnect spinner occupies an extra 30px slot in the header, and it still fits at 360.