### PR TITLE
fix(mcp): let image results reach the model instead of a placeholder

### DIFF
--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -122,66 +123,70 @@ func mcpToolDefs() []agent.ToolDefinition {
 // through to its normal dispatch. Errors from the underlying client are
 // propagated as-is so the agent loop sees the same error surface it would
 // for any other tool.
-func executeMCP(ctx context.Context, name string, input map[string]any) (out string, ok bool, err error) {
+func executeMCP(ctx context.Context, name string, input map[string]any) (out agent.ToolResult, ok bool, err error) {
 	if !strings.HasPrefix(name, "mcp__") {
-		return "", false, nil
+		return agent.ToolResult{}, false, nil
+	}
+	fail := func(format string, args ...any) (agent.ToolResult, bool, error) {
+		return agent.ToolResult{}, true, fmt.Errorf(format, args...)
 	}
 	server, tool, ok2 := parseMCPName(name)
 	if !ok2 {
-		return "", true, fmt.Errorf("mcp: malformed tool name %q (want mcp__<server>__<tool>)", name)
+		return fail("mcp: malformed tool name %q (want mcp__<server>__<tool>)", name)
 	}
 	reg := ActiveMCPRegistry()
 	if reg == nil {
-		return "", true, fmt.Errorf("mcp: no registry registered")
+		return fail("mcp: no registry registered")
 	}
 	conn := reg.Get(server)
 	if conn == nil {
-		return "", true, fmt.Errorf("mcp: server %q is not connected", server)
+		return fail("mcp: server %q is not connected", server)
 	}
 
 	switch tool {
 	case "resource_read":
 		uri, _ := input["uri"].(string)
 		if uri == "" {
-			return "", true, fmt.Errorf("mcp: resource_read needs uri")
+			return fail("mcp: resource_read needs uri")
 		}
 		contents, err := conn.Client.ReadResource(ctx, uri)
 		if err != nil {
 			markIfReauthRequired(conn, err)
-			return "", true, err
+			return agent.ToolResult{}, true, err
 		}
 		conn.ClearReauthRequired()
-		return formatResourceContents(contents), true, nil
+		return agent.ToolResult{Text: formatResourceContents(contents)}, true, nil
 
 	case "prompt_get":
 		promptName, _ := input["name"].(string)
 		if promptName == "" {
-			return "", true, fmt.Errorf("mcp: prompt_get needs name")
+			return fail("mcp: prompt_get needs name")
 		}
 		argMap := convertStringMap(input["arguments"])
 		result, err := conn.Client.GetPrompt(ctx, promptName, argMap)
 		if err != nil {
 			markIfReauthRequired(conn, err)
-			return "", true, err
+			return agent.ToolResult{}, true, err
 		}
 		conn.ClearReauthRequired()
-		return formatPromptResult(result), true, nil
+		return agent.ToolResult{Text: formatPromptResult(result)}, true, nil
 
 	default:
 		result, err := conn.Client.CallTool(ctx, tool, input)
 		if err != nil {
 			markIfReauthRequired(conn, err)
-			return "", true, err
+			return agent.ToolResult{}, true, err
 		}
 		conn.ClearReauthRequired()
-		out := formatToolResult(result)
+		res := formatToolResult(result)
 		if result.IsError {
 			// The tool ran but reported an error in-band. Surface it as a
 			// Go error so the agent loop tags the tool_result IsError too —
-			// matches the contract built-in tools use.
-			return out, true, fmt.Errorf("mcp tool error: %s", out)
+			// matches the contract built-in tools use. Blocks are dropped:
+			// an errored result's image, if any, isn't worth sending.
+			return agent.ToolResult{Text: res.Text}, true, fmt.Errorf("mcp tool error: %s", res.Text)
 		}
-		return out, true, nil
+		return res, true, nil
 	}
 }
 
@@ -286,14 +291,21 @@ func joinPromptNames(ps []mcp.Prompt) string {
 	return strings.Join(names, ", ")
 }
 
-// formatToolResult flattens an MCP tool result's content blocks into a
-// single string for the agent's text-content tool_result. Non-text blocks
-// are summarised so the agent at least knows what came back.
-func formatToolResult(r *mcp.CallToolResult) string {
+// formatToolResult turns an MCP tool result into the agent's ToolResult:
+// text content is flattened into Text, and image content becomes real image
+// Blocks so a multimodal model actually sees the pixels rather than a
+// description of them. Every block still leaves a line in Text — a
+// screenshot's accompanying "[image: image/png, 48 KiB]" is what a non-vision
+// model, the transcript, and the UI have to go on.
+//
+// Content types the agent has no block for (audio; a resource carrying binary
+// blob data) stay text-only summaries.
+func formatToolResult(r *mcp.CallToolResult) agent.ToolResult {
 	if r == nil {
-		return ""
+		return agent.ToolResult{}
 	}
 	var b strings.Builder
+	var blocks []agent.ContentBlock
 	for i, c := range r.Content {
 		if i > 0 {
 			b.WriteString("\n")
@@ -302,7 +314,15 @@ func formatToolResult(r *mcp.CallToolResult) string {
 		case "text":
 			b.WriteString(c.Text)
 		case "image":
-			fmt.Fprintf(&b, "[image: %s, %d bytes]", c.MIMEType, len(c.Data))
+			data, err := base64.StdEncoding.DecodeString(c.Data)
+			if err != nil || len(data) == 0 {
+				// Undecodable payload: say so rather than handing the model a
+				// broken image block it can't interpret.
+				fmt.Fprintf(&b, "[image: %s, undecodable payload]", c.MIMEType)
+				break
+			}
+			blocks = append(blocks, agent.NewImageBlock(c.MIMEType, data))
+			fmt.Fprintf(&b, "[image: %s, %s]", c.MIMEType, humanBytes(len(data)))
 		case "audio":
 			fmt.Fprintf(&b, "[audio: %s, %d bytes]", c.MIMEType, len(c.Data))
 		case "resource":
@@ -317,7 +337,21 @@ func formatToolResult(r *mcp.CallToolResult) string {
 			fmt.Fprintf(&b, "[unknown content type %q]", c.Type)
 		}
 	}
-	return b.String()
+	return agent.ToolResult{Text: b.String(), Blocks: blocks}
+}
+
+// humanBytes renders a decoded payload size for the text summary. The raw
+// count is noise at image sizes; KiB/MiB is what tells someone reading the
+// transcript whether a screenshot came back at all.
+func humanBytes(n int) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MiB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f KiB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d bytes", n)
+	}
 }
 
 func formatResourceContents(cs []mcp.ResourceContent) string {

--- a/internal/tools/mcp_test.go
+++ b/internal/tools/mcp_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -76,9 +77,10 @@ func TestParseMCPName_RejectsMalformed(t *testing.T) {
 }
 
 func TestFormatToolResult_MixedContent(t *testing.T) {
+	imgBytes := []byte("not-really-an-image-but-round-trips")
 	r := &mcp.CallToolResult{Content: []mcp.Content{
 		{Type: "text", Text: "first"},
-		{Type: "image", MIMEType: "image/png", Data: "<base64 …>"},
+		{Type: "image", MIMEType: "image/png", Data: base64.StdEncoding.EncodeToString(imgBytes)},
 		{Type: "resource", Resource: &mcp.EmbeddedResource{
 			URI: "file:///x", MIMEType: "text/plain", Text: "embedded",
 		}},
@@ -90,9 +92,51 @@ func TestFormatToolResult_MixedContent(t *testing.T) {
 		"[resource file:///x]",
 		"embedded",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("missing %q in:\n%s", want, out)
+		if !strings.Contains(out.Text, want) {
+			t.Errorf("missing %q in:\n%s", want, out.Text)
 		}
+	}
+	// The point of the change: the image reaches the model as a real block,
+	// not just as the text summary above.
+	if len(out.Blocks) != 1 {
+		t.Fatalf("Blocks = %d, want 1 image block", len(out.Blocks))
+	}
+	blk := out.Blocks[0]
+	if blk.Type != "image" || blk.Image == nil {
+		t.Fatalf("block = %+v, want an image block with data", blk)
+	}
+	if string(blk.Image.Data) != string(imgBytes) {
+		t.Errorf("block data = %q, want the decoded payload %q", blk.Image.Data, imgBytes)
+	}
+}
+
+// TestFormatToolResult_UndecodableImage: a server sending a payload that
+// isn't valid base64 must not produce a broken image block — say so in text
+// instead.
+func TestFormatToolResult_UndecodableImage(t *testing.T) {
+	r := &mcp.CallToolResult{Content: []mcp.Content{
+		{Type: "image", MIMEType: "image/png", Data: "<not base64 …>"},
+	}}
+	out := formatToolResult(r)
+	if len(out.Blocks) != 0 {
+		t.Errorf("Blocks = %d, want none for an undecodable payload", len(out.Blocks))
+	}
+	if !strings.Contains(out.Text, "undecodable") {
+		t.Errorf("Text = %q, want it to mention the undecodable payload", out.Text)
+	}
+}
+
+// TestFormatToolResult_TextOnlyHasNoBlocks keeps the common case allocation-
+// free of blocks, so text results look exactly as they did before.
+func TestFormatToolResult_TextOnlyHasNoBlocks(t *testing.T) {
+	out := formatToolResult(&mcp.CallToolResult{Content: []mcp.Content{
+		{Type: "text", Text: "plain"},
+	}})
+	if out.Text != "plain" {
+		t.Errorf("Text = %q, want plain", out.Text)
+	}
+	if out.Blocks != nil {
+		t.Errorf("Blocks = %v, want nil for a text-only result", out.Blocks)
 	}
 }
 
@@ -202,7 +246,7 @@ func TestExecuteMCP_SuccessfulCallClearsReauthFlag(t *testing.T) {
 		t.Fatal("expected executeMCP to recognize the mcp__ tool name")
 	}
 	if err != nil {
-		t.Fatalf("executeMCP: %v (out=%q)", err, out)
+		t.Fatalf("executeMCP: %v (out=%q)", err, out.Text)
 	}
 	if _, ok := conn.ReauthRequired(); ok {
 		t.Error("a successful call through the connection must clear the reauth flag")

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -114,8 +114,8 @@ func (r DefaultRegistry) ExecuteStream(ctx context.Context, name string, input m
 	// MCP tools land here too — route them first so an "mcp__…" name
 	// never falls through to the unknown-tool path. executeMCP returns
 	// ok=false when the name isn't ours, then dispatch continues below.
-	if out, ok, err := executeMCP(ctx, name, input); ok {
-		return agent.ToolResult{Text: out}, err
+	if res, ok, err := executeMCP(ctx, name, input); ok {
+		return res, err
 	}
 
 	// Tool Search bridge: describe the deferred MCP catalog, or invoke a tool

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -277,12 +277,12 @@ func execToolCall(ctx context.Context, input map[string]any) (agent.ToolResult, 
 	if args == nil {
 		args = map[string]any{}
 	}
-	out, ok, err := executeMCP(ctx, name, args)
+	res, ok, err := executeMCP(ctx, name, args)
 	if !ok {
 		// executeMCP only declines names without the mcp__ prefix.
 		return agent.ToolResult{Text: ""}, fmt.Errorf("mcp_call: %q is not an MCP tool (MCP names look like 'mcp__<server>__<tool>'). If it's a built-in tool such as sub_agent, call it directly by name instead of through mcp_call", name)
 	}
-	return agent.ToolResult{Text: out}, err
+	return res, err
 }
 
 // ToolCallTarget unwraps an mcp_call bridge invocation into the real MCP tool


### PR DESCRIPTION
## Problem

An MCP tool returning an image had its base64 payload **dropped** and replaced with a text placeholder:

```go
case "image":
    fmt.Fprintf(&b, "[image: %s, %d bytes]", c.MIMEType, len(c.Data))
```

So screenshot-producing MCP servers (browser/playwright-style) were effectively useless in octo — the model got a description of a picture it could never see.

## Fix

The plumbing already existed and MCP simply wasn't using it: `agent.ToolResult` carries `Blocks []ContentBlock` for rich content, `ContentBlock` has an image type the provider adapters already serialise, and **both `browser.go:619` and `read_file.go:252` already send images exactly this way**. This change routes MCP image content down the same proven path via `agent.NewImageBlock`, which also applies the shared downscale/re-encode pass so oversized captures stay inside provider size limits.

Details:

- Every content block still contributes a line to `Text` — a non-vision model, the session transcript, and the UI have only that to go on — but the size is now human-readable (`48.2 KiB`) rather than a raw byte count.
- A payload that isn't valid base64 reports `[image: image/png, undecodable payload]` rather than producing an image block nothing can render.
- An in-band error result (`isError: true`) drops its blocks — a failed call's image isn't worth sending.
- Text-only results produce `Blocks == nil`, so the common case is byte-identical to before.

`executeMCP` now returns `agent.ToolResult` instead of a `string`, since a string can't carry blocks. Both call sites (`registry.go`, `tool_search.go`) previously wrapped the string in `agent.ToolResult{Text: out}` and now pass the result straight through.

**Audio is unchanged** — still a text summary, because the agent has no audio block type. Noted rather than silently implied.

## Test plan

- [x] `go test -race ./internal/tools/ ./internal/agent/` — green
- [x] `make vet` / `make fmt-check` clean

| Test | Covers |
|---|---|
| `TestFormatToolResult_MixedContent` | image becomes a real block whose bytes match the decoded payload, text/resource unchanged |
| `TestFormatToolResult_UndecodableImage` | bad base64 ⇒ no block, text says so |
| `TestFormatToolResult_TextOnlyHasNoBlocks` | text-only results stay block-free |

Not covered by an automated test: the final hop to a live multimodal model. That hop is the same code path the browser tool and `read_file` already ship on, which is why this doesn't add new provider-level plumbing to verify.