### PR TITLE
fix(web): close endpoints add-model menu on outside click

### DIFF
--- a/web/src/components/settings/EndpointsSection.svelte
+++ b/web/src/components/settings/EndpointsSection.svelte
@@ -274,8 +274,15 @@
   }
 </script>
 
-<svelte:window onclick={() => (menu = null)} />
-
+<!--
+  SettingsModal's .modal stops click propagation to window (so clicking
+  inside the modal doesn't bubble out and close it as a backdrop click),
+  which means a `<svelte:window onclick>` here never fires. Closing the
+  popover menu on outside clicks has to happen on this component's own
+  root instead, since toggle buttons and menu items already stopPropagation
+  or clear `menu` themselves.
+-->
+<div class="ep-section" onclick={() => (menu = null)}>
 {#if loading}
   <div class="ep-loading">{$t('settings.loading')}</div>
 {:else if view === 'form'}
@@ -564,8 +571,10 @@
     </div>
   {/if}
 {/if}
+</div>
 
 <style>
+.ep-section { display: contents; }
 .ep-loading { padding: 40px; text-align: center; color: var(--text-tertiary); font-size: 14px; }
 
 /* ── list head ── */


### PR DESCRIPTION
## Summary
- The "+ Add model" catalogue popover in Settings → Endpoints didn't close when clicking blank space, because `SettingsModal`'s `.modal` stops click propagation to `window` (to avoid closing the modal like a backdrop click), which silently broke `EndpointsSection`'s `<svelte:window onclick>` used to dismiss the popover.
- Moved the outside-click handler to the component's own root element instead, so it fires on clicks anywhere within the Endpoints tab without depending on bubbling past the modal.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npm run build` — succeeds
- [x] Isolated fake-HOME walkthrough (`octo serve` + headless Chrome CDP): opened Settings → Endpoints, clicked "+ Add model" (dropdown opens), clicked blank space inside the modal, verified the dropdown closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)