### PR TITLE
feat(mcp): refresh surface listings on listChanged notifications

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -364,11 +364,12 @@ func printMCP(w io.Writer) {
 		if info.Version != "" {
 			nameVer = fmt.Sprintf("%s %s", info.Name, info.Version)
 		}
+		nTools, nRes, nPrompts := len(c.Tools()), len(c.Resources()), len(c.Prompts())
 		fmt.Fprintf(w, "  %s (%s): %d tool%s, %d resource%s, %d prompt%s\n",
 			c.Name, nameVer,
-			len(c.Tools), pluralS(len(c.Tools)),
-			len(c.Resources), pluralS(len(c.Resources)),
-			len(c.Prompts), pluralS(len(c.Prompts)))
+			nTools, pluralS(nTools),
+			nRes, pluralS(nRes),
+			nPrompts, pluralS(nPrompts))
 		if instr := c.Client.Instructions(); instr != "" {
 			for _, line := range strings.Split(instr, "\n") {
 				fmt.Fprintf(w, "      %s\n", line)

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -66,6 +66,12 @@ type Client struct {
 	// at the Call call site.
 	sendMu sync.Mutex
 
+	// onNotification, when set, receives server-initiated notifications by
+	// method name. Guarded because it's read from the receive loop and set
+	// from whoever owns the client.
+	notifyMu       sync.Mutex
+	onNotification func(method string)
+
 	rxDone chan struct{} // closed when the receive loop exits
 	closed atomic.Bool
 }
@@ -342,10 +348,29 @@ func (c *Client) rehandshakeLocked(ctx context.Context) error {
 	return c.transport.Send(ctx, &Message{JSONRPC: "2.0", Method: MethodInitialized})
 }
 
+// SetNotificationHandler registers fn to receive server-initiated
+// notifications by method name (e.g. notifications/tools/list_changed). Pass
+// nil to clear. Set it before Initialize if the very first notifications
+// matter.
+//
+// fn is invoked on its own goroutine, one per notification, deliberately: the
+// receive loop is the only thing that delivers responses, so a handler that
+// called back into the client and waited for a reply would block the loop that
+// has to deliver that reply — a deadlock. Spawning means handlers can call the
+// client freely, at the cost of no ordering guarantee between concurrent
+// notifications, so a handler must tolerate being run more than once
+// concurrently.
+func (c *Client) SetNotificationHandler(fn func(method string)) {
+	c.notifyMu.Lock()
+	c.onNotification = fn
+	c.notifyMu.Unlock()
+}
+
 // receiveLoop runs for the life of the Client, pulling frames off the
 // transport and dispatching responses to the matching pending channel.
-// Notifications from the server are silently dropped — v1 doesn't react to
-// list_changed / progress / log messages.
+// Notifications are handed to the registered handler, if any; server-initiated
+// requests are still ignored (nothing here implements a server-callable
+// surface, and answering with an error would be noise).
 func (c *Client) receiveLoop() {
 	defer close(c.rxDone)
 	ctx := context.Background()
@@ -359,8 +384,15 @@ func (c *Client) receiveLoop() {
 			c.deliverResponse(msg)
 			continue
 		}
-		// Server-initiated request or notification: ignore for v1. A
-		// future revision can add a handler hook here.
+		if msg.IsNotification() {
+			c.notifyMu.Lock()
+			fn := c.onNotification
+			c.notifyMu.Unlock()
+			if fn != nil {
+				go fn(msg.Method)
+			}
+		}
+		// Server-initiated request: ignored — see the doc comment above.
 	}
 }
 

--- a/internal/mcp/list_changed_test.go
+++ b/internal/mcp/list_changed_test.go
@@ -1,0 +1,341 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// listChangedServer serves tools/list from a swappable set and can push a
+// tools/list_changed notification down an SSE response, which is how a real
+// server announces a new set mid-session.
+type listChangedServer struct {
+	mu        sync.Mutex
+	tools     []string
+	listCalls int
+	// pushOnNextCall makes the next tools/call response an SSE stream that
+	// carries a list_changed notification ahead of the actual result.
+	pushOnNextCall bool
+}
+
+func (s *listChangedServer) setTools(names ...string) {
+	s.mu.Lock()
+	s.tools = names
+	s.mu.Unlock()
+}
+
+func (s *listChangedServer) armPush() {
+	s.mu.Lock()
+	s.pushOnNextCall = true
+	s.mu.Unlock()
+}
+
+func (s *listChangedServer) lists() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.listCalls
+}
+
+func (s *listChangedServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		var in Message
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		switch in.Method {
+		case MethodInitialize:
+			writeJSONRPC(w, in.ID, InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities: ServerCapabilities{
+					Tools:     &ToolsCapability{ListChanged: true},
+					Resources: &ResourcesCapability{},
+					Prompts:   &PromptsCapability{},
+				},
+				ServerInfo: Implementation{Name: "churn", Version: "1"},
+			})
+		case MethodToolsList:
+			s.mu.Lock()
+			s.listCalls++
+			names := append([]string(nil), s.tools...)
+			s.mu.Unlock()
+			out := make([]Tool, 0, len(names))
+			for _, n := range names {
+				out = append(out, Tool{Name: n})
+			}
+			writeJSONRPC(w, in.ID, ListToolsResult{Tools: out})
+		case MethodResourcesList:
+			writeJSONRPC(w, in.ID, ListResourcesResult{})
+		case MethodPromptsList:
+			writeJSONRPC(w, in.ID, ListPromptsResult{})
+		case MethodToolsCall:
+			s.mu.Lock()
+			push := s.pushOnNextCall
+			s.pushOnNextCall = false
+			s.mu.Unlock()
+			if !push {
+				writeJSONRPC(w, in.ID, CallToolResult{Content: []Content{{Type: "text", Text: "ok"}}})
+				return
+			}
+			// SSE response: notification first, then the result.
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: MethodToolListChanged})
+			fmt.Fprintf(w, "data: %s\n\n", notif)
+			res, _ := json.Marshal(CallToolResult{Content: []Content{{Type: "text", Text: "ok"}}})
+			resp, _ := json.Marshal(Message{JSONRPC: "2.0", ID: in.ID, Result: res})
+			fmt.Fprintf(w, "data: %s\n\n", resp)
+		default:
+			writeJSONRPC(w, in.ID, map[string]any{})
+		}
+	}
+}
+
+func connectTo(t *testing.T, url string) (*Registry, *Connection) {
+	t.Helper()
+	reg := NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := reg.Connect(ctx, "churn", ServerEntry{URL: url},
+		Implementation{Name: "test", Version: "1"}, nil, nil); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	conn := reg.Get("churn")
+	if conn == nil {
+		t.Fatal("no connection registered")
+	}
+	return reg, conn
+}
+
+// waitForTools polls until the connection's tool list matches want, which is
+// the observable effect of the refresh. The refresh is asynchronous by design
+// (it can't run on the receive loop without deadlocking), so a poll is the
+// honest way to await it.
+func waitForTools(t *testing.T, conn *Connection, want string, limit time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(limit)
+	for time.Now().Before(deadline) {
+		var got string
+		for i, tl := range conn.Tools() {
+			if i > 0 {
+				got += ","
+			}
+			got += tl.Name
+		}
+		if got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	var got []string
+	for _, tl := range conn.Tools() {
+		got = append(got, tl.Name)
+	}
+	t.Fatalf("tools = %v, never became %q within %v", got, want, limit)
+}
+
+// TestListChanged_RefreshesTools is the behaviour the feature exists for: the
+// server says its tools changed, and the connection reflects the new set
+// without anyone reconnecting it by hand.
+func TestListChanged_RefreshesTools(t *testing.T) {
+	fake := &listChangedServer{}
+	fake.setTools("old")
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	reg, conn := connectTo(t, srv.URL)
+	defer reg.Close()
+
+	waitForTools(t, conn, "old", time.Second)
+
+	// The server swaps its tool set and announces it on the next call's stream.
+	fake.setTools("fresh", "alsofresh")
+	fake.armPush()
+	if _, err := conn.Client.CallTool(context.Background(), "old", nil); err != nil {
+		t.Fatal(err)
+	}
+	waitForTools(t, conn, "fresh,alsofresh", 5*time.Second)
+}
+
+// TestListChanged_FailedRefreshKeepsPreviousList: if the re-list fails, the
+// old listing must stay. An empty list would make the server look like it has
+// no tools at all, which is worse than a stale one the model can still call.
+func TestListChanged_FailedRefreshKeepsPreviousList(t *testing.T) {
+	var failLists atomic.Bool
+	var mu sync.Mutex
+	tools := []string{"keepme"}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in Message
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		switch in.Method {
+		case MethodInitialize:
+			writeJSONRPC(w, in.ID, InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{ListChanged: true}},
+				ServerInfo:      Implementation{Name: "flaky", Version: "1"},
+			})
+		case MethodToolsList:
+			if failLists.Load() {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			names := append([]string(nil), tools...)
+			mu.Unlock()
+			out := make([]Tool, 0, len(names))
+			for _, n := range names {
+				out = append(out, Tool{Name: n})
+			}
+			writeJSONRPC(w, in.ID, ListToolsResult{Tools: out})
+		case MethodToolsCall:
+			// Announce the change, then fail every subsequent list.
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			failLists.Store(true)
+			notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: MethodToolListChanged})
+			fmt.Fprintf(w, "data: %s\n\n", notif)
+			res, _ := json.Marshal(CallToolResult{Content: []Content{{Type: "text", Text: "ok"}}})
+			resp, _ := json.Marshal(Message{JSONRPC: "2.0", ID: in.ID, Result: res})
+			fmt.Fprintf(w, "data: %s\n\n", resp)
+		default:
+			writeJSONRPC(w, in.ID, map[string]any{})
+		}
+	}))
+	defer srv.Close()
+
+	reg, conn := connectTo(t, srv.URL)
+	defer reg.Close()
+	waitForTools(t, conn, "keepme", time.Second)
+
+	if _, err := conn.Client.CallTool(context.Background(), "keepme", nil); err != nil {
+		t.Fatal(err)
+	}
+	// Give the (failing) refresh time to run and not clobber anything.
+	time.Sleep(300 * time.Millisecond)
+	got := conn.Tools()
+	if len(got) != 1 || got[0].Name != "keepme" {
+		t.Errorf("tools = %v, want the previous listing kept after a failed refresh", got)
+	}
+}
+
+// TestListChanged_BurstCoalesces: a server firing many notifications must not
+// produce one list call each. The contract is "at most one refresh in flight
+// plus one queued", so a big burst collapses into a small number of passes.
+func TestListChanged_BurstCoalesces(t *testing.T) {
+	fake := &listChangedServer{}
+	fake.setTools("t1")
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	reg, conn := connectTo(t, srv.URL)
+	defer reg.Close()
+	waitForTools(t, conn, "t1", time.Second)
+
+	before := fake.lists()
+	const burst = 40
+	var wg sync.WaitGroup
+	for range burst {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn.refreshSurfaces(MethodToolListChanged)
+		}()
+	}
+	wg.Wait()
+	// Let any queued follow-up pass finish.
+	time.Sleep(300 * time.Millisecond)
+
+	// Each coalesced pass costs at most 3 list calls (tools+resources+prompts
+	// on a follow-up). 40 notifications collapsing to a handful of passes is
+	// the point; one-per-notification would be ~40.
+	if got := fake.lists() - before; got > burst/2 {
+		t.Errorf("tools/list calls = %d for %d notifications; coalescing is not working", got, burst)
+	}
+}
+
+// TestListChanged_ConcurrentReadersSeeNoRace: a refresh replaces the listings
+// while other goroutines read them — a data race without listMu. Meaningful
+// under -race.
+func TestListChanged_ConcurrentReadersSeeNoRace(t *testing.T) {
+	fake := &listChangedServer{}
+	fake.setTools("a", "b")
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	reg, conn := connectTo(t, srv.URL)
+	defer reg.Close()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for _, tl := range conn.Tools() {
+						_ = tl.Name
+					}
+					_ = conn.Resources()
+					_ = conn.Prompts()
+				}
+			}
+		}()
+	}
+
+	for i := range 10 {
+		fake.setTools(fmt.Sprintf("gen%d", i), fmt.Sprintf("gen%d-b", i))
+		conn.refreshSurfaces(MethodToolListChanged)
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// TestListChanged_UnrelatedNotificationIgnored: only the list_changed methods
+// trigger work. A progress or log notification must not cause list traffic.
+func TestListChanged_UnrelatedNotificationIgnored(t *testing.T) {
+	fake := &listChangedServer{}
+	fake.setTools("t1")
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	reg, conn := connectTo(t, srv.URL)
+	defer reg.Close()
+	waitForTools(t, conn, "t1", time.Second)
+
+	before := fake.lists()
+	// Drive the client's handler directly with methods it should ignore.
+	conn.Client.notifyMu.Lock()
+	fn := conn.Client.onNotification
+	conn.Client.notifyMu.Unlock()
+	if fn == nil {
+		t.Fatal("no notification handler installed")
+	}
+	fn("notifications/progress")
+	fn("notifications/message")
+	time.Sleep(200 * time.Millisecond)
+
+	if got := fake.lists() - before; got != 0 {
+		t.Errorf("unrelated notifications caused %d list calls, want 0", got)
+	}
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -91,6 +91,13 @@ const (
 	MethodPromptsList   = "prompts/list"
 	MethodPromptsGet    = "prompts/get"
 	MethodShutdown      = "shutdown"
+
+	// Server-initiated notifications announcing that a surface's contents
+	// changed, sent by servers that advertised the matching listChanged
+	// capability. Connection.watchListChanges re-lists in response.
+	MethodToolListChanged     = "notifications/tools/list_changed"
+	MethodResourceListChanged = "notifications/resources/list_changed"
+	MethodPromptListChanged   = "notifications/prompts/list_changed"
 )
 
 // ── initialize handshake ─────────────────────────────────────────────────

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -33,12 +33,29 @@ func NewRegistry() *Registry {
 // Connection is the per-server bundle of state the adapters need: the
 // client itself plus the pre-fetched tools/resources/prompts lists so the
 // agent loop doesn't re-list on every turn.
+//
+// The listings are behind accessors rather than exported fields because they
+// are no longer written once at connect time: a server that advertises
+// listChanged can announce a new set at any moment, which refreshes them
+// underneath readers. Unexporting is what makes that safe — the compiler finds
+// every reader instead of leaving a silent race for the next one added.
 type Connection struct {
-	Name      string
-	Client    *Client
-	Tools     []Tool
-	Resources []Resource
-	Prompts   []Prompt
+	Name   string
+	Client *Client
+
+	// listMu guards the three surface listings against the refresh a
+	// listChanged notification triggers.
+	listMu    sync.RWMutex
+	tools     []Tool
+	resources []Resource
+	prompts   []Prompt
+
+	// refreshMu serialises refreshes and coalesces bursts: a server that fires
+	// several listChanged notifications in a row should cause one more refresh
+	// after the current one, not one per notification.
+	refreshMu      sync.Mutex
+	refreshing     bool
+	refreshPending bool
 
 	// reauthMu guards reauthErr, set by MarkReauthRequired when a call made
 	// through this (otherwise still "live") connection surfaces
@@ -50,6 +67,126 @@ type Connection struct {
 	reauthMu  sync.Mutex
 	reauthErr error
 }
+
+// Tools returns the server's advertised tools as of the last listing. The
+// slice is not copied — treat it as read-only; a refresh replaces it wholesale
+// rather than mutating it, so a caller iterating an older slice keeps seeing a
+// consistent snapshot.
+func (c *Connection) Tools() []Tool {
+	c.listMu.RLock()
+	defer c.listMu.RUnlock()
+	return c.tools
+}
+
+// Resources returns the server's advertised resources. Same contract as Tools.
+func (c *Connection) Resources() []Resource {
+	c.listMu.RLock()
+	defer c.listMu.RUnlock()
+	return c.resources
+}
+
+// Prompts returns the server's advertised prompts. Same contract as Tools.
+func (c *Connection) Prompts() []Prompt {
+	c.listMu.RLock()
+	defer c.listMu.RUnlock()
+	return c.prompts
+}
+
+func (c *Connection) setTools(t []Tool) {
+	c.listMu.Lock()
+	c.tools = t
+	c.listMu.Unlock()
+}
+
+func (c *Connection) setResources(r []Resource) {
+	c.listMu.Lock()
+	c.resources = r
+	c.listMu.Unlock()
+}
+
+func (c *Connection) setPrompts(p []Prompt) {
+	c.listMu.Lock()
+	c.prompts = p
+	c.listMu.Unlock()
+}
+
+// watchListChanges makes the connection react to the server announcing that a
+// surface changed. Without this a server's new tools stayed invisible until
+// someone reconnected it by hand, even though it had said so.
+//
+// Wired for every connection: the notification only arrives if the server
+// chose to send it, so gating on the advertised listChanged capability would
+// only add a way to ignore a server that changed its mind.
+func (c *Connection) watchListChanges() {
+	c.Client.SetNotificationHandler(func(method string) {
+		switch method {
+		case MethodToolListChanged, MethodResourceListChanged, MethodPromptListChanged:
+			c.refreshSurfaces(method)
+		}
+	})
+}
+
+// refreshSurfaces re-lists the surface named by method. Runs at most one
+// refresh at a time per connection; a notification arriving during one is
+// collapsed into a single follow-up pass, so a server that fires a burst
+// doesn't produce a burst of list calls.
+//
+// It re-lists all three surfaces on the follow-up pass rather than tracking
+// which methods were coalesced — three cheap list calls beat the bookkeeping,
+// and a server churning one surface is usually churning others.
+func (c *Connection) refreshSurfaces(method string) {
+	c.refreshMu.Lock()
+	if c.refreshing {
+		c.refreshPending = true
+		c.refreshMu.Unlock()
+		return
+	}
+	c.refreshing = true
+	c.refreshMu.Unlock()
+
+	for {
+		c.refreshOnce(method)
+
+		c.refreshMu.Lock()
+		if !c.refreshPending {
+			c.refreshing = false
+			c.refreshMu.Unlock()
+			return
+		}
+		c.refreshPending = false
+		c.refreshMu.Unlock()
+		method = "" // follow-up pass: refresh everything
+	}
+}
+
+// refreshOnce performs one round of list calls. A failure leaves the previous
+// listing in place: a stale list the model can still call beats an empty one
+// that makes the server look like it has nothing.
+func (c *Connection) refreshOnce(method string) {
+	ctx, cancel := context.WithTimeout(context.Background(), listRefreshTimeout)
+	defer cancel()
+
+	if method == "" || method == MethodToolListChanged {
+		if tools, err := c.Client.ListTools(ctx); err == nil {
+			c.setTools(tools)
+		}
+	}
+	if method == "" || method == MethodResourceListChanged {
+		if resources, err := c.Client.ListResources(ctx); err == nil {
+			c.setResources(resources)
+		}
+	}
+	if method == "" || method == MethodPromptListChanged {
+		if prompts, err := c.Client.ListPrompts(ctx); err == nil {
+			c.setPrompts(prompts)
+		}
+	}
+}
+
+// listRefreshTimeout bounds a listChanged-triggered refresh. It runs on its own
+// goroutine with no user waiting, so it needs a ceiling of its own rather than
+// inheriting a turn's context. A var so tests can shrink it.
+var listRefreshTimeout = 30 * time.Second
 
 // MarkReauthRequired records that a call through this connection hit
 // ErrReauthRequired. Safe for concurrent callers.
@@ -181,14 +318,17 @@ func connectOne(ctx context.Context, name string, entry ServerEntry, info Implem
 	// to enumerate. We tolerate per-surface failures — a server with
 	// broken resources/list still gets its tools/list cached.
 	if tools, err := client.ListTools(connectCtx); err == nil {
-		conn.Tools = tools
+		conn.setTools(tools)
 	}
 	if resources, err := client.ListResources(connectCtx); err == nil {
-		conn.Resources = resources
+		conn.setResources(resources)
 	}
 	if prompts, err := client.ListPrompts(connectCtx); err == nil {
-		conn.Prompts = prompts
+		conn.setPrompts(prompts)
 	}
+	// Only now, with the initial listings in hand: a notification arriving
+	// mid-prefetch would otherwise race the pre-fetch to write them.
+	conn.watchListChanges()
 	return conn, nil
 }
 

--- a/internal/mcp/registry_manage_test.go
+++ b/internal/mcp/registry_manage_test.go
@@ -135,8 +135,8 @@ func TestRegistryConnect_AddAndReplace(t *testing.T) {
 	if conn == nil {
 		t.Fatal("connection not installed")
 	}
-	if len(conn.Tools) != 2 {
-		t.Fatalf("tools = %d, want 2", len(conn.Tools))
+	if len(conn.Tools()) != 2 {
+		t.Fatalf("tools = %d, want 2", len(conn.Tools()))
 	}
 	if _, ok := r.ConnectError("fake"); ok {
 		t.Error("successful connect must not leave an error")

--- a/internal/server/mcp_handlers.go
+++ b/internal/server/mcp_handlers.go
@@ -138,7 +138,7 @@ func (s *Server) mcpServerList() ([]mcpServerInfo, error) {
 				info.Error = msg
 			} else {
 				info.Status = "connected"
-				info.Tools = len(conn.Tools)
+				info.Tools = len(conn.Tools())
 			}
 		default:
 			info.Status = "disconnected"
@@ -236,7 +236,7 @@ func (s *Server) handleGetMCPServer(w http.ResponseWriter, r *http.Request) {
 				info.Error = msg
 			} else {
 				info.Status = "connected"
-				info.Tools = len(conn.Tools)
+				info.Tools = len(conn.Tools())
 			}
 		} else {
 			info.Status = "disconnected"
@@ -255,8 +255,8 @@ func (s *Server) handleGetMCPServer(w http.ResponseWriter, r *http.Request) {
 		if reg != nil {
 			conn := reg.Get(name)
 			if conn != nil {
-				detail.ToolList = make([]mcpToolInfo, 0, len(conn.Tools))
-				for _, t := range conn.Tools {
+				detail.ToolList = make([]mcpToolInfo, 0, len(conn.Tools()))
+				for _, t := range conn.Tools() {
 					detail.ToolList = append(detail.ToolList, mcpToolInfo{
 						Name:        t.Name,
 						Description: t.Description,

--- a/internal/server/mcp_oauth_handlers_test.go
+++ b/internal/server/mcp_oauth_handlers_test.go
@@ -190,7 +190,7 @@ func TestMCPOAuth_WebAuthCodeFlow_EndToEnd(t *testing.T) {
 	if reg == nil || reg.Get("secure") == nil {
 		t.Fatal("authorized server should be connected in the registry")
 	}
-	if n := len(reg.Get("secure").Tools); n != 1 {
+	if n := len(reg.Get("secure").Tools()); n != 1 {
 		t.Fatalf("tools = %d, want 1", n)
 	}
 

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -65,7 +65,7 @@ func mcpToolDefs() []agent.ToolDefinition {
 		// Server tools: one definition per advertised tool. The MCP tool's
 		// inputSchema is already a JSON Schema object, so we pass it through
 		// verbatim into Parameters.
-		for _, t := range conn.Tools {
+		for _, t := range conn.Tools() {
 			defs = append(defs, agent.ToolDefinition{
 				Name:        mcpToolName(conn.Name, t.Name),
 				Description: fmt.Sprintf("[mcp:%s] %s", conn.Name, t.Description),
@@ -78,7 +78,7 @@ func mcpToolDefs() []agent.ToolDefinition {
 		if conn.Client.Capabilities().Resources != nil {
 			defs = append(defs, agent.ToolDefinition{
 				Name:        mcpToolName(conn.Name, "resource_read"),
-				Description: fmt.Sprintf("[mcp:%s] Read an MCP resource by URI. Available resources: %s", conn.Name, joinResourceURIs(conn.Resources)),
+				Description: fmt.Sprintf("[mcp:%s] Read an MCP resource by URI. Available resources: %s", conn.Name, joinResourceURIs(conn.Resources())),
 				Parameters: map[string]any{
 					"type": "object",
 					"properties": map[string]any{
@@ -96,7 +96,7 @@ func mcpToolDefs() []agent.ToolDefinition {
 		if conn.Client.Capabilities().Prompts != nil {
 			defs = append(defs, agent.ToolDefinition{
 				Name:        mcpToolName(conn.Name, "prompt_get"),
-				Description: fmt.Sprintf("[mcp:%s] Materialise an MCP prompt template. Available prompts: %s", conn.Name, joinPromptNames(conn.Prompts)),
+				Description: fmt.Sprintf("[mcp:%s] Materialise an MCP prompt template. Available prompts: %s", conn.Name, joinPromptNames(conn.Prompts())),
 				Parameters: map[string]any{
 					"type": "object",
 					"properties": map[string]any{


### PR DESCRIPTION
Last of the MCP gaps found while chasing the SSE connection failure (#2019, #2020, #2023, #2024, #2025).

## Problem

`receiveLoop` dropped every non-response frame with a comment saying a future revision could add a hook. So `notifications/tools/list_changed` — a server announcing its tools changed — was ignored: the new tools stayed invisible until someone reconnected the server by hand, **even though the server had said so**.

Not a corner case: servers in the wild advertise `listChanged: true` on all three surfaces.

## Fix

`Client` grows a notification-handler hook; each `Connection` uses it to re-list the changed surface.

**Why the handler runs on its own goroutine** — this is load-bearing, not incidental. The receive loop is the only thing that delivers responses, so a handler that called back into the client and waited for a reply would block the very loop that has to deliver that reply. Deadlock. Spawning per notification means handlers can call the client freely; the cost is no ordering guarantee, so handlers must tolerate concurrent runs, which the refresh does.

**Coalescing.** At most one refresh in flight per connection plus one queued, so a server firing a burst causes one follow-up pass instead of one pass per notification. The follow-up refreshes all three surfaces rather than tracking which methods were collapsed — three cheap list calls beat the bookkeeping.

**Failure handling.** A failed re-list keeps the previous listing. An empty list would make the server look like it has nothing, which is worse than a stale list the model can still call.

## API change

`Connection.Tools`/`Resources`/`Prompts` become accessors over unexported fields, guarded by an RWMutex.

These are no longer written once at connect time, and **unexporting is what makes that safe** — the compiler located all seven readers (`internal/tools/mcp.go`, `internal/server/mcp_handlers.go` ×4, `cmd/octo/repl.go`) instead of leaving a silent race for whoever adds the eighth. `watchListChanges` is wired only after the initial pre-fetch, so an early notification can't race it.

## Scope note

The **web/server path rebuilds its tool list per turn** (`tools.DefaultToolsForCtx` in `server.go`/`tasks_handlers.go`), so it picks new tools up on the next turn automatically — no extra plumbing.

The **CLI snapshots `cfg.tools`** at session start and refreshes through its existing `mcpReadyMsg` path, so there a mid-session change lands on the next recompute rather than immediately. Wiring a live TUI refresh would duplicate that existing mechanism and is left alone deliberately.

## Test plan

- [x] `go test -race ./internal/... ./cmd/...` — full repo, no failures
- [x] `make vet` / `make fmt-check` clean

| Test | Covers |
|---|---|
| `TestListChanged_RefreshesTools` | server swaps its tools, announces it on an SSE stream, connection reflects the new set |
| `TestListChanged_FailedRefreshKeepsPreviousList` | re-list returning 500 leaves the old listing intact |
| `TestListChanged_BurstCoalesces` | 40 concurrent notifications collapse to a handful of list calls, not ~40 |
| `TestListChanged_ConcurrentReadersSeeNoRace` | 4 readers across 10 refreshes under `-race` |
| `TestListChanged_UnrelatedNotificationIgnored` | progress/log notifications cause zero list traffic |