### PR TITLE
fix(web): make the sidebar session running indicator actually work

### DIFF
--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -291,6 +291,12 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (sessionID st
 	runCtx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxKeySessionID{}, sessionID))
 	runCtx = tools.WithSessionID(runCtx, sessionID)
 	s.registerInterrupt(sessionID, cancel)
+	// Global running-state pair: cron fires session_created before this turn
+	// body runs, which makes every tab refresh its session list and seed
+	// status "running" — without the paired turn_ended, an unsubscribed tab's
+	// sidebar spinner would stick forever (session_update below only reaches
+	// subscribers).
+	defer s.broadcastTurnActivityStart(sessionID)()
 	defer func() {
 		cancel()
 		s.interruptMu.Lock()

--- a/internal/server/turn_activity_test.go
+++ b/internal/server/turn_activity_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/scheduler"
 )
 
 // TestDoAgentTurn_BroadcastsRunningActivityPair: the sidebar's running spinner
@@ -48,5 +50,47 @@ func TestDoAgentTurn_BroadcastsRunningActivityPair(t *testing.T) {
 	})
 	if ended["session_id"] != sess.ID {
 		t.Fatalf("turn_ended session_id = %v, want %v", ended["session_id"], sess.ID)
+	}
+}
+
+// TestRunTask_BroadcastsRunningActivityPair: the scheduled-task turn body is a
+// separate runner from doAgentTurn but registers an interrupt the same way, so
+// sessionStatus reports "running" for its duration — and cron's session_created
+// broadcast makes every tab refresh its list mid-run and seed that status.
+// Without the same global pair, an unsubscribed tab's spinner would stick
+// forever once the task finished.
+func TestRunTask_BroadcastsRunningActivityPair(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.sender = erroringSender{}
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]queuedTurn)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sessionID, err := srv.CreateSession(scheduler.Task{Name: "t"})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Registered but never subscribed — only a global broadcast can reach it.
+	other := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.wsHub.register <- other
+
+	if _, err := srv.RunTask(context.Background(), scheduler.Task{Name: "t", Prompt: "will fail", SessionID: sessionID}); err == nil {
+		t.Fatal("RunTask should surface the provider error")
+	}
+
+	started := drainForEvent(t, other, func(ev map[string]any) bool {
+		return ev["type"] == "session_activity" && ev["kind"] == "turn_started"
+	})
+	if started["session_id"] != sessionID {
+		t.Fatalf("turn_started session_id = %v, want %v", started["session_id"], sessionID)
+	}
+	ended := drainForEvent(t, other, func(ev map[string]any) bool {
+		return ev["type"] == "session_activity" && ev["kind"] == "turn_ended"
+	})
+	if ended["session_id"] != sessionID {
+		t.Fatalf("turn_ended session_id = %v, want %v", ended["session_id"], sessionID)
 	}
 }

--- a/internal/server/turn_activity_test.go
+++ b/internal/server/turn_activity_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+)
+
+// TestDoAgentTurn_BroadcastsRunningActivityPair: the sidebar's running spinner
+// on tabs NOT subscribed to the session is driven by the global
+// session_activity turn_started/turn_ended pair (session_update carries status
+// only to subscribers). turn_ended rides a defer, so the pair must arrive even
+// when the turn errors out — otherwise a failed turn leaves the session stuck
+// "running" in every other tab's sidebar. Uses erroringSender to exercise
+// exactly that path.
+func TestDoAgentTurn_BroadcastsRunningActivityPair(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.sender = erroringSender{}
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]queuedTurn)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Title = "fixed title"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Registered but never subscribed — only a global broadcast can reach it.
+	other := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.wsHub.register <- other
+
+	srv.doAgentTurn(sess, "question", nil, nil)
+
+	started := drainForEvent(t, other, func(ev map[string]any) bool {
+		return ev["type"] == "session_activity" && ev["kind"] == "turn_started"
+	})
+	if started["session_id"] != sess.ID {
+		t.Fatalf("turn_started session_id = %v, want %v", started["session_id"], sess.ID)
+	}
+	ended := drainForEvent(t, other, func(ev map[string]any) bool {
+		return ev["type"] == "session_activity" && ev["kind"] == "turn_ended"
+	})
+	if ended["session_id"] != sess.ID {
+		t.Fatalf("turn_ended session_id = %v, want %v", ended["session_id"], sess.ID)
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -757,6 +757,10 @@ func (s *Server) wsCompactSession(sid string) {
 		ctx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxKeySessionID{}, sid))
 		ctx = tools.WithSessionID(ctx, sid)
 		s.registerInterrupt(sid, cancel)
+		// Compaction holds an interrupt registration too, so sessionStatus
+		// reports "running" for its duration — a session list fetched meanwhile
+		// seeds other tabs' spinners, and only this global pair clears them.
+		defer s.broadcastTurnActivityStart(sid)()
 		defer func() {
 			cancel()
 			s.interruptMu.Lock()
@@ -1468,6 +1472,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// kickIdleSteerTurn, which also flow through here.
 	runCtx = tools.WithWaker(runCtx, s.wakerFor(sess.ID))
 	s.registerInterrupt(sess.ID, cancel)
+	defer s.broadcastTurnActivityStart(sess.ID)()
 	defer func() {
 		cancel()
 		s.interruptMu.Lock()
@@ -1481,23 +1486,6 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		"type":       "session_update",
 		"session_id": sess.ID,
 		"status":     "running",
-	})
-
-	// Cross-session running-state pair for the sidebar's activity spinner:
-	// session_update above only reaches tabs subscribed to this session, so a
-	// tab looking at another session needs a global signal. turn_ended rides a
-	// defer so no exit path (early tool-prep error, interrupt, panic) leaves a
-	// session stuck "running". turn_complete stays separate — it means "clean
-	// completion" and drives the desktop notification.
-	s.wsHub.broadcast("", wsEventSessionActivity{
-		Type:      "session_activity",
-		SessionID: sess.ID,
-		Kind:      "turn_started",
-	})
-	defer s.wsHub.broadcast("", wsEventSessionActivity{
-		Type:      "session_activity",
-		SessionID: sess.ID,
-		Kind:      "turn_ended",
 	})
 
 	a := s.buildAgent(sess)
@@ -2289,6 +2277,32 @@ func (s *Server) registerInterrupt(sessionID string, cancel context.CancelFunc) 
 	s.interruptMu.Lock()
 	s.interrupts[sessionID] = cancel
 	s.interruptMu.Unlock()
+}
+
+// broadcastTurnActivityStart emits the global session_activity turn_started
+// signal and returns the matching turn_ended emitter. session_update{status}
+// only reaches tabs subscribed to the session, so this pair is what keeps the
+// sidebar's running spinner honest on every other tab. Every body that
+// registers an interrupt (doAgentTurn, RunTask, compaction) must call this
+// right after registerInterrupt and defer the returned func BEFORE the
+// interrupt-unregister defer — LIFO runs the unregister first, so a status
+// snapshot taken after turn_ended can never still report "running". The defer
+// also guarantees the pair survives every exit path (early tool-prep error,
+// interrupt, panic): an unpaired turn_started would stick a session spinning
+// in other tabs' sidebars forever.
+func (s *Server) broadcastTurnActivityStart(sessionID string) func() {
+	s.wsHub.broadcast("", wsEventSessionActivity{
+		Type:      "session_activity",
+		SessionID: sessionID,
+		Kind:      "turn_started",
+	})
+	return func() {
+		s.wsHub.broadcast("", wsEventSessionActivity{
+			Type:      "session_activity",
+			SessionID: sessionID,
+			Kind:      "turn_ended",
+		})
+	}
 }
 
 // sessionStatus returns the status string the frontend keys on ("running"

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1483,6 +1483,23 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		"status":     "running",
 	})
 
+	// Cross-session running-state pair for the sidebar's activity spinner:
+	// session_update above only reaches tabs subscribed to this session, so a
+	// tab looking at another session needs a global signal. turn_ended rides a
+	// defer so no exit path (early tool-prep error, interrupt, panic) leaves a
+	// session stuck "running". turn_complete stays separate — it means "clean
+	// completion" and drives the desktop notification.
+	s.wsHub.broadcast("", wsEventSessionActivity{
+		Type:      "session_activity",
+		SessionID: sess.ID,
+		Kind:      "turn_started",
+	})
+	defer s.wsHub.broadcast("", wsEventSessionActivity{
+		Type:      "session_activity",
+		SessionID: sess.ID,
+		Kind:      "turn_ended",
+	})
+
 	a := s.buildAgent(sess)
 	if len(blocks) > 0 {
 		// Image attachments fold into the same user turn as the text when

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -300,7 +300,7 @@ type wsEventDismissConfirmation struct {
 type wsEventSessionActivity struct {
 	Type      string `json:"type"`
 	SessionID string `json:"session_id"`
-	Kind      string `json:"kind"` // "question_pending" | "question_resolved" | "confirm_pending" | "confirm_resolved" | "turn_complete"
+	Kind      string `json:"kind"` // "question_pending" | "question_resolved" | "confirm_pending" | "confirm_resolved" | "turn_started" | "turn_ended" | "turn_complete"
 }
 
 type wsEventBackgroundTaskUpdate struct {

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -111,7 +111,7 @@ type wsEventSessionList struct {
 type wsSessionInfo struct {
 	ID                  string `json:"id"`
 	Name                string `json:"name"`
-	Status              string `json:"status,omitempty"` // "idle" | "working"
+	Status              string `json:"status,omitempty"` // "idle" | "running"
 	CreatedAt           int64  `json:"created_at"`       // unix ms
 	Source              string `json:"source,omitempty"` // "manual" | "cron" | "channel" | "setup"
 	AgentProfile        string `json:"agent_profile,omitempty"`

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -243,6 +243,14 @@
           s.id === sid ? { ...s, pending_confirmation: ev.kind === 'confirm_pending' } : s
         ))
       }
+      // Running-state pair — keeps the sidebar's activity spinner live for
+      // sessions this tab isn't subscribed to (session_update carries status
+      // only to subscribers).
+      if (ev.kind === 'turn_started' || ev.kind === 'turn_ended') {
+        sessions.update(list => list.map(s =>
+          s.id === sid ? { ...s, status: ev.kind === 'turn_started' ? 'running' : 'idle' } : s
+        ))
+      }
       if (ev.kind === 'question_pending' || ev.kind === 'confirm_pending' || ev.kind === 'turn_complete') {
         notifyForSessionActivity(sid, ev.kind)
       }

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -181,7 +181,7 @@
   function sessionIcon(s: any): string {
     if (s.source === 'cron') return 'ant-design:clock-circle-outlined'
     if (s.source === 'channel') return 'ant-design:send-outlined'
-    if (s.status === 'working') return 'ant-design:code-outlined'
+    if (s.status === 'running') return 'ant-design:code-outlined'
     return 'ant-design:message-outlined'
   }
 
@@ -518,7 +518,7 @@
           </span>
           {/if}
 
-          {#if (s as any).status === 'working'}
+          {#if (s as any).status === 'running'}
             <iconify-icon icon="ant-design:loading-outlined" width="14" style="color:var(--blue-6);flex:0 0 auto;animation:octo-spin 0.8s linear infinite"></iconify-icon>
           {:else}
             <iconify-icon icon={icon} width="14" style="color:{solid ? 'var(--blue-6)' : 'var(--text-tertiary)'};flex:0 0 auto"></iconify-icon>

--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -15,7 +15,7 @@
   function sessionIcon(s: any): string {
     if (s.source === 'cron') return 'ant-design:clock-circle-outlined'
     if (s.source === 'channel') return 'ant-design:send-outlined'
-    if (s.status === 'working') return 'ant-design:loading-outlined'
+    if (s.status === 'running') return 'ant-design:loading-outlined'
     return 'ant-design:message-outlined'
   }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -15,7 +15,10 @@ export interface Session {
   updated_at: string
   model: string
   model_id: string
-  status: 'idle' | 'working' | string
+  // "running" while a turn is in flight (see server sessionStatus) — seeded by
+  // session_list, kept live via session_update (subscribed tabs) and the
+  // global session_activity turn_started/turn_ended pair (all tabs).
+  status: 'idle' | 'running' | string
   source: string
   agent_profile: string
   pinned: boolean
@@ -388,7 +391,7 @@ export interface WsEventNextMessageSuggestion {
 export interface WsEventSessionActivity {
   type: 'session_activity'
   session_id: string
-  kind: 'question_pending' | 'question_resolved' | 'confirm_pending' | 'confirm_resolved' | 'turn_complete'
+  kind: 'question_pending' | 'question_resolved' | 'confirm_pending' | 'confirm_resolved' | 'turn_started' | 'turn_ended' | 'turn_complete'
 }
 
 // Discriminated union of all WebSocket event types

--- a/web/src/mobile/feedGroups.ts
+++ b/web/src/mobile/feedGroups.ts
@@ -40,7 +40,7 @@ export const feedGroups = derived(
       // session list), so the feed sees it without subscribing to the session.
       if (s.pending_confirmation) todo.push({ session: s, kind: 'approval' })
       else if (s.pending_question) todo.push({ session: s, kind: 'reply' })
-      else if (s.status === 'working') active.push({ session: s, kind: 'running' })
+      else if (s.status === 'running') active.push({ session: s, kind: 'running' })
       else recent.push({ session: s, kind: 'done' })
     }
 


### PR DESCRIPTION
## Problem

Feature request (with a LiveAgent screenshot as reference): the session list should show a running indicator on sessions with a turn in flight.

It turns out the UI for this **already exists** — `Sidebar.svelte` renders a spinning loading icon in place of the session icon, `CommandPalette` and the mobile feed have their own checks — but all four sites test `status === "working"`, while the server's `sessionStatus()` has only ever emitted `"running"` / `"idle"`. The indicator was dead code from day one.

Two gaps:

1. **Status string mismatch** — frontend checked a value the server never sends.
2. **No cross-session liveness** — `session_update {status}` broadcasts only to tabs subscribed to that session, so a tab looking at session B never learns session A started running. Only `turn_complete` had a global companion.

## Fix

**Frontend** — align the four checks (`Sidebar` ×2, `CommandPalette`, `mobile/feedGroups`) with the wire value `"running"`; update the `Session.status` / `WsEventSessionActivity` types. `App.svelte`'s global `session_activity` handler now maps `turn_started`/`turn_ended` onto `session.status`, the same pattern as the existing `question_pending`/`confirm_pending` handling. This also revives the mobile feed's "running" card grouping, which was dead for the same reason.

**Server** — `doAgentTurn` (the single-turn body shared by the loop, retry, and edit-rerun paths) broadcasts a global `session_activity` pair: `turn_started` after the interrupt is registered, `turn_ended` on a **defer** so no exit path — early tool-prep error return, interrupt, panic — can leave a session stuck spinning in other tabs. `turn_complete` is deliberately untouched: it means *clean* completion and drives the desktop notification; conflating them would fire "finished replying" notifications on errored turns.

Initial state needs no new wiring: `session_list` / REST `GET /api/sessions` already carry `sessionStatus()`, so a freshly opened tab renders in-flight sessions correctly.

## Testing

- New `TestDoAgentTurn_BroadcastsRunningActivityPair`: an **unsubscribed** WS conn receives both `turn_started` and `turn_ended` for an **erroring** turn — locking in both the global reach and the defer pairing on the failure path.
- `go test -race ./internal/server/` green; `go vet`, `gofmt` clean.
- `vite build` + `svelte-check` (0 errors) + `vitest` 144/144 from `web/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-ups (second commit)

An isolated review found that `doAgentTurn` is not the only interrupt-holding turn body — and any body that registers an interrupt makes `sessionStatus()` report `"running"` to list fetches, which can seed other tabs' spinners with nothing global to clear them:

- **`RunTask` (scheduled/cron)** — the worst case: cron broadcasts `session_created` *before* the turn body runs, so every tab refreshes its session list mid-run and seeds `status: "running"`; the task end only notified subscribers. Stuck spinner on every other tab.
- **Compaction** — same mechanism, narrower window.

Extracted `broadcastTurnActivityStart(sessionID) func()` and paired all three bodies. The `turn_ended` defer is registered **before** the interrupt-unregister defer (LIFO runs the unregister first), so a status snapshot taken after `turn_ended` can never still report `"running"`. Also fixed the stale `"idle" | "working"` comment on `wsSessionInfo.Status` — the likely origin of the frontend's dead `'working'` checks.

New `TestRunTask_BroadcastsRunningActivityPair` locks the cron path the same way (unsubscribed conn, erroring turn).
