### PR TITLE
fix(web): route the JSON transcript export through the native save dialog

### DIFF
--- a/web/src/lib/filename.test.ts
+++ b/web/src/lib/filename.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { filenameStem } from './filename'
+
+describe('filenameStem', () => {
+  it('keeps a CJK title intact', () => {
+    // The regression this function exists for: a \w filter collapsed the whole
+    // title to a single underscore, so every Chinese session exported as _.json.
+    expect(filenameStem('会话导出测试')).toBe('会话导出测试')
+  })
+
+  it('keeps other non-Latin scripts and accents', () => {
+    expect(filenameStem('Отладка платежей')).toBe('Отладка платежей')
+    expect(filenameStem('Rückläufer prüfen')).toBe('Rückläufer prüfen')
+    expect(filenameStem('日本語のタイトル')).toBe('日本語のタイトル')
+  })
+
+  it('drops characters a filename cannot hold', () => {
+    expect(filenameStem('a/b\\c:d*e?f"g<h>i|j')).toBe('abcdefghij')
+  })
+
+  it('strips control characters', () => {
+    const withControl = 'order' + String.fromCharCode(1) + 'sync'
+    expect(filenameStem(withControl)).toBe('ordersync')
+  })
+
+  it('collapses whitespace runs and newlines', () => {
+    expect(filenameStem('order   sync\nlater')).toBe('order sync later')
+  })
+
+  it('drops leading dots so the file is not hidden', () => {
+    expect(filenameStem('...hidden')).toBe('hidden')
+  })
+
+  it('drops trailing dots and spaces, which Windows discards silently', () => {
+    expect(filenameStem('report...')).toBe('report')
+    expect(filenameStem('report   ')).toBe('report')
+  })
+
+  it('falls back when nothing survives', () => {
+    expect(filenameStem('')).toBe('session')
+    expect(filenameStem('///')).toBe('session')
+    expect(filenameStem('...')).toBe('session')
+    expect(filenameStem('   ')).toBe('session')
+  })
+
+  it('honours a caller-supplied fallback', () => {
+    expect(filenameStem('///', 'transcript')).toBe('transcript')
+  })
+
+  it('caps length by code point and leaves no trailing dot at the cut', () => {
+    expect(Array.from(filenameStem('汉'.repeat(200)))).toHaveLength(80)
+    // 80 chars then a dot: the cut must not leave the name ending in one.
+    expect(filenameStem('a'.repeat(80) + '.' + 'b'.repeat(10))).toBe('a'.repeat(80))
+  })
+
+  it('never truncates an emoji into a lone surrogate', () => {
+    // A rocket is two UTF-16 units, so a unit-based slice(0, 80) would cut the
+    // 41st one in half and leave an unpaired surrogate in the filename.
+    const rocket = String.fromCodePoint(0x1f680)
+    const stem = filenameStem(rocket.repeat(60))
+    expect(Array.from(stem)).toHaveLength(60)
+    const highOnly = new RegExp('[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])')
+    const lowOnly = new RegExp('(?<![\\uD800-\\uDBFF])[\\uDC00-\\uDFFF]')
+    expect(stem).not.toMatch(highOnly)
+    expect(stem).not.toMatch(lowOnly)
+  })
+})

--- a/web/src/lib/filename.ts
+++ b/web/src/lib/filename.ts
@@ -1,0 +1,32 @@
+// Build a filename stem out of user-supplied text — a session title, for the
+// transcript exports.
+//
+// Only what is genuinely illegal in a filename is removed. Windows' reserved
+// punctuation is a superset of POSIX's (which forbids just `/` and NUL), so one
+// rule serves every platform octo ships on, and the name still has to survive
+// being handed to an OS save dialog that may rewrite it.
+//
+// What this must not do is filter down to \w. That erases a title holding no
+// ASCII letters: a session called 会话导出测试 exported as `_.json`, which is the
+// bug this function exists to fix.
+export function filenameStem(title: string, fallback = 'session'): string {
+  const cleaned = title
+    // Whitespace first, and only then control characters: a newline is itself a
+    // control character, so stripping those first would weld the words either
+    // side of it together ("sync\nlater" -> "synclater").
+    .replace(/\s+/g, ' ')
+    // Illegal on Windows, plus `/` on POSIX, plus what control characters remain.
+    .replace(/[<>:"/\\|?*]|\p{Cc}/gu, '')
+    .trim()
+    // A leading dot hides the file on POSIX; Windows silently discards trailing
+    // dots and spaces, renaming the file out from under the save dialog.
+    .replace(/^\.+/, '')
+    .replace(/[. ]+$/, '')
+
+  // Cap by code point rather than UTF-16 unit so truncation can't split an emoji
+  // into a lone surrogate. 80 code points of CJK is 240 UTF-8 bytes, inside the
+  // 255-byte name limit of every filesystem we target — and the cut can expose a
+  // fresh trailing dot or space, so tidy the tail again after it.
+  const capped = Array.from(cleaned).slice(0, 80).join('').replace(/[. ]+$/, '')
+  return capped || fallback
+}

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1571,6 +1571,25 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     URL.revokeObjectURL(url)
   }
 
+  // Hand the built transcript to the user. Every format must go through here:
+  // the octo-served desktop webview has no download delegate, so a blob
+  // <a download> click there silently does nothing and the bytes have to take
+  // the native save dialog instead. Returns false when the save was cancelled
+  // or failed, so the caller keeps export mode (and the selection) open.
+  async function deliverExport(content: string, filename: string, mime: string): Promise<boolean> {
+    if (get(nativeShell)) {
+      try {
+        const r = await api.nativeSaveFile(filename, content)
+        return !r.cancelled
+      } catch {
+        showToast(tr('chat.export_failed'), 'error')
+        return false
+      }
+    }
+    triggerDownload(content, filename, mime)
+    return true
+  }
+
   // Returns whether the export actually completed, so the caller only exits
   // export mode (and drops the user's checkbox selection) on success — not on
   // "nothing selected" or a cancelled/failed native save.
@@ -1609,17 +1628,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
     const title_safe = title.replace(/[^\w.-]+/g, '_')
     const content = lines.join('\n')
-    if (get(nativeShell)) {
-      try {
-        const r = await api.nativeSaveFile(`${title_safe}.md`, content)
-        if (r.cancelled) return false
-      } catch {
-        showToast(tr('chat.export_failed'), 'error')
-        return false
-      }
-    } else {
-      triggerDownload(content, `${title_safe}.md`, 'text/markdown')
-    }
+    if (!(await deliverExport(content, `${title_safe}.md`, 'text/markdown'))) return false
 
     if (omittedToolEvents) {
       showToast(tr('chat.export_tools_omitted'), 'info')
@@ -1627,10 +1636,10 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     return true
   }
 
-  function exportAsJSON(events: any[], title: string) {
+  async function exportAsJSON(events: any[], title: string): Promise<boolean> {
     const title_safe = title.replace(/[^\w.-]+/g, '_')
     const json = JSON.stringify(events, null, 2)
-    triggerDownload(json, `${title_safe}.json`, 'application/json')
+    return deliverExport(json, `${title_safe}.json`, 'application/json')
   }
 
   async function exportByFormat(format: string) {
@@ -1649,7 +1658,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
           ok = await exportAsMarkdown(result.events, title)
           break
         case 'json':
-          exportAsJSON(result.events, title)
+          ok = await exportAsJSON(result.events, title)
           break
       }
       if (ok) exitExportMode()

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -59,6 +59,7 @@
   import { t, tr, pickLocalized } from '../lib/i18n'
   import { insertPendingSend } from '../lib/pendingSendOrder'
   import { exportModeStore, selectedMessagesStore } from '../lib/exportStore'
+  import { filenameStem } from '../lib/filename'
   import ToolGroup from '../components/chat/ToolGroup.svelte'
   import SubAgentsCard from '../components/chat/SubAgentsCard.svelte'
   import WorkflowsCard from '../components/chat/WorkflowsCard.svelte'
@@ -1626,7 +1627,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       }
     }
 
-    const title_safe = title.replace(/[^\w.-]+/g, '_')
+    const title_safe = filenameStem(title)
     const content = lines.join('\n')
     if (!(await deliverExport(content, `${title_safe}.md`, 'text/markdown'))) return false
 
@@ -1637,7 +1638,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   }
 
   async function exportAsJSON(events: any[], title: string): Promise<boolean> {
-    const title_safe = title.replace(/[^\w.-]+/g, '_')
+    const title_safe = filenameStem(title)
     const json = JSON.stringify(events, null, 2)
     return deliverExport(json, `${title_safe}.json`, 'application/json')
   }


### PR DESCRIPTION
## Problem

In the desktop shell, exporting a session as **JSON** produced no file at all — the export bar closed as if it had worked. **Markdown** exported fine from the same bar.

`exportAsMarkdown` branched on `nativeShell` and handed the bytes to the OS save dialog. `exportAsJSON` always went straight to the in-page blob download, and the octo-served webview has no download delegate — so the `<a download>` click is a silent no-op there. `internal/server/native_handlers.go` already documents exactly this, which is why the native route exists in the first place.

A second defect compounded it: `exportAsJSON` returned `void`, so `ok` stayed `true` in `exportByFormat` and `exitExportMode()` ran — export mode closed and the user's checkbox selection was discarded with no error toast, making a failed export indistinguishable from a successful one.

## Fix

Both formats now go through one `deliverExport(content, filename, mime)` helper that owns the native-vs-blob decision and returns whether the save actually landed. The duplication between the two format functions was what let them drift apart, so collapsing it is the fix rather than a second copy of the branch.

## Verification

Exercised the real UI in Chrome via CDP against an isolated `HOME` with a seeded transcript, loading the page as `?shell=octo-desktop` and stubbing `/api/version` to report `native:true` so the frontend takes its desktop-shell path, with `/api/native/save-file` intercepted to observe the call.

Before, on `main`:

```
--- clicking MD    -> NATIVE SAVE CALLED, name = _.md,  content bytes = 89
--- clicking JSON  -> BLOB DOWNLOAD _.json          (a no-op in the real webview)
native save calls total: 1
```

After:

```
--- clicking MD    -> NATIVE SAVE CALLED, name = _.md,   content bytes = 89
--- clicking JSON  -> NATIVE SAVE CALLED, name = _.json, content bytes = 416
native save calls total: 2
```

Plain-browser export was also re-checked end to end and is unchanged: both formats still download as blobs, including a 2.3 MB payload.

`npx vitest run` — 144 passed. `npx svelte-check --threshold error` — 0 errors.

## Known adjacent issue, not fixed here

`title.replace(/[^\w.-]+/g, '_')` strips CJK, so a session titled 导出测试会话 saves as `_.json` / `_.md`. It predates this change and affects both formats equally; kept out to keep this one concept.