### PR TITLE
fix(web): stop composer textarea from showing a phantom horizontal scrollbar

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -1310,7 +1310,7 @@ textarea {
   border: none; outline: none; resize: none; font-size: 14px; line-height: 1.6;
   font-family: inherit; color: var(--text); background: transparent;
   flex: 1; min-width: 0; margin: 4px 4px 5px;
-  max-height: 156px; overflow-y: hidden; min-height: 24px; /* ≈ MIN_TEXTAREA_PX in autoResize */
+  max-height: 156px; overflow-y: hidden; overflow-x: hidden; min-height: 24px; /* ≈ MIN_TEXTAREA_PX in autoResize */
 }
 .agent-chip {
   display: inline-flex; align-items: center; gap: 6px;


### PR DESCRIPTION
## Summary
- When the settings "Font size" is set to Large (or any non-default value), the chat composer textarea intermittently shows a horizontal gray bar under the placeholder — a phantom scrollbar, not real overflow.
- Root cause: the "font size" setting scales `document.documentElement` via CSS `zoom`. Chrome's default UA style for `<textarea>` is `overflow: auto` on both axes; the composer only ever overrode `overflow-y`, leaving `overflow-x` on `auto`. Under a non-integer zoom factor, subpixel rounding between `scrollWidth`/`clientWidth` is enough to trip `overflow-x: auto` and paint a scrollbar even though nothing actually overflows (confirmed via computed style: `overflow-x` resolves to `auto` before this fix).
- Fix: explicitly set `overflow-x: hidden` on the textarea — it already wraps text and never needs horizontal scrolling.

## Test plan
- [x] `svelte-check` — 0 errors
- [x] Verified via headless Chrome that `<textarea>` with only `overflow-y` set resolves `overflow-x` to `auto` by default; setting `overflow-x: hidden` removes that axis entirely
- [ ] Manual: Settings → General → Font size → Large, confirm no stray scrollbar in the composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)