### PR TITLE
tools: close self-kill guard bypasses via runtime shell shadows

### DIFF
--- a/dev-docs/server-self-restart-design.md
+++ b/dev-docs/server-self-restart-design.md
@@ -93,6 +93,44 @@ confirmation prompt; on IM channels the in-chat reply prompt (see
 sub-agents see the tool (the restarter registration is process-global) but
 inherit the parent's gate, so they face the same confirmation.
 
+## Self-kill guard
+
+The agent runs inside the very process its shell commands can kill. Left
+alone, a "restart the service" instruction routinely turns into `pkill octo`
+or `kill <pid>` — taking down worker, supervisor, and the user's web/IM
+session mid-turn. The terminal tool therefore refuses commands that would
+terminate the server or its supervisor, steering the model to
+`restart_server`. Two layers, both armed only in server mode
+(`tools.SetServerGuard`):
+
+1. **Textual** (`guardServerSelfKill` in `internal/tools/server_guard.go`) —
+   scans the command string before execution: `pkill`/`killall … octo`,
+   `kill` of a protected pid (positive, or the `kill -- -PGID` process-group
+   form — a daemonized server leads its own group), and
+   pgrep/pidof-resolve-then-kill shapes. This is the only layer on the
+   `--sandbox` branch, where no shell wrapper is injected.
+2. **Runtime shadows** (`posixKillGuardWrapper` / `windowsKillGuardWrapper`,
+   injected by `shellCommand` alongside the safe-rm wrapper) — shell
+   functions shadowing `kill`/`pkill`/`killall` (POSIX) and
+   `Stop-Process`/`taskkill` (PowerShell, plus a `taskkill.exe` alias) that
+   check targets **after** the shell has expanded variables and command
+   substitutions, catching what the textual pass cannot see (`kill $P`,
+   `pkill -f serve`, `kill $(cat pidfile)`). pkill/killall patterns are
+   matched against `ps` output for just the protected pids — deliberately
+   not via pgrep, whose macOS build cannot see its own ancestors while
+   procps on Linux can.
+
+The shadows read `OCTO_SERVER_PID` / `OCTO_SERVER_PPID` / `OCTO_GUARD_MSG`,
+exported by `guardEnv` only while the guard is on; inherited copies are
+scrubbed first (`scrubGuardEnv`), so a nested octo never arms its shadows
+with a stale parent pid set and plain CLI/TUI runs are behavior-identical.
+Anything ambiguous fails open: rich pkill matching flags, `ps` lookup
+failures, PowerShell pipeline input and abbreviated parameters. Function
+shadows also only intercept shell-function dispatch — `/bin/kill`,
+`command kill`, `env`/`xargs`, nested shells, and script files written then
+executed all bypass them. Accepted residual holes: this guards reflexive
+model behavior, not an adversary; real confinement is `--sandbox`.
+
 ## Drain sequence
 
 A restart request flips the server into draining state (`drainGate` in
@@ -154,6 +192,7 @@ catch-all for everything else.
 | Drain state | `internal/server/drain.go` | `drainGate`: in-flight count, intake refusal, drain wait + timeout |
 | Restart endpoint | `internal/server/restart.go` | `POST /api/restart`, 202 then background drain |
 | Restart tool | `internal/tools/restart.go` + server wiring | `restart_server`, `SetRestarter`-injected, permission-gated |
+| Self-kill guard | `internal/tools/server_guard.go` + `sandbox.go` wrapper injection | textual scan + runtime kill shadows, `SetServerGuard`-armed |
 
 ## Testing
 
@@ -166,6 +205,10 @@ catch-all for everything else.
   draining 503 on turn endpoints, scheduled-run refusal, polite IM reply via a
   fake adapter, restart-vs-plain-shutdown sentinel on a real ephemeral-port
   listener, single-flight `Shutdown` under `-race`.
+- Self-kill guard: textual cases as pure unit tests, plus real wrapped-shell
+  execution of the runtime shadows on POSIX and Windows. Blocked cases use
+  signal-0 probes (POSIX) or a decoy process and `-WhatIf` (Windows), so a
+  shadow regression fails an assertion instead of killing the test run.
 - CI matrix (Linux/macOS/Windows) exercises the spawn/wait path on all three;
   the Windows rename dance belongs to the (future) upgrade flow, not this
   machinery.

--- a/docs/src/content/docs/guides/self-host.md
+++ b/docs/src/content/docs/guides/self-host.md
@@ -74,6 +74,13 @@ can never end up on an allow-list by accident. Either path waits for in-flight t
 during that drain window are refused with a message asking you to try again in a moment, on every
 transport including IM.
 
+The agent can't take the crude route instead: it runs inside the very server process, so shell
+commands that would kill `octo serve` or its supervisor (`kill <pid>`, `pkill octo` — including
+indirect forms that only become visible after shell expansion, like `kill $P`) are refused with a
+message pointing the model at `restart_server`. This guards against the model reflexively killing
+its own host and dropping your session; it is not a sandbox — for real confinement see
+[Sandbox the agent](/docs/guides/sandbox-the-agent/).
+
 > The `restart_server` tool relies on a supervisor respawn contract. The desktop build runs the
 > server in-process with no supervisor, so the tool is omitted there — channel config is instead
 > applied via hot-reload (`POST /api/channels/<platform>/reload`), and other changes take effect when

--- a/docs/src/content/docs/zh/guides/self-host.md
+++ b/docs/src/content/docs/zh/guides/self-host.md
@@ -61,6 +61,12 @@ octo serve -addr :8088 --access-key <key>
 轮次跑完（或者等满 30 秒超时，以先到者为准）才真正退出进程；在这段排空窗口期新发起的轮次会被拒绝，
 提示你过一会儿再试一次——所有传输方式（包括 IM）都是这个提示。
 
+模型没法绕开这套机制走粗暴路线：agent 本身就跑在 server 进程里，所以会杀掉 `octo serve` 或其
+supervisor 的 shell 命令（`kill <pid>`、`pkill octo`，包括 `kill $P` 这类要等 shell 展开后才现形的
+间接写法）都会被拒绝，并提示模型改用 `restart_server`。这层防护针对的是模型条件反射式的
+"杀进程重启"，避免你的会话被它自己掐断；它不是沙箱——真正的隔离见
+[沙箱化运行](/docs/zh/guides/sandbox-the-agent/)。
+
 > `restart_server` 依赖 supervisor 重启契约。桌面版以内嵌进程方式运行 server，没有 supervisor，
 > 所以不提供这个工具——channel 配置走热加载生效（`POST /api/channels/<platform>/reload`），
 > 其他改动则需重启应用。

--- a/internal/skills/defaults/product_help/TROUBLESHOOTING.md
+++ b/internal/skills/defaults/product_help/TROUBLESHOOTING.md
@@ -84,6 +84,12 @@ Also remember that a session is **bound to a model at creation time**. Changing 
 - `octo serve --status` tells you whether the process holding the port is octo's own daemon
 - Use a different port (`-addr :<port>`) or stop the existing instance (`octo serve --stop`) first
 
+### Agent says "refusing to kill the octo server process"
+
+- Expected behavior, not an error: the agent runs inside `octo serve`, so shell commands that would kill the server (`kill <pid>`, `pkill octo`, including variable-expanded forms like `kill $P`) are refused — otherwise the agent would drop your session mid-turn
+- To restart properly: let the agent call the `restart_server` tool (it asks for confirmation), hit `POST /api/restart`, or run `octo serve --stop` and start it again yourself
+- Desktop app: the server runs in-process with no supervisor, so `restart_server` doesn't exist there — restart the app instead
+
 ## MCP
 
 ### "No MCP servers connected"

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -132,28 +132,35 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 		ps := resolvePowerShell()
 		projectDir := WorkingDirOrCWD(ctx)
 		// Wrap Remove-Item to copy to trash first (parity with the POSIX rm
-		// wrapper), but only when we can locate the octo binary and a project
-		// dir; otherwise run the command bare (no protection, but never broken).
+		// wrapper) and shadow Stop-Process/taskkill so the self-kill guard
+		// holds after variable expansion, but only when we can locate the
+		// octo binary and a project dir; otherwise run the command bare (no
+		// protection, but never broken). The kill-guard shadows are inert
+		// no-ops unless guardEnv() armed them (octo serve only).
 		if exe, err := os.Executable(); err == nil && projectDir != "" {
-			wrapped := executil.PowerShellUTF8EncodingPrefix + fmt.Sprintf(windowsSafeRmWrapper, strings.ReplaceAll(exe, "'", "''"), command)
+			wrapped := executil.PowerShellUTF8EncodingPrefix + windowsKillGuardWrapper +
+				fmt.Sprintf(windowsSafeRmWrapper, strings.ReplaceAll(exe, "'", "''"), command)
 			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", wrapped)
-			cmd.Env = withBundledBinPath(append(os.Environ(), "OCTO_TRASH_PROJECT="+projectDir))
+			cmd.Env = withBundledBinPath(append(append(os.Environ(), "OCTO_TRASH_PROJECT="+projectDir), guardEnv()...))
 		} else {
 			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", executil.PowerShellUTF8EncodingPrefix+command)
 			cmd.Env = withBundledBinPath(os.Environ())
 		}
 		executil.SetNoWindow(cmd)
 	} else {
+		// Always wrap: the rm shadow no-ops without OCTO_TRASH_DIR and the
+		// kill shadows no-op without OCTO_SERVER_PID, so plain CLI usage sees
+		// no behavior change — wrapping unconditionally just lets octo serve
+		// arm the runtime self-kill guard via guardEnv().
 		projectDir := WorkingDirOrCWD(ctx)
+		env := os.Environ()
 		if projectDir != "" {
-			trashDir := trash.ProjectDir(projectDir)
-			wrapped := fmt.Sprintf(safeRmWrapper, command)
-			cmd = exec.CommandContext(ctx, "sh", "-c", wrapped)
-			cmd.Env = withBundledBinPath(append(os.Environ(), "OCTO_TRASH_DIR="+trashDir))
-		} else {
-			cmd = exec.CommandContext(ctx, "sh", "-c", command)
-			cmd.Env = withBundledBinPath(os.Environ())
+			env = append(env, "OCTO_TRASH_DIR="+trash.ProjectDir(projectDir))
 		}
+		env = append(env, guardEnv()...)
+		wrapped := posixKillGuardWrapper + fmt.Sprintf(safeRmWrapper, command)
+		cmd = exec.CommandContext(ctx, "sh", "-c", wrapped)
+		cmd.Env = withBundledBinPath(env)
 	}
 	if attr := setProcessGroupOpts(); attr != nil {
 		cmd.SysProcAttr = attr

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -141,7 +141,7 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 			wrapped := executil.PowerShellUTF8EncodingPrefix + windowsKillGuardWrapper +
 				fmt.Sprintf(windowsSafeRmWrapper, strings.ReplaceAll(exe, "'", "''"), command)
 			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", wrapped)
-			cmd.Env = withBundledBinPath(append(append(os.Environ(), "OCTO_TRASH_PROJECT="+projectDir), guardEnv()...))
+			cmd.Env = withBundledBinPath(append(append(scrubGuardEnv(os.Environ()), "OCTO_TRASH_PROJECT="+projectDir), guardEnv()...))
 		} else {
 			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", executil.PowerShellUTF8EncodingPrefix+command)
 			cmd.Env = withBundledBinPath(os.Environ())
@@ -151,9 +151,10 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 		// Always wrap: the rm shadow no-ops without OCTO_TRASH_DIR and the
 		// kill shadows no-op without OCTO_SERVER_PID, so plain CLI usage sees
 		// no behavior change — wrapping unconditionally just lets octo serve
-		// arm the runtime self-kill guard via guardEnv().
+		// arm the runtime self-kill guard via guardEnv(). Inherited guard
+		// variables are scrubbed first so only guardEnv() ever arms a shadow.
 		projectDir := WorkingDirOrCWD(ctx)
-		env := os.Environ()
+		env := scrubGuardEnv(os.Environ())
 		if projectDir != "" {
 			env = append(env, "OCTO_TRASH_DIR="+trash.ProjectDir(projectDir))
 		}

--- a/internal/tools/server_guard.go
+++ b/internal/tools/server_guard.go
@@ -47,6 +47,14 @@ var (
 	// a bare boundary) also keeps digits glued to a word — e.g. "octo123" — from
 	// matching, matching the old `\b\d+\b` behavior for that case.
 	reNum = regexp.MustCompile(`(?:^|[^-\w])(\d+)\b`)
+	// reNegNum matches a negative pid argument inside a kill tail: `kill -- -PGID`
+	// signals a whole process group, and a daemonized server is its own group
+	// leader, so its pid doubles as a killable pgid. The digits are compared
+	// against the exact protected pids, so signal specs (`-9`, `-15`) can never
+	// collide — signal numbers stop far below real pid ranges. The leading
+	// whitespace requirement keeps digits inside hyphenated words (a script
+	// named kill-server-1234) from matching.
+	reNegNum = regexp.MustCompile(`(?:^|\s)-(\d+)\b`)
 )
 
 // guardServerSelfKill returns a non-nil error when command, run inside an octo
@@ -85,6 +93,11 @@ func guardServerSelfKill(command string) error {
 				return errServerSelfKill()
 			}
 		}
+		for _, m := range reNegNum.FindAllStringSubmatch(seg[1], -1) {
+			if protected[m[1]] {
+				return errServerSelfKill()
+			}
+		}
 	}
 	return nil
 }
@@ -109,6 +122,25 @@ func guardEnv() []string {
 	return env
 }
 
+// scrubGuardEnv removes inherited guard variables from env. A terminal command
+// spawned by a guarded server carries them, so a nested octo run from that
+// command would otherwise arm its own wrapper shadows with the parent's
+// (possibly stale, possibly pid-recycled) values. Scrubbing first makes
+// guardEnv the only source of truth: guard off means inert shadows, guard on
+// means this process's own pids.
+func scrubGuardEnv(env []string) []string {
+	out := env[:0]
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "OCTO_SERVER_PID=") ||
+			strings.HasPrefix(kv, "OCTO_SERVER_PPID=") ||
+			strings.HasPrefix(kv, "OCTO_GUARD_MSG=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
 // posixKillGuardWrapper shadows kill/pkill/killall in the injected POSIX shell
 // so the self-kill guard holds at RUNTIME — after the shell has expanded
 // variables and command substitutions (`kill $P`, `kill $(cat pidfile)`,
@@ -123,6 +155,12 @@ func guardEnv() []string {
 // simple invocation shapes ([signal] [-f] [-x] pattern / killall name) are
 // resolved; richer matching flags (-u/-P/-t/-n/-o/-v/...) fail open, as does
 // any lookup failure — the textual guard upstream remains as a backstop.
+//
+// Function shadows only intercept shell-function dispatch: a direct binary
+// path (/bin/kill), `command kill`, dispatch via env/xargs, and nested shells
+// (`sh -c 'kill …'`, commands written to a script file and executed) all
+// bypass them. Accepted residual holes — this guards against reflexive model
+// behavior, not an adversary.
 //
 // Not fmt.Sprintf'd — concatenated raw — so `%` needs no escaping. Requires
 // the guardEnv() variables; with OCTO_SERVER_PID unset every shadow passes
@@ -151,7 +189,7 @@ __octo_kill_guard() {
   local _self="${OCTO_SERVER_PID:-}" _super="${OCTO_SERVER_PPID:-}"
   [ -z "$_self" ] && return 0
   local _msg="${OCTO_GUARD_MSG:-refusing to kill the octo server process that is hosting this session}"
-  local _a _skip=0
+  local _a _t _skip=0
   case "$_op" in
   (kill)
     for _a in "$@"; do
@@ -160,6 +198,20 @@ __octo_kill_guard() {
       else
         case "$_a" in
           (-s|-n|--signal) _skip=1 ;;  # signal spec consumes the next arg
+          (-[0-9]*)
+            # Signal spec (-9) or negative pid (kill -- -PGID: a whole process
+            # group, and a daemonized server leads its own group). Signal
+            # numbers never reach pid range, so an exact digit match can only
+            # be a group kill of a protected process.
+            _t="${_a#-}"
+            case "$_t" in
+              (*[!0-9]*) : ;;
+              (*)
+                if [ "$_t" = "$_self" ]; then printf '%s\n' "$_msg" >&2; return 1; fi
+                if [ -n "$_super" ] && [ "$_t" = "$_super" ]; then printf '%s\n' "$_msg" >&2; return 1; fi
+                ;;
+            esac
+            ;;
           (-*|%*) : ;;                 # other flags and job specs carry no target pid
           (*[!0-9]*) : ;;              # non-numeric: not a pid
           (*)
@@ -217,14 +269,16 @@ killall() { if __octo_kill_guard killall "$@"; then command killall "$@"; else r
 // windowsKillGuardWrapper is the PowerShell counterpart of
 // posixKillGuardWrapper: it shadows Stop-Process (whose aliases kill/spps
 // resolve to the cmdlet name and so hit this function — functions take
-// precedence) and taskkill.exe, resolving their -Id//PID arguments directly
-// and their -Name//IM process names via Get-Process, then refusing when a
-// guarded pid is among the targets. Variable-expanded targets
-// (`Stop-Process -Id $p`) are already concrete by the time the function runs,
-// which is what closes the holes the textual guard cannot see. Best-effort
-// like the Remove-Item wrapper: pipeline input and /FI filter expressions are
-// not resolved and fall through to the real command. Concatenated raw (not
-// fmt.Sprintf'd).
+// precedence) and taskkill (plus a taskkill.exe alias, so the
+// extension-qualified spelling resolves here too — aliases outrank
+// applications), resolving their -Id//PID arguments directly and their
+// -Name//IM process names via Get-Process, then refusing when a guarded pid
+// is among the targets. Variable-expanded targets (`Stop-Process -Id $p`) are
+// already concrete by the time the function runs, which is what closes the
+// holes the textual guard cannot see. Best-effort like the Remove-Item
+// wrapper: pipeline input, /FI filter expressions, and abbreviated or
+// colon-joined parameter forms (`-Nam octo`, `-Id:123`) are not resolved and
+// fall through to the real command. Concatenated raw (not fmt.Sprintf'd).
 const windowsKillGuardWrapper = `$__octoGuardPids = @()
 if ($env:OCTO_SERVER_PID) { $__octoGuardPids += [int]$env:OCTO_SERVER_PID }
 if ($env:OCTO_SERVER_PPID) { $__octoGuardPids += [int]$env:OCTO_SERVER_PPID }
@@ -275,6 +329,7 @@ function taskkill {
   }
   & "$env:SystemRoot\System32\taskkill.exe" @args
 }
+Set-Alias -Name taskkill.exe -Value taskkill
 `
 
 // errServerSelfKill is returned by guardServerSelfKill when the model tries to

--- a/internal/tools/server_guard.go
+++ b/internal/tools/server_guard.go
@@ -50,10 +50,13 @@ var (
 )
 
 // guardServerSelfKill returns a non-nil error when command, run inside an octo
-// server process, would terminate that server (or its supervisor). It is a
-// best-effort textual guard over the common vectors — `pkill/killall octo` and
-// `kill <server-pid>` — not a sandbox; it exists to stop the model from
-// reflexively killing the process it is hosted by.
+// server process, would terminate that server (or its supervisor). It is the
+// first of two layers: a best-effort TEXTUAL guard over the common vectors —
+// `pkill/killall octo` and `kill <server-pid>` — that also covers the --sandbox
+// branch where no wrapper is injected. The second layer is the runtime shadow
+// (posixKillGuardWrapper / windowsKillGuardWrapper), which sees target pids
+// after shell expansion and so catches the indirections (`kill $P`,
+// `pkill -f serve`) this textual pass cannot.
 func guardServerSelfKill(command string) error {
 	if !serverGuardOn.Load() {
 		return nil
@@ -85,6 +88,194 @@ func guardServerSelfKill(command string) error {
 	}
 	return nil
 }
+
+// guardEnv returns the environment variables that arm the runtime self-kill
+// guard inside the injected shell wrappers: the protected pid set plus the
+// refusal message the shadow prints. Empty when the guard is off (plain
+// CLI/TUI usage), so the wrapper shadows stay inert no-ops there.
+func guardEnv() []string {
+	if !serverGuardOn.Load() {
+		return nil
+	}
+	env := []string{
+		"OCTO_SERVER_PID=" + strconv.Itoa(serverSelfPID),
+		"OCTO_GUARD_MSG=" + errServerSelfKill().Error(),
+	}
+	// PPID 1 (reparented to init/launchd) is unkillable and not protected,
+	// mirroring the textual guard.
+	if serverSuperPID > 1 {
+		env = append(env, "OCTO_SERVER_PPID="+strconv.Itoa(serverSuperPID))
+	}
+	return env
+}
+
+// posixKillGuardWrapper shadows kill/pkill/killall in the injected POSIX shell
+// so the self-kill guard holds at RUNTIME — after the shell has expanded
+// variables and command substitutions (`kill $P`, `kill $(cat pidfile)`,
+// `pkill -f serve`) that the textual guardServerSelfKill cannot see. This is
+// the same shadow-function mechanism as safeRmWrapper.
+//
+// Resolution does NOT use pgrep: on macOS pgrep/pkill deliberately cannot see
+// their own ancestors (the octo server IS the wrapper's ancestor, so macOS
+// pkill can't hit it anyway), while procps on Linux has no such blind spot —
+// exactly where the guard matters. Instead each pkill/killall invocation is
+// matched locally against `ps` output for just the protected pids. Only the
+// simple invocation shapes ([signal] [-f] [-x] pattern / killall name) are
+// resolved; richer matching flags (-u/-P/-t/-n/-o/-v/...) fail open, as does
+// any lookup failure — the textual guard upstream remains as a backstop.
+//
+// Not fmt.Sprintf'd — concatenated raw — so `%` needs no escaping. Requires
+// the guardEnv() variables; with OCTO_SERVER_PID unset every shadow passes
+// straight through to the real command. Every case pattern carries the
+// optional leading paren: a bare ')' inside a pattern can prematurely close
+// command substitutions on older bash (macOS /bin/sh is bash 3.2).
+const posixKillGuardWrapper = `__octo_guard_match() {
+  # Would the pattern match process $3? Matched against ps output for just
+  # that pid. $1: name|namex|full|fullx  $2: ERE pattern  $3: pid
+  local _mode="$1" _pat="$2" _pid="$3" _args _name _comm
+  _args=$(ps -p "$_pid" -o args= 2>/dev/null)
+  [ -z "$_args" ] && return 1
+  _name="${_args%% *}"; _name="${_name##*/}"
+  _comm=$(ps -p "$_pid" -o comm= 2>/dev/null)
+  case "$_mode" in
+    (name)  printf '%s\n%s\n' "$_name" "$_comm" | grep -E -e "$_pat" >/dev/null 2>&1 ;;
+    (namex) [ "$_name" = "$_pat" ] || [ "$_comm" = "$_pat" ] ;;
+    (full)  printf '%s\n' "$_args" | grep -E -e "$_pat" >/dev/null 2>&1 ;;
+    (fullx) [ "$_args" = "$_pat" ] ;;
+    (*) return 1 ;;
+  esac
+}
+__octo_kill_guard() {
+  # $1: op (kill|pkill|killall); rest: original args, already shell-expanded.
+  local _op="$1"; shift
+  local _self="${OCTO_SERVER_PID:-}" _super="${OCTO_SERVER_PPID:-}"
+  [ -z "$_self" ] && return 0
+  local _msg="${OCTO_GUARD_MSG:-refusing to kill the octo server process that is hosting this session}"
+  local _a _skip=0
+  case "$_op" in
+  (kill)
+    for _a in "$@"; do
+      if [ "$_skip" = 1 ]; then
+        _skip=0
+      else
+        case "$_a" in
+          (-s|-n|--signal) _skip=1 ;;  # signal spec consumes the next arg
+          (-*|%*) : ;;                 # other flags and job specs carry no target pid
+          (*[!0-9]*) : ;;              # non-numeric: not a pid
+          (*)
+            if [ "$_a" = "$_self" ]; then printf '%s\n' "$_msg" >&2; return 1; fi
+            if [ -n "$_super" ] && [ "$_a" = "$_super" ]; then printf '%s\n' "$_msg" >&2; return 1; fi
+            ;;
+        esac
+      fi
+    done
+    ;;
+  (pkill)
+    # Simple shapes only: [signal] [-f] [-x] pattern. Anything richer
+    # (_bad=1) falls through unguarded.
+    local _mode=name _pat= _bad=0
+    for _a in "$@"; do
+      if [ "$_skip" = 1 ]; then
+        _skip=0
+      else
+        case "$_a" in
+          (--signal|--queue) _skip=1 ;;
+          (--signal=*|--queue=*|-e|--echo|-[0-9]*|-SIG*) : ;;
+          (-HUP|-INT|-QUIT|-ILL|-TRAP|-ABRT|-BUS|-FPE|-KILL|-USR1|-SEGV|-USR2|-PIPE|-ALRM|-TERM|-STKFLT|-CHLD|-CONT|-STOP|-TSTP|-TTIN|-TTOU|-URG|-XCPU|-XFSZ|-VTALRM|-PROF|-WINCH|-IO|-PWR|-SYS|-POLL|-IOT|-CLD) : ;;
+          (-f|--full)  case "$_mode" in (name) _mode=full ;; (namex) _mode=fullx ;; esac ;;
+          (-x|--exact) case "$_mode" in (name) _mode=namex ;; (full) _mode=fullx ;; esac ;;
+          (-*) _bad=1 ;;
+          (*) if [ -n "$_pat" ]; then _bad=1; else _pat="$_a"; fi ;;
+        esac
+      fi
+    done
+    if [ "$_bad" = 0 ] && [ -n "$_pat" ]; then
+      if __octo_guard_match "$_mode" "$_pat" "$_self"; then printf '%s\n' "$_msg" >&2; return 1; fi
+      if [ -n "$_super" ] && __octo_guard_match "$_mode" "$_pat" "$_super"; then printf '%s\n' "$_msg" >&2; return 1; fi
+    fi
+    ;;
+  (killall)
+    # killall signals processes by exact name; flags carry no target.
+    for _a in "$@"; do
+      case "$_a" in
+        (-*) : ;;
+        (*)
+          if __octo_guard_match namex "$_a" "$_self"; then printf '%s\n' "$_msg" >&2; return 1; fi
+          if [ -n "$_super" ] && __octo_guard_match namex "$_a" "$_super"; then printf '%s\n' "$_msg" >&2; return 1; fi
+          ;;
+      esac
+    done
+    ;;
+  esac
+  return 0
+}
+kill() { if __octo_kill_guard kill "$@"; then command kill "$@"; else return 1; fi }
+pkill() { if __octo_kill_guard pkill "$@"; then command pkill "$@"; else return 1; fi }
+killall() { if __octo_kill_guard killall "$@"; then command killall "$@"; else return 1; fi }
+`
+
+// windowsKillGuardWrapper is the PowerShell counterpart of
+// posixKillGuardWrapper: it shadows Stop-Process (whose aliases kill/spps
+// resolve to the cmdlet name and so hit this function — functions take
+// precedence) and taskkill.exe, resolving their -Id//PID arguments directly
+// and their -Name//IM process names via Get-Process, then refusing when a
+// guarded pid is among the targets. Variable-expanded targets
+// (`Stop-Process -Id $p`) are already concrete by the time the function runs,
+// which is what closes the holes the textual guard cannot see. Best-effort
+// like the Remove-Item wrapper: pipeline input and /FI filter expressions are
+// not resolved and fall through to the real command. Concatenated raw (not
+// fmt.Sprintf'd).
+const windowsKillGuardWrapper = `$__octoGuardPids = @()
+if ($env:OCTO_SERVER_PID) { $__octoGuardPids += [int]$env:OCTO_SERVER_PID }
+if ($env:OCTO_SERVER_PPID) { $__octoGuardPids += [int]$env:OCTO_SERVER_PPID }
+$__octoGuardMsg = "$env:OCTO_GUARD_MSG"
+if (-not $__octoGuardMsg) { $__octoGuardMsg = 'refusing to kill the octo server process that is hosting this session' }
+function __octo-TestGuardedPid($pids) {
+  foreach ($p in @($pids)) {
+    $v = 0
+    if ([int]::TryParse("$p", [ref]$v) -and ($__octoGuardPids -contains $v)) { return $true }
+  }
+  return $false
+}
+function Stop-Process {
+  if ($__octoGuardPids.Count -gt 0) {
+    $targets = @()
+    $names = @()
+    for ($i = 0; $i -lt $args.Count; $i++) {
+      $a = $args[$i]
+      if ($a -is [string]) {
+        if (($a -ieq '-Id') -or ($a -ieq '-PID')) { if ($i + 1 -lt $args.Count) { $targets += $args[$i + 1]; $i++ } }
+        elseif (($a -ieq '-Name') -or ($a -ieq '-ProcessName')) { if ($i + 1 -lt $args.Count) { $names += $args[$i + 1]; $i++ } }
+        elseif (-not $a.StartsWith('-')) {
+          $v = 0
+          if ([int]::TryParse($a, [ref]$v)) { $targets += $v } else { $names += $a }
+        }
+      } elseif ($a -is [int]) { $targets += $a }
+    }
+    foreach ($n in $names) {
+      Get-Process -Name "$n" -ErrorAction SilentlyContinue | ForEach-Object { $targets += $_.Id }
+    }
+    if (__octo-TestGuardedPid $targets) { throw $__octoGuardMsg }
+  }
+  Microsoft.PowerShell.Management\Stop-Process @args
+}
+function taskkill {
+  if ($__octoGuardPids.Count -gt 0) {
+    $targets = @()
+    $names = @()
+    for ($i = 0; $i -lt $args.Count; $i++) {
+      $a = "$($args[$i])"
+      if ($a -ieq '/PID') { if ($i + 1 -lt $args.Count) { $targets += $args[$i + 1]; $i++ } }
+      elseif ($a -ieq '/IM') { if ($i + 1 -lt $args.Count) { $names += ("$($args[$i + 1])" -replace '\.exe$', ''); $i++ } }
+    }
+    foreach ($n in $names) {
+      Get-Process -Name $n -ErrorAction SilentlyContinue | ForEach-Object { $targets += $_.Id }
+    }
+    if (__octo-TestGuardedPid $targets) { throw $__octoGuardMsg }
+  }
+  & "$env:SystemRoot\System32\taskkill.exe" @args
+}
+`
 
 // errServerSelfKill is returned by guardServerSelfKill when the model tries to
 // kill the octo server process hosting the current session. The message

--- a/internal/tools/server_guard_shadow_common_test.go
+++ b/internal/tools/server_guard_shadow_common_test.go
@@ -1,0 +1,20 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+// runGuardedCommand builds and runs a terminal command through shellCommand
+// with whatever guard state the caller has set up, returning the combined
+// output and the process error (non-nil on refusal as well as on ordinary
+// command failure). Shared by the POSIX and Windows shadow tests.
+func runGuardedCommand(t *testing.T, command string) (string, error) {
+	t.Helper()
+	cmd, err := shellCommand(context.Background(), command)
+	if err != nil {
+		t.Fatalf("shellCommand(%q) failed to build: %v", command, err)
+	}
+	out, runErr := cmd.CombinedOutput()
+	return string(out), runErr
+}

--- a/internal/tools/server_guard_shadow_test.go
+++ b/internal/tools/server_guard_shadow_test.go
@@ -1,0 +1,132 @@
+//go:build !windows
+
+package tools
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// runGuardedCommand builds and runs a terminal command through shellCommand
+// with the self-kill guard armed, returning the combined output and the
+// process error (non-nil on refusal as well as on ordinary command failure).
+func runGuardedCommand(t *testing.T, command string) (string, error) {
+	t.Helper()
+	cmd, err := shellCommand(context.Background(), command)
+	if err != nil {
+		t.Fatalf("shellCommand(%q) failed to build: %v", command, err)
+	}
+	out, runErr := cmd.CombinedOutput()
+	return string(out), runErr
+}
+
+func TestGuardEnv_ArmedOnlyWhenGuardOn(t *testing.T) {
+	SetServerGuard(false)
+	if got := guardEnv(); len(got) != 0 {
+		t.Fatalf("guard off: want no guard env, got %v", got)
+	}
+
+	SetServerGuard(true)
+	defer SetServerGuard(false)
+	env := guardEnv()
+	wantPID := "OCTO_SERVER_PID=" + strconv.Itoa(serverSelfPID)
+	var hasPID, hasMsg bool
+	for _, kv := range env {
+		hasPID = hasPID || kv == wantPID
+		hasMsg = hasMsg || (strings.HasPrefix(kv, "OCTO_GUARD_MSG=") &&
+			strings.Contains(kv, "refusing to kill the octo server process"))
+	}
+	if !hasPID {
+		t.Errorf("guard env missing %q, got %v", wantPID, env)
+	}
+	if !hasMsg {
+		t.Errorf("guard env missing refusal message, got %v", env)
+	}
+}
+
+// TestKillGuardShadow_BlocksExpandedSelfKill covers the indirections the
+// textual guard cannot see: the target pid only appears after the shell
+// expands a variable or after pkill resolves a name/pattern at runtime. The
+// commands are chosen to slip past guardServerSelfKill so the refusal
+// provably comes from the runtime shadow.
+func TestKillGuardShadow_BlocksExpandedSelfKill(t *testing.T) {
+	SetServerGuard(true)
+	defer SetServerGuard(false)
+
+	self := strconv.Itoa(serverSelfPID)
+	blocked := []string{
+		"P=$(echo " + self + "); kill $P",         // variable indirection
+		"P=$(echo " + self + "); kill -s TERM $P", // signal spec consuming an arg
+		"P=$(echo " + self + "); kill -n 9 $P",    // -n form
+		"pkill -f tools.test",                     // -f pattern without the word "octo"
+		"pkill -x tools.test",                     // exact name
+		"killall tools.test",                      // killall by name
+	}
+	for _, c := range blocked {
+		// Prove the command actually reaches the runtime shadow: the textual
+		// guard must NOT be the one rejecting it.
+		if err := guardServerSelfKill(c); err != nil {
+			t.Errorf("%q: textual guard rejected it, shadow would go untested: %v", c, err)
+			continue
+		}
+		out, err := runGuardedCommand(t, c)
+		if err == nil {
+			t.Errorf("%q: want refusal (nonzero exit), command succeeded", c)
+			continue
+		}
+		if !strings.Contains(out, "refusing to kill the octo server process") {
+			t.Errorf("%q: want refusal message, got %q (err=%v)", c, out, err)
+		}
+	}
+}
+
+// TestKillGuardShadow_AllowsUnrelatedTargets: the shadow must stay invisible
+// for commands that do not target the server — no refusal message, and the
+// command's own result (success or the shell's own error) is preserved.
+func TestKillGuardShadow_AllowsUnrelatedTargets(t *testing.T) {
+	SetServerGuard(true)
+	defer SetServerGuard(false)
+
+	allowed := []string{
+		"kill 999999999",                         // some unrelated, nonexistent pid
+		"pkill -x definitely_no_such_proc_xyz",   // matches nothing
+		"killall definitely_no_such_proc_xyz",    // matches nothing
+		"git commit -m \"fix pkill regression\"", // kill-word inside an argument
+	}
+	for _, c := range allowed {
+		out, _ := runGuardedCommand(t, c)
+		if strings.Contains(out, "refusing to kill the octo server process") {
+			t.Errorf("%q: must not be refused, got %q", c, out)
+		}
+	}
+
+	// A benign command runs through the wrapper untouched.
+	out, err := runGuardedCommand(t, "echo hello-guard")
+	if err != nil || !strings.Contains(out, "hello-guard") {
+		t.Errorf("echo through wrapper: out=%q err=%v", out, err)
+	}
+}
+
+// TestKillGuardShadow_GuardOffIsInert: with the guard disarmed (plain CLI/TUI
+// usage) the shadows are no-ops — no OCTO_SERVER_PID is exported and nothing
+// is refused.
+func TestKillGuardShadow_GuardOffIsInert(t *testing.T) {
+	SetServerGuard(false)
+
+	cmd, err := shellCommand(context.Background(), "echo hi")
+	if err != nil {
+		t.Fatalf("shellCommand: %v", err)
+	}
+	for _, kv := range cmd.Env {
+		if strings.HasPrefix(kv, "OCTO_SERVER_PID=") || strings.HasPrefix(kv, "OCTO_GUARD_MSG=") {
+			t.Errorf("guard off: env must not arm the shadow, found %q", kv)
+		}
+	}
+
+	out, _ := runGuardedCommand(t, "kill 999999999")
+	if strings.Contains(out, "refusing to kill the octo server process") {
+		t.Errorf("guard off: nothing may be refused, got %q", out)
+	}
+}

--- a/internal/tools/server_guard_shadow_test.go
+++ b/internal/tools/server_guard_shadow_test.go
@@ -9,19 +9,6 @@ import (
 	"testing"
 )
 
-// runGuardedCommand builds and runs a terminal command through shellCommand
-// with the self-kill guard armed, returning the combined output and the
-// process error (non-nil on refusal as well as on ordinary command failure).
-func runGuardedCommand(t *testing.T, command string) (string, error) {
-	t.Helper()
-	cmd, err := shellCommand(context.Background(), command)
-	if err != nil {
-		t.Fatalf("shellCommand(%q) failed to build: %v", command, err)
-	}
-	out, runErr := cmd.CombinedOutput()
-	return string(out), runErr
-}
-
 func TestGuardEnv_ArmedOnlyWhenGuardOn(t *testing.T) {
 	SetServerGuard(false)
 	if got := guardEnv(); len(got) != 0 {
@@ -51,18 +38,24 @@ func TestGuardEnv_ArmedOnlyWhenGuardOn(t *testing.T) {
 // expands a variable or after pkill resolves a name/pattern at runtime. The
 // commands are chosen to slip past guardServerSelfKill so the refusal
 // provably comes from the runtime shadow.
+//
+// Every case uses signal 0 (existence probe): the shadow's decision path is
+// signal-independent, but if the shadow ever regresses the real command sends
+// no signal — the assertion fails cleanly instead of the test run killing
+// itself mid-flight.
 func TestKillGuardShadow_BlocksExpandedSelfKill(t *testing.T) {
 	SetServerGuard(true)
 	defer SetServerGuard(false)
 
 	self := strconv.Itoa(serverSelfPID)
 	blocked := []string{
-		"P=$(echo " + self + "); kill $P",         // variable indirection
-		"P=$(echo " + self + "); kill -s TERM $P", // signal spec consuming an arg
-		"P=$(echo " + self + "); kill -n 9 $P",    // -n form
-		"pkill -f tools.test",                     // -f pattern without the word "octo"
-		"pkill -x tools.test",                     // exact name
-		"killall tools.test",                      // killall by name
+		"P=$(echo " + self + "); kill -0 $P",     // variable indirection
+		"P=$(echo " + self + "); kill -s 0 $P",   // signal spec consuming an arg
+		"P=$(echo " + self + "); kill -n 0 $P",   // -n form
+		"P=$(echo " + self + "); kill -0 -- -$P", // negative pid: whole process group
+		"pkill -0 -f tools.test",                 // -f pattern without the word "octo"
+		"pkill -0 -x tools.test",                 // exact name
+		"killall -0 tools.test",                  // killall by name
 	}
 	for _, c := range blocked {
 		// Prove the command actually reaches the runtime shadow: the textual
@@ -111,9 +104,15 @@ func TestKillGuardShadow_AllowsUnrelatedTargets(t *testing.T) {
 
 // TestKillGuardShadow_GuardOffIsInert: with the guard disarmed (plain CLI/TUI
 // usage) the shadows are no-ops — no OCTO_SERVER_PID is exported and nothing
-// is refused.
+// is refused. Guard variables inherited from a parent process (a nested octo
+// run from a guarded server's own terminal command) are scrubbed rather than
+// passed through, so the invariant holds regardless of environment hygiene.
 func TestKillGuardShadow_GuardOffIsInert(t *testing.T) {
 	SetServerGuard(false)
+
+	// Simulate a stale parent value; it must not survive into the command env.
+	t.Setenv("OCTO_SERVER_PID", "4242")
+	t.Setenv("OCTO_GUARD_MSG", "stale parent refusal")
 
 	cmd, err := shellCommand(context.Background(), "echo hi")
 	if err != nil {

--- a/internal/tools/server_guard_shadow_windows_test.go
+++ b/internal/tools/server_guard_shadow_windows_test.go
@@ -1,0 +1,136 @@
+//go:build windows
+
+package tools
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// startGuardDecoy starts a disposable process under a unique image name (a
+// copy of cmd.exe running ping) and returns its pid. The Windows shadow tests
+// protect the DECOY rather than the test process itself: if the shadow ever
+// regresses, the real Stop-Process/taskkill can only hit the decoy — the test
+// then fails on the missing refusal message instead of the run killing itself.
+func startGuardDecoy(t *testing.T) int {
+	t.Helper()
+	sysroot := os.Getenv("SystemRoot")
+	if sysroot == "" {
+		t.Skip("no SystemRoot; cannot stage the decoy binary")
+	}
+	src, err := os.ReadFile(filepath.Join(sysroot, "System32", "cmd.exe"))
+	if err != nil {
+		t.Skipf("cannot read cmd.exe to stage the decoy: %v", err)
+	}
+	exe := filepath.Join(t.TempDir(), "octoguarddecoy.exe")
+	if err := os.WriteFile(exe, src, 0o755); err != nil {
+		t.Fatalf("staging decoy: %v", err)
+	}
+	cmd := exec.Command(exe, "/c", "ping", "-n", "120", "127.0.0.1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting decoy: %v", err)
+	}
+	// Registered after t.TempDir(), so this runs first (LIFO) and releases the
+	// exe file lock before the directory is removed.
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd.Process.Pid
+}
+
+// protectPid points the guard at pid instead of the test process, restoring
+// the real values on cleanup. The supervisor slot is parked at 1 (never
+// protected) so exactly one pid is under guard.
+func protectPid(t *testing.T, pid int) {
+	t.Helper()
+	origSelf, origSuper := serverSelfPID, serverSuperPID
+	serverSelfPID, serverSuperPID = pid, 1
+	t.Cleanup(func() { serverSelfPID, serverSuperPID = origSelf, origSuper })
+}
+
+// TestKillGuardShadowWindows_BlocksResolvedSelfKill is the Windows
+// counterpart of TestKillGuardShadow_BlocksExpandedSelfKill: targets that
+// only become concrete after PowerShell expands a variable or Get-Process
+// resolves a name must be refused by the Stop-Process/taskkill shadows.
+// Stop-Process cases carry -WhatIf so a shadow regression performs no kill;
+// taskkill has no dry-run, but its only possible victim is the decoy.
+func TestKillGuardShadowWindows_BlocksResolvedSelfKill(t *testing.T) {
+	decoy := startGuardDecoy(t)
+	protectPid(t, decoy)
+	SetServerGuard(true)
+	defer SetServerGuard(false)
+
+	blocked := []string{
+		fmt.Sprintf("Stop-Process -Id %d -WhatIf", decoy),          // literal id
+		fmt.Sprintf("$p = %d; Stop-Process -Id $p -WhatIf", decoy), // variable expansion
+		fmt.Sprintf("$p = %d; kill -Id $p -WhatIf", decoy),         // kill alias resolves to the shadow
+		"Stop-Process -Name octoguarddecoy -WhatIf",                // name resolved via Get-Process
+		fmt.Sprintf("taskkill /PID %d", decoy),                     // taskkill function shadow
+		fmt.Sprintf("taskkill.exe /PID %d", decoy),                 // extension-qualified spelling (alias)
+		"taskkill /F /IM octoguarddecoy.exe",                       // image name resolved via Get-Process
+	}
+	for _, c := range blocked {
+		// The refusal must come from the runtime shadow: the textual guard
+		// does not understand PowerShell verbs and must pass these.
+		if err := guardServerSelfKill(c); err != nil {
+			t.Errorf("%q: textual guard rejected it, shadow would go untested: %v", c, err)
+			continue
+		}
+		out, err := runGuardedCommand(t, c)
+		if err == nil {
+			t.Errorf("%q: want refusal (nonzero exit), command succeeded", c)
+			continue
+		}
+		if !strings.Contains(out, "refusing to kill the octo server process") {
+			t.Errorf("%q: want refusal message, got %q (err=%v)", c, out, err)
+		}
+	}
+}
+
+// TestKillGuardShadowWindows_AllowsUnrelatedTargets: commands that do not
+// target a guarded pid pass through the shadows unrefused.
+func TestKillGuardShadowWindows_AllowsUnrelatedTargets(t *testing.T) {
+	decoy := startGuardDecoy(t)
+	protectPid(t, decoy)
+	SetServerGuard(true)
+	defer SetServerGuard(false)
+
+	allowed := []string{
+		"Stop-Process -Id 999999999 -WhatIf",             // unrelated, nonexistent pid
+		"Stop-Process -Name no_such_proc_xyz -WhatIf",    // matches nothing
+		"taskkill /PID 999999999",                        // unrelated pid; fails on its own terms
+		"Write-Output 'taskkill /IM octo.exe regressed'", // kill-words inside a string argument
+	}
+	for _, c := range allowed {
+		out, _ := runGuardedCommand(t, c)
+		if strings.Contains(out, "refusing to kill the octo server process") {
+			t.Errorf("%q: must not be refused, got %q", c, out)
+		}
+	}
+
+	out, err := runGuardedCommand(t, "Write-Output hello-guard")
+	if err != nil || !strings.Contains(out, "hello-guard") {
+		t.Errorf("passthrough through wrapper: out=%q err=%v", out, err)
+	}
+}
+
+// TestKillGuardShadowWindows_GuardOffIsInert: with the guard disarmed the
+// shadows are no-ops, and stale guard variables inherited from a parent
+// process are scrubbed rather than arming them.
+func TestKillGuardShadowWindows_GuardOffIsInert(t *testing.T) {
+	decoy := startGuardDecoy(t)
+	SetServerGuard(false)
+
+	t.Setenv("OCTO_SERVER_PID", fmt.Sprint(decoy))
+	t.Setenv("OCTO_GUARD_MSG", "stale parent refusal")
+
+	out, _ := runGuardedCommand(t, fmt.Sprintf("Stop-Process -Id %d -WhatIf", decoy))
+	if strings.Contains(out, "refusing to kill the octo server process") {
+		t.Errorf("guard off: nothing may be refused, got %q", out)
+	}
+}

--- a/internal/tools/server_guard_test.go
+++ b/internal/tools/server_guard_test.go
@@ -29,6 +29,8 @@ func TestGuardServerSelfKill_Blocks(t *testing.T) {
 		"kill " + self,
 		"kill -9 " + self,
 		"kill -TERM " + super,
+		"kill -- -" + self, // negative pid: the server's own process group
+		"kill -TERM -- -" + super,
 		"kill $(pgrep octo)",
 		"kill $(pidof octo)",
 	}


### PR DESCRIPTION
## Problem

The self-kill guard in `octo serve` is purely textual (`guardServerSelfKill`): it scans the command string before execution. Kill targets that only materialize **after shell expansion** slip through:

- `P=$(pgrep octo)` in an earlier command, then `kill $P` — the guard sees the literal `$P`
- `pkill -f serve` / `pkill -x octo` — no literal `octo` in the command for the name regex to catch
- `kill $(cat /tmp/pidfile)` and similar indirections

## Fix

Add a second, runtime layer using the same shadow-function mechanism as `safeRmWrapper` — target pids are checked **after** the shell has expanded variables and command substitutions:

**POSIX** (`posixKillGuardWrapper`): shadow `kill` / `pkill` / `killall` in the injected shell.
- `kill` args are scanned post-expansion against the protected pid set (signal specs `-s/-n/--signal` and flags excluded); a **negative pid** (`kill -- -PGID`, whole process group) is compared by its digits — a daemonized server leads its own group, so its pid doubles as a killable pgid, and signal numbers never reach pid range so the exact match cannot false-positive
- `pkill` / `killall` patterns are matched locally against `ps` output for **just the protected pids** — deliberately *not* via pgrep: on macOS, pgrep/pkill cannot see their own ancestors (the server is the wrapper's ancestor, so macOS pkill couldn't hit it anyway), while procps on Linux has no such blind spot — exactly where the guard matters
- Only simple invocation shapes are resolved (`[signal] [-f] [-x] pattern`, `killall name`); richer matching flags fail open

**Windows** (`windowsKillGuardWrapper`): shadow `Stop-Process` (covers its `kill` alias) and `taskkill` — plus a `taskkill.exe` alias so the extension-qualified spelling resolves to the shadow too — resolving `-Id`/`/PID` directly and `-Name`/`/IM` via `Get-Process`.

The textual guard also gains the negative-pid check (`kill -- -<protected>`), since it alone covers the `--sandbox` branch where no wrapper is injected.

The protected pids (server + supervisor) and the refusal message are exported as `OCTO_SERVER_PID` / `OCTO_SERVER_PPID` / `OCTO_GUARD_MSG` **only when the server guard is armed**. Any inherited copies of these variables are scrubbed first, so a nested octo (run from a guarded server's own terminal command) never arms its shadows with a stale, possibly pid-recycled parent set — guard-off inertness holds regardless of environment hygiene. Plain CLI/TUI usage is behavior-identical.

## Testing

- `server_guard_shadow_test.go` executes the real wrapped shell: variable-indirection kills, signal-spec forms, negative-pid/process-group form, `pkill -f/-x`, `killall` — all provably rejected by the runtime shadow (each case is asserted to pass the textual guard first, so the refusal can't come from it). **Every blocked case uses signal 0**: the shadow's decision path is signal-independent, but a shadow regression then sends no signal — the test fails cleanly instead of killing its own run
- `server_guard_shadow_windows_test.go` runs the PowerShell shadows on the CI Windows runners: a uniquely named decoy process (staged copy of cmd.exe) is protected instead of the test process, and Stop-Process cases carry `-WhatIf` — a regression can at worst touch the decoy. Covers literal/variable `-Id`, the `kill` alias, `-Name` and `/IM` resolution via Get-Process, `taskkill` and `taskkill.exe`, pass-through, and guard-off inertness incl. stale-env scrubbing
- Pass-through cases verified: unrelated pids, non-matching patterns, kill-words inside quoted arguments, guard-off inertness
- Manual smoke on macOS including the ancestor-blind-pgrep scenario and benign `pkill` pass-through
- `make test` green (race), `make vet` / `make fmt-check` clean, `GOOS=windows go vet ./internal/tools/` clean

## Known residual gaps (accepted: this guards reflexive model behavior, not an adversary)

- Function shadows only intercept shell-function dispatch: `/bin/kill`, `command kill`, dispatch via `env`/`xargs`, nested shells (`sh -c 'kill …'`), and commands written to a script file then executed all bypass them
- `--sandbox` still relies on the textual guard only
- pkill with rich matching flags (`-u`, `-P`, `-t`, `-n`, `-o`, `-v`) fails open
- Windows pipeline input (`Get-Process octo | Stop-Process`), `taskkill /FI` filters, and abbreviated/colon-joined parameter forms (`-Nam octo`, `-Id:123`) are not resolved and fail open