### PR TITLE
fix(web): style markdown tables in artifact preview (stacked on #2052)

### DIFF
--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -669,6 +669,13 @@ function darkMDStyles(): string {
     `.code-lang{font-size:11px;color:#888;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}`,
     `.copy-btn{margin-left:auto;height:24px;padding:0 8px;border:none;background:transparent;border-radius:5px;font-size:11px;color:#888;cursor:pointer;font-family:inherit}`,
     `.copy-btn:hover{background:#3d3d3d;color:#58a6ff}`,
+    // Markdown tables — mirrors the app's .rich-answer/.md-content table skin
+    // (see ChatView/ProfileView) with the preview iframe's own palette.
+    `.table-scroll{overflow-x:auto;margin:10px 0}`,
+    `table{width:max-content;min-width:100%;max-width:none;border-collapse:collapse;border-spacing:0;font-size:13.5px;line-height:1.55}`,
+    `th,td{padding:7px 14px;text-align:left;vertical-align:top;border:1px solid #30363d}`,
+    `th{background:#2d2d2d;font-weight:600;color:#e6edf3;white-space:nowrap}`,
+    `tbody tr:nth-child(even) td{background:#282a2e}`,
     `pre{margin:0;padding:12px 14px;overflow-x:auto;font-size:13px;line-height:1.6;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#d4d4d4}`,
     `code.hljs{background:transparent;padding:0}`,
     `.hljs{color:#c9d1d9;background:#0d1117}`,
@@ -698,6 +705,13 @@ function lightMDStyles(): string {
     `.code-lang{font-size:11px;color:#57606a;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}`,
     `.copy-btn{margin-left:auto;height:24px;padding:0 8px;border:none;background:transparent;border-radius:5px;font-size:11px;color:#57606a;cursor:pointer;font-family:inherit}`,
     `.copy-btn:hover{background:#d0d7de;color:#0969da}`,
+    // Markdown tables — mirrors the app's .rich-answer/.md-content table skin
+    // (see ChatView/ProfileView) with the preview iframe's own palette.
+    `.table-scroll{overflow-x:auto;margin:10px 0}`,
+    `table{width:max-content;min-width:100%;max-width:none;border-collapse:collapse;border-spacing:0;font-size:13.5px;line-height:1.55}`,
+    `th,td{padding:7px 14px;text-align:left;vertical-align:top;border:1px solid #d0d7de}`,
+    `th{background:#eaeef2;font-weight:600;color:#1f2328;white-space:nowrap}`,
+    `tbody tr:nth-child(even) td{background:#f6f8fa}`,
     `pre{margin:0;padding:12px 14px;overflow-x:auto;font-size:13px;line-height:1.6;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#24292f}`,
     `code.hljs{background:transparent;padding:0}`,
     // highlight.js GitHub (light) theme — simplified


### PR DESCRIPTION
## Summary

Prerequisite: this PR **stacks on #2052** (`fix/markdown-table-styles`) — its `renderer.table` override (which wraps tables in `.table-scroll`) must land first. When merging, merge #2052 first, then this one; or fold both together.

## Problem

The artifact **markdown preview** reuses `renderMarkdown`, so after #2052 wide tables get the `.table-scroll` wrapper — but the preview's inline iframe styles (`darkMDStyles` / `lightMDStyles` in `web/src/lib/artifacts.ts`) had **no table rules at all**. Tables in the artifact preview rendered with the same default cramped layout the chat bubble had before #2052.

## Change

- `web/src/lib/artifacts.ts`: add the same table skin to both preview palettes, using the iframe's own hardcoded colors (no CSS vars available inside the sandboxed preview) to mirror the `.rich-answer` / `.md-content` tables added in #2052:
  - `.table-scroll` wrapper → `overflow-x: auto` with vertical margin
  - bordered `th`/`td` with generous padding
  - emphasized `th` header row (background, semibold, `nowrap`)
  - zebra striping on even `tbody` rows
  - `width:max-content; min-width:100%` so narrow tables fill, wide ones scroll

Palette — dark: border `#30363d`, header bg `#2d2d2d`, heading `#e6edf3`; light: border `#d0d7de`, header bg `#eaeef2`, zebra `#f6f8fa`, heading `#1f2328`.

## Verification

- `npm run build` (vite build) passes.
- `npx vitest run` on artifact tests: 47/47 pass (`artifacts.test.ts` + `artifact-actions.test.ts`).
