### PR TITLE
feat(desktop): add New Session item to the system tray

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -410,6 +410,12 @@ func (b *nativeBridge) showWindow() { b.showWindowAt("") }
 // "Settings"). The frontend maps the "settings" hash route to the modal.
 func (b *nativeBridge) openSettings() { b.showWindowAt("settings") }
 
+// openNewSession brings the window up and starts a new session (tray
+// "New Session" / a keyboard-⌘N-equivalent from the shell side). The frontend
+// maps the "new" hash route to createNewSession(), the same action the in-app
+// "New Session" button and Cmd/Ctrl+N trigger.
+func (b *nativeBridge) openNewSession() { b.showWindowAt("new") }
+
 // showWindowAt brings the hub window to the foreground, re-creating it if it was
 // closed to the tray (KeepRunningInBackground), and navigates to the given
 // frontend hash route (empty = leave it where it is). The frontend routes on

--- a/cmd/octo-desktop/lang.go
+++ b/cmd/octo-desktop/lang.go
@@ -15,6 +15,7 @@ import (
 type uiStrings struct {
 	trayShow, trayQuit string
 	traySettings       string
+	trayNewSession     string
 	trayCheckUpdates   string
 	trayUpdateAvailFmt string // "↑ Update to v%s"
 	trayStarting       string
@@ -50,6 +51,7 @@ type uiStrings struct {
 var enStrings = uiStrings{
 	trayShow:           "Show Octo",
 	trayQuit:           "Quit Octo",
+	trayNewSession:     "New Session",
 	traySettings:       "Settings…",
 	trayCheckUpdates:   "Check for Updates…",
 	trayUpdateAvailFmt: "↑ Update to v%s",
@@ -86,6 +88,7 @@ var enStrings = uiStrings{
 var zhStrings = uiStrings{
 	trayShow:           "显示 Octo",
 	trayQuit:           "退出 Octo",
+	trayNewSession:     "新建会话",
 	traySettings:       "设置…",
 	trayCheckUpdates:   "检查更新…",
 	trayUpdateAvailFmt: "↑ 更新到 v%s",

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -549,6 +549,7 @@ func buildTrayMenu(app *application.App, bridge *nativeBridge) *application.Menu
 	}
 	m.AddSeparator()
 	m.Add(L().trayShow).OnClick(func(*application.Context) { bridge.showWindow() })
+	m.Add(L().trayNewSession).OnClick(func(*application.Context) { bridge.openNewSession() })
 	m.Add(L().traySettings).OnClick(func(*application.Context) { bridge.openSettings() })
 	// A known-newer release replaces the "check" item with a one-click update
 	// (in-place when this build supports it, else the download page) — the

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, sessions, sessionGroups, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell, panelContent, cmdkOpen, settingsModalOpen } from './lib/stores'
+  import { view, sessions, sessionGroups, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell, panelContent, cmdkOpen, settingsModalOpen, createNewSession, isDesktopShell } from './lib/stores'
   import MobileApp from './mobile/MobileApp.svelte'
   import { ws, wsState } from './lib/ws'
   import { notificationsEnabled } from './lib/notifications'
@@ -58,6 +58,15 @@
       settingsModalOpen.set(true)
       const hash = normalizeHash(get(view), get(activeSessionId))
       history.replaceState(null, '', location.pathname + location.search + hash)
+      return
+    }
+    // The desktop tray's "New Session" item navigates to #new (see
+    // nativeBridge.openNewSession). Desktop-gated: under a plain browser this
+    // hash is unreachable from the shell, so don't let a hand-typed #new create
+    // a throwaway session there. createNewSession() re-normalizes the hash to
+    // the fresh #/chat/{id}, so a reload won't loop back into #new.
+    if (v === 'new' && isDesktopShell) {
+      createNewSession().catch((err: any) => showToast(err.message, 'error'))
       return
     }
     if (!VALID_VIEWS.includes(v)) return


### PR DESCRIPTION
## Summary

Adds a **New Session** item to the Wails desktop shell's system tray menu — the "quick new session" tray action the design (`dev-docs/wails-desktop-design.md`) listed but never shipped.

The tray item starts a fresh session through the same `createNewSession()` action the keyboard **Cmd/Ctrl+N** shortcut (#2051) and the in-app "New Session" button use, so all three entry points behave identically.

## Changes

- **`cmd/octo-desktop/main.go`** — `buildTrayMenu`: insert `New Session` between *Show Octo* and *Settings…*, wired to a new `nativeBridge.openNewSession()`.
- **`cmd/octo-desktop/bridge.go`** — `openNewSession()` navigates the window to the frontend `new` hash route (mirroring the existing `openSettings()` → `settings` pattern).
- **`cmd/octo-desktop/lang.go`** — i18n: en `New Session`, zh `新建会话`.
- **`web/src/App.svelte`** — `applyHash` maps `#new` to `createNewSession()`, gated on `isDesktopShell` so a hand-typed `#new` in a plain browser can't create a throwaway session. The created session re-normalizes the hash to `#/chat/{id}`, so a reload won't loop back into `#new`.

## Design notes

- **Window lifecycle parity**: `openNewSession()` goes through `showWindowAt("new")`, which re-creates a window closed to the tray (KeepRunningInBackground) — so "New Session" from the tray both surfaces the window and starts the fresh session.
- **Browser safety**: the tray can only navigate `#new` in the desktop shell; desktop-gating the route means a manual `…#new` in a browser is inert.

## Verification

- `cmd/octo-desktop`: `go vet ./...` clean, `go test ./...` pass (incl. `TestShellURL`).
- `web`: `npm run build` (vite) passes; `npx vitest run` 195/195 pass.