### PR TITLE
feat(desktop): bind Cmd/Ctrl+N to new session (Wails shell) + desktop-only shortcut hint

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, sessions, sessionGroups, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell, panelContent, cmdkOpen, settingsModalOpen } from './lib/stores'
+  import { view, sessions, sessionGroups, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell, panelContent, cmdkOpen, settingsModalOpen, createNewSession, isDesktopShell } from './lib/stores'
   import MobileApp from './mobile/MobileApp.svelte'
   import { ws, wsState } from './lib/ws'
   import { notificationsEnabled } from './lib/notifications'
@@ -350,10 +350,19 @@
 
   // Cmd/Ctrl+K toggles the command palette — the Header pill advertises the
   // shortcut, and it fires even while an input has focus (palette convention).
+  // Cmd/Ctrl+N starts a new session — a native desktop-shell bind. Under a
+  // plain browser Cmd+N is a reserved browser shortcut (new window) the page
+  // never sees, so the handler is gated to the Wails shell (isDesktopShell)
+  // where the keypress actually reaches the page and is safe to claim.
   function onGlobalKeydown(e: KeyboardEvent) {
     if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'k') {
       e.preventDefault()
       cmdkOpen.update(v => !v)
+      return
+    }
+    if (isDesktopShell && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'n') {
+      e.preventDefault()
+      createNewSession().catch((err: any) => showToast(err.message, 'error'))
     }
   }
 </script>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -10,6 +10,7 @@
   import * as api from './lib/api'
   import { installExternalLinkInterceptor } from './lib/externalLinks'
   import { normalizeHash } from './lib/hashRouting'
+  import { globalKeyIntent } from './lib/globalKeys'
   import AuthGate from './components/overlays/AuthGate.svelte'
   import FirstRunSetup from './components/overlays/FirstRunSetup.svelte'
   import Header from './components/layout/Header.svelte'
@@ -353,14 +354,14 @@
   // Cmd/Ctrl+N starts a new session — a native desktop-shell bind. Under a
   // plain browser Cmd+N is a reserved browser shortcut (new window) the page
   // never sees, so the handler is gated to the Wails shell (isDesktopShell)
-  // where the keypress actually reaches the page and is safe to claim.
+  // where the keypress actually reaches the page and is safe to claim. The
+  // key→intent mapping lives in lib/globalKeys for unit testing.
   function onGlobalKeydown(e: KeyboardEvent) {
-    if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'k') {
+    const intent = globalKeyIntent(e, { shell: isDesktopShell })
+    if (intent === 'palette') {
       e.preventDefault()
       cmdkOpen.update(v => !v)
-      return
-    }
-    if (isDesktopShell && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'n') {
+    } else if (intent === 'new-session') {
       e.preventDefault()
       createNewSession().catch((err: any) => showToast(err.message, 'error'))
     }

--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -43,7 +43,7 @@
 
   // Static actions (always available)
   const actions = [
-    { id: 'new', icon: 'ant-design:plus-outlined', label: () => $t('nav.new_session'), shortcut: '⌘N', run: () => newSession() },
+    { id: 'new', icon: 'ant-design:plus-outlined', label: () => $t('nav.new_session'), shortcut: '', run: () => newSession() },
     { id: 'agents', icon: 'ant-design:robot-outlined', label: () => $t('nav.agents'), shortcut: '', run: () => goTo('agents') },
     { id: 'skills', icon: 'ant-design:thunderbolt-outlined', label: () => $t('nav.skills'), shortcut: '', run: () => goTo('skills') },
     { id: 'workflows', icon: 'ant-design:partition-outlined', label: () => $t('nav.workflows'), shortcut: '', run: () => goTo('workflows') },

--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cmdkOpen, view, sessions, activeSessionId, skills, openAgentSession, createNewSession, showToast, panelContent, settingsModalOpen } from '../../lib/stores'
+  import { cmdkOpen, view, sessions, activeSessionId, skills, openAgentSession, createNewSession, showToast, panelContent, settingsModalOpen, isDesktopShell } from '../../lib/stores'
   import { t } from '../../lib/i18n'
 
   let query = $state('')
@@ -43,7 +43,7 @@
 
   // Static actions (always available)
   const actions = [
-    { id: 'new', icon: 'ant-design:plus-outlined', label: () => $t('nav.new_session'), shortcut: '', run: () => newSession() },
+    { id: 'new', icon: 'ant-design:plus-outlined', label: () => $t('nav.new_session'), shortcut: isDesktopShell ? '⌘N' : '', run: () => newSession() },
     { id: 'agents', icon: 'ant-design:robot-outlined', label: () => $t('nav.agents'), shortcut: '', run: () => goTo('agents') },
     { id: 'skills', icon: 'ant-design:thunderbolt-outlined', label: () => $t('nav.skills'), shortcut: '', run: () => goTo('skills') },
     { id: 'workflows', icon: 'ant-design:partition-outlined', label: () => $t('nav.workflows'), shortcut: '', run: () => goTo('workflows') },

--- a/web/src/lib/globalKeys.test.ts
+++ b/web/src/lib/globalKeys.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { globalKeyIntent } from './globalKeys'
+
+describe('globalKeyIntent', () => {
+  const on = { shell: true }
+  const off = { shell: false }
+
+  it('Cmd/Ctrl+K opens the palette regardless of shell', () => {
+    expect(globalKeyIntent({ key: 'k', metaKey: true }, on)).toBe('palette')
+    expect(globalKeyIntent({ key: 'k', ctrlKey: true }, on)).toBe('palette')
+    expect(globalKeyIntent({ key: 'k', metaKey: true }, off)).toBe('palette')
+  })
+
+  it('accepts uppercase keys (Shift not held)', () => {
+    expect(globalKeyIntent({ key: 'K', metaKey: true }, on)).toBe('palette')
+  })
+
+  it('Cmd/Ctrl+N opens a new session only in the desktop shell', () => {
+    expect(globalKeyIntent({ key: 'n', metaKey: true }, on)).toBe('new-session')
+    expect(globalKeyIntent({ key: 'n', ctrlKey: true }, on)).toBe('new-session')
+    expect(globalKeyIntent({ key: 'n', metaKey: true }, off)).toBeNull()
+  })
+
+  it('a modifier is required — bare keys fall through', () => {
+    for (const key of ['k', 'K', 'n', 'a', 'Enter']) {
+      expect(globalKeyIntent({ key }, on)).toBeNull()
+    }
+  })
+
+  it('an Alt or Shift modifier disables both shortcuts', () => {
+    expect(globalKeyIntent({ key: 'k', metaKey: true, altKey: true }, on)).toBeNull()
+    expect(globalKeyIntent({ key: 'k', metaKey: true, shiftKey: true }, on)).toBeNull()
+    expect(globalKeyIntent({ key: 'n', metaKey: true, altKey: true }, on)).toBeNull()
+    expect(globalKeyIntent({ key: 'n', metaKey: true, shiftKey: true }, on)).toBeNull()
+  })
+
+  it('other keys are not shortcuts', () => {
+    for (const key of ['a', 'Enter', 'Tab', ' ']) {
+      expect(globalKeyIntent({ key, metaKey: true }, on)).toBeNull()
+    }
+  })
+})

--- a/web/src/lib/globalKeys.ts
+++ b/web/src/lib/globalKeys.ts
@@ -1,0 +1,29 @@
+// Which global window shortcut a keydown means. Pure logic so the modifier
+// interpretation is testable on its own, mirroring composerKeys.ts.
+
+export interface GlobalKeyEvent {
+  key: string
+  metaKey?: boolean
+  ctrlKey?: boolean
+  altKey?: boolean
+  shiftKey?: boolean
+}
+
+export interface GlobalKeyOpts {
+  // Whether the page runs in the native desktop shell. The Cmd/Ctrl+N
+  // "new session" bind is desktop-only: under a plain browser Cmd+N is a
+  // reserved browser shortcut the page never sees. Pass isDesktopShell.
+  shell: boolean
+}
+
+// 'palette' toggles the command palette (⌘K); 'new-session' starts a new
+// session (⌘N, desktop shell only); null means the caller should keep
+// handling the keypress normally.
+export function globalKeyIntent(e: GlobalKeyEvent, opts: GlobalKeyOpts): 'palette' | 'new-session' | null {
+  const mod = (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey
+  if (!mod) return null
+  const k = e.key.toLowerCase()
+  if (k === 'k') return 'palette'
+  if (k === 'n' && opts.shell) return 'new-session'
+  return null
+}


### PR DESCRIPTION
## Summary

Makes the New Session `⌘N` shortcut **actually work in the Wails desktop shell**, and shows the `⌘N` hint only there.

## Context

The `⌘N` hint was originally removed (#2051's first commit) because it never worked in a **browser**: `Cmd+N` (macOS) / `Ctrl+N` (Windows) is a reserved browser shortcut (new window) that the page JS never sees, so `preventDefault()` can't stop it. That constraint holds for `octo serve` in a browser — but **not** for the Wails desktop shell, whose webview isn't a browser: the keypress reaches the page and can be claimed safely.

So rather than delete the hint outright, this PR implements the shortcut for the desktop shell and gates the hint to match.

## Changes

- **`web/src/App.svelte`** — extend the global `onGlobalKeydown` (which already handles `⌘K`) with a `Cmd/Ctrl+N` branch that calls `createNewSession()`. The branch is gated on `isDesktopShell` (the `?shell=octo-desktop` URL marker set by `cmd/octo-desktop/bridge.go`), so:
  - **Desktop shell**: `Cmd/Ctrl+N` creates a new session (same action as the palette entry / sidebar button / tray).
  - **Browser / `octo serve`**: the page never intercepts `Cmd+N`; the browser keeps its native new-window behavior. Nothing regresses.
- **`web/src/components/overlays/CommandPalette.svelte`** — the New Session action's shortcut is now `isDesktopShell ? '⌘N' : ''` — the hint shows only on desktop, where it's real, and stays hidden on plain web to avoid re-advertising a key that can't fire there.

## Verification

- `npm run build` (vite build) passes, 286 modules.
- `npx vitest run` — 189/189 pass.
- No change to behavior under `octo serve` (native Cmd+N handling preserved).

## Merge note

This PR supersedes the original "remove misleading hint" direction: the hint is re-added for the desktop shell where the shortcut genuinely works, and kept hidden on web.