### PR TITLE
chore: bump version to 1.15.8

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.7"
+var Version = "1.15.8"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch over v1.15.7. 13 commits, headlined by the session-export fixes.

**Export** — JSON transcripts produced no file at all in the desktop shell while Markdown worked (#2041); non-ASCII session titles collapsed to a single underscore, so every Chinese session exported as `_.json` (#2041); PDF export added, printing the transcript through the engine's own print pipeline rather than a bundled PDF library (#2042).

**Settings / models** — direct endpoint and model editing in Settings (#2039), catalogue picker for adding models on known providers (#2043).

**Fixes** — the sidebar's running indicator never lit up, because the UI watched for `working` while the server broadcast `running` (#2040); a large font size clipped the page bottom (#2035); self-kill guard bypasses via runtime shell shadows (#2033).

**Chores** — Wails v3, wrangler-action 4, and an npm minor/patch group across three directories (#2036–#2038); contributor and acknowledgement edits in the docs (#2030/#2031/#2034).

version.go only, per the established release flow.