### PR TITLE
feat(mcp): negotiate protocol version, paginate lists, release sessions

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -41,6 +41,9 @@ type Client struct {
 	caps         ServerCapabilities
 	serverInfo   Implementation
 	instructions string
+	// protocolVersion is what the server answered with in the handshake, not
+	// necessarily the ProtocolVersion constant we asked for.
+	protocolVersion string
 
 	nextID atomic.Uint64
 
@@ -95,6 +98,15 @@ func (c *Client) Initialize(ctx context.Context) error {
 	c.caps = result.Capabilities
 	c.serverInfo = result.ServerInfo
 	c.instructions = result.Instructions
+	c.protocolVersion = result.ProtocolVersion
+
+	// Transports that carry the negotiated revision on the wire (HTTP, via
+	// the MCP-Protocol-Version header) learn it here — before the
+	// initialized notification below, so every post-handshake request
+	// advertises it. stdio needs nothing and doesn't implement the setter.
+	if pv, ok := c.transport.(protocolVersionSetter); ok && result.ProtocolVersion != "" {
+		pv.SetProtocolVersion(result.ProtocolVersion)
+	}
 
 	// notifications/initialized lets the server know we're done handshaking
 	// and ready for normal traffic. Fire-and-forget — the server doesn't
@@ -105,9 +117,22 @@ func (c *Client) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// protocolVersionSetter is implemented by transports that must advertise the
+// negotiated protocol revision on every request. Only HTTP needs it — stdio
+// carries no per-request metadata — so it stays an optional capability
+// rather than part of the Transport interface.
+type protocolVersionSetter interface {
+	SetProtocolVersion(v string)
+}
+
 // ServerInfo returns the {name, version} the server advertised in its
 // initialize response. Useful for /mcp output.
 func (c *Client) ServerInfo() Implementation { return c.serverInfo }
+
+// ProtocolVersion returns the spec revision the server chose in the
+// handshake, which may differ from the ProtocolVersion we requested. Empty
+// before Initialize completes.
+func (c *Client) ProtocolVersion() string { return c.protocolVersion }
 
 // Capabilities returns the server's advertised capabilities so callers can
 // avoid calling tools/list against a server that doesn't support tools.
@@ -275,15 +300,42 @@ func (c *Client) Close() error {
 
 // ── Typed convenience wrappers ───────────────────────────────────────────
 
+// maxListPages bounds cursor-following so a server that keeps handing back a
+// fresh cursor can't spin us forever. Generous enough that hitting it means
+// the server is broken, not that someone has a lot of tools.
+const maxListPages = 100
+
+// nextPageCursor decides whether to fetch another page. A server signals the
+// end with an empty cursor; one that repeats the cursor it just gave us is
+// buggy, and following it would loop forever, so treat that as the end too.
+func nextPageCursor(next, current string) (string, bool) {
+	if next == "" || next == current {
+		return "", false
+	}
+	return next, true
+}
+
 func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
 	if c.caps.Tools == nil {
 		return nil, nil
 	}
-	var r ListToolsResult
-	if err := c.Call(ctx, MethodToolsList, struct{}{}, &r); err != nil {
-		return nil, err
+	var all []Tool
+	cursor := ""
+	for range maxListPages {
+		var r ListToolsResult
+		if err := c.Call(ctx, MethodToolsList, PaginatedParams{Cursor: cursor}, &r); err != nil {
+			return nil, err
+		}
+		all = append(all, r.Tools...)
+		next, more := nextPageCursor(r.NextCursor, cursor)
+		if !more {
+			return all, nil
+		}
+		cursor = next
 	}
-	return r.Tools, nil
+	// Erroring rather than returning a truncated list: silently exposing a
+	// subset of a server's tools is the failure this pagination exists to fix.
+	return nil, fmt.Errorf("mcp: tools/list did not terminate within %d pages", maxListPages)
 }
 
 func (c *Client) CallTool(ctx context.Context, name string, args map[string]any) (*CallToolResult, error) {
@@ -298,11 +350,21 @@ func (c *Client) ListResources(ctx context.Context) ([]Resource, error) {
 	if c.caps.Resources == nil {
 		return nil, nil
 	}
-	var r ListResourcesResult
-	if err := c.Call(ctx, MethodResourcesList, struct{}{}, &r); err != nil {
-		return nil, err
+	var all []Resource
+	cursor := ""
+	for range maxListPages {
+		var r ListResourcesResult
+		if err := c.Call(ctx, MethodResourcesList, PaginatedParams{Cursor: cursor}, &r); err != nil {
+			return nil, err
+		}
+		all = append(all, r.Resources...)
+		next, more := nextPageCursor(r.NextCursor, cursor)
+		if !more {
+			return all, nil
+		}
+		cursor = next
 	}
-	return r.Resources, nil
+	return nil, fmt.Errorf("mcp: resources/list did not terminate within %d pages", maxListPages)
 }
 
 func (c *Client) ReadResource(ctx context.Context, uri string) ([]ResourceContent, error) {
@@ -317,11 +379,21 @@ func (c *Client) ListPrompts(ctx context.Context) ([]Prompt, error) {
 	if c.caps.Prompts == nil {
 		return nil, nil
 	}
-	var r ListPromptsResult
-	if err := c.Call(ctx, MethodPromptsList, struct{}{}, &r); err != nil {
-		return nil, err
+	var all []Prompt
+	cursor := ""
+	for range maxListPages {
+		var r ListPromptsResult
+		if err := c.Call(ctx, MethodPromptsList, PaginatedParams{Cursor: cursor}, &r); err != nil {
+			return nil, err
+		}
+		all = append(all, r.Prompts...)
+		next, more := nextPageCursor(r.NextCursor, cursor)
+		if !more {
+			return all, nil
+		}
+		cursor = next
 	}
-	return r.Prompts, nil
+	return nil, fmt.Errorf("mcp: prompts/list did not terminate within %d pages", maxListPages)
 }
 
 func (c *Client) GetPrompt(ctx context.Context, name string, args map[string]string) (*GetPromptResult, error) {

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // HTTPTransport speaks JSON-RPC 2.0 over a single HTTP endpoint, per the
@@ -29,7 +30,10 @@ import (
 //     anyway) or the stream itself closes.
 //   - The server-issued Mcp-Session-Id header is captured on the first
 //     response and echoed on every subsequent request, so the server can
-//     resume per-client state.
+//     resume per-client state. Close releases it with a DELETE.
+//   - The protocol revision the server picks during initialize is echoed
+//     back in MCP-Protocol-Version on every later request, which servers
+//     implementing 2025-03-26 or later require.
 //
 // What we don't implement (v1 omission)
 //   - SSE stream resumption via Last-Event-ID on reconnect.
@@ -52,6 +56,16 @@ type HTTPTransport struct {
 	// Mcp-Session-Id. Subsequent requests echo it back.
 	sessionMu sync.Mutex
 	sessionID string
+
+	// protocolVersion is the revision the server chose during initialize,
+	// pushed in by Client.Initialize via SetProtocolVersion. Echoed back in
+	// MCP-Protocol-Version on every request once known — servers
+	// implementing 2025-03-26 or later require the header and reject
+	// requests without it. Empty until the handshake completes (the
+	// initialize request itself carries the version in its params, not a
+	// header), so we simply omit it then.
+	protoMu         sync.Mutex
+	protocolVersion string
 
 	// inbox queues the response of each Send so Receive can hand it back.
 	// Buffered so a Send never blocks (paired with one Receive per Send,
@@ -153,6 +167,11 @@ func (t *HTTPTransport) doRequest(ctx context.Context, msg *Message, forceFreshT
 		req.Header.Set("Mcp-Session-Id", t.sessionID)
 	}
 	t.sessionMu.Unlock()
+	t.protoMu.Lock()
+	if t.protocolVersion != "" {
+		req.Header.Set("MCP-Protocol-Version", t.protocolVersion)
+	}
+	t.protoMu.Unlock()
 
 	// Bearer-token injection from OAuth provider, if configured.
 	if t.oauth != nil {
@@ -247,6 +266,12 @@ func (t *HTTPTransport) queue(ctx context.Context, m *Message) error {
 // scanning once the frame answering our request has been queued — it is
 // never returned to the caller.
 var errSSEResponseReceived = errors.New("mcp: sse response received")
+
+// sessionDeleteTimeout bounds the best-effort session-termination DELETE that
+// Close fires. Short on purpose: Close runs on teardown paths (process exit,
+// /exit, a server being removed) where blocking is worse than leaking a
+// session the server will time out on its own. A var so tests can shrink it.
+var sessionDeleteTimeout = 3 * time.Second
 
 // maxSSEEventBytes bounds both a single SSE line (via scanner.Buffer) and
 // the total size of one event's "data:" lines accumulated across multiple
@@ -361,14 +386,70 @@ func (t *HTTPTransport) Receive(ctx context.Context) (*Message, error) {
 	}
 }
 
+// SetProtocolVersion records the revision the server chose during the
+// initialize handshake so later requests can advertise it. Called by
+// Client.Initialize before it sends notifications/initialized, so every
+// post-handshake request carries the header.
+func (t *HTTPTransport) SetProtocolVersion(v string) {
+	t.protoMu.Lock()
+	t.protocolVersion = v
+	t.protoMu.Unlock()
+}
+
 // Close tears the transport down. Idempotent. After Close, any pending
 // Receive caller is unblocked with io.EOF; further Sends return an error.
+//
+// If the server issued a session id, Close first tries to release it with a
+// DELETE (the spec's session-termination request) so the server can drop its
+// per-client state instead of holding it until an idle timeout. That is a
+// courtesy on a teardown path: it gets a short independent timeout — the
+// caller's context is typically already cancelled by the time we're closing —
+// and any failure is ignored, since there is nothing useful to do about a
+// server that won't let go of a session we're abandoning anyway.
 func (t *HTTPTransport) Close() error {
 	if !t.closed.CompareAndSwap(false, true) {
 		return nil
 	}
+	t.deleteSession()
 	close(t.done)
 	return nil
+}
+
+func (t *HTTPTransport) deleteSession() {
+	t.sessionMu.Lock()
+	sid := t.sessionID
+	t.sessionMu.Unlock()
+	if sid == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sessionDeleteTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, t.url, nil)
+	if err != nil {
+		return
+	}
+	for k, v := range t.headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Mcp-Session-Id", sid)
+	t.protoMu.Lock()
+	if t.protocolVersion != "" {
+		req.Header.Set("MCP-Protocol-Version", t.protocolVersion)
+	}
+	t.protoMu.Unlock()
+	// Reuse the cached OAuth token if we have one, but never start an
+	// interactive authorization just to say goodbye.
+	if t.oauth != nil {
+		if tok, terr := t.oauth.Token(ctx); terr == nil && tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	resp, err := t.hc.Do(req)
+	if err != nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	_ = resp.Body.Close()
 }
 
 // isJSONContentType reports whether ct (a Content-Type header value)

--- a/internal/mcp/http_test.go
+++ b/internal/mcp/http_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -379,6 +380,176 @@ func TestHTTPTransport_NotificationEmptyBody200(t *testing.T) {
 	notif := &Message{JSONRPC: "2.0", Method: "notifications/initialized"}
 	if err := tx.Send(context.Background(), notif); err != nil {
 		t.Errorf("notification Send returned error: %v", err)
+	}
+}
+
+// TestHTTPTransport_ProtocolVersionHeader: once the handshake settles on a
+// revision, every later request must advertise it — servers implementing
+// 2025-03-26 or later reject requests that don't.
+func TestHTTPTransport_ProtocolVersionHeader(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("MCP-Protocol-Version"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{}`),
+		})
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+	req := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+
+	// Before the handshake there is no negotiated version to send.
+	if err := tx.Send(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	tx.SetProtocolVersion("2025-03-26")
+	if err := tx.Send(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(seen))
+	}
+	if seen[0] != "" {
+		t.Errorf("pre-handshake request carried version %q, want none", seen[0])
+	}
+	if seen[1] != "2025-03-26" {
+		t.Errorf("post-handshake request carried %q, want 2025-03-26", seen[1])
+	}
+}
+
+// TestHTTPTransport_CloseDeletesSession: Close releases a server-issued
+// session so the server can drop its state instead of holding it to timeout.
+func TestHTTPTransport_CloseDeletesSession(t *testing.T) {
+	type call struct{ method, session, version string }
+	var mu sync.Mutex
+	var calls []call
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls = append(calls, call{r.Method, r.Header.Get("Mcp-Session-Id"), r.Header.Get("MCP-Protocol-Version")})
+		mu.Unlock()
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "sess-9")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{}`),
+		})
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	tx.SetProtocolVersion("2025-03-26")
+	req := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	if err := tx.Send(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 2 {
+		t.Fatalf("calls = %+v, want a POST then a DELETE", calls)
+	}
+	del := calls[1]
+	if del.method != http.MethodDelete {
+		t.Errorf("second call method = %s, want DELETE", del.method)
+	}
+	if del.session != "sess-9" {
+		t.Errorf("DELETE session = %q, want sess-9", del.session)
+	}
+	if del.version != "2025-03-26" {
+		t.Errorf("DELETE version header = %q, want 2025-03-26", del.version)
+	}
+}
+
+// TestHTTPTransport_CloseWithoutSessionSkipsDelete: no session id means there
+// is nothing to release, so Close must not fire a stray DELETE.
+func TestHTTPTransport_CloseWithoutSessionSkipsDelete(t *testing.T) {
+	var mu sync.Mutex
+	deletes := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			mu.Lock()
+			deletes++
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	notif := &Message{JSONRPC: "2.0", Method: "notifications/initialized"}
+	if err := tx.Send(context.Background(), notif); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if deletes != 0 {
+		t.Errorf("fired %d DELETEs without a session id, want 0", deletes)
+	}
+}
+
+// TestHTTPTransport_CloseSurvivesDeleteFailure: the DELETE is a courtesy on a
+// teardown path — an unreachable or hostile server must not make Close hang
+// or fail.
+func TestHTTPTransport_CloseSurvivesDeleteFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "sess-x")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{}`),
+		})
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	req := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	if err := tx.Send(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- tx.Close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Close returned %v, want nil despite the failed DELETE", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close hung on a failing DELETE")
 	}
 }
 

--- a/internal/mcp/pagination_test.go
+++ b/internal/mcp/pagination_test.go
@@ -1,0 +1,338 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// pagingServer answers initialize, then serves tools/list from a fixed list
+// of pages, recording the cursor each request carried so a test can assert
+// the client actually walked the chain. cursorFor decides what NextCursor a
+// page reports, which is how the pathological cases (a repeated cursor, a
+// cursor that never ends) are simulated.
+type pagingServer struct {
+	tx        *mockTransport
+	pages     [][]Tool
+	cursorFor func(page int, lastCursor string) string
+
+	mu   sync.Mutex
+	seen []string // cursor received per tools/list request, in order
+
+	stopped  chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+func newPagingServer(pages [][]Tool) *pagingServer {
+	return &pagingServer{
+		tx:      newMockTransport(),
+		pages:   pages,
+		stopped: make(chan struct{}),
+		// Default: page N reports cursor "cN" until the last page, which ends
+		// the walk with an empty cursor.
+		cursorFor: func(page int, _ string) string {
+			if page >= len(pages)-1 {
+				return ""
+			}
+			return "c" + string(rune('1'+page))
+		},
+	}
+}
+
+func (s *pagingServer) cursors() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.seen...)
+}
+
+func (s *pagingServer) start() {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		reqs := 0
+		for {
+			select {
+			case <-s.stopped:
+				return
+			case req, ok := <-s.tx.in:
+				if !ok {
+					return
+				}
+				if req.IsNotification() {
+					continue
+				}
+				switch req.Method {
+				case MethodInitialize:
+					b, _ := json.Marshal(InitializeResult{
+						ProtocolVersion: ProtocolVersion,
+						Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+						ServerInfo:      Implementation{Name: "pager", Version: "1"},
+					})
+					s.tx.out <- &Message{JSONRPC: "2.0", ID: req.ID, Result: b}
+				case MethodToolsList:
+					var p PaginatedParams
+					_ = json.Unmarshal(req.Params, &p)
+					s.mu.Lock()
+					s.seen = append(s.seen, p.Cursor)
+					s.mu.Unlock()
+
+					idx := reqs
+					reqs++
+					var tools []Tool
+					if idx < len(s.pages) {
+						tools = s.pages[idx]
+					}
+					b, _ := json.Marshal(ListToolsResult{
+						Tools:      tools,
+						NextCursor: s.cursorFor(idx, p.Cursor),
+					})
+					s.tx.out <- &Message{JSONRPC: "2.0", ID: req.ID, Result: b}
+				default:
+					s.tx.out <- &Message{
+						JSONRPC: "2.0", ID: req.ID,
+						Error: &RPCError{Code: -32601, Message: "unexpected " + req.Method},
+					}
+				}
+			}
+		}
+	}()
+}
+
+func (s *pagingServer) stop() {
+	s.stopOnce.Do(func() {
+		close(s.stopped)
+		_ = s.tx.Close()
+	})
+	s.wg.Wait()
+}
+
+func (s *pagingServer) client(t *testing.T) *Client {
+	t.Helper()
+	s.start()
+	c := NewClient(s.tx, Implementation{Name: "test", Version: "1"})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	return c
+}
+
+// TestListTools_FollowsCursor is the regression this pagination exists for:
+// a server that splits its tools across pages used to have everything past
+// page 1 silently dropped, with no error to hint at it.
+func TestListTools_FollowsCursor(t *testing.T) {
+	srv := newPagingServer([][]Tool{
+		{{Name: "a"}, {Name: "b"}},
+		{{Name: "c"}},
+		{{Name: "d"}, {Name: "e"}},
+	})
+	defer srv.stop()
+	c := srv.client(t)
+	defer c.Close()
+
+	tools, err := c.ListTools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, tl := range tools {
+		got = append(got, tl.Name)
+	}
+	if strings.Join(got, ",") != "a,b,c,d,e" {
+		t.Errorf("tools = %v, want all five across three pages", got)
+	}
+	// First request carries no cursor; each later one carries what the
+	// previous page returned.
+	if want := ",c1,c2"; strings.Join(srv.cursors(), ",") != want {
+		t.Errorf("cursors sent = %q, want %q", strings.Join(srv.cursors(), ","), want)
+	}
+}
+
+// TestListTools_SinglePageSendsNoCursor pins the wire compatibility claim:
+// an unpaginated server sees exactly one request, with no cursor.
+func TestListTools_SinglePageSendsNoCursor(t *testing.T) {
+	srv := newPagingServer([][]Tool{{{Name: "only"}}})
+	defer srv.stop()
+	c := srv.client(t)
+	defer c.Close()
+
+	tools, err := c.ListTools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "only" {
+		t.Errorf("tools = %v, want [only]", tools)
+	}
+	if got := srv.cursors(); len(got) != 1 || got[0] != "" {
+		t.Errorf("cursors sent = %q, want exactly one empty cursor", got)
+	}
+}
+
+// TestListTools_RepeatedCursorStops guards the loop: a server that keeps
+// handing back the cursor it was just given must not spin us forever.
+func TestListTools_RepeatedCursorStops(t *testing.T) {
+	srv := newPagingServer([][]Tool{{{Name: "a"}}, {{Name: "b"}}})
+	srv.cursorFor = func(page int, _ string) string {
+		if page == 0 {
+			return "stuck"
+		}
+		return "stuck" // same cursor again — the client must give up here
+	}
+	defer srv.stop()
+	c := srv.client(t)
+	defer c.Close()
+
+	done := make(chan struct{})
+	var tools []Tool
+	var err error
+	go func() {
+		tools, err = c.ListTools(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ListTools never returned — the repeated cursor looped")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Both pages fetched, then the repeat ends it.
+	if len(tools) != 2 {
+		t.Errorf("tools = %v, want the two pages fetched before the repeat", tools)
+	}
+}
+
+// TestListTools_RunawayPagingErrors: a server handing back an endless chain
+// of fresh cursors gets cut off with an error rather than being followed
+// forever or silently truncated.
+func TestListTools_RunawayPagingErrors(t *testing.T) {
+	srv := newPagingServer([][]Tool{{{Name: "a"}}})
+	page := 0
+	srv.cursorFor = func(_ int, _ string) string {
+		page++
+		return "cursor-" + string(rune('a'+page%26)) + string(rune('a'+page/26))
+	}
+	defer srv.stop()
+	c := srv.client(t)
+	defer c.Close()
+
+	done := make(chan struct{})
+	var err error
+	go func() {
+		_, err = c.ListTools(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ListTools never returned on a runaway cursor chain")
+	}
+	if err == nil || !strings.Contains(err.Error(), "did not terminate") {
+		t.Errorf("err = %v, want a did-not-terminate error", err)
+	}
+	if n := len(srv.cursors()); n != maxListPages {
+		t.Errorf("requests = %d, want the %d-page cap", n, maxListPages)
+	}
+}
+
+// TestInitialize_RecordsNegotiatedVersion: the session runs on whatever the
+// server answered with, not on the version we asked for.
+func TestInitialize_RecordsNegotiatedVersion(t *testing.T) {
+	tx := newMockTransport()
+	stopped := make(chan struct{})
+	defer close(stopped)
+	go func() {
+		for {
+			select {
+			case <-stopped:
+				return
+			case req, ok := <-tx.in:
+				if !ok || req.IsNotification() {
+					continue
+				}
+				if req.Method == MethodInitialize {
+					b, _ := json.Marshal(InitializeResult{
+						ProtocolVersion: "2025-03-26", // newer than we requested
+						Capabilities:    ServerCapabilities{},
+						ServerInfo:      Implementation{Name: "newer", Version: "1"},
+					})
+					tx.out <- &Message{JSONRPC: "2.0", ID: req.ID, Result: b}
+				}
+			}
+		}
+	}()
+
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.ProtocolVersion(); got != "2025-03-26" {
+		t.Errorf("ProtocolVersion() = %q, want the server's answer 2025-03-26", got)
+	}
+}
+
+// versionRecordingTransport captures SetProtocolVersion so we can assert the
+// client pushes the negotiated revision down to transports that need it.
+type versionRecordingTransport struct {
+	*mockTransport
+	mu  sync.Mutex
+	got string
+}
+
+func (v *versionRecordingTransport) SetProtocolVersion(s string) {
+	v.mu.Lock()
+	v.got = s
+	v.mu.Unlock()
+}
+
+func (v *versionRecordingTransport) version() string {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.got
+}
+
+func TestInitialize_PushesVersionToTransport(t *testing.T) {
+	tx := &versionRecordingTransport{mockTransport: newMockTransport()}
+	stopped := make(chan struct{})
+	defer close(stopped)
+	go func() {
+		for {
+			select {
+			case <-stopped:
+				return
+			case req, ok := <-tx.in:
+				if !ok || req.IsNotification() {
+					continue
+				}
+				if req.Method == MethodInitialize {
+					b, _ := json.Marshal(InitializeResult{
+						ProtocolVersion: "2025-06-18",
+						Capabilities:    ServerCapabilities{},
+						ServerInfo:      Implementation{Name: "s", Version: "1"},
+					})
+					tx.out <- &Message{JSONRPC: "2.0", ID: req.ID, Result: b}
+				}
+			}
+		}
+	}()
+
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := tx.version(); got != "2025-06-18" {
+		t.Errorf("transport received version %q, want 2025-06-18", got)
+	}
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -19,11 +19,12 @@ import (
 	"encoding/json"
 )
 
-// ProtocolVersion is the MCP spec revision this client implements. Sent in
-// the initialize request; the server is expected to echo it back (or a
-// compatible newer/older version it can downgrade to). We don't currently
-// negotiate — if the server returns a different version we accept it and
-// hope for the best.
+// ProtocolVersion is the MCP spec revision this client implements and asks
+// for in the initialize request. The server answers with the revision it
+// will actually speak — the same one, or another it can serve — and that
+// answer, not this constant, is what the session runs on. Client.Initialize
+// records it and the HTTP transport echoes it back in MCP-Protocol-Version
+// on every later request, which servers from 2025-03-26 onward require.
 const ProtocolVersion = "2024-11-05"
 
 // ── JSON-RPC 2.0 frame ───────────────────────────────────────────────────
@@ -151,6 +152,14 @@ type Tool struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description,omitempty"`
 	InputSchema json.RawMessage `json:"inputSchema,omitempty"`
+}
+
+// PaginatedParams is the request shape shared by the list methods. An empty
+// Cursor asks for the first page — which marshals to the same `{}` the
+// unpaginated calls used to send — and each later request carries the
+// NextCursor the previous page handed back.
+type PaginatedParams struct {
+	Cursor string `json:"cursor,omitempty"`
 }
 
 type ListToolsResult struct {

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -278,6 +278,12 @@ func (r *Registry) Len() int {
 // Close tears every connection down. Idempotent. Errors per server are
 // dropped — Close is end-of-life and the user can't do anything with the
 // errors anyway.
+//
+// Connections close concurrently because closing one is no longer purely
+// local: an HTTP transport releases its session with a DELETE, which waits on
+// a server that may be slow or gone. Serially that cost would add up across
+// servers and stall process exit; in parallel the whole teardown is bounded
+// by the slowest single connection however many are configured.
 func (r *Registry) Close() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -285,9 +291,15 @@ func (r *Registry) Close() {
 		return
 	}
 	r.closed = true
+	var wg sync.WaitGroup
 	for _, c := range r.conns {
-		_ = c.Client.Close()
+		wg.Add(1)
+		go func(c *Connection) {
+			defer wg.Done()
+			_ = c.Client.Close()
+		}(c)
 	}
+	wg.Wait()
 }
 
 func sortedKeys(m map[string]*Connection) []string {

--- a/internal/mcp/registry_manage_test.go
+++ b/internal/mcp/registry_manage_test.go
@@ -50,6 +50,75 @@ func fakeMCPServer(t *testing.T, toolNames ...string) *httptest.Server {
 	}))
 }
 
+// TestRegistryClose_ConcurrentAcrossServers pins the exit-latency invariant.
+// Closing an HTTP connection now waits on a session-terminating DELETE, so
+// closing servers one after another would make teardown cost scale with the
+// number of configured servers. Several servers that stall their DELETE must
+// still close in about the time one takes, not the sum.
+func TestRegistryClose_ConcurrentAcrossServers(t *testing.T) {
+	const servers = 4
+	const stall = 400 * time.Millisecond
+
+	makeStalling := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				time.Sleep(stall) // a server that's slow to let go
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			var in Message
+			_ = json.Unmarshal(body, &in)
+			if in.ID == nil {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			var result any
+			switch in.Method {
+			case "initialize":
+				result = InitializeResult{
+					ProtocolVersion: ProtocolVersion,
+					Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+					ServerInfo:      Implementation{Name: "slow", Version: "0"},
+				}
+			case "tools/list":
+				result = map[string]any{"tools": []Tool{}}
+			default:
+				result = map[string]any{}
+			}
+			raw, _ := json.Marshal(result)
+			// Hand out a session id so Close has something to release.
+			w.Header().Set("Mcp-Session-Id", "sess-close")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(Message{JSONRPC: "2.0", ID: in.ID, Result: raw})
+		}))
+	}
+
+	reg := NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for i := range servers {
+		srv := makeStalling()
+		defer srv.Close()
+		name := "slow" + string(rune('a'+i))
+		if err := reg.Connect(ctx, name, ServerEntry{URL: srv.URL},
+			Implementation{Name: "test", Version: "1"}, nil, nil); err != nil {
+			t.Fatalf("connect %s: %v", name, err)
+		}
+	}
+
+	start := time.Now()
+	reg.Close()
+	elapsed := time.Since(start)
+
+	// Serial teardown would take servers*stall; allow generous headroom over
+	// a single stall while still failing if the cost is being summed.
+	if limit := stall * 5 / 2; elapsed > limit {
+		t.Errorf("Close took %v for %d stalling servers (limit %v) — teardown looks serial",
+			elapsed, servers, limit)
+	}
+}
+
 func TestRegistryConnect_AddAndReplace(t *testing.T) {
 	srv := fakeMCPServer(t, "ping", "pong")
 	defer srv.Close()


### PR DESCRIPTION
Three MCP spec-compliance gaps that real servers hit. Found while chasing why a server that answers over SSE wouldn't connect (#2019, #2020) — these are the next things it would have tripped on.

## 1. Protocol version was never negotiated or advertised

`InitializeResult.ProtocolVersion` was parsed and discarded, and nothing ever sent an `MCP-Protocol-Version` header. Servers implementing **2025-03-26 or later require that header on every request after the handshake** and reject requests without it.

`Client.Initialize` now records what the server actually chose (which may differ from the `ProtocolVersion` constant we ask for — one real server answers `2025-03-26` to our `2024-11-05`) and pushes it into transports that carry per-request metadata. That's an optional `protocolVersionSetter` interface rather than a `Transport` method, since only HTTP needs it. It's set *before* `notifications/initialized`, so every post-handshake request carries it.

New `Client.ProtocolVersion()` accessor for parity with `ServerInfo()`/`Capabilities()`.

## 2. Pagination was declared but never implemented

`NextCursor` existed on all three list result structs and was **read nowhere in the repo** — `ListTools` returned page one and stopped. A server with more tools than fit one page had the rest silently dropped: no error, no warning, the model just couldn't see them.

All three list methods now walk the cursor chain. Guards: stop on an empty cursor (normal end) or a repeated one (buggy server, would otherwise loop forever), and error past a 100-page cap rather than silently truncating — silent truncation is the bug being fixed, so failing loudly is the point. An empty cursor marshals away under `omitempty`, so an unpaginated server sees the same `{}` request body as before.

## 3. Sessions were abandoned, not released

`Close` dropped the `Mcp-Session-Id` on the floor, leaving servers holding per-client state until an idle timeout. It now sends the spec's session-termination `DELETE`, carrying the session id, protocol version, and a cached OAuth token if there is one (never starting an interactive authorization just to say goodbye). Failures are ignored — it's a courtesy on a teardown path.

**This required a companion fix:** closing a connection is no longer purely local, so `Registry.Close()` — which closed connections sequentially under its mutex — would have made process exit cost `N × timeout` with unreachable servers. It now closes them concurrently, bounding teardown by the slowest single connection regardless of server count.

## Test plan

- [x] `go test -race ./internal/mcp/ ./internal/tools/ ./internal/app/ ./internal/server/` — all green
- [x] `make vet`, `gofmt -l` clean

New tests:

| Test | Covers |
|---|---|
| `TestListTools_FollowsCursor` | three pages collected, cursors echoed in order (`""`, `c1`, `c2`) |
| `TestListTools_SinglePageSendsNoCursor` | wire compatibility — one request, no cursor |
| `TestListTools_RepeatedCursorStops` | server repeating a cursor terminates instead of looping |
| `TestListTools_RunawayPagingErrors` | endless fresh cursors hit the page cap and error |
| `TestInitialize_RecordsNegotiatedVersion` | session runs on the server's answer, not our constant |
| `TestInitialize_PushesVersionToTransport` | negotiated revision reaches the transport |
| `TestHTTPTransport_ProtocolVersionHeader` | absent pre-handshake, present after |
| `TestHTTPTransport_CloseDeletesSession` | DELETE carries session id + version |
| `TestHTTPTransport_CloseWithoutSessionSkipsDelete` | no session ⇒ no stray DELETE |
| `TestHTTPTransport_CloseSurvivesDeleteFailure` | Close neither hangs nor errors on a failing DELETE |
| `TestRegistryClose_ConcurrentAcrossServers` | 4 servers each stalling their DELETE 400ms close in ~0.41s, not ~1.6s |