### PR TITLE
fix(mobile): override transitive uuid to patch CVE-2026-41907

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -2651,14 +2651,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,5 +22,8 @@
     "esbuild": "^0.28.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- `xcode` (a dev dependency of `@capacitor/cli`) pins `uuid@^7.0.3`, in the vulnerable range for [GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq) / CVE-2026-41907 (missing buffer bounds check in `v3()`/`v5()`/`v6()`).
- `xcode` has no newer release with an updated `uuid` range, so this adds an `overrides` entry in `mobile/package.json` to force `uuid` to `^11.1.1` across the tree.
- `xcode` only calls `uuid.v4()`, whose named-export API is unchanged across uuid's major versions, so this is a safe forced upgrade for a dev-only tool.
- Clears Dependabot alert https://github.com/open-octo/octo-agent/security/dependabot/61.

## Test plan
- [x] `npm install` in `mobile/` regenerates the lockfile with `uuid@11.1.1`
- [x] `node -e "require('uuid').v4()"` still works
- [x] `npm run typecheck` passes
- [x] `npm test` passes (19/19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)