### PR TITLE
fix(agent): reject image formats no provider accepts, by sniffing bytes

### DIFF
--- a/cmd/octo/tuirepl_attach_test.go
+++ b/cmd/octo/tuirepl_attach_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 // fakeAttachment builds a pendingAttachment with a dummy image block for tests.
-func fakeAttachment() pendingAttachment {
+func fakeAttachment(t *testing.T) pendingAttachment {
+	t.Helper()
 	return pendingAttachment{
-		block: agent.NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'}),
+		block: mustPNGBlock(t),
 		label: "image (PNG, 4 B)",
 	}
 }
@@ -20,7 +21,7 @@ func fakeAttachment() pendingAttachment {
 // image-only message is valid).
 func TestTUI_SubmitImageOnlyStartsTurn(t *testing.T) {
 	m := newTestModel()
-	m.pendingAttachments = []pendingAttachment{fakeAttachment()}
+	m.pendingAttachments = []pendingAttachment{fakeAttachment(t)}
 	setInput(m, "")
 
 	_, _ = m.submit()
@@ -37,7 +38,7 @@ func TestTUI_SubmitImageOnlyStartsTurn(t *testing.T) {
 // through the real key handler.
 func TestTUI_EscDiscardsAttachments(t *testing.T) {
 	m := newTestModel()
-	m.pendingAttachments = []pendingAttachment{fakeAttachment()}
+	m.pendingAttachments = []pendingAttachment{fakeAttachment(t)}
 
 	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
 
@@ -51,7 +52,7 @@ func TestTUI_EscDiscardsAttachments(t *testing.T) {
 func TestTUI_MidTurnSendsAttachments(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
-	m.pendingAttachments = []pendingAttachment{fakeAttachment()}
+	m.pendingAttachments = []pendingAttachment{fakeAttachment(t)}
 	setInput(m, "also look here")
 
 	_, _ = m.submit()
@@ -72,4 +73,17 @@ func TestTUI_MidTurnSendsAttachments(t *testing.T) {
 	if len(items[0].Blocks) != 1 {
 		t.Errorf("inbox blocks = %d, want 1 (the image)", len(items[0].Blocks))
 	}
+}
+
+// mustPNGBlock builds an image block from a minimal valid PNG. NewImageBlock
+// identifies the format by sniffing the bytes rather than trusting the caller's
+// label, so a fixture needs the real 8-byte signature — truncated stand-ins are
+// correctly rejected.
+func mustPNGBlock(t *testing.T) agent.ContentBlock {
+	t.Helper()
+	blk, ok := agent.NewImageBlock("image/png", []byte("\x89PNG\r\n\x1a\n"))
+	if !ok {
+		t.Fatal("fixture PNG was rejected by NewImageBlock")
+	}
+	return blk
 }

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -563,9 +563,18 @@ func (m *tuiModel) tryAttachDroppedImage() bool {
 	case ".tif":
 		mime = "image/tiff"
 	}
-	label := fmt.Sprintf("image (%s, %s)", shortMIME(mime), humanByteSize(len(data)))
+	blk, ok := agent.NewImageBlock(mime, data)
+	if !ok {
+		// The extension said image but the bytes aren't a format the model
+		// accepts (imageExts admits .bmp/.tiff/.heic/.ico). Refuse here —
+		// attaching it would fail the whole turn at the provider instead.
+		m.println(noticeStyle.Render(fmt.Sprintf(
+			"📎 %s is not a format the model accepts (PNG, JPEG, GIF or WebP)", shortMIME(mime))))
+		return false
+	}
+	label := fmt.Sprintf("image (%s, %s)", shortMIME(blk.Image.MIMEType), humanByteSize(len(blk.Image.Data)))
 	m.pendingAttachments = append(m.pendingAttachments, pendingAttachment{
-		block: agent.NewImageBlock(mime, data),
+		block: blk,
 		label: label,
 	})
 	// Splice the path token out of the (original) textarea value.
@@ -693,9 +702,15 @@ func (m *tuiModel) pasteClipboardImage() (tea.Model, tea.Cmd) {
 		m.println(noticeStyle.Render("📋 " + err.Error()))
 		return m, nil
 	}
-	label := fmt.Sprintf("image (%s, %s)", shortMIME(mime), humanByteSize(len(data)))
+	blk, ok := agent.NewImageBlock(mime, data)
+	if !ok {
+		m.println(noticeStyle.Render(fmt.Sprintf(
+			"📋 clipboard image is %s, which the model can't accept (PNG, JPEG, GIF or WebP)", shortMIME(mime))))
+		return m, nil
+	}
+	label := fmt.Sprintf("image (%s, %s)", shortMIME(blk.Image.MIMEType), humanByteSize(len(blk.Image.Data)))
 	m.pendingAttachments = append(m.pendingAttachments, pendingAttachment{
-		block: agent.NewImageBlock(mime, data),
+		block: blk,
 		label: label,
 	})
 	return m, nil

--- a/internal/agent/attach_test.go
+++ b/internal/agent/attach_test.go
@@ -11,7 +11,7 @@ func TestAttachUserBlocks_MergedWithText(t *testing.T) {
 	send := &fakeSender{reply: Reply{Content: "ok", StopReason: "end_turn"}}
 	a := New(send, "m")
 
-	a.AttachUserBlocks([]ContentBlock{NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'})})
+	a.AttachUserBlocks([]ContentBlock{mustPNGBlock(t)})
 	if _, err := a.Turn(context.Background(), "what is this?"); err != nil {
 		t.Fatalf("Turn: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestAttachUserBlocks_ImageOnly(t *testing.T) {
 	send := &fakeSender{reply: Reply{Content: "ok", StopReason: "end_turn"}}
 	a := New(send, "m")
 
-	a.AttachUserBlocks([]ContentBlock{NewImageBlock("image/png", []byte{1, 2, 3})})
+	a.AttachUserBlocks([]ContentBlock{mustPNGBlock(t)})
 	if _, err := a.Turn(context.Background(), ""); err != nil {
 		t.Fatalf("image-only Turn should be allowed: %v", err)
 	}
@@ -68,4 +68,17 @@ func TestEmptyInput_StillRejectedWithoutBlocks(t *testing.T) {
 	if _, err := a.Turn(context.Background(), ""); err == nil {
 		t.Fatal("empty input with no attachment should still error")
 	}
+}
+
+// mustPNGBlock builds an image block from a minimal valid PNG. NewImageBlock
+// identifies the format by sniffing the bytes rather than trusting the caller's
+// label, so a fixture needs the real 8-byte signature — truncated stand-ins are
+// correctly rejected.
+func mustPNGBlock(t *testing.T) ContentBlock {
+	t.Helper()
+	blk, ok := NewImageBlock("image/png", []byte("\x89PNG\r\n\x1a\n"))
+	if !ok {
+		t.Fatal("fixture PNG was rejected by NewImageBlock")
+	}
+	return blk
 }

--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -129,10 +129,64 @@ func NewToolResultBlock(toolUseID, result string, isError bool) ContentBlock {
 // (see compressImageData): oversized captures are downscaled and re-encoded
 // so every attach path — clipboard, composer, IM, tool results — stays under
 // provider size limits without each caller re-implementing it.
-func NewImageBlock(mimeType string, data []byte) ContentBlock {
-	mimeType, data = compressImageData(mimeType, data)
+//
+// ok is false when the bytes aren't an image format the providers accept, in
+// which case there is no block to send and the caller should describe the
+// content in text instead. Sending one anyway costs the whole turn: the media
+// type travels verbatim into Anthropic's `source.media_type` and OpenAI's data
+// URL, and an unsupported value fails the entire request, not just the image.
+//
+// The format is decided by sniffing the bytes, not by the caller's mimeType.
+// Callers get that string from somewhere untrustworthy — a file extension, or
+// an MCP server that names whatever it likes (including nothing) — and a wrong
+// label is indistinguishable from a wrong image until the provider rejects it.
+func NewImageBlock(mimeType string, data []byte) (ContentBlock, bool) {
+	sniffed := sniffImageType(data)
+	if sniffed == "" {
+		return ContentBlock{}, false
+	}
+	// Trust the bytes over the label. compressImageData may re-encode to JPEG,
+	// which is itself supported, so the result stays valid either way.
+	outType, outData := compressImageData(sniffed, data)
+	if !modelImageTypes[outType] {
+		return ContentBlock{}, false
+	}
 	return ContentBlock{
 		Type:  "image",
-		Image: &ImageData{MIMEType: mimeType, Data: data},
+		Image: &ImageData{MIMEType: outType, Data: outData},
+	}, true
+}
+
+// modelImageTypes are the formats every provider adapter can put on the wire.
+// Anthropic documents exactly these four; OpenAI accepts a superset, so the
+// intersection is what's safe to send without branching per vendor.
+var modelImageTypes = map[string]bool{
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+// sniffImageType identifies an image from its magic bytes, returning "" for
+// anything that isn't one of the provider-supported formats. Hand-rolled
+// rather than using http.DetectContentType because only these four matter and
+// the decision needs to be exact — DetectContentType also reports formats
+// (bmp, tiff) the providers reject, which would just move the problem.
+//
+// Deliberately not attempting conversion for the rejects: the standard library
+// decodes png, jpeg and gif only, which are already supported, so there is no
+// bmp/tiff/heic/svg case that could be re-encoded without a new dependency.
+func sniffImageType(data []byte) string {
+	switch {
+	case len(data) >= 8 && string(data[:8]) == "\x89PNG\r\n\x1a\n":
+		return "image/png"
+	case len(data) >= 3 && string(data[:3]) == "\xff\xd8\xff":
+		return "image/jpeg"
+	case len(data) >= 6 && (string(data[:6]) == "GIF87a" || string(data[:6]) == "GIF89a"):
+		return "image/gif"
+	// RIFF container: bytes 8..12 name the payload, "WEBP" for an image.
+	case len(data) >= 12 && string(data[:4]) == "RIFF" && string(data[8:12]) == "WEBP":
+		return "image/webp"
 	}
+	return ""
 }

--- a/internal/agent/image_compress_test.go
+++ b/internal/agent/image_compress_test.go
@@ -115,11 +115,17 @@ func TestCompressImageData_PixelBombUntouched(t *testing.T) {
 // NewImageBlock wires the normalization: a big image comes out as a JPEG
 // block, a small one keeps its bytes.
 func TestNewImageBlock_Normalizes(t *testing.T) {
-	big := NewImageBlock("image/png", encodePNG(t, 2400, 1600))
+	big, ok := NewImageBlock("image/png", encodePNG(t, 2400, 1600))
+	if !ok {
+		t.Fatal("big PNG rejected")
+	}
 	if big.Image.MIMEType != "image/jpeg" {
 		t.Errorf("big block mime = %q, want image/jpeg", big.Image.MIMEType)
 	}
-	small := NewImageBlock("image/png", encodePNG(t, 64, 64))
+	small, ok := NewImageBlock("image/png", encodePNG(t, 64, 64))
+	if !ok {
+		t.Fatal("small PNG rejected")
+	}
 	if small.Image.MIMEType != "image/png" {
 		t.Errorf("small block mime = %q, want unchanged image/png", small.Image.MIMEType)
 	}

--- a/internal/agent/image_sniff_test.go
+++ b/internal/agent/image_sniff_test.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+)
+
+// TestSniffImageType covers the formats a provider will and won't accept.
+// bmp/tiff/heic/svg are the interesting rejects: read_file's extension table
+// admits all four, and an MCP server can name any of them, so before sniffing
+// they reached the provider verbatim and failed the entire request.
+func TestSniffImageType(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{"png", []byte("\x89PNG\r\n\x1a\n" + "IHDR..."), "image/png"},
+		{"jpeg", []byte("\xff\xd8\xff\xe0" + "JFIF"), "image/jpeg"},
+		{"gif87a", []byte("GIF87a" + "rest"), "image/gif"},
+		{"gif89a", []byte("GIF89a" + "rest"), "image/gif"},
+		{"webp", []byte("RIFF\x00\x00\x00\x00WEBPVP8 "), "image/webp"},
+
+		{"bmp rejected", []byte("BM\x00\x00\x00\x00\x00\x00"), ""},
+		{"tiff little-endian rejected", []byte("II*\x00\x08\x00\x00\x00"), ""},
+		{"tiff big-endian rejected", []byte("MM\x00*\x00\x00\x00\x08"), ""},
+		{"heic rejected", []byte("\x00\x00\x00\x18ftypheic"), ""},
+		{"svg rejected", []byte(`<svg xmlns="http://www.w3.org/2000/svg"/>`), ""},
+		{"ico rejected", []byte("\x00\x00\x01\x00\x01\x00\x20\x20"), ""},
+
+		{"empty", nil, ""},
+		{"truncated png signature", []byte{0x89, 'P', 'N', 'G'}, ""},
+		{"riff that is not webp", []byte("RIFF\x00\x00\x00\x00AVI LIST"), ""},
+		{"plain text", []byte("this is not an image at all"), ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sniffImageType(c.data); got != c.want {
+				t.Errorf("sniffImageType = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestNewImageBlock_RejectsUnsupported: the block is refused rather than built,
+// so callers fall back to text instead of failing the turn at the provider.
+func TestNewImageBlock_RejectsUnsupported(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		mime string
+		data []byte
+	}{
+		{"svg claiming to be svg", "image/svg+xml", []byte(`<svg/>`)},
+		{"bmp claiming to be bmp", "image/bmp", []byte("BM\x00\x00\x00\x00\x00\x00")},
+		{"garbage claiming to be png", "image/png", []byte("definitely not a png")},
+		{"empty payload", "image/png", nil},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if _, ok := NewImageBlock(c.mime, c.data); ok {
+				t.Error("NewImageBlock accepted bytes no provider can render")
+			}
+		})
+	}
+}
+
+// TestNewImageBlock_TrustsBytesOverLabel: the caller's mimeType is a hint from
+// an untrustworthy source (a file extension, or an MCP server naming whatever
+// it likes). A real PNG mislabelled as SVG is still sent, as a PNG.
+func TestNewImageBlock_TrustsBytesOverLabel(t *testing.T) {
+	realPNG := encodePNG(t, 32, 32)
+
+	blk, ok := NewImageBlock("image/svg+xml", realPNG)
+	if !ok {
+		t.Fatal("a real PNG was rejected because of its wrong label")
+	}
+	if blk.Image.MIMEType != "image/png" {
+		t.Errorf("media type = %q, want the sniffed image/png", blk.Image.MIMEType)
+	}
+
+	// The same applies when no label is offered at all.
+	blk, ok = NewImageBlock("", realPNG)
+	if !ok {
+		t.Fatal("a real PNG was rejected for having no label")
+	}
+	if blk.Image.MIMEType != "image/png" {
+		t.Errorf("media type = %q, want image/png from an empty label", blk.Image.MIMEType)
+	}
+}
+
+// TestNewImageBlock_NormalizedTypeStaysSupported: compressImageData re-encodes
+// oversized images to JPEG, so the type that leaves must still be one the
+// providers accept — otherwise normalization could reintroduce the bug.
+func TestNewImageBlock_NormalizedTypeStaysSupported(t *testing.T) {
+	blk, ok := NewImageBlock("image/png", encodePNG(t, 2400, 1600))
+	if !ok {
+		t.Fatal("oversized PNG rejected")
+	}
+	if !modelImageTypes[blk.Image.MIMEType] {
+		t.Errorf("normalized media type %q is not one the providers accept", blk.Image.MIMEType)
+	}
+}
+
+// encodePNGGray is a second fixture builder kept local to this file so the
+// sniff tests don't depend on image_compress_test.go's helper surviving.
+func encodePNGGray(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewGray(image.Rect(0, 0, w, h))
+	img.Set(0, 0, color.Gray{Y: 200})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestNewImageBlock_SmallImageKeepsBytes pins that a modest image passes
+// through untouched, so the sniff didn't accidentally add a re-encode.
+func TestNewImageBlock_SmallImageKeepsBytes(t *testing.T) {
+	data := encodePNGGray(t, 48, 48)
+	blk, ok := NewImageBlock("image/png", data)
+	if !ok {
+		t.Fatal("small PNG rejected")
+	}
+	if blk.Image.MIMEType != "image/png" {
+		t.Errorf("media type = %q, want image/png", blk.Image.MIMEType)
+	}
+	if !bytes.Equal(blk.Image.Data, data) {
+		t.Error("small PNG bytes were altered")
+	}
+}

--- a/internal/agent/inbox_test.go
+++ b/internal/agent/inbox_test.go
@@ -43,7 +43,7 @@ func TestInbox_EnqueueDrain(t *testing.T) {
 
 func TestInbox_EnqueueWithBlocks(t *testing.T) {
 	var ib Inbox
-	img := NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'})
+	img := mustPNGBlock(t)
 	ib.EnqueueWithBlocks("look at this", []ContentBlock{img})
 	ib.Enqueue("plain text")
 
@@ -61,7 +61,7 @@ func TestInbox_EnqueueWithBlocks(t *testing.T) {
 
 func TestInbox_EnqueueWithBlocks_ImageOnly(t *testing.T) {
 	var ib Inbox
-	img := NewImageBlock("image/png", []byte{1, 2, 3})
+	img := mustPNGBlock(t)
 	ib.EnqueueWithBlocks("", []ContentBlock{img})
 
 	items := ib.Drain()

--- a/internal/agent/steer_midturn_test.go
+++ b/internal/agent/steer_midturn_test.go
@@ -11,8 +11,11 @@ import (
 // historically dropped any image blocks). Covers the three steer shapes the
 // feature must support: image-only, text-only, and multiple images.
 func TestAgent_MidTurnSteer_AnsweredInTurn(t *testing.T) {
-	img1 := NewImageBlock("image/png", []byte("one"))
-	img2 := NewImageBlock("image/jpeg", []byte("two"))
+	img1 := mustPNGBlock(t)
+	img2, ok := NewImageBlock("image/jpeg", []byte("\xff\xd8\xffJPEGBODY"))
+	if !ok {
+		t.Fatal("fixture JPEG was rejected by NewImageBlock")
+	}
 
 	cases := []struct {
 		name        string

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -172,7 +172,7 @@ func TestSend_UserImage_WireFormat(t *testing.T) {
 			Role: agent.RoleUser,
 			Blocks: []agent.ContentBlock{
 				agent.NewTextBlock("what is this?"),
-				agent.NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'}),
+				mustPNGBlock(t),
 			},
 		}},
 	})
@@ -503,4 +503,17 @@ func TestSend_ToolUseWithNonToolUseStopReason(t *testing.T) {
 	if !gotTool {
 		t.Error("expected an edit_file tool_use block")
 	}
+}
+
+// mustPNGBlock builds an image block from a minimal valid PNG. NewImageBlock
+// identifies the format by sniffing the bytes rather than trusting the caller's
+// label, so a fixture needs the real 8-byte signature — truncated stand-ins are
+// correctly rejected.
+func mustPNGBlock(t *testing.T) agent.ContentBlock {
+	t.Helper()
+	blk, ok := agent.NewImageBlock("image/png", []byte("\x89PNG\r\n\x1a\n"))
+	if !ok {
+		t.Fatal("fixture PNG was rejected by NewImageBlock")
+	}
+	return blk
 }

--- a/internal/provider/anthropic/tools_test.go
+++ b/internal/provider/anthropic/tools_test.go
@@ -422,7 +422,7 @@ func TestSend_ImageBlock_WireFormat(t *testing.T) {
 		}),
 		agent.NewToolResultMessage([]agent.ContentBlock{
 			agent.NewToolResultBlock("call-1", "Image: /tmp/img.png (image/png, 12 B)", false),
-			agent.NewImageBlock("image/png", []byte{0x89, 0x50}),
+			mustPNGBlock(t),
 		}),
 	}
 
@@ -483,8 +483,10 @@ func TestSend_ImageBlock_WireFormat(t *testing.T) {
 	if src["media_type"] != "image/png" {
 		t.Errorf("source.media_type = %v, want image/png", src["media_type"])
 	}
-	if src["data"] != "iVA=" { // base64 of {0x89, 0x50}
-		t.Errorf("source.data = %v, want iVA=", src["data"])
+	// base64 of the PNG signature the fixture carries. NewImageBlock sniffs
+	// the bytes, so the fixture must be a real signature rather than a stub.
+	if want := "iVBORw0KGgo="; src["data"] != want {
+		t.Errorf("source.data = %v, want %s", src["data"], want)
 	}
 }
 

--- a/internal/provider/openai/tools_test.go
+++ b/internal/provider/openai/tools_test.go
@@ -295,7 +295,7 @@ func TestSend_UserImage_WireFormat(t *testing.T) {
 		Role: agent.RoleUser,
 		Blocks: []agent.ContentBlock{
 			agent.NewTextBlock("what is this?"),
-			agent.NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'}),
+			mustPNGBlock(t),
 		},
 	}}
 
@@ -414,7 +414,7 @@ func TestSend_ImageBlock_WireFormat(t *testing.T) {
 		}),
 		agent.NewToolResultMessage([]agent.ContentBlock{
 			agent.NewToolResultBlock("call-1", "Image: /tmp/img.png (image/png, 12 B)", false),
-			agent.NewImageBlock("image/png", []byte{0x89, 0x50}),
+			mustPNGBlock(t),
 		}),
 	}
 
@@ -594,4 +594,17 @@ func TestSendStream_OpenAI_ToolInputDeltaCallbackFires(t *testing.T) {
 	if resp.StopReason != "tool_use" {
 		t.Errorf("StopReason = %q (should normalise tool_calls → tool_use)", resp.StopReason)
 	}
+}
+
+// mustPNGBlock builds an image block from a minimal valid PNG. NewImageBlock
+// identifies the format by sniffing the bytes rather than trusting the caller's
+// label, so a fixture needs the real 8-byte signature — truncated stand-ins are
+// correctly rejected.
+func mustPNGBlock(t *testing.T) agent.ContentBlock {
+	t.Helper()
+	blk, ok := agent.NewImageBlock("image/png", []byte("\x89PNG\r\n\x1a\n"))
+	if !ok {
+		t.Fatal("fixture PNG was rejected by NewImageBlock")
+	}
+	return blk
 }

--- a/internal/server/attachments.go
+++ b/internal/server/attachments.go
@@ -193,7 +193,14 @@ func saveImageAttachment(name, dataURL string) (agent.ContentBlock, string, erro
 	// raw upload: rehydration from disk deliberately bypasses recompression,
 	// so a raw multi-megabyte copy would otherwise be sent verbatim on every
 	// resumed session. The block and its on-disk copy now agree.
-	block := agent.NewImageBlock(mime, data)
+	block, ok := agent.NewImageBlock(mime, data)
+	if !ok {
+		// Reject at the upload boundary rather than letting an unsupported
+		// format through to fail the whole turn later, where the error would
+		// name the provider instead of the file the user picked.
+		return agent.ContentBlock{}, "", fmt.Errorf(
+			"%s is not an image format the model accepts (PNG, JPEG, GIF or WebP)", name)
+	}
 	dstName := fmt.Sprintf("%d_%s%s", time.Now().UnixNano(), base, extForImageMIME(block.Image.MIMEType))
 	dstPath := filepath.Join(dir, dstName)
 	if err := os.WriteFile(dstPath, block.Image.Data, 0o600); err != nil {

--- a/internal/server/ws_handlers_test.go
+++ b/internal/server/ws_handlers_test.go
@@ -149,7 +149,7 @@ func TestLastVisibleUserIdx_None(t *testing.T) {
 // An image-only user message (no text) is still a retryable prompt.
 func TestLastVisibleUserIdx_ImageOnly(t *testing.T) {
 	img := agent.NewUserMessage("")
-	img.Blocks = []agent.ContentBlock{agent.NewImageBlock("image/png", []byte("hi"))}
+	img.Blocks = []agent.ContentBlock{mustPNGBlock(t)}
 	msgs := []agent.Message{
 		agent.NewUserMessage("first"), // 0
 		agent.NewAssistantMessage("ok"),
@@ -159,4 +159,17 @@ func TestLastVisibleUserIdx_ImageOnly(t *testing.T) {
 	if got := lastVisibleUserIdx(msgs); got != 2 {
 		t.Errorf("lastVisibleUserIdx = %d, want 2 (image-only prompt)", got)
 	}
+}
+
+// mustPNGBlock builds an image block from a minimal valid PNG. NewImageBlock
+// identifies the format by sniffing the bytes rather than trusting the caller's
+// label, so a fixture needs the real 8-byte signature — truncated stand-ins are
+// correctly rejected.
+func mustPNGBlock(t *testing.T) agent.ContentBlock {
+	t.Helper()
+	blk, ok := agent.NewImageBlock("image/png", []byte("\x89PNG\r\n\x1a\n"))
+	if !ok {
+		t.Fatal("fixture PNG was rejected by NewImageBlock")
+	}
+	return blk
 }

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -614,10 +614,13 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		}
 		// Return the image as a vision block so the model actually sees the page
 		// (not just a file path), and keep the on-disk copy for artifacts.
-		return agent.ToolResult{
-			Text:   "screenshot saved to " + path,
-			Blocks: []agent.ContentBlock{agent.NewImageBlock("image/png", shot)},
-		}, nil
+		res := agent.ToolResult{Text: "screenshot saved to " + path}
+		// CDP hands back PNG, so the sniff should always pass; if it somehow
+		// doesn't, the path in Text still tells the user where the file is.
+		if blk, ok := agent.NewImageBlock("image/png", shot); ok {
+			res.Blocks = []agent.ContentBlock{blk}
+		}
+		return res, nil
 
 	case "observe":
 		// Text-only "look at this page": the current URL/title + the page's

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -321,8 +321,17 @@ func formatToolResult(r *mcp.CallToolResult) agent.ToolResult {
 				fmt.Fprintf(&b, "[image: %s, undecodable payload]", c.MIMEType)
 				break
 			}
-			blocks = append(blocks, agent.NewImageBlock(c.MIMEType, data))
-			fmt.Fprintf(&b, "[image: %s, %s]", c.MIMEType, humanBytes(len(data)))
+			blk, ok := agent.NewImageBlock(c.MIMEType, data)
+			if !ok {
+				// The server names its own media type and can name anything —
+				// svg, bmp, or nothing at all. Sending one the provider rejects
+				// fails the entire turn, so fall back to describing it.
+				fmt.Fprintf(&b, "[image: %s, %s — format not supported for model input]",
+					c.MIMEType, humanBytes(len(data)))
+				break
+			}
+			blocks = append(blocks, blk)
+			fmt.Fprintf(&b, "[image: %s, %s]", blk.Image.MIMEType, humanBytes(len(blk.Image.Data)))
 		case "audio":
 			fmt.Fprintf(&b, "[audio: %s, %d bytes]", c.MIMEType, len(c.Data))
 		case "resource":

--- a/internal/tools/mcp_test.go
+++ b/internal/tools/mcp_test.go
@@ -77,7 +77,10 @@ func TestParseMCPName_RejectsMalformed(t *testing.T) {
 }
 
 func TestFormatToolResult_MixedContent(t *testing.T) {
-	imgBytes := []byte("not-really-an-image-but-round-trips")
+	// A real PNG signature: the image block is built by sniffing the bytes, so
+	// an arbitrary payload is (correctly) refused no matter what the server
+	// calls it — see TestFormatToolResult_UnsupportedImageFormat.
+	imgBytes := []byte("\x89PNG\r\n\x1a\nIHDR-and-the-rest")
 	r := &mcp.CallToolResult{Content: []mcp.Content{
 		{Type: "text", Text: "first"},
 		{Type: "image", MIMEType: "image/png", Data: base64.StdEncoding.EncodeToString(imgBytes)},
@@ -107,6 +110,36 @@ func TestFormatToolResult_MixedContent(t *testing.T) {
 	}
 	if string(blk.Image.Data) != string(imgBytes) {
 		t.Errorf("block data = %q, want the decoded payload %q", blk.Image.Data, imgBytes)
+	}
+}
+
+// TestFormatToolResult_UnsupportedImageFormat: an MCP server names its own
+// media type and can name anything. A format the providers reject must degrade
+// to a text line — building the block anyway fails the entire turn at the
+// provider, which is worse than the placeholder this used to produce.
+func TestFormatToolResult_UnsupportedImageFormat(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		mime  string
+		bytes []byte
+	}{
+		{"svg", "image/svg+xml", []byte(`<svg xmlns="http://www.w3.org/2000/svg"/>`)},
+		{"bmp", "image/bmp", []byte("BM\x00\x00\x00\x00\x00\x00")},
+		{"tiff", "image/tiff", []byte("II*\x00\x08\x00\x00\x00")},
+		{"empty media type with junk bytes", "", []byte("nonsense")},
+		{"png label, non-png bytes", "image/png", []byte("lying about this")},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			out := formatToolResult(&mcp.CallToolResult{Content: []mcp.Content{
+				{Type: "image", MIMEType: c.mime, Data: base64.StdEncoding.EncodeToString(c.bytes)},
+			}})
+			if len(out.Blocks) != 0 {
+				t.Errorf("Blocks = %d, want none for a format no provider accepts", len(out.Blocks))
+			}
+			if !strings.Contains(out.Text, "not supported") {
+				t.Errorf("Text = %q, want it to say the format isn't supported", out.Text)
+			}
+		})
 	}
 }
 

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -247,9 +247,19 @@ func readImageFile(absPath, displayPath, mimeType string) (agent.ToolResult, err
 	}
 
 	desc := fmt.Sprintf("Image: %s (%s, %s)", displayPath, mimeType, formatBytes(info.Size()))
+	blk, ok := agent.NewImageBlock(mimeType, data)
+	if !ok {
+		// imageExtensions admits formats the providers don't accept (bmp, ico,
+		// tiff, heic). Sending one fails the whole request, so say what
+		// happened instead — the model can suggest converting the file.
+		return agent.ToolResult{Text: fmt.Sprintf(
+			"%s — this format cannot be sent to the model (only PNG, JPEG, GIF and WebP are accepted). Convert it first if it needs to be viewed.",
+			desc,
+		)}, nil
+	}
 	return agent.ToolResult{
 		Text:   desc,
-		Blocks: []agent.ContentBlock{agent.NewImageBlock(mimeType, data)},
+		Blocks: []agent.ContentBlock{blk},
 	}, nil
 }
 

--- a/pkg/octoagent/octoagent.go
+++ b/pkg/octoagent/octoagent.go
@@ -142,8 +142,11 @@ func NewToolResultBlock(toolUseID, result string, isError bool) ContentBlock {
 	return agent.NewToolResultBlock(toolUseID, result, isError)
 }
 
-// NewImageBlock creates a ContentBlock with Type=="image".
-func NewImageBlock(mimeType string, data []byte) ContentBlock {
+// NewImageBlock creates a ContentBlock with Type=="image". ok is false when
+// the bytes aren't an image format the providers accept, in which case there
+// is no block to send — describe the content in text instead. The format is
+// determined by sniffing the bytes; mimeType is only a hint.
+func NewImageBlock(mimeType string, data []byte) (ContentBlock, bool) {
 	return agent.NewImageBlock(mimeType, data)
 }
 


### PR DESCRIPTION
Found by a cumulative review of the recent MCP work. It's the one item there that's a **functional regression** rather than a missing path.

## Problem

An image block's media type travels verbatim into Anthropic's `source.media_type` (`anthropic/client.go:595,635`) and OpenAI's `data:%s;base64,` URL (`openai/client.go:531`). Anthropic accepts **only** jpeg/png/gif/webp. Nothing validated it, and an unsupported value fails **the entire request**, not just the image.

#2024 made that reachable by a remote party: an MCP server names its own `mimeType` and can say `image/svg+xml`, `image/bmp`, or nothing at all — and `compressImageData` passes svg through by design plus anything the stdlib can't decode by fallthrough. So one such tool result now fails the whole turn, **worse than the text placeholder MCP produced before it sent images at all**.

But it was never MCP-only. `read_file`'s `imageExtensions` table already admitted `.bmp`, `.ico`, `.tiff`, `.heic` — none of which Anthropic accepts. The hole is in the shared path, so that's where it's fixed.

## Fix

`NewImageBlock` now returns `(ContentBlock, bool)`. It decides the format by **sniffing the magic bytes** and refuses anything outside the four types every adapter can serialise.

Sniffing rather than trusting the argument is the substance of the change, not an implementation detail: callers get that string from a file extension or from a server that names whatever it likes, and a wrong label is indistinguishable from a wrong image until the provider rejects it. A real PNG mislabelled `image/svg+xml` now goes through **as a PNG**; a `.png` file containing garbage is refused.

**No conversion is attempted for the rejects.** The standard library decodes png, jpeg and gif only — all already supported — so there is no bmp/tiff/heic/svg case that could be re-encoded without adding a dependency. Refusing is the honest option.

## Caller fallbacks (compiler-enforced)

Returning a second value meant every call site had to handle it, which found one I hadn't anticipated — the web upload path:

| Call site | Fallback |
|---|---|
| `internal/tools/mcp.go` | text line: `[image: …, N KiB — format not supported for model input]` |
| `internal/tools/read_file.go` | explains the format can't be sent and suggests converting |
| `internal/server/attachments.go` | rejects at upload with an error naming the user's file |
| `cmd/octo/tuirepl_view.go` ×2 | refuses the drag/paste with a notice, rather than attaching a turn-killer |
| `internal/tools/browser.go` | keeps the on-disk path in Text (CDP always yields PNG, so this shouldn't trigger) |
| `pkg/octoagent` | public wrapper mirrors the new signature |

## Test plan

- [x] `go test -race ./internal/... ./cmd/... ./pkg/...` — full repo green
- [x] `make vet` / `make fmt-check` clean

New: `TestSniffImageType` (16 cases — the four accepted formats plus bmp/tiff-both-endians/heic/svg/ico rejects, empty, truncated signature, RIFF-that-isn't-WebP, plain text), `TestNewImageBlock_RejectsUnsupported`, `TestNewImageBlock_TrustsBytesOverLabel`, `TestNewImageBlock_NormalizedTypeStaysSupported` (guards that the JPEG re-encode can't reintroduce the bug), `TestNewImageBlock_SmallImageKeepsBytes`, `TestFormatToolResult_UnsupportedImageFormat` (5 cases).

Existing fixtures that passed stub bytes like `{0x89, 'P', 'N', 'G'}` now carry real signatures via a `mustPNGBlock` helper — **two tests failed until they did**, which is itself the check that the sniff is load-bearing rather than decorative.