### PR TITLE
fix(web): large font size clipped the page bottom

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -410,8 +410,11 @@
 <Toast />
 
 <style>
+/* height 100% (via the html/body/#app chain), NOT 100vh: viewport units are
+   not compensated for the root zoom the font-size setting applies, so 100vh
+   under zoom 1.1 paints 110% of the viewport and clips the composer. */
 .app {
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
   background: var(--bg-layout);
@@ -430,7 +433,7 @@
   min-height: 0;
 }
 .splash {
-  height: 100vh; display: flex; align-items: center; justify-content: center;
+  height: 100%; display: flex; align-items: center; justify-content: center;
   background: var(--bg-layout);
 }
 .splash-msg {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -15,6 +15,11 @@
    Any var a pack omits falls back to the default pack, so packs can be partial.
    ────────────────────────────────────────────────────────────────────────── */
 :root {
+  /* Written by the font-size setting alongside the root CSS zoom. Viewport
+     units are NOT compensated for zoom, so viewport-sized lengths must use
+     calc(Nvh / var(--font-zoom)) to land back on the real viewport. */
+  --font-zoom: 1;
+
   /* Primary */
   --blue-1: #E5F2FF;
   --blue-2: #B3D7FF;

--- a/web/src/components/ArtifactModal.svelte
+++ b/web/src/components/ArtifactModal.svelte
@@ -114,9 +114,12 @@
   display: flex; align-items: center; justify-content: center;
   padding: 12px;
 }
+/* Percentages of the fixed inset:0 backdrop, NOT vw/vh: viewport units are
+   not compensated for the root zoom the font-size setting applies, so 94vh
+   under zoom 1.1 would overflow the screen. */
 .modal {
-  width: min(1400px, 96vw);
-  height: 94vh;
+  width: min(1400px, 96%);
+  height: 94%;
   min-width: 320px;
   background: var(--bg-container);
   border: 1px solid var(--border-secondary);
@@ -128,9 +131,9 @@
 }
 /* Small desktop window / narrow viewport: fill the screen, drop the chrome */
 @media (max-width: 900px), (max-height: 600px) {
-  .backdrop { padding: 8px; }
+  .backdrop { padding: 0; }
   .modal {
-    width: 100vw; height: 100vh; max-width: none; max-height: none;
+    width: 100%; height: 100%; max-width: none; max-height: none;
     border-radius: 0; border: none;
   }
 }

--- a/web/src/components/overlays/AgentDetailModal.svelte
+++ b/web/src/components/overlays/AgentDetailModal.svelte
@@ -138,7 +138,7 @@
 .modal-body {
   padding: 0 20px 16px;
   display: flex; flex-direction: column; gap: 16px;
-  max-height: 50vh; overflow-y: auto;
+  max-height: calc(50vh / var(--font-zoom)); overflow-y: auto;
 }
 h4 { margin: 0 0 8px; font-size: 12px; font-weight: 600; color: var(--text-tertiary); }
 .desc-text { margin: 0; font-size: 13px; line-height: 1.6; color: var(--text-secondary); }

--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -201,7 +201,7 @@
 .backdrop {
   position: fixed; inset: 0; z-index: 1000;
   background: var(--scrim);
-  display: flex; align-items: flex-start; justify-content: center; padding-top: 12vh;
+  display: flex; align-items: flex-start; justify-content: center; padding-top: calc(12vh / var(--font-zoom));
 }
 .palette {
   width: 92%; max-width: 520px; background: var(--bg-container);

--- a/web/src/components/overlays/FolderPickerModal.svelte
+++ b/web/src/components/overlays/FolderPickerModal.svelte
@@ -180,7 +180,7 @@
 .modal {
   width: 100%; max-width: 520px;
   display: flex; flex-direction: column;
-  max-height: 70vh;
+  max-height: calc(70vh / var(--font-zoom));
   background: var(--bg-container);
   border: 1px solid var(--border);
   border-radius: 12px;

--- a/web/src/components/overlays/QuestionModal.svelte
+++ b/web/src/components/overlays/QuestionModal.svelte
@@ -294,7 +294,7 @@
     margin: 0;
     font-size: 14px; line-height: 1.6; color: var(--text-secondary);
     white-space: pre-wrap; word-break: break-word;
-    max-height: 40vh; overflow-y: auto;
+    max-height: calc(40vh / var(--font-zoom)); overflow-y: auto;
   }
   .options { display: flex; flex-wrap: wrap; gap: 10px; }
   .custom-input-wrap { display: flex; }

--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -247,7 +247,11 @@
   }
 
   $effect(() => {
-    ;(document.documentElement.style as any).zoom = fontZoomMap[fontSize] ?? '1'
+    const zoom = fontZoomMap[fontSize] ?? '1'
+    ;(document.documentElement.style as any).zoom = zoom
+    // Viewport units are not compensated for zoom — publish the factor so
+    // vh/vw-sized boxes can divide themselves back onto the real viewport.
+    document.documentElement.style.setProperty('--font-zoom', zoom)
     localStorage.setItem('octo.fontSize', fontSize)
   })
 
@@ -539,7 +543,7 @@
   /* Fixed height (not max-height) so switching between categories with very
      different content lengths (关于 vs 端点) never resizes the modal itself
      — each pane scrolls internally instead. */
-  width: 100%; max-width: 760px; height: 78vh;
+  width: 100%; max-width: 760px; height: calc(78vh / var(--font-zoom));
   background: var(--bg-container); border: 1px solid var(--border); border-radius: var(--radius-card);
   box-shadow: 0 24px 48px rgba(15,23,42,0.18);
   display: flex; flex-direction: column; overflow: hidden;

--- a/web/src/mobile/QuestionOverlay.svelte
+++ b/web/src/mobile/QuestionOverlay.svelte
@@ -228,7 +228,7 @@
   .qo-card {
     pointer-events: auto;
     width: 100%;
-    max-height: 90vh;
+    max-height: calc(90vh / var(--font-zoom));
     overflow-y: auto;
     display: flex;
     flex-direction: column;

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -2548,7 +2548,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
    scrollable conversation underneath rather than hiding it. Cap the height so a
    long plan scrolls inside the bar instead of swallowing the message area. */
 .session-tasks .plan-steps {
-  max-height: min(320px, 40vh);
+  max-height: min(320px, calc(40vh / var(--font-zoom)));
   overflow-y: auto;
 }
 
@@ -2962,7 +2962,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 }
 .modal {
   background: var(--bg-container); border: 1px solid var(--border-secondary);
-  border-radius: 12px; width: 520px; max-width: 90vw; box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  border-radius: 12px; width: 520px; max-width: calc(90vw / var(--font-zoom)); box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
 }
 .modal-header {
   display: flex; align-items: center; justify-content: space-between;

--- a/web/src/views/WorkflowsView.svelte
+++ b/web/src/views/WorkflowsView.svelte
@@ -223,7 +223,7 @@
   display: flex; align-items: center; justify-content: center; cursor: pointer; color: var(--text-tertiary);
 }
 .modal-close:hover { background: var(--hover-neutral); color: var(--text); }
-.modal-body { padding: 20px 24px; max-height: 60vh; overflow-y: auto; }
+.modal-body { padding: 20px 24px; max-height: calc(60vh / var(--font-zoom)); overflow-y: auto; }
 .modal-footer {
   padding: 16px 24px 20px; display: flex; align-items: center; justify-content: flex-end; gap: 8px;
   border-top: 1px solid var(--border-table);


### PR DESCRIPTION
## Problem

User report: selecting the **Large** font size cuts off the bottom of the page — the composer is half-hidden.

The font-size setting is implemented as CSS `zoom` on `<html>` (0.9 / 1 / 1.1). Per css-viewport, viewport units are **not** compensated for zoom: under `zoom: 1.1` a `height: 100vh` box paints 110% of the viewport, pushing the bottom 10% (the composer) off screen. Small (0.9) leaves a 10% dead strip instead, just less visible.

Verified empirically in headless Chrome (root `zoom: 1.1`, viewport 713px): a `100vh` element measures 784px (713 × 1.1), a `100%` element exactly 713px, and a `calc(100vh / 1.1)` element exactly 713px.

## Fix

Two complementary mechanisms:

**Percentages where a zoom-safe chain exists** — percentage lengths resolve against the already-zoom-adjusted ancestor box:

- `App.svelte` — `.app` and `.splash`: `100vh` → `100%` (the `html/body/#app` chain is already `height: 100%`).
- `ArtifactModal.svelte` — `.modal`: `94vh`/`96vw` → percentages of the `position: fixed; inset: 0` backdrop (constraint-based, zoom-safe); the narrow-viewport full-bleed rule: `100vw/100vh` → `100%` with backdrop padding dropped to keep the edge-to-edge fill.

**`--font-zoom` compensation everywhere else** — `max-height` caps and offsets whose containing block has no definite height can't use percentages. The settings effect now publishes the zoom factor as `--font-zoom` on the root (declared `1` in `:root` as the default), and every remaining vh/vw length divides by it: `calc(Nvh / var(--font-zoom))`. Covers SettingsModal (78vh), FolderPickerModal (70vh), WorkflowsView (60vh), AgentDetailModal (50vh), QuestionModal (40vh), mobile QuestionOverlay (90vh), CommandPalette (12vh top offset), and ChatView (40vh plan cap, 90vw modal cap).

## Testing

- `vite build` + `svelte-check` (0 errors) in the worktree.
- Headless-Chrome measurements above confirm both mechanisms land exactly on the real viewport under zoom 1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known behavior delta (reviewed, accepted)

At default Medium (zoom 1) the artifact modal is ~3% smaller than before: `94%/96%` resolve against the backdrop's content box (viewport minus its 12px padding), while the old `94vh/96vw` competed with that padding. The new value is arguably the intended geometry; noted here for the record.
