### PR TITLE
fix(mcp): correct the protocol-version story and four lifecycle faults

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -22,7 +23,7 @@ var defaultCallTimeout = 60 * time.Second
 
 // Client is a single MCP server connection: one transport, one initialize
 // handshake, request/response dispatch by ID. It's safe for concurrent
-// callers — Call serialises through the transport via sendMu, and the
+// callers — Call serialises writes through a one-slot send semaphore, and the
 // receive loop demultiplexes responses on a per-request channel.
 //
 // Lifecycle:
@@ -61,10 +62,15 @@ type Client struct {
 	pendingMu sync.Mutex
 	pending   map[string]chan *Message
 
-	// sendMu is the transport's write lock. Stdio transport already
-	// serialises but the contract is per-Client, so we hold it explicitly
-	// at the Call call site.
-	sendMu sync.Mutex
+	// sendSem is the transport's write lock, held for a whole send attempt so a
+	// session recovery can't have another request interleaved onto the dead
+	// session. A 1-buffered channel rather than a Mutex because acquisition has
+	// to be abandonable: an SSE response keeps the lock for as long as the
+	// server streams (plus resume attempts), and sync.Mutex.Lock ignores
+	// context — so queued callers could not be released by their own deadline
+	// or by an interrupt, only by the holder finishing. Waiting on a channel
+	// lets them select on ctx instead.
+	sendSem chan struct{}
 
 	// onNotification, when set, receives server-initiated notifications by
 	// method name. Guarded because it's read from the receive loop and set
@@ -74,6 +80,11 @@ type Client struct {
 
 	rxDone chan struct{} // closed when the receive loop exits
 	closed atomic.Bool
+
+	// deadErr is set when the receive loop exits, recording why. Distinct from
+	// closed on purpose — see markDead.
+	deadMu  sync.Mutex
+	deadErr error
 }
 
 // NewClient builds a Client around an already-Open transport. The caller
@@ -85,6 +96,7 @@ func NewClient(t Transport, info Implementation) *Client {
 		info:      info,
 		pending:   make(map[string]chan *Message),
 		rxDone:    make(chan struct{}),
+		sendSem:   make(chan struct{}, 1),
 	}
 }
 
@@ -189,6 +201,12 @@ func (c *Client) Call(ctx context.Context, method string, params, result any) er
 	if c.closed.Load() {
 		return errors.New("mcp: client closed")
 	}
+	// The receive loop is what matches a response to this request. If it has
+	// already exited there is nobody left to do that, so waiting out the
+	// deadline below would just be a slow way to fail.
+	if err := c.dead(); err != nil {
+		return fmt.Errorf("mcp: connection is no longer readable: %w", err)
+	}
 	// Bound the call when the caller gave no deadline, so a server that never
 	// replies can't wedge the turn indefinitely (stdio's Receive can't be
 	// interrupted by ctx once it blocks in Decode — only Close or a deadline
@@ -263,20 +281,29 @@ func (c *Client) Notify(ctx context.Context, method string, params any) error {
 	return c.sendRecoveringSession(ctx, msg)
 }
 
-// sendRecoveringSession is the single write path to the transport. It holds
-// sendMu for the whole attempt, so if the server reports our session gone it
+// sendRecoveringSession is the single write path to the transport. It holds the
+// send slot for the whole attempt, so if the server reports our session gone it
 // can run the recovery handshake and replay msg with no other sender able to
 // slip a request onto the dead session in between.
 //
-// The handshake deliberately does NOT go back through Call/Notify: those take
-// sendMu, which is not reentrant, so reusing them here would deadlock. It
-// talks to the transport directly instead — safe precisely because we already
-// hold the lock. Only one recovery is attempted; a second expiry in a row is
-// a server we can't keep a session with, and returning the error beats
+// The handshake deliberately does NOT go back through Call/Notify: those
+// acquire the same slot, which isn't reentrant, so reusing them here would
+// deadlock. It talks to the transport directly instead — safe precisely because
+// we already hold the slot. Only one recovery is attempted; a second expiry in
+// a row is a server we can't keep a session with, and returning the error beats
 // looping.
 func (c *Client) sendRecoveringSession(ctx context.Context, msg *Message) error {
-	c.sendMu.Lock()
-	defer c.sendMu.Unlock()
+	// An SSE response can hold this slot for the length of the stream, so a
+	// waiting caller must be able to give up on its own deadline rather than
+	// only when the holder finishes.
+	select {
+	case c.sendSem <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.rxDone:
+		return fmt.Errorf("mcp: connection is no longer readable while waiting to send")
+	}
+	defer func() { <-c.sendSem }()
 
 	err := c.transport.Send(ctx, msg)
 	if !errors.Is(err, ErrSessionExpired) {
@@ -291,10 +318,10 @@ func (c *Client) sendRecoveringSession(ctx context.Context, msg *Message) error 
 }
 
 // rehandshakeLocked re-runs initialize + initialized on a transport whose
-// session the server has forgotten. Caller must hold sendMu; this sends on
+// session the server has forgotten. Caller must hold the send slot; this sends on
 // the transport without taking it. Waiting for the initialize response is
 // fine under the lock: the receive loop is a separate goroutine and delivers
-// it through the pending map, which sendMu doesn't guard.
+// it through the pending map, which the send slot doesn't guard.
 func (c *Client) rehandshakeLocked(ctx context.Context) error {
 	id := c.nextID.Add(1)
 	idBytes := []byte(strconv.FormatUint(id, 10))
@@ -377,6 +404,9 @@ func (c *Client) receiveLoop() {
 	for {
 		msg, err := c.transport.Receive(ctx)
 		if err != nil {
+			// Nothing will demux responses after this, so record why and let
+			// Call fail fast instead of waiting out a full timeout per attempt.
+			c.markDead(err)
 			c.abortPending(err)
 			return
 		}
@@ -414,6 +444,43 @@ func (c *Client) removePending(id string) {
 		close(ch)
 	}
 	c.pendingMu.Unlock()
+}
+
+// markDead records that the receive loop has stopped, so no response will ever
+// be demuxed again. Kept separate from closed: Close's CompareAndSwap on that
+// flag is what gates tearing the transport down, so reusing it here would make
+// a later Close skip transport.Close and leak the connection.
+//
+// The distinction matters most on stdio, where this is reachable without
+// anything being closed: one malformed line desynchronises the JSON decoder, or
+// a server closes stdout while staying alive. Before this, the client stayed
+// "connected" — writes to stdin still succeeded, so /mcp and the panel kept
+// reporting it live while every call sat out its full deadline waiting for a
+// reply nobody was left to deliver.
+func (c *Client) markDead(err error) {
+	if err == nil {
+		err = io.EOF
+	}
+	c.deadMu.Lock()
+	if c.deadErr == nil {
+		c.deadErr = err
+	}
+	c.deadMu.Unlock()
+}
+
+// dead reports the receive loop's exit error, or nil while it's running.
+func (c *Client) dead() error {
+	c.deadMu.Lock()
+	defer c.deadMu.Unlock()
+	return c.deadErr
+}
+
+// Live reports whether this client can still carry traffic: not closed, and its
+// receive loop still running. Callers that report connection status (the /mcp
+// listing, the panel) should prefer it over assuming a registered connection is
+// usable.
+func (c *Client) Live() bool {
+	return !c.closed.Load() && c.dead() == nil
 }
 
 func (c *Client) abortPending(_ error) {

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -32,8 +32,11 @@ import (
 //     response and echoed on every subsequent request, so the server can
 //     resume per-client state. Close releases it with a DELETE.
 //   - The protocol revision the server picks during initialize is echoed
-//     back in MCP-Protocol-Version on every later request, which servers
-//     implementing 2025-03-26 or later require.
+//     back in MCP-Protocol-Version on every later request. That header is a
+//     2025-06-18 requirement ("Require negotiated protocol version to be
+//     specified via MCP-Protocol-Version header in subsequent requests when
+//     using HTTP"); it does not exist in 2025-03-26. Sending it regardless
+//     costs nothing against older servers and is mandatory for newer ones.
 //   - A response stream that breaks before answering is resumed with a GET
 //     carrying Last-Event-ID, when the server tagged its events with ids.
 //   - A 404 answering a request that carried a session id is reported as
@@ -63,11 +66,10 @@ type HTTPTransport struct {
 
 	// protocolVersion is the revision the server chose during initialize,
 	// pushed in by Client.Initialize via SetProtocolVersion. Echoed back in
-	// MCP-Protocol-Version on every request once known — servers
-	// implementing 2025-03-26 or later require the header and reject
-	// requests without it. Empty until the handshake completes (the
-	// initialize request itself carries the version in its params, not a
-	// header), so we simply omit it then.
+	// MCP-Protocol-Version on every request once known — a 2025-06-18 server
+	// requires that header and answers 400 without it. Empty until the
+	// handshake completes (initialize carries the version in its params, not a
+	// header) and again after an expiry, so it is simply omitted then.
 	protoMu         sync.Mutex
 	protocolVersion string
 
@@ -207,8 +209,15 @@ func (t *HTTPTransport) doRequest(ctx context.Context, msg *Message, forceFreshT
 	}
 
 	if resp.StatusCode == http.StatusNoContent {
-		// 204: server accepted a notification. No body to parse, no inbox
-		// queue — the client doesn't expect a response for notifications.
+		// 204 with nothing to parse. For a notification that's the accepted
+		// outcome (the spec's own answer is 202, and both are handled below
+		// anyway). For a request it's a protocol violation — the spec requires
+		// either application/json or an SSE stream — and returning success
+		// would queue nothing, leaving the caller to wait out its whole
+		// timeout for a response that is never coming. Name it instead.
+		if !msg.IsNotification() {
+			return false, fmt.Errorf("mcp: http 204 to a %s request: server must answer with JSON or an SSE stream", msg.Method)
+		}
 		return false, nil
 	}
 	if resp.StatusCode == http.StatusUnauthorized {

--- a/internal/mcp/lifecycle_test.go
+++ b/internal/mcp/lifecycle_test.go
@@ -1,0 +1,363 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestRequest204IsRejected: 204 is a valid answer to a notification but a
+// protocol violation in response to a request — the spec requires JSON or an
+// SSE stream. Returning success there queued nothing, so the caller sat out
+// its entire timeout waiting for a response that was never coming.
+func TestRequest204IsRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+
+	err := tx.Send(context.Background(), &Message{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
+	})
+	if err == nil {
+		t.Fatal("expected an error for 204 answering a request")
+	}
+	if !strings.Contains(err.Error(), "204") {
+		t.Errorf("err = %v, want it to name the status", err)
+	}
+
+	// A notification still accepts 204 — that path must not regress.
+	if err := tx.Send(context.Background(), &Message{
+		JSONRPC: "2.0", Method: "notifications/initialized",
+	}); err != nil {
+		t.Errorf("204 to a notification returned %v, want nil", err)
+	}
+}
+
+// TestRequest204DoesNotHangCall proves the point end to end: before this, the
+// call burned its whole deadline. It must now fail promptly.
+func TestRequest204DoesNotHangCall(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in Message
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.Method == MethodInitialize {
+			writeJSONRPC(w, in.ID, InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+				ServerInfo:      Implementation{Name: "rude", Version: "1"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNoContent) // wrong for a request
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	_, err := c.CallTool(ctx, "ping", nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("call took %v — it waited for a response that can't arrive", elapsed)
+	}
+}
+
+// deadTransport delivers one Receive error and then blocks, modelling a stdio
+// server that desynchronised its decoder or closed stdout while staying alive:
+// writes still succeed, but nothing will ever demux a response again.
+type deadTransport struct {
+	mu    sync.Mutex
+	sends int
+	fail  chan struct{}
+	done  chan struct{}
+}
+
+func newDeadTransport() *deadTransport {
+	return &deadTransport{fail: make(chan struct{}), done: make(chan struct{})}
+}
+
+func (d *deadTransport) Send(_ context.Context, _ *Message) error {
+	d.mu.Lock()
+	d.sends++
+	d.mu.Unlock()
+	return nil // stdin is still writable
+}
+
+func (d *deadTransport) Receive(ctx context.Context) (*Message, error) {
+	select {
+	case <-d.fail:
+		return nil, errors.New("invalid character 'x' looking for beginning of value")
+	case <-d.done:
+		return nil, io.EOF
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (d *deadTransport) Close() error {
+	select {
+	case <-d.done:
+	default:
+		close(d.done)
+	}
+	return nil
+}
+
+func (d *deadTransport) sendCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sends
+}
+
+// TestReceiveLoopDeath_FailsCallsFast: once the receive loop has exited there
+// is nobody to match a response, so a call must fail immediately instead of
+// waiting out its deadline. The old behaviour made a single malformed line
+// from a stdio server cost 60s per call while the panel still said connected.
+func TestReceiveLoopDeath_FailsCallsFast(t *testing.T) {
+	prev := defaultCallTimeout
+	defaultCallTimeout = 30 * time.Second // long enough that a hang is obvious
+	defer func() { defaultCallTimeout = prev }()
+
+	tx := newDeadTransport()
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	go c.receiveLoop()
+
+	// Kill the reader, then wait for the loop to actually exit.
+	close(tx.fail)
+	select {
+	case <-c.rxDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("receive loop never exited")
+	}
+
+	if c.Live() {
+		t.Error("Live() is true after the receive loop died")
+	}
+
+	before := tx.sendCount()
+	start := time.Now()
+	err := c.Call(context.Background(), MethodToolsList, struct{}{}, nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a client whose reader has died")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Call took %v — it waited for a reply nobody can deliver", elapsed)
+	}
+	if !strings.Contains(err.Error(), "no longer readable") {
+		t.Errorf("err = %v, want it to say the connection is unreadable", err)
+	}
+	// And it shouldn't have bothered writing.
+	if after := tx.sendCount(); after != before {
+		t.Errorf("Call still wrote to a dead connection (%d → %d sends)", before, after)
+	}
+}
+
+// TestClose_AfterReceiveLoopDeath_StillClosesTransport guards the reason the
+// dead flag is separate from closed: reusing closed would make Close's
+// CompareAndSwap skip the teardown and leak the connection.
+func TestClose_AfterReceiveLoopDeath_StillClosesTransport(t *testing.T) {
+	tx := newDeadTransport()
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	go c.receiveLoop()
+	close(tx.fail)
+	<-c.rxDone
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	select {
+	case <-tx.done:
+	default:
+		t.Error("Close did not tear the transport down after the receive loop had died")
+	}
+}
+
+// TestSendSlot_ReleasedByCallerDeadline: a slow SSE response holds the write
+// slot for the length of the stream. A caller queued behind it must be able to
+// give up on its own deadline — with a plain Mutex it could only be released by
+// the holder finishing, so neither its timeout nor an interrupt reached it.
+func TestSendSlot_ReleasedByCallerDeadline(t *testing.T) {
+	release := make(chan struct{})
+	var once sync.Once
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in Message
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if in.Method == MethodInitialize {
+			writeJSONRPC(w, in.ID, InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+				ServerInfo:      Implementation{Name: "slow-stream", Version: "1"},
+			})
+			return
+		}
+		// A stream that stays open, holding the send slot.
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		notif, _ := json.Marshal(Message{JSONRPC: "2.0", Method: "notifications/progress"})
+		fmt.Fprintf(w, "data: %s\n\n", notif)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-release
+		res, _ := json.Marshal(CallToolResult{Content: []Content{{Type: "text", Text: "done"}}})
+		resp, _ := json.Marshal(Message{JSONRPC: "2.0", ID: in.ID, Result: res})
+		fmt.Fprintf(w, "data: %s\n\n", resp)
+	}))
+	defer srv.Close()
+	defer once.Do(func() { close(release) })
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	c := NewClient(tx, Implementation{Name: "test", Version: "1"})
+	defer c.Close()
+	initCtx, cancelInit := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelInit()
+	if err := c.Initialize(initCtx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Occupy the slot with the streaming call.
+	holderDone := make(chan struct{})
+	go func() {
+		defer close(holderDone)
+		hctx, hcancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer hcancel()
+		_, _ = c.CallTool(hctx, "slow", nil)
+	}()
+
+	// Give the holder time to take the slot and start streaming.
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		time.Sleep(300 * time.Millisecond)
+	}()
+	<-drained
+
+	// A second caller with a short deadline must come back on its own.
+	shortCtx, shortCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer shortCancel()
+	start := time.Now()
+	err := c.Call(shortCtx, MethodToolsList, struct{}{}, nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("queued call should have failed on its own deadline")
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("queued call took %v — it could not be released by its deadline", elapsed)
+	}
+
+	once.Do(func() { close(release) })
+	select {
+	case <-holderDone:
+	case <-time.After(10 * time.Second):
+		t.Error("holder never finished")
+	}
+}
+
+// TestRegistryClose_DoesNotHoldLockAcrossIO: a connection whose Close blocks
+// (a stdio grandchild keeping the stderr pipe open makes cmd.Wait hang even
+// after a Kill) must not wedge every Registry reader with it.
+func TestRegistryClose_DoesNotHoldLockAcrossIO(t *testing.T) {
+	blocked := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			<-blocked // a server that never lets go of the session
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		var in Message
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		var result any
+		switch in.Method {
+		case MethodInitialize:
+			result = InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+				ServerInfo:      Implementation{Name: "clingy", Version: "1"},
+			}
+		case MethodToolsList:
+			result = map[string]any{"tools": []Tool{}}
+		default:
+			result = map[string]any{}
+		}
+		raw, _ := json.Marshal(result)
+		w.Header().Set("Mcp-Session-Id", "sticky")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{JSONRPC: "2.0", ID: in.ID, Result: raw})
+	}))
+	defer srv.Close()
+	// Registered after srv.Close so it runs BEFORE it: httptest.Close waits for
+	// outstanding handlers, and this one is parked on blocked. Releasing it
+	// first is what keeps the test from deadlocking on its own fixture.
+	defer close(blocked)
+
+	reg := NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := reg.Connect(ctx, "clingy", ServerEntry{URL: srv.URL},
+		Implementation{Name: "test", Version: "1"}, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		reg.Close()
+	}()
+
+	// Close is now stuck on the DELETE. Readers must still be served — before,
+	// they queued behind r.mu for as long as the teardown took.
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		_ = reg.Get("clingy")
+		_ = reg.Connections()
+		_ = reg.Len()
+	}()
+	select {
+	case <-readDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Registry readers blocked behind a stalled Close")
+	}
+
+	// The DELETE's own timeout eventually frees Close.
+	select {
+	case <-closeDone:
+	case <-time.After(sessionDeleteTimeout + 5*time.Second):
+		t.Error("Close never returned")
+	}
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -19,13 +19,62 @@ import (
 	"encoding/json"
 )
 
-// ProtocolVersion is the MCP spec revision this client implements and asks
-// for in the initialize request. The server answers with the revision it
-// will actually speak — the same one, or another it can serve — and that
-// answer, not this constant, is what the session runs on. Client.Initialize
-// records it and the HTTP transport echoes it back in MCP-Protocol-Version
-// on every later request, which servers from 2025-03-26 onward require.
-const ProtocolVersion = "2024-11-05"
+// ProtocolVersion is the revision this client asks for in initialize. The
+// server answers with the revision it will actually speak — the same one, or
+// another it can serve — and that answer, not this constant, is what the
+// session runs on; Client.Initialize records it.
+//
+// 2025-03-26 is the revision whose transport this package implements: it is
+// where Streamable HTTP, Mcp-Session-Id, DELETE termination and Last-Event-ID
+// resumption are defined. Asking for 2024-11-05, as this used to, was
+// incoherent — that revision has no Streamable HTTP at all (2025-03-26 states
+// it "replaces the HTTP+SSE transport from protocol version 2024-11-05"), so
+// the client named a revision without the transport it was speaking.
+//
+// Newer revisions exist and are deliberately not claimed:
+//
+//   - 2025-06-18 contributes the MCP-Protocol-Version header this client does
+//     send, but also adds elicitation (server-to-client requests, which
+//     receiveLoop drops) and structured tool output, whose servers only SHOULD
+//     keep filling the plain content field this package reads.
+//   - 2025-11-25 is the last revision built on the initialize handshake.
+//   - 2026-07-28 removes the handshake altogether: version, identity and
+//     capabilities travel as per-request _meta, servers must implement
+//     server/discover, and an unsupported version comes back as a typed
+//     UnsupportedProtocolVersionError to retry against. In its own terminology
+//     this client is "legacy", and a legacy client cannot talk to a
+//     modern-only server at all — there is no fall-forward. Becoming
+//     "dual-era" is a separate piece of work, not a bump of this constant.
+//
+// The header is sent regardless of which revision was negotiated: it costs
+// nothing against a server that ignores it and is mandatory for one that
+// doesn't.
+const ProtocolVersion = "2025-03-26"
+
+// supportedProtocolVersions are the revisions this client can actually speak —
+// the ones whose semantics are implemented here, not every revision that
+// exists. A server may legitimately answer initialize with something else,
+// which is what SupportedProtocolVersion exists to detect.
+var supportedProtocolVersions = map[string]bool{
+	"2024-11-05": true, // stdio only in practice; no Streamable HTTP
+	"2025-03-26": true,
+}
+
+// SupportedProtocolVersion reports whether v is a revision this client
+// implements. An empty version counts as supported: servers that omit it from
+// the initialize result are assumed to mean the one we asked for.
+//
+// The spec says a client SHOULD disconnect when it doesn't support the
+// server's version. This client warns instead, and that is a deliberate
+// deviation from a SHOULD: newer revisions have so far stayed wire-compatible
+// for the subset used here, so disconnecting would break setups that work
+// today in exchange for strictness no user asked for. What the spec is really
+// guarding against — an unsupported revision failing later in some unrelated
+// way, with an error that doesn't mention versions — is addressed by saying so
+// up front at connect time.
+func SupportedProtocolVersion(v string) bool {
+	return v == "" || supportedProtocolVersions[v]
+}
 
 // ── JSON-RPC 2.0 frame ───────────────────────────────────────────────────
 //

--- a/internal/mcp/protocol_test.go
+++ b/internal/mcp/protocol_test.go
@@ -71,9 +71,40 @@ func TestRPCError_ErrorReturnsMessage(t *testing.T) {
 }
 
 func TestProtocolVersion_IsSpecRevision(t *testing.T) {
-	// Sanity guard against accidental version bumps. If we ever upgrade
-	// this string the test should flag the change so it's intentional.
-	if ProtocolVersion != "2024-11-05" {
-		t.Errorf("ProtocolVersion = %q, expected the documented 2024-11-05 spec", ProtocolVersion)
+	// Sanity guard against accidental version bumps: changing the requested
+	// revision changes what the server is told we implement, so it should
+	// never happen as a side effect of something else.
+	//
+	// 2025-03-26 is the revision that defines the transport in http.go
+	// (Streamable HTTP, Mcp-Session-Id, DELETE, Last-Event-ID). It replaced
+	// 2024-11-05's HTTP+SSE transport, which is why asking for 2024-11-05 here
+	// was wrong: it named a revision with no Streamable HTTP.
+	if ProtocolVersion != "2025-03-26" {
+		t.Errorf("ProtocolVersion = %q, want 2025-03-26 — the revision whose transport this package implements", ProtocolVersion)
+	}
+	// Whatever it is, we must claim to support it ourselves.
+	if !SupportedProtocolVersion(ProtocolVersion) {
+		t.Errorf("ProtocolVersion %q is not in supportedProtocolVersions", ProtocolVersion)
+	}
+}
+
+func TestSupportedProtocolVersion(t *testing.T) {
+	for _, v := range []string{"2024-11-05", "2025-03-26"} {
+		if !SupportedProtocolVersion(v) {
+			t.Errorf("SupportedProtocolVersion(%q) = false, want true", v)
+		}
+	}
+	// Empty means the server omitted it; assume the revision we asked for.
+	if !SupportedProtocolVersion("") {
+		t.Error("an omitted version should count as supported")
+	}
+	// Real revisions we deliberately don't claim: 2025-06-18 (elicitation,
+	// structured output), 2025-11-25, and 2026-07-28, which replaces the
+	// initialize handshake with per-request metadata entirely. See the
+	// ProtocolVersion doc comment.
+	for _, v := range []string{"2025-06-18", "2025-11-25", "2026-07-28", "2099-01-01", "garbage"} {
+		if SupportedProtocolVersion(v) {
+			t.Errorf("SupportedProtocolVersion(%q) = true, want false", v)
+		}
 	}
 }

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -260,6 +260,13 @@ func ConnectAll(ctx context.Context, cfg *Config, info Implementation, authPromp
 			}
 			continue
 		}
+		// A revision we don't implement is worth saying out loud here. Left
+		// silent, it surfaces later as some unrelated-looking failure on a
+		// specific feature, with nothing pointing at the version as the cause.
+		if pv := conn.Client.ProtocolVersion(); !SupportedProtocolVersion(pv) && warn != nil {
+			fmt.Fprintf(warn, "mcp: server %q negotiated protocol version %s, which this client does not implement (asked for %s) — it may misbehave in ways unrelated to what you were doing\n",
+				name, pv, ProtocolVersion)
+		}
 		r.conns[name] = conn
 	}
 	return r
@@ -419,20 +426,34 @@ func (r *Registry) Len() int {
 // dropped — Close is end-of-life and the user can't do anything with the
 // errors anyway.
 //
-// Connections close concurrently because closing one is no longer purely
-// local: an HTTP transport releases its session with a DELETE, which waits on
-// a server that may be slow or gone. Serially that cost would add up across
-// servers and stall process exit; in parallel the whole teardown is bounded
-// by the slowest single connection however many are configured.
+// Connections close concurrently because closing one is not purely local: an
+// HTTP transport releases its session with a DELETE, and a stdio transport
+// waits on a subprocess. Serially that cost would add up across servers and
+// stall process exit; in parallel the whole teardown is bounded by the slowest
+// single connection however many are configured.
+//
+// The waiting happens outside r.mu, which matters more than the parallelism.
+// Closing can block indefinitely — a stdio server whose stderr is a log file
+// (so os/exec builds a pipe) keeps cmd.Wait blocked as long as any grandchild
+// holds the write end, even after a Kill. Holding the registry lock across
+// that would wedge every reader with it: Get on each MCP tool dispatch, /mcp
+// output, the panel's server list. Marking closed and snapshotting under the
+// lock is enough to make this idempotent and to stop new work being registered.
 func (r *Registry) Close() {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if r.closed {
+		r.mu.Unlock()
 		return
 	}
 	r.closed = true
-	var wg sync.WaitGroup
+	conns := make([]*Connection, 0, len(r.conns))
 	for _, c := range r.conns {
+		conns = append(conns, c)
+	}
+	r.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, c := range conns {
 		wg.Add(1)
 		go func(c *Connection) {
 			defer wg.Done()

--- a/internal/mcp/registry_manage_test.go
+++ b/internal/mcp/registry_manage_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -243,6 +244,73 @@ func TestRegistryConnect_AfterCloseRejected(t *testing.T) {
 
 	if err := r.Connect(ctx, "late", ServerEntry{URL: srv.URL}, Implementation{Name: "test"}, nil, nil); err == nil {
 		t.Fatal("Connect on a closed registry must error")
+	}
+}
+
+// TestConnectAll_WarnsOnUnsupportedProtocolVersion: a server answering with a
+// revision this client doesn't implement must say so at connect time. Silent,
+// it resurfaces later as a feature-specific failure with nothing pointing at
+// the version.
+func TestConnectAll_WarnsOnUnsupportedProtocolVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var in Message
+		_ = json.Unmarshal(body, &in)
+		if in.ID == nil {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		var result any
+		switch in.Method {
+		case "initialize":
+			result = InitializeResult{
+				ProtocolVersion: "2099-01-01", // a revision we can't possibly implement
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+				ServerInfo:      Implementation{Name: "futuristic", Version: "0"},
+			}
+		case "tools/list":
+			result = map[string]any{"tools": []Tool{}}
+		default:
+			result = map[string]any{}
+		}
+		raw, _ := json.Marshal(result)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{JSONRPC: "2.0", ID: in.ID, Result: raw})
+	}))
+	defer srv.Close()
+
+	var warn strings.Builder
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cfg := &Config{Servers: map[string]ServerEntry{"future": {URL: srv.URL}}}
+	r := ConnectAll(ctx, cfg, Implementation{Name: "test"}, nil, &warn, nil)
+	defer r.Close()
+
+	// Warned, but still connected — the deviation from the spec's SHOULD
+	// disconnect is deliberate, so a working setup keeps working.
+	if r.Get("future") == nil {
+		t.Error("server should still connect despite the version warning")
+	}
+	got := warn.String()
+	if !strings.Contains(got, "2099-01-01") || !strings.Contains(got, "does not implement") {
+		t.Errorf("warn output = %q, want it to name the unsupported version", got)
+	}
+}
+
+// TestConnectAll_QuietOnSupportedVersion: the happy path must not nag.
+func TestConnectAll_QuietOnSupportedVersion(t *testing.T) {
+	srv := fakeMCPServer(t, "ok-tool") // answers with ProtocolVersion
+	defer srv.Close()
+
+	var warn strings.Builder
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cfg := &Config{Servers: map[string]ServerEntry{"good": {URL: srv.URL}}}
+	r := ConnectAll(ctx, cfg, Implementation{Name: "test"}, nil, &warn, nil)
+	defer r.Close()
+
+	if got := warn.String(); got != "" {
+		t.Errorf("warn output = %q, want nothing for a supported version", got)
 	}
 }
 


### PR DESCRIPTION
Completes the follow-up work from the cumulative review of #2019/#2020/#2023/#2024/#2025/#2026, after #2027 and #2028.

## Part 1 — the protocol-version story was partly fiction

Three comments claimed servers *"implementing 2025-03-26 or later require"* the `MCP-Protocol-Version` header. **That requirement does not exist in 2025-03-26** — I fetched the revision's transports page and it has no protocol-version-header section at all. The header arrives in **2025-06-18**, whose changelog reads: *"Require negotiated protocol version to be specified via `MCP-Protocol-Version` header in subsequent requests when using HTTP"*.

The mechanism was right; the justification was invented. That's worse than a missing comment, because the next person would have built on it.

Relatedly, `ProtocolVersion` asked for **2024-11-05** while this package speaks Streamable HTTP — a transport that revision doesn't have. 2025-03-26 introduced it explicitly to *"replace the HTTP+SSE transport from protocol version 2024-11-05"*. So the client named a revision without the transport it was using. It now asks for **2025-03-26**, which is what `http.go` actually implements.

Newer revisions are documented as deliberately unclaimed, with reasons:

| Revision | Why not |
|---|---|
| 2025-06-18 | adds elicitation (server→client requests, which `receiveLoop` drops) and structured tool output (servers only *SHOULD* keep filling the `content` field this package reads) |
| 2025-11-25 | last handshake-based revision |
| **2026-07-28** | **removes the initialize handshake entirely** — version/identity/capabilities become per-request `_meta`, `server/discover` becomes mandatory, unsupported versions return a typed `UnsupportedProtocolVersionError`. In its own terminology this client is "legacy", and a legacy client **cannot talk to a modern-only server at all**. Becoming dual-era is separate work, not a bump of this constant. |

Nothing validated the server's *answer* either, so an unimplemented revision surfaced later as an unrelated-looking failure. `ConnectAll` now warns, naming the version.

It **does not disconnect**, which the spec words as a SHOULD. Deliberate: newer revisions have stayed wire-compatible for the subset used here, so refusing would break setups that work today in exchange for strictness nobody asked for. What the SHOULD guards against — a version problem surfacing as something else — is handled by saying so up front.

## Part 2 — four lifecycle faults

**1. The send lock couldn't be abandoned.** An SSE response holds it for as long as the server streams (plus resume attempts), and `sync.Mutex.Lock` ignores context. So once #2019 made streams possible, callers queued behind one could not be released by their own deadline *or by an interrupt* — only by the holder finishing. Now a one-slot channel acquired under `select`.

**2. A dead receive loop left a zombie that still looked healthy.** `receiveLoop` returned without recording that it had died. On stdio that's reachable while nothing is closed — one malformed line desynchronises the JSON decoder, or a server closes stdout and keeps running. Writes to stdin still succeeded, `/mcp` and the panel still said "connected", and **every call waited out its full 60s timeout** for a reply nobody was left to deliver. The new refresh and rehandshake paths made that worse (3 list calls × 30s per pass; a rehandshake waiting under the send lock).

Deliberately **not** reusing the `closed` flag: `Close`'s `CompareAndSwap` on it is what gates tearing the transport down, so sharing it would make a later `Close` skip that and leak the connection. New `Live()` accessor for status reporting.

**3. `Registry.Close` held `r.mu` across network and process I/O.** A stdio server whose stderr is a log file (so `os/exec` builds a pipe) keeps `cmd.Wait` blocked while any grandchild holds the write end — *even after a Kill*. That permanently wedges every registry reader with it: `Get` on each MCP tool dispatch, `/mcp` output, the panel's server list. Now snapshots under the lock and closes outside it. (Pre-existing; #2023 parallelised this without narrowing the scope.)

**4. A 204 answering a request hung the caller.** It queued nothing and returned success, so the call waited out its whole deadline. The spec requires JSON or an SSE stream there. Now named as the violation it is; notifications still accept 204.

## Test plan

- [x] `go test -race ./internal/... ./cmd/... ./pkg/...` — full repo green
- [x] `make vet` / `make fmt-check` clean

| Test | Covers |
|---|---|
| `TestProtocolVersion_IsSpecRevision` | constant is 2025-03-26 and self-consistent with the supported set |
| `TestSupportedProtocolVersion` | 2025-06-18 / 2025-11-25 / 2026-07-28 correctly *not* claimed |
| `TestConnectAll_WarnsOnUnsupportedProtocolVersion` | warns and still connects |
| `TestConnectAll_QuietOnSupportedVersion` | no nagging on the happy path |
| `TestRequest204IsRejected` | 204→request errors, 204→notification still fine |
| `TestRequest204DoesNotHangCall` | call fails in <2s instead of burning the deadline |
| `TestReceiveLoopDeath_FailsCallsFast` | dead reader ⇒ immediate failure, `Live()` false, no write attempted |
| `TestClose_AfterReceiveLoopDeath_StillClosesTransport` | the reason `dead` is separate from `closed` |
| `TestSendSlot_ReleasedByCallerDeadline` | caller queued behind a live stream returns on its own deadline |
| `TestRegistryClose_DoesNotHoldLockAcrossIO` | readers served while a `Close` is stalled on a hostile DELETE |