### PR TITLE
docs: remove the LINUX DO community acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,6 @@ octo 站在两个项目的肩膀上，这点不遮掩：**[Claude Code](https://
 
 完整记录见 [contributors 图表](https://github.com/open-octo/octo-agent/graphs/contributors)。
 
-## 社区鸣谢
-
-感谢 [LINUX DO 社区](https://linux.do) 对开源交流与项目成长的支持。
-
 ## 许可
 
 MIT。见 [`LICENSE.txt`](LICENSE.txt)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -208,11 +208,6 @@ Thanks to everyone who has contributed to octo:
 
 The full record lives in the [contributors graph](https://github.com/open-octo/octo-agent/graphs/contributors).
 
-## Community acknowledgement
-
-Thanks to the [LINUX DO community](https://linux.do) for supporting open-source
-exchange and this project's growth.
-
 ## License
 
 MIT. See [`LICENSE.txt`](LICENSE.txt).


### PR DESCRIPTION
Removes the community acknowledgement section (added in #2031) from both READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)