### PR TITLE
feat(mcp): recover expired sessions and resume broken SSE streams

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -38,6 +38,14 @@ type Client struct {
 	// caps is populated after Initialize so callers can branch on which
 	// surfaces the server actually advertised. Tools/Resources/Prompts are
 	// pointers in the spec; nil means "not supported".
+	//
+	// metaMu guards all four: they are written by the initialize handshake,
+	// which is no longer a once-at-startup event — recovering an expired
+	// session re-runs it mid-session, concurrently with readers like
+	// Capabilities() or a ListTools call already in flight. A restarted server
+	// may legitimately answer with different capabilities than the session we
+	// lost, so these really can change under readers.
+	metaMu       sync.RWMutex
 	caps         ServerCapabilities
 	serverInfo   Implementation
 	instructions string
@@ -95,10 +103,7 @@ func (c *Client) Initialize(ctx context.Context) error {
 	if err := c.Call(ctx, MethodInitialize, params, &result); err != nil {
 		return fmt.Errorf("mcp: initialize: %w", err)
 	}
-	c.caps = result.Capabilities
-	c.serverInfo = result.ServerInfo
-	c.instructions = result.Instructions
-	c.protocolVersion = result.ProtocolVersion
+	c.storeHandshake(result)
 
 	// Transports that carry the negotiated revision on the wire (HTTP, via
 	// the MCP-Protocol-Version header) learn it here — before the
@@ -125,23 +130,50 @@ type protocolVersionSetter interface {
 	SetProtocolVersion(v string)
 }
 
+// storeHandshake records what a (re)initialize answered with. Called from
+// both the startup handshake and expired-session recovery.
+func (c *Client) storeHandshake(r InitializeResult) {
+	c.metaMu.Lock()
+	c.caps = r.Capabilities
+	c.serverInfo = r.ServerInfo
+	c.instructions = r.Instructions
+	c.protocolVersion = r.ProtocolVersion
+	c.metaMu.Unlock()
+}
+
 // ServerInfo returns the {name, version} the server advertised in its
 // initialize response. Useful for /mcp output.
-func (c *Client) ServerInfo() Implementation { return c.serverInfo }
+func (c *Client) ServerInfo() Implementation {
+	c.metaMu.RLock()
+	defer c.metaMu.RUnlock()
+	return c.serverInfo
+}
 
 // ProtocolVersion returns the spec revision the server chose in the
 // handshake, which may differ from the ProtocolVersion we requested. Empty
 // before Initialize completes.
-func (c *Client) ProtocolVersion() string { return c.protocolVersion }
+func (c *Client) ProtocolVersion() string {
+	c.metaMu.RLock()
+	defer c.metaMu.RUnlock()
+	return c.protocolVersion
+}
 
 // Capabilities returns the server's advertised capabilities so callers can
 // avoid calling tools/list against a server that doesn't support tools.
-func (c *Client) Capabilities() ServerCapabilities { return c.caps }
+func (c *Client) Capabilities() ServerCapabilities {
+	c.metaMu.RLock()
+	defer c.metaMu.RUnlock()
+	return c.caps
+}
 
 // Instructions returns the optional human-readable instructions the server
 // included in its initialize response. Some servers use this to tell the
 // agent how their tools should be used.
-func (c *Client) Instructions() string { return c.instructions }
+func (c *Client) Instructions() string {
+	c.metaMu.RLock()
+	defer c.metaMu.RUnlock()
+	return c.instructions
+}
 
 // Call issues a request and blocks for the matched response. params is
 // json-marshalled; result, if non-nil, is unmarshalled from the response's
@@ -185,10 +217,7 @@ func (c *Client) Call(ctx context.Context, method string, params, result any) er
 		msg.Params = p
 	}
 
-	c.sendMu.Lock()
-	err := c.transport.Send(ctx, msg)
-	c.sendMu.Unlock()
-	if err != nil {
+	if err := c.sendRecoveringSession(ctx, msg); err != nil {
 		return err
 	}
 
@@ -225,9 +254,92 @@ func (c *Client) Notify(ctx context.Context, method string, params any) error {
 		}
 		msg.Params = p
 	}
+	return c.sendRecoveringSession(ctx, msg)
+}
+
+// sendRecoveringSession is the single write path to the transport. It holds
+// sendMu for the whole attempt, so if the server reports our session gone it
+// can run the recovery handshake and replay msg with no other sender able to
+// slip a request onto the dead session in between.
+//
+// The handshake deliberately does NOT go back through Call/Notify: those take
+// sendMu, which is not reentrant, so reusing them here would deadlock. It
+// talks to the transport directly instead — safe precisely because we already
+// hold the lock. Only one recovery is attempted; a second expiry in a row is
+// a server we can't keep a session with, and returning the error beats
+// looping.
+func (c *Client) sendRecoveringSession(ctx context.Context, msg *Message) error {
 	c.sendMu.Lock()
 	defer c.sendMu.Unlock()
+
+	err := c.transport.Send(ctx, msg)
+	if !errors.Is(err, ErrSessionExpired) {
+		return err
+	}
+	if rerr := c.rehandshakeLocked(ctx); rerr != nil {
+		// Report the original expiry as the cause — that's what the caller
+		// needs to understand — with the recovery failure as context.
+		return fmt.Errorf("%w (recovery handshake failed: %v)", err, rerr)
+	}
 	return c.transport.Send(ctx, msg)
+}
+
+// rehandshakeLocked re-runs initialize + initialized on a transport whose
+// session the server has forgotten. Caller must hold sendMu; this sends on
+// the transport without taking it. Waiting for the initialize response is
+// fine under the lock: the receive loop is a separate goroutine and delivers
+// it through the pending map, which sendMu doesn't guard.
+func (c *Client) rehandshakeLocked(ctx context.Context) error {
+	id := c.nextID.Add(1)
+	idBytes := []byte(strconv.FormatUint(id, 10))
+	idKey := string(idBytes)
+
+	ch := make(chan *Message, 1)
+	c.pendingMu.Lock()
+	c.pending[idKey] = ch
+	c.pendingMu.Unlock()
+	defer c.removePending(idKey)
+
+	params, err := json.Marshal(InitializeParams{
+		ProtocolVersion: ProtocolVersion,
+		Capabilities:    ClientCapabilities{},
+		ClientInfo:      c.info,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal initialize params: %w", err)
+	}
+	if err := c.transport.Send(ctx, &Message{
+		JSONRPC: "2.0", ID: idBytes, Method: MethodInitialize, Params: params,
+	}); err != nil {
+		return err
+	}
+
+	select {
+	case resp := <-ch:
+		if resp == nil {
+			return errors.New("connection closed")
+		}
+		if resp.Error != nil {
+			return resp.Error
+		}
+		var result InitializeResult
+		if len(resp.Result) > 0 {
+			if err := json.Unmarshal(resp.Result, &result); err != nil {
+				return fmt.Errorf("unmarshal initialize result: %w", err)
+			}
+		}
+		// A restarted server may answer with different capabilities or even a
+		// different protocol revision than the session we lost, so adopt what
+		// it says now rather than assuming continuity.
+		c.storeHandshake(result)
+		if pv, ok := c.transport.(protocolVersionSetter); ok && result.ProtocolVersion != "" {
+			pv.SetProtocolVersion(result.ProtocolVersion)
+		}
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return c.transport.Send(ctx, &Message{JSONRPC: "2.0", Method: MethodInitialized})
 }
 
 // receiveLoop runs for the life of the Client, pulling frames off the
@@ -316,7 +428,7 @@ func nextPageCursor(next, current string) (string, bool) {
 }
 
 func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
-	if c.caps.Tools == nil {
+	if c.Capabilities().Tools == nil {
 		return nil, nil
 	}
 	var all []Tool
@@ -347,7 +459,7 @@ func (c *Client) CallTool(ctx context.Context, name string, args map[string]any)
 }
 
 func (c *Client) ListResources(ctx context.Context) ([]Resource, error) {
-	if c.caps.Resources == nil {
+	if c.Capabilities().Resources == nil {
 		return nil, nil
 	}
 	var all []Resource
@@ -376,7 +488,7 @@ func (c *Client) ReadResource(ctx context.Context, uri string) ([]ResourceConten
 }
 
 func (c *Client) ListPrompts(ctx context.Context) ([]Prompt, error) {
-	if c.caps.Prompts == nil {
+	if c.Capabilities().Prompts == nil {
 		return nil, nil
 	}
 	var all []Prompt

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -34,11 +34,15 @@ import (
 //   - The protocol revision the server picks during initialize is echoed
 //     back in MCP-Protocol-Version on every later request, which servers
 //     implementing 2025-03-26 or later require.
+//   - A response stream that breaks before answering is resumed with a GET
+//     carrying Last-Event-ID, when the server tagged its events with ids.
+//   - A 404 answering a request that carried a session id is reported as
+//     ErrSessionExpired so the Client can re-handshake and replay.
 //
 // What we don't implement (v1 omission)
-//   - SSE stream resumption via Last-Event-ID on reconnect.
-//   - The optional GET endpoint for server-initiated notifications outside
-//     of a request/response cycle.
+//   - A standing GET listener for server-initiated messages outside of a
+//     request/response cycle. The GET above is only used to resume a broken
+//     response stream.
 //   - Bidirectional concurrent sends. The client serialises one request at
 //     a time anyway.
 //
@@ -163,10 +167,11 @@ func (t *HTTPTransport) doRequest(ctx context.Context, msg *Message, forceFreshT
 		req.Header.Set(k, v)
 	}
 	t.sessionMu.Lock()
-	if t.sessionID != "" {
-		req.Header.Set("Mcp-Session-Id", t.sessionID)
-	}
+	sentSession := t.sessionID
 	t.sessionMu.Unlock()
+	if sentSession != "" {
+		req.Header.Set("Mcp-Session-Id", sentSession)
+	}
 	t.protoMu.Lock()
 	if t.protocolVersion != "" {
 		req.Header.Set("MCP-Protocol-Version", t.protocolVersion)
@@ -216,6 +221,21 @@ func (t *HTTPTransport) doRequest(ctx context.Context, msg *Message, forceFreshT
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return false, fmt.Errorf("mcp: http 401: %s", bytes.TrimSpace(b))
 	}
+	if resp.StatusCode == http.StatusNotFound && sentSession != "" {
+		// A 404 answering a request that carried a session id is how the spec
+		// says a server reports that session gone (idle timeout, restart).
+		// Drop it so the caller's recovery handshake goes out clean, and
+		// report it as the typed error Client watches for. A 404 on a request
+		// with no session id is an ordinary wrong-endpoint error and falls
+		// through below.
+		t.sessionMu.Lock()
+		if t.sessionID == sentSession {
+			t.sessionID = ""
+		}
+		t.sessionMu.Unlock()
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return false, fmt.Errorf("%w: %s", ErrSessionExpired, bytes.TrimSpace(b))
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return false, fmt.Errorf("mcp: http %d: %s", resp.StatusCode, bytes.TrimSpace(b))
@@ -262,10 +282,29 @@ func (t *HTTPTransport) queue(ctx context.Context, m *Message) error {
 	}
 }
 
-// errSSEResponseReceived is an internal sentinel readSSE uses to stop
+// errSSEResponseReceived is an internal sentinel scanSSE uses to stop
 // scanning once the frame answering our request has been queued — it is
 // never returned to the caller.
 var errSSEResponseReceived = errors.New("mcp: sse response received")
+
+// errSSEIncomplete marks a stream that ended or broke before delivering the
+// response we were waiting for. It's the one failure resumption can repair,
+// so it's what separates "try Last-Event-ID" from "give up". Wrapped with
+// detail at each return site; callers match it with errors.Is.
+var errSSEIncomplete = errors.New("mcp: sse stream incomplete")
+
+// maxSSEResumeAttempts bounds Last-Event-ID replays for a single request. A
+// server that drops the stream this many times running isn't going to deliver
+// it, and retrying past that turns a visible failure into a hang.
+const maxSSEResumeAttempts = 3
+
+// ErrSessionExpired reports that the server no longer recognises the session
+// id we were using — it answered 404 to a request that carried one, which is
+// how the spec has a server say a session is gone (idle timeout, restart).
+// The transport has already dropped the dead id by the time this surfaces.
+// Client.Call watches for it and recovers by re-running the handshake and
+// replaying the request once; callers of Call therefore never normally see it.
+var ErrSessionExpired = errors.New("mcp: session expired")
 
 // sessionDeleteTimeout bounds the best-effort session-termination DELETE that
 // Close fires. Short on purpose: Close runs on teardown paths (process exit,
@@ -299,7 +338,112 @@ var maxSSEEventBytes = 16 * 1024 * 1024
 // which expect no response; every frame is still queued as it arrives
 // (some servers may emit acks or other notifications on that stream), the
 // loop just never exits early and instead runs to stream close.
+//
+// A stream that dies before delivering the response is resumed rather than
+// failed, provided the server opted into resumability by tagging events with
+// id: — see resumeSSE.
 func (t *HTTPTransport) readSSE(ctx context.Context, body io.Reader, wantID []byte) error {
+	lastID, err := t.scanSSE(ctx, body, wantID)
+	if !errors.Is(err, errSSEIncomplete) {
+		return err
+	}
+	return t.resumeSSE(ctx, wantID, lastID, err)
+}
+
+// resumeSSE picks up a response stream that broke before answering. The spec's
+// mechanism is a GET to the same endpoint carrying Last-Event-ID, which the
+// server answers by replaying what came after that event.
+//
+// Resumption needs an event id to resume from: a server that never tagged its
+// events hasn't opted in and has no way to know where to restart, so there the
+// original failure stands. Attempts are capped — a server that keeps dropping
+// the stream is broken, and retrying forever would just hide that.
+func (t *HTTPTransport) resumeSSE(ctx context.Context, wantID []byte, lastID string, cause error) error {
+	for attempt := 0; attempt < maxSSEResumeAttempts; attempt++ {
+		if lastID == "" {
+			break
+		}
+		body, err := t.openResumeStream(ctx, lastID)
+		if err != nil {
+			return fmt.Errorf("%w (resume attempt %d: %v)", cause, attempt+1, err)
+		}
+		var next string
+		next, err = t.scanSSE(ctx, body, wantID)
+		_ = body.Close()
+		if !errors.Is(err, errSSEIncomplete) {
+			return err // delivered the response, or failed for a reason resuming won't fix
+		}
+		cause = err
+		if next == "" || next == lastID {
+			break // no forward progress; resuming again would replay the same gap
+		}
+		lastID = next
+	}
+	return cause
+}
+
+// openResumeStream issues the spec's replay request: a GET on the endpoint
+// with Last-Event-ID set, asking the server to continue an interrupted stream.
+func (t *HTTPTransport) openResumeStream(ctx context.Context, lastID string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, t.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Last-Event-ID", lastID)
+	for k, v := range t.headers {
+		req.Header.Set(k, v)
+	}
+	t.sessionMu.Lock()
+	sid := t.sessionID
+	t.sessionMu.Unlock()
+	if sid != "" {
+		req.Header.Set("Mcp-Session-Id", sid)
+	}
+	t.protoMu.Lock()
+	if t.protocolVersion != "" {
+		req.Header.Set("MCP-Protocol-Version", t.protocolVersion)
+	}
+	t.protoMu.Unlock()
+	if t.oauth != nil {
+		tok, terr := t.oauth.Token(ctx)
+		if terr != nil {
+			return nil, fmt.Errorf("oauth token: %w", terr)
+		}
+		if tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+
+	resp, err := t.hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		// A server with no GET endpoint (405) lands here; the caller reports
+		// the original stream failure, which is the more useful error.
+		return nil, fmt.Errorf("http %d: %s", resp.StatusCode, bytes.TrimSpace(b))
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "" && !isEventStreamContentType(ct) {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("resume stream Content-Type %q, want text/event-stream", ct)
+	}
+	return resp.Body, nil
+}
+
+// scanSSE consumes one SSE body, queuing every frame it decodes. It returns
+// the last event id the server tagged (empty if it tagged none, which means
+// the stream isn't resumable) plus:
+//
+//   - nil once the frame answering wantID has been queued, or once a
+//     wantID-less (notification) stream ends;
+//   - errSSEIncomplete if the stream ended or broke before that, which is the
+//     resumable case;
+//   - any other error for failures resuming can't fix (undecodable frame,
+//     oversized event, transport shutdown).
+func (t *HTTPTransport) scanSSE(ctx context.Context, body io.Reader, wantID []byte) (string, error) {
 	scanner := bufio.NewScanner(body)
 	// Default 64KiB line limit is too small for a single-line JSON-RPC
 	// frame carrying a large tool result; give it room.
@@ -307,6 +451,10 @@ func (t *HTTPTransport) readSSE(ctx context.Context, body io.Reader, wantID []by
 
 	var data []string
 	var dataLen int
+	// lastID is the most recent id: the server tagged an event with. It's what
+	// a resume request replays from, so it's tracked even though nothing else
+	// here acts on it.
+	var lastID string
 	flush := func() error {
 		if len(data) == 0 {
 			return nil
@@ -333,9 +481,9 @@ func (t *HTTPTransport) readSSE(ctx context.Context, body io.Reader, wantID []by
 		case line == "":
 			if err := flush(); err != nil {
 				if err == errSSEResponseReceived {
-					return nil
+					return lastID, nil
 				}
-				return err
+				return lastID, err
 			}
 		case strings.HasPrefix(line, "data:"):
 			field := strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " ")
@@ -344,28 +492,32 @@ func (t *HTTPTransport) readSSE(ctx context.Context, body io.Reader, wantID []by
 			// doesn't help since this accumulates across many lines.
 			dataLen += len(field) + 1 // +1 for the "\n" separator flush joins lines with
 			if dataLen > maxSSEEventBytes {
-				return fmt.Errorf("mcp: sse event exceeds %d bytes without a terminating blank line", maxSSEEventBytes)
+				return lastID, fmt.Errorf("mcp: sse event exceeds %d bytes without a terminating blank line", maxSSEEventBytes)
 			}
 			data = append(data, field)
+		case strings.HasPrefix(line, "id:"):
+			lastID = strings.TrimPrefix(strings.TrimPrefix(line, "id:"), " ")
 		default:
-			// event:, id:, retry:, or a comment line — v1 doesn't act on these.
+			// event:, retry:, or a comment line — nothing acts on these.
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("mcp: read sse stream: %w", err)
+		// A mid-stream read failure is exactly what resumption is for.
+		return lastID, fmt.Errorf("%w: read sse stream: %v", errSSEIncomplete, err)
 	}
 	// Stream closed without a trailing blank line before EOF: flush
 	// whatever event was still buffered.
 	if err := flush(); err != nil {
 		if err == errSSEResponseReceived {
-			return nil
+			return lastID, nil
 		}
-		return err
+		return lastID, err
 	}
 	if len(wantID) > 0 {
-		return fmt.Errorf("mcp: sse stream closed without a response to request id %s", wantID)
+		return lastID, fmt.Errorf("%w: stream closed without a response to request id %s",
+			errSSEIncomplete, wantID)
 	}
-	return nil
+	return lastID, nil
 }
 
 // Receive blocks for the next queued frame. A plain-JSON response queues

--- a/internal/mcp/session_recovery_test.go
+++ b/internal/mcp/session_recovery_test.go
@@ -1,0 +1,334 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// expiringServer models a server that forgets its session partway through:
+// it hands out session ids, and once expireAfter tool calls have been served
+// on a session it answers 404 to anything still carrying that id, forcing the
+// client to start a new session.
+type expiringServer struct {
+	mu       sync.Mutex
+	nextID   int
+	live     map[string]bool // session id -> still valid
+	calls    int             // tools/call requests served
+	expireAt int             // expire the current session after this many calls
+	handshak int             // initialize requests seen
+	sessions []string        // session id sent with each request, in order
+}
+
+func newExpiringServer(expireAfter int) *expiringServer {
+	return &expiringServer{live: map[string]bool{}, expireAt: expireAfter}
+}
+
+func (s *expiringServer) handshakes() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.handshak
+}
+
+func (s *expiringServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		var in Message
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		sent := r.Header.Get("Mcp-Session-Id")
+
+		s.mu.Lock()
+		s.sessions = append(s.sessions, sent)
+		// A request on a session we've retired: 404, per the spec's
+		// session-termination signal.
+		if sent != "" && !s.live[sent] {
+			s.mu.Unlock()
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("session not found"))
+			return
+		}
+		isInit := in.Method == MethodInitialize
+		if isInit {
+			s.handshak++
+			s.nextID++
+			sid := "sess-" + string(rune('a'+s.nextID))
+			s.live[sid] = true
+			s.calls = 0
+			s.mu.Unlock()
+			w.Header().Set("Mcp-Session-Id", sid)
+			writeJSONRPC(w, in.ID, InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+				ServerInfo:      Implementation{Name: "expiring", Version: "1"},
+			})
+			return
+		}
+		if in.ID == nil { // notification
+			s.mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if in.Method == MethodToolsCall {
+			s.calls++
+			if s.expireAt > 0 && s.calls > s.expireAt {
+				delete(s.live, sent) // retire it, then answer this one with 404
+				s.mu.Unlock()
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("session expired"))
+				return
+			}
+		}
+		s.mu.Unlock()
+		switch in.Method {
+		case MethodToolsList:
+			writeJSONRPC(w, in.ID, ListToolsResult{Tools: []Tool{{Name: "ping"}}})
+		case MethodToolsCall:
+			writeJSONRPC(w, in.ID, CallToolResult{Content: []Content{{Type: "text", Text: "pong"}}})
+		default:
+			writeJSONRPC(w, in.ID, map[string]any{})
+		}
+	}
+}
+
+func writeJSONRPC(w http.ResponseWriter, id json.RawMessage, result any) {
+	raw, _ := json.Marshal(result)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(Message{JSONRPC: "2.0", ID: id, Result: raw})
+}
+
+// TestSessionExpiry_RecoversTransparently is the point of the feature: a call
+// landing on a session the server has forgotten must re-handshake and succeed
+// rather than surfacing an error the user has to fix by reconnecting by hand.
+func TestSessionExpiry_RecoversTransparently(t *testing.T) {
+	fake := newExpiringServer(1) // first tool call fine, second gets 404
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	tx, err := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := fake.handshakes(); got != 1 {
+		t.Fatalf("handshakes after Initialize = %d, want 1", got)
+	}
+
+	if _, err := c.CallTool(ctx, "ping", nil); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	// This one hits the retired session; recovery should be invisible here.
+	res, err := c.CallTool(ctx, "ping", nil)
+	if err != nil {
+		t.Fatalf("call after session expiry should have recovered, got: %v", err)
+	}
+	if len(res.Content) == 0 || res.Content[0].Text != "pong" {
+		t.Errorf("result = %+v, want the replayed call's pong", res.Content)
+	}
+	if got := fake.handshakes(); got != 2 {
+		t.Errorf("handshakes = %d, want 2 (the original plus recovery)", got)
+	}
+}
+
+// TestSessionExpiry_ReplayCarriesNewSession: the replayed request must go out
+// on the session the recovery handshake established, not the dead one.
+func TestSessionExpiry_ReplayCarriesNewSession(t *testing.T) {
+	fake := newExpiringServer(1)
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.CallTool(ctx, "ping", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.CallTool(ctx, "ping", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	// The recovery initialize must carry no session id (we dropped the dead
+	// one), and the final replay must carry the fresh one.
+	var sawEmptyAfterFirst bool
+	for i, s := range fake.sessions {
+		if i > 0 && s == "" {
+			sawEmptyAfterFirst = true
+		}
+	}
+	if !sawEmptyAfterFirst {
+		t.Errorf("no session-less request after the expiry; recovery handshake reused a dead id: %q", fake.sessions)
+	}
+	last := fake.sessions[len(fake.sessions)-1]
+	if last == "" || !fake.live[last] {
+		t.Errorf("replay went out on session %q, want the live post-recovery one (live=%v)", last, fake.live)
+	}
+}
+
+// TestSessionExpiry_NoSessionMeansPlain404: a 404 on a request that never
+// carried a session id is an ordinary wrong-endpoint error. Treating it as an
+// expiry would hide a misconfigured URL behind a pointless retry.
+func TestSessionExpiry_NoSessionMeansPlain404(t *testing.T) {
+	var mu sync.Mutex
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("no such endpoint"))
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+	err := tx.Send(context.Background(), &Message{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	})
+	if err == nil {
+		t.Fatal("expected an error for 404")
+	}
+	if errors.Is(err, ErrSessionExpired) {
+		t.Errorf("err = %v, want a plain HTTP error not ErrSessionExpired", err)
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("err = %v, want it to mention the status", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 1 {
+		t.Errorf("made %d requests, want 1 (no retry for a plain 404)", requests)
+	}
+}
+
+// TestSessionExpiry_GivesUpAfterOneRecovery: a server that expires every
+// session immediately must produce an error, not an endless handshake loop.
+func TestSessionExpiry_GivesUpAfterOneRecovery(t *testing.T) {
+	// expireAt=0 with a live-session check that retires on first use: every
+	// tool call 404s, including the one replayed after recovery.
+	var mu sync.Mutex
+	handshakes := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in Message
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.Method == MethodInitialize {
+			mu.Lock()
+			handshakes++
+			mu.Unlock()
+			w.Header().Set("Mcp-Session-Id", "always-stale")
+			writeJSONRPC(w, in.ID, InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+				ServerInfo:      Implementation{Name: "hostile", Version: "1"},
+			})
+			return
+		}
+		if in.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		// Every real request claims the session is gone.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("gone again"))
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.CallTool(ctx, "ping", nil)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error from a server that expires every session")
+		}
+		if !errors.Is(err, ErrSessionExpired) {
+			t.Errorf("err = %v, want it to wrap ErrSessionExpired", err)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("CallTool never returned — recovery is looping")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	// One startup handshake plus exactly one recovery attempt.
+	if handshakes != 2 {
+		t.Errorf("handshakes = %d, want 2 (no retry storm)", handshakes)
+	}
+}
+
+// TestSessionExpiry_ConcurrentReadersSeeNoRace exercises the metaMu guard:
+// recovery rewrites the handshake metadata mid-session while other goroutines
+// read it, which is a data race without the lock. Meaningful under -race.
+func TestSessionExpiry_ConcurrentReadersSeeNoRace(t *testing.T) {
+	fake := newExpiringServer(1)
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = c.Capabilities()
+					_ = c.ServerInfo()
+					_ = c.Instructions()
+					_ = c.ProtocolVersion()
+				}
+			}
+		}()
+	}
+
+	if _, err := c.CallTool(ctx, "ping", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.CallTool(ctx, "ping", nil); err != nil { // triggers recovery
+		t.Fatal(err)
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/internal/mcp/sse_resume_test.go
+++ b/internal/mcp/sse_resume_test.go
@@ -1,0 +1,257 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSSEResume_PicksUpAfterBrokenStream: the POST stream dies after a tagged
+// notification but before the response. The client must resume with a GET
+// carrying Last-Event-ID and get its answer from the replay.
+func TestSSEResume_PicksUpAfterBrokenStream(t *testing.T) {
+	var mu sync.Mutex
+	var lastEventID string
+	var gets int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			mu.Lock()
+			gets++
+			lastEventID = r.Header.Get("Last-Event-ID")
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			// Replay what came after event 1: the response.
+			resp, _ := json.Marshal(Message{
+				JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{"resumed":true}`),
+			})
+			fmt.Fprintf(w, "id: 2\ndata: %s\n\n", resp)
+			return
+		}
+		// POST: emit one tagged notification, then hang up mid-stream.
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: "notifications/progress"})
+		fmt.Fprintf(w, "id: 1\ndata: %s\n\n", notif)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Returning here closes the body without ever sending the response.
+	}))
+	defer srv.Close()
+
+	tx, err := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	if err := tx.Send(ctx, req); err != nil {
+		t.Fatalf("Send should have recovered via resume, got: %v", err)
+	}
+
+	// The notification from the first stream, then the resumed response.
+	first, err := tx.Receive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Method != "notifications/progress" {
+		t.Errorf("first frame = %+v, want the pre-break notification", first)
+	}
+	second, err := tx.Receive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(second.Result) != `{"resumed":true}` {
+		t.Errorf("second frame result = %s, want the resumed response", second.Result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gets != 1 {
+		t.Errorf("resume GETs = %d, want 1", gets)
+	}
+	if lastEventID != "1" {
+		t.Errorf("Last-Event-ID = %q, want 1 (the last event before the break)", lastEventID)
+	}
+}
+
+// TestSSEResume_UntaggedStreamDoesNotResume: without event ids the server
+// never opted into resumability and couldn't know where to restart, so the
+// original failure must stand instead of firing a pointless GET.
+func TestSSEResume_UntaggedStreamDoesNotResume(t *testing.T) {
+	var mu sync.Mutex
+	gets := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			mu.Lock()
+			gets++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: "notifications/progress"})
+		fmt.Fprintf(w, "data: %s\n\n", notif) // no id: — not resumable
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+	err := tx.Send(context.Background(), &Message{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	})
+	if err == nil {
+		t.Fatal("expected an error when an untagged stream ends without the response")
+	}
+	if !strings.Contains(err.Error(), "without a response") {
+		t.Errorf("err = %v, want the stream-incomplete error", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if gets != 0 {
+		t.Errorf("fired %d resume GETs for an untagged stream, want 0", gets)
+	}
+}
+
+// TestSSEResume_StopsWithoutForwardProgress: a server that replays the same
+// event id forever must not be retried forever.
+func TestSSEResume_StopsWithoutForwardProgress(t *testing.T) {
+	var mu sync.Mutex
+	gets := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			mu.Lock()
+			gets++
+			mu.Unlock()
+		}
+		// Always the same tagged notification, never the response.
+		notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: "notifications/progress"})
+		fmt.Fprintf(w, "id: same\ndata: %s\n\n", notif)
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- tx.Send(context.Background(), &Message{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+		})
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error; the response never arrived")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("Send never returned — resume is looping")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	// First resume sees "same" again → no forward progress → stop. One GET.
+	if gets > maxSSEResumeAttempts {
+		t.Errorf("resume GETs = %d, want at most %d", gets, maxSSEResumeAttempts)
+	}
+}
+
+// TestSSEResume_ServerWithoutGETReportsOriginalFailure: a server answering 405
+// to the resume GET has no replay endpoint. The error the caller sees should
+// describe the stream that actually broke, not the missing GET.
+func TestSSEResume_ServerWithoutGETReportsOriginalFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: "notifications/progress"})
+		fmt.Fprintf(w, "id: 7\ndata: %s\n\n", notif)
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+	err := tx.Send(context.Background(), &Message{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "without a response") {
+		t.Errorf("err = %v, want the original stream failure to lead", err)
+	}
+	if !strings.Contains(err.Error(), "405") {
+		t.Errorf("err = %v, want the resume attempt's 405 as context", err)
+	}
+}
+
+// TestSSEResume_CarriesSessionAndVersion: the resume GET is a normal MCP
+// request and must identify itself the same way a POST does, or a server that
+// enforces either header will refuse to replay.
+func TestSSEResume_CarriesSessionAndVersion(t *testing.T) {
+	var mu sync.Mutex
+	var gotSession, gotVersion, gotAccept string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			mu.Lock()
+			gotSession = r.Header.Get("Mcp-Session-Id")
+			gotVersion = r.Header.Get("MCP-Protocol-Version")
+			gotAccept = r.Header.Get("Accept")
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			resp, _ := json.Marshal(Message{
+				JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{}`),
+			})
+			fmt.Fprintf(w, "id: 2\ndata: %s\n\n", resp)
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "sess-resume")
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: "notifications/progress"})
+		fmt.Fprintf(w, "id: 1\ndata: %s\n\n", notif)
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+	tx.SetProtocolVersion("2025-03-26")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := tx.Send(ctx, &Message{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotSession != "sess-resume" {
+		t.Errorf("resume GET session = %q, want sess-resume", gotSession)
+	}
+	if gotVersion != "2025-03-26" {
+		t.Errorf("resume GET version = %q, want 2025-03-26", gotVersion)
+	}
+	if !strings.Contains(gotAccept, "text/event-stream") {
+		t.Errorf("resume GET Accept = %q, want it to accept an event stream", gotAccept)
+	}
+}


### PR DESCRIPTION
Follow-up to #2023/#2024. Two failure modes that both ended a turn with an error the user had to clear by reconnecting the server by hand.

## 1. Expired session → re-handshake and replay

A server that has forgotten our session answers **404** to any request still carrying the id (idle timeout, restart). That surfaced as a generic `mcp: http 404: …` and stayed broken until the user reconnected.

The transport now reports it as a typed `ErrSessionExpired` — after dropping the dead id, so the recovery handshake goes out clean — and the Client recovers by re-running `initialize` and replaying the request once.

- A 404 on a request that **never carried a session id** is still an ordinary wrong-endpoint error. Retrying that would hide a misconfigured URL behind a pointless handshake.
- Exactly one recovery per request. A server that expires every session gets an error, not a retry storm.

**Concurrency:** recovery is threaded through one write path that holds `sendMu` for the whole attempt, so no other sender can put a request onto the dead session mid-recovery. The handshake talks to the transport directly instead of going back through `Call`/`Notify` — those take `sendMu`, which is not reentrant, so reusing them would deadlock. Waiting for the initialize response under the lock is safe: the receive loop is a separate goroutine and delivers through the pending map, which `sendMu` doesn't guard.

**Companion fix:** `initialize` is no longer a once-at-startup event, so the metadata it writes (capabilities, server info, instructions, protocol version) is now guarded by an RWMutex. A restarted server may legitimately answer with *different* capabilities than the session we lost, concurrently with readers like `Capabilities()` or a `ListTools` already in flight — a real race without the lock, and one of the new tests exercises it under `-race`.

## 2. Broken SSE stream → resume with Last-Event-ID

A response stream that died mid-flight failed the whole request. `scanSSE` now tracks the `id:` field and, when a stream ends before delivering its answer, issues the spec's replay request (GET + `Last-Event-ID`) and continues from there.

Guards:

- **Only when the server tagged events.** No `id:` means the server never opted into resumability and has no way to know where to restart, so the original failure stands and no pointless GET is fired.
- **Capped attempts**, and it stops early as soon as a replay stops making forward progress (same id returned again) — otherwise a server replaying one event forever would loop.
- A server with no GET endpoint (405) surfaces **the original stream failure** as the primary error, with the resume attempt's status as context — the broken stream is the useful part.

`readSSE` was split into `scanSSE` (consume one body) + `resumeSSE` (orchestrate replays). All pre-existing SSE tests pass unchanged, which is the check that the refactor preserved behavior.

## Test plan

- [x] `go test -race ./internal/mcp/ ./internal/tools/` — green
- [x] `make vet` / `make fmt-check` clean

| Test | Covers |
|---|---|
| `TestSessionExpiry_RecoversTransparently` | call on a forgotten session succeeds; exactly 2 handshakes |
| `TestSessionExpiry_ReplayCarriesNewSession` | recovery handshake sends no stale id; replay uses the fresh one |
| `TestSessionExpiry_NoSessionMeansPlain404` | sessionless 404 stays a plain error, no retry |
| `TestSessionExpiry_GivesUpAfterOneRecovery` | hostile server ⇒ error wrapping `ErrSessionExpired`, no loop |
| `TestSessionExpiry_ConcurrentReadersSeeNoRace` | 4 goroutines reading metadata across a recovery, under `-race` |
| `TestSSEResume_PicksUpAfterBrokenStream` | stream dies after `id: 1`; GET replays with `Last-Event-ID: 1` |
| `TestSSEResume_UntaggedStreamDoesNotResume` | no ids ⇒ zero resume GETs |
| `TestSSEResume_StopsWithoutForwardProgress` | repeated id terminates within the attempt cap |
| `TestSSEResume_ServerWithoutGETReportsOriginalFailure` | 405 ⇒ original failure leads, 405 as context |
| `TestSSEResume_CarriesSessionAndVersion` | resume GET carries session id, protocol version, SSE Accept |