### PR TITLE
fix(tools): include free-text answer alongside chosen options

### DIFF
--- a/internal/tools/ask_user_question.go
+++ b/internal/tools/ask_user_question.go
@@ -210,20 +210,29 @@ func (AskUserQuestionTool) Execute(ctx context.Context, _ string, input map[stri
 }
 
 // formatAskResponse turns the asker's structured reply into the text the LLM
-// reads as its tool_result. Three shapes:
+// reads as its tool_result. Four shapes:
 //
-//	cancelled                  → "(user cancelled)"
-//	plain selection(s)         → "User chose: A" or "User chose: A, B"
-//	"Other" with free text     → "User chose: Other — <text>"
+//	cancelled                       → "(user cancelled)"
+//	plain selection(s)              → "User chose: A" or "User chose: A, B"
+//	"Other" with free text          → "User chose: Other — <text>"
+//	selection(s) plus free text     → "User chose: A — <text>"
+//
+// The web UI lets a user pick an option and add free text in the same
+// submission (unlike the TUI/IM askers, which only ever populate one of
+// Choices or Custom), so both fields must be surfaced rather than one
+// silently dropping the other.
 func formatAskResponse(r AskResponse) string {
 	if r.Cancelled {
 		return "(user cancelled)"
 	}
-	if r.Custom != "" && len(r.Choices) == 0 {
-		return "User chose: Other — " + r.Custom
-	}
 	if len(r.Choices) == 0 {
+		if r.Custom != "" {
+			return "User chose: Other — " + r.Custom
+		}
 		return "(user cancelled)" // defensive: no choices and no custom → nothing to report
+	}
+	if r.Custom != "" {
+		return "User chose: " + strings.Join(r.Choices, ", ") + " — " + r.Custom
 	}
 	return "User chose: " + strings.Join(r.Choices, ", ")
 }

--- a/internal/tools/ask_user_question_test.go
+++ b/internal/tools/ask_user_question_test.go
@@ -422,6 +422,8 @@ func TestFormatAskResponse(t *testing.T) {
 		{"single", AskResponse{Choices: []string{"OAuth"}}, "User chose: OAuth"},
 		{"multi", AskResponse{Choices: []string{"a", "b"}}, "User chose: a, b"},
 		{"other", AskResponse{Custom: "Kerberos"}, "User chose: Other — Kerberos"},
+		{"choice plus custom", AskResponse{Choices: []string{"OAuth"}, Custom: "because xxx"}, "User chose: OAuth — because xxx"},
+		{"multi plus custom", AskResponse{Choices: []string{"a", "b"}, Custom: "because xxx"}, "User chose: a, b — because xxx"},
 		{"empty (defensive)", AskResponse{}, "(user cancelled)"},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- `formatAskResponse` handled cancelled / choices-only / custom-only replies, but not the combination of both.
- The web `ask_user_question` modal lets a user pick an option and add free text in the same submission; that combination silently dropped the free text so the model only ever saw the selected option.
- Now formats as `User chose: <choices> — <custom text>` when both are present.

Fixes #2045

## Test plan
- [x] `go test ./internal/tools/ -run TestFormatAskResponse -v`
- [x] `gofmt -l` / `go vet ./internal/tools/...` clean