### PR TITLE
docs: acknowledge the LINUX DO community

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ octo 站在两个项目的肩膀上，这点不遮掩：**[Claude Code](https://
   <img src="https://contrib.rocks/image?repo=open-octo/octo-agent" alt="Contributors" />
 </a>
 
+## 社区鸣谢
+
+感谢 [LINUX DO 社区](https://linux.do) 对开源交流与项目成长的支持。
+
 ## 许可
 
 MIT。见 [`LICENSE.txt`](LICENSE.txt)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -198,6 +198,11 @@ Thanks to everyone who has contributed to octo:
   <img src="https://contrib.rocks/image?repo=open-octo/octo-agent" alt="Contributors" />
 </a>
 
+## Community acknowledgement
+
+Thanks to the [LINUX DO community](https://linux.do) for supporting open-source
+exchange and this project's growth.
+
 ## License
 
 MIT. See [`LICENSE.txt`](LICENSE.txt).


### PR DESCRIPTION
Adds a short acknowledgement section to both READMEs (Chinese default and `README_EN.md`), linking to https://linux.do.

Context: the LINUX DO community requires projects promoted there to link back to it. `README_CN.md` is only a redirect stub, so it is untouched.

Docs-only change — no code, no dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)