### PR TITLE
chore: bump version to 1.15.7

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.6"
+var Version = "1.15.7"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Includes since 1.15.6:

- **#2019** — MCP Streamable HTTP transport accepts `text/event-stream` responses instead of hard-failing the initialize handshake.
- **#2020** — the same transport no longer tries to decode a response body for fire-and-forget notifications, which servers may acknowledge with an empty 200/202 instead of 204.

Together those two unblock MCP servers that answer over SSE.

- **#2021** — web: the header search button no longer collapses into wrapped, overflowing text in narrow windows.