### PR TITLE
fix(mcp): stop teardown authorizing, finish the recovery path

### DIFF
--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -228,11 +228,7 @@ func (t *HTTPTransport) doRequest(ctx context.Context, msg *Message, forceFreshT
 		// report it as the typed error Client watches for. A 404 on a request
 		// with no session id is an ordinary wrong-endpoint error and falls
 		// through below.
-		t.sessionMu.Lock()
-		if t.sessionID == sentSession {
-			t.sessionID = ""
-		}
-		t.sessionMu.Unlock()
+		t.forgetSession(sentSession)
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return false, fmt.Errorf("%w: %s", ErrSessionExpired, bytes.TrimSpace(b))
 	}
@@ -365,6 +361,12 @@ func (t *HTTPTransport) resumeSSE(ctx context.Context, wantID []byte, lastID str
 		}
 		body, err := t.openResumeStream(ctx, lastID)
 		if err != nil {
+			// An expiry discovered here must stay recognisable: it's the one
+			// failure the Client can repair, and burying it under the
+			// stream-incomplete cause would strand the connection.
+			if errors.Is(err, ErrSessionExpired) {
+				return err
+			}
 			return fmt.Errorf("%w (resume attempt %d: %v)", cause, attempt+1, err)
 		}
 		var next string
@@ -418,6 +420,18 @@ func (t *HTTPTransport) openResumeStream(ctx context.Context, lastID string) (io
 	resp, err := t.hc.Do(req)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode == http.StatusNotFound && sid != "" {
+		// The spec names an expiring session as the one sanctioned reason for a
+		// server to close a response stream early, so this is a likely way for
+		// a resume to fail rather than an exotic one. Report it as the expiry
+		// it is — the caller propagates it so the Client re-handshakes — and
+		// not as "the stream broke", which would leave the dead session id in
+		// place and fail the call with an unrelated message.
+		t.forgetSession(sid)
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("%w: %s", ErrSessionExpired, bytes.TrimSpace(b))
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
@@ -538,6 +552,33 @@ func (t *HTTPTransport) Receive(ctx context.Context) (*Message, error) {
 	}
 }
 
+// forgetSession drops the state that belonged to a session the server has
+// declared gone, so the recovery handshake starts from nothing.
+//
+// The protocol version goes with the session id, not just the id alone: a
+// revision is negotiated per session, and the recovery initialize is precisely
+// the request that renegotiates it. Carrying the old value into it would make
+// a server that restarted onto a revision it no longer supports answer 400
+// (which the spec requires for an unsupported version header) instead of
+// negotiating, turning a recoverable expiry into a wedged connection.
+//
+// sentSession guards against clobbering a newer session: by the time a 404
+// lands, a concurrent request may already have established a replacement.
+func (t *HTTPTransport) forgetSession(sentSession string) {
+	t.sessionMu.Lock()
+	stale := t.sessionID == sentSession
+	if stale {
+		t.sessionID = ""
+	}
+	t.sessionMu.Unlock()
+	if !stale {
+		return
+	}
+	t.protoMu.Lock()
+	t.protocolVersion = ""
+	t.protoMu.Unlock()
+}
+
 // SetProtocolVersion records the revision the server chose during the
 // initialize handshake so later requests can advertise it. Called by
 // Client.Initialize before it sends notifications/initialized, so every
@@ -589,10 +630,14 @@ func (t *HTTPTransport) deleteSession() {
 		req.Header.Set("MCP-Protocol-Version", t.protocolVersion)
 	}
 	t.protoMu.Unlock()
-	// Reuse the cached OAuth token if we have one, but never start an
-	// interactive authorization just to say goodbye.
-	if t.oauth != nil {
-		if tok, terr := t.oauth.Token(ctx); terr == nil && tok != "" {
+	// Reuse an already-cached OAuth token if there is one, but never start an
+	// interactive authorization just to say goodbye. This must not call
+	// Token: that escalates through refresh to a full authorize, which opens
+	// a browser — so a near-expired token whose refresh failed would pop an
+	// authorization page when the user typed /exit, then fail anyway on this
+	// path's short deadline.
+	if cp, ok := t.oauth.(cachedTokenProvider); ok {
+		if tok := cp.CachedToken(); tok != "" {
 			req.Header.Set("Authorization", "Bearer "+tok)
 		}
 	}

--- a/internal/mcp/oauth.go
+++ b/internal/mcp/oauth.go
@@ -83,6 +83,14 @@ type OAuthProvider interface {
 	Invalidate()
 }
 
+// cachedTokenProvider is the optional half of OAuthProvider used on teardown
+// paths, where Token's escalation to refresh-then-authorize is unacceptable —
+// nobody wants a browser opening because they typed /exit. A provider that
+// doesn't implement it simply contributes no Authorization header there.
+type cachedTokenProvider interface {
+	CachedToken() string
+}
+
 // OAuthClient implements OAuthProvider against a single MCP resource URL.
 // Persists state under ~/.octo/mcp-tokens/<server>.json so a fresh
 // `octo` session reuses the access token + refresh token from the
@@ -195,6 +203,34 @@ func (o *OAuthClient) Token(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return o.state.AccessToken, nil
+}
+
+// CachedToken returns the cached access token only if one is present and not
+// close to expiry. It never refreshes, never registers, and never starts an
+// authorization flow — unlike Token, which escalates through all three.
+//
+// This exists for teardown paths (releasing a session on Close): they want to
+// authenticate the goodbye if they cheaply can, but must not open a browser
+// for it. Empty means "nothing usable cached", and the caller should proceed
+// without an Authorization header rather than trying harder.
+func (o *OAuthClient) CachedToken() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.loadOnce.Do(func() {
+		if st, err := loadOAuthState(o.storePath); err == nil {
+			o.state = st
+		}
+	})
+	// Same staleness rule Token uses: a token cached before resource-binding
+	// was recorded isn't audience-bound and would 401 anyway.
+	if o.state == nil || o.state.AccessToken == "" || o.state.Resource == "" {
+		return ""
+	}
+	if !o.state.ExpiresAt.After(time.Now().Add(60 * time.Second)) {
+		return ""
+	}
+	return o.state.AccessToken
 }
 
 // Invalidate forgets the current access token without throwing away the

--- a/internal/mcp/recovery_gaps_test.go
+++ b/internal/mcp/recovery_gaps_test.go
@@ -1,0 +1,397 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// escalatingOAuth stands in for the real provider, whose Token() escalates
+// through refresh to a full authorization — discovery, registration, and
+// opening a browser — when the cache is stale. Here Token() just succeeds and
+// counts, because what's under test is *who calls it*: a teardown path must
+// read the cache instead, so any Token call from Close is the failure.
+type escalatingOAuth struct {
+	mu           sync.Mutex
+	tokenCalls   int
+	cachedCalls  int
+	cachedResult string
+}
+
+func (o *escalatingOAuth) Token(context.Context) (string, error) {
+	o.mu.Lock()
+	o.tokenCalls++
+	o.mu.Unlock()
+	return "live-token", nil
+}
+
+func (o *escalatingOAuth) Invalidate() {}
+
+func (o *escalatingOAuth) CachedToken() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.cachedCalls++
+	return o.cachedResult
+}
+
+func (o *escalatingOAuth) counts() (tokens, cached int) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.tokenCalls, o.cachedCalls
+}
+
+// TestClose_NeverStartsInteractiveAuth: releasing a session on teardown must
+// not reach for a token it would have to authorize for. Typing /exit should
+// never open a browser.
+func TestClose_NeverStartsInteractiveAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "sess-bye")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{}`),
+		})
+	}))
+	defer srv.Close()
+
+	oa := &escalatingOAuth{}
+	tx, err := NewHTTPTransport(HTTPConfig{URL: srv.URL, OAuth: oa})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	if err := tx.Send(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	beforeTokens, _ := oa.counts()
+	if err := tx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	afterTokens, cached := oa.counts()
+
+	if afterTokens != beforeTokens {
+		t.Errorf("Close called Token %d extra time(s); it must only read the cache",
+			afterTokens-beforeTokens)
+	}
+	if cached == 0 {
+		t.Error("Close never consulted CachedToken; the DELETE went out unauthenticated")
+	}
+}
+
+// TestClose_UsesCachedTokenWhenAvailable: the goodbye is still authenticated
+// when a usable token happens to be cached.
+func TestClose_UsesCachedTokenWhenAvailable(t *testing.T) {
+	var mu sync.Mutex
+	var deleteAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			mu.Lock()
+			deleteAuth = r.Header.Get("Authorization")
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "sess-bye")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{}`),
+		})
+	}))
+	defer srv.Close()
+
+	oa := &escalatingOAuth{cachedResult: "cached-abc"}
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL, OAuth: oa})
+	req := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	if err := tx.Send(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if deleteAuth != "Bearer cached-abc" {
+		t.Errorf("DELETE Authorization = %q, want the cached bearer token", deleteAuth)
+	}
+}
+
+// TestSSEMidStreamExpiry_RecoversAndClearsSession is the gap the reviewers
+// found empirically: the spec names an expiring session as the one sanctioned
+// reason to close a response stream early, so the resume GET is a likely place
+// to meet a 404 — and it used to be reported as "the stream broke" while the
+// dead session id stayed installed.
+func TestSSEMidStreamExpiry_RecoversAndClearsSession(t *testing.T) {
+	var mu sync.Mutex
+	sessions := 0
+	var sawGet bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method == http.MethodGet {
+			// The resume attempt: session is gone.
+			mu.Lock()
+			sawGet = true
+			mu.Unlock()
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("session gone"))
+			return
+		}
+		var in Message
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if in.Method == MethodInitialize {
+			mu.Lock()
+			sessions++
+			sid := fmt.Sprintf("sess-%d", sessions)
+			mu.Unlock()
+			w.Header().Set("Mcp-Session-Id", sid)
+			writeJSONRPC(w, in.ID, InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+				ServerInfo:      Implementation{Name: "expiring-stream", Version: "1"},
+			})
+			return
+		}
+		mu.Lock()
+		firstSession := sessions == 1
+		mu.Unlock()
+		if firstSession && in.Method == MethodToolsCall {
+			// Tagged event, then hang up without the response — the shape of a
+			// stream cut short by an expiring session.
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: "notifications/progress"})
+			fmt.Fprintf(w, "id: ev-1\ndata: %s\n\n", notif)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			return
+		}
+		switch in.Method {
+		case MethodToolsCall:
+			writeJSONRPC(w, in.ID, CallToolResult{Content: []Content{{Type: "text", Text: "recovered"}}})
+		case MethodToolsList:
+			writeJSONRPC(w, in.ID, ListToolsResult{Tools: []Tool{{Name: "ping"}}})
+		default:
+			writeJSONRPC(w, in.ID, map[string]any{})
+		}
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// The call whose stream dies mid-flight. Recovery must make it succeed.
+	res, err := c.CallTool(ctx, "ping", nil)
+	if err != nil {
+		t.Fatalf("call should have recovered from a mid-stream expiry, got: %v", err)
+	}
+	if len(res.Content) == 0 || res.Content[0].Text != "recovered" {
+		t.Errorf("result = %+v, want the replayed call's result", res.Content)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !sawGet {
+		t.Error("no resume GET was attempted")
+	}
+	if sessions != 2 {
+		t.Errorf("handshakes = %d, want 2 (original plus recovery)", sessions)
+	}
+}
+
+// TestSSEMidStreamExpiry_SurfacesTypedError checks the transport-level
+// contract directly: the resume 404 becomes ErrSessionExpired and the dead
+// session id is dropped, rather than an opaque stream failure that leaves it
+// installed.
+func TestSSEMidStreamExpiry_SurfacesTypedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("session gone"))
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "sess-A")
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: "notifications/progress"})
+		fmt.Fprintf(w, "id: ev-1\ndata: %s\n\n", notif)
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+	tx.SetProtocolVersion("2025-03-26")
+
+	err := tx.Send(context.Background(), &Message{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/call",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, ErrSessionExpired) {
+		t.Errorf("err = %v, want it to wrap ErrSessionExpired", err)
+	}
+
+	tx.sessionMu.Lock()
+	sid := tx.sessionID
+	tx.sessionMu.Unlock()
+	if sid != "" {
+		t.Errorf("session id = %q after an expiry, want it dropped", sid)
+	}
+}
+
+// TestForgetSession_ClearsProtocolVersion: a revision is negotiated per
+// session, and the recovery initialize is the request that renegotiates it.
+// Carrying the old version header into it lets a server that restarted onto a
+// different revision answer 400 instead of negotiating.
+func TestForgetSession_ClearsProtocolVersion(t *testing.T) {
+	var mu sync.Mutex
+	var versions []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		versions = append(versions, r.Header.Get("MCP-Protocol-Version"))
+		sent := r.Header.Get("Mcp-Session-Id")
+		mu.Unlock()
+		if sent == "dead-session" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "dead-session")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{}`),
+		})
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+
+	// First request establishes the session; then adopt a negotiated version.
+	req := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	if err := tx.Send(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	tx.SetProtocolVersion("2025-06-18")
+
+	// Second request carries the dead session and gets 404.
+	if err := tx.Send(context.Background(), req); !errors.Is(err, ErrSessionExpired) {
+		t.Fatalf("err = %v, want ErrSessionExpired", err)
+	}
+
+	tx.protoMu.Lock()
+	pv := tx.protocolVersion
+	tx.protoMu.Unlock()
+	if pv != "" {
+		t.Errorf("protocol version = %q after expiry, want it cleared so initialize renegotiates", pv)
+	}
+
+	// And a following request must not advertise the stale revision.
+	_ = tx.Send(context.Background(), req)
+	mu.Lock()
+	defer mu.Unlock()
+	last := versions[len(versions)-1]
+	if last == "2025-06-18" {
+		t.Errorf("post-expiry request still advertised %q", last)
+	}
+}
+
+// TestForgetSession_IgnoresStaleClobber: a 404 for an old session must not
+// wipe state a concurrent request has already replaced.
+func TestForgetSession_IgnoresStaleClobber(t *testing.T) {
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: "http://example.invalid"})
+	defer tx.Close()
+
+	tx.sessionMu.Lock()
+	tx.sessionID = "newer-session"
+	tx.sessionMu.Unlock()
+	tx.SetProtocolVersion("2025-03-26")
+
+	tx.forgetSession("older-session") // late 404 for a session we've moved past
+
+	tx.sessionMu.Lock()
+	sid := tx.sessionID
+	tx.sessionMu.Unlock()
+	tx.protoMu.Lock()
+	pv := tx.protocolVersion
+	tx.protoMu.Unlock()
+
+	if sid != "newer-session" {
+		t.Errorf("session id = %q, want the newer session untouched", sid)
+	}
+	if pv != "2025-03-26" {
+		t.Errorf("protocol version = %q, want it untouched", pv)
+	}
+}
+
+// TestResume405StillReportsStreamFailure guards the distinction: a server with
+// no GET endpoint is not an expiry, so the original stream failure must still
+// lead and no session state should be dropped.
+func TestResume405StillReportsStreamFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "sess-keep")
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: "notifications/progress"})
+		fmt.Fprintf(w, "id: ev-9\ndata: %s\n\n", notif)
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+	err := tx.Send(context.Background(), &Message{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if errors.Is(err, ErrSessionExpired) {
+		t.Errorf("err = %v, want a stream failure not an expiry", err)
+	}
+	if !strings.Contains(err.Error(), "405") {
+		t.Errorf("err = %v, want the 405 as context", err)
+	}
+	tx.sessionMu.Lock()
+	sid := tx.sessionID
+	tx.sessionMu.Unlock()
+	if sid != "sess-keep" {
+		t.Errorf("session id = %q, want it kept — a 405 is not an expiry", sid)
+	}
+}


### PR DESCRIPTION
Three gaps a cumulative review of #2019/#2020/#2023/#2024/#2025/#2026 turned up. Each is a mechanism that was added with one of its paths missed.

## 1. `/exit` could open a browser (from #2023)

`deleteSession`'s comment promised it would "never start an interactive authorization just to say goodbye" — but it called `OAuthProvider.Token`, and `OAuthClient.Token` escalates: cached → refresh → **full `authorize()`, which discovers, registers, and calls `openBrowser()`**.

So with a token inside its 60s expiry slack whose refresh failed (revoked, AS unreachable, or just the 3s teardown deadline), typing `/exit` or removing an OAuth server would pop an authorization page and then fail anyway.

Fixed with an explicitly cache-only accessor (`CachedToken`) used on teardown. It's an optional interface, so a provider without a cache concept contributes no `Authorization` header there instead of trying harder.

## 2. Session expiring mid-stream wasn't recovered (interaction of #2025's two halves)

404 was mapped to `ErrSessionExpired` in the POST path only. A 404 answering the **resume GET** fell through to the generic non-2xx branch, so the call failed as `sse stream incomplete: … (resume attempt 1: http 404: session gone)` with the dead session id still installed — an error unrelated to the cause, and recovery only happened on the *next* call.

This is not exotic. The 2025-03-26 spec says a server **SHOULD NOT** close a response stream before answering *"unless the session expires"* — expiry is the one sanctioned reason, so the resume GET is a likely place to meet a 404.

Now reported as the expiry it is, and `resumeSSE` keeps it recognisable rather than burying it under the stream-incomplete cause. A 405 (no GET endpoint) is still **not** treated as an expiry and still leaves the session intact.

## 3. Recovery handshake advertised the dead session's revision (interaction of #2023 + #2025)

Expiry cleared `sessionID` but not `protocolVersion`, so the recovery `initialize` went out carrying the previously negotiated version — on the one request whose entire purpose is to renegotiate it. A server that restarted onto a revision it no longer supports **must** answer 400 to an unsupported version header, turning a recoverable expiry into a connection wedged until manual reconnect.

Both now clear together in `forgetSession`, guarded on the session id that was actually sent so a late 404 can't wipe state a concurrent request already replaced.

## Test plan

- [x] `go test -race ./internal/mcp/` — green, including all pre-existing tests
- [x] `make vet` / `gofmt -l` clean

| Test | Covers |
|---|---|
| `TestClose_NeverStartsInteractiveAuth` | Close makes zero `Token` calls and does consult the cache |
| `TestClose_UsesCachedTokenWhenAvailable` | the DELETE is still authenticated when a usable token is cached |
| `TestSSEMidStreamExpiry_RecoversAndClearsSession` | end-to-end: stream dies, resume 404s, call still succeeds after re-handshake |
| `TestSSEMidStreamExpiry_SurfacesTypedError` | transport contract: resume 404 ⇒ `ErrSessionExpired`, session id dropped |
| `TestForgetSession_ClearsProtocolVersion` | version cleared on expiry; the next request doesn't advertise the stale one |
| `TestForgetSession_IgnoresStaleClobber` | a late 404 leaves a newer session's state alone |
| `TestResume405StillReportsStreamFailure` | 405 stays a stream failure and keeps the session |