### PR TITLE
fix(cli): session model consistency — resume sender rebuild + persist /model switches

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -417,6 +417,38 @@ func resolveResumedModel(sessionRef, startProvider string, startEntry config.Mod
 	return p, m, e, rebuild, true
 }
 
+// resumeModelRef returns the session's model reference for resume: the
+// binding recorded by a mid-session /model switch (ModelConfig, a composite
+// "<endpoint>::<model>" when an endpoint was addressed explicitly) when
+// present, else the bare wire model. The binding keeps the exact endpoint
+// when the same model exists on several ones, mirroring the server's
+// senderForSession.
+func resumeModelRef(sess *agent.Session) string {
+	if sess.ModelConfig != "" {
+		return sess.ModelConfig
+	}
+	return sess.Model
+}
+
+// resumeLite re-infers the session's implicit lite model after a resume
+// changed the active model. The startup lite inference ran against the config
+// default; after resume the conversation runs on the session's own model, so
+// compaction should follow the session's endpoint, key, and prompt cache.
+// Only a lite that came from the startup sender (implicit inference) or was
+// absent is touched — an explicit cfg.Lite entry built from its own sender is
+// left alone.
+func resumeLite(a *agent.Agent, prevSender agent.Sender, provider, model string, entry config.ModelEntry) {
+	if a.LiteSender != prevSender && a.LiteSender != nil {
+		return
+	}
+	if lm := app.ImplicitLiteModel(provider, model, resolveBaseURL(provider, entry)); lm != "" {
+		a.LiteSender = a.GetSender()
+		a.LiteModel = lm
+	} else {
+		a.LiteSender, a.LiteModel = nil, ""
+	}
+}
+
 // runChat handles `octo [flags] [message]` — every invocation that isn't a
 // named subcommand.
 //
@@ -1032,6 +1064,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if useTUI {
 		var sess *agent.Session
 		if resumeID != "" {
+			startProvider, startModel, startEntry := provName, resolvedModel, entry
 			sess, err = agent.LoadSession(resumeID)
 			if err != nil {
 				fmt.Fprintf(stderr, "octo: %v\n", err)
@@ -1062,11 +1095,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				// /model switch) over its bare wire model — the binding keeps the
 				// exact endpoint when the same model exists on several ones,
 				// mirroring the server's senderForSession.
-				ref := sess.Model
-				if sess.ModelConfig != "" {
-					ref = sess.ModelConfig
-				}
-				p, m, e, rebuild, ok := resolveResumedModel(ref, provName, entry, cfg)
+				p, m, e, rebuild, ok := resolveResumedModel(resumeModelRef(sess), provName, entry, cfg)
 				if !ok {
 					fmt.Fprintf(stderr, "octo: warning: session model %q is no longer configured; resuming on %q\n", sess.Model, resolvedModel)
 					a.Model = resolvedModel
@@ -1090,25 +1119,25 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 						} else {
 							llmSender = newSender
 							a.SetSender(llmSender)
-							// The implicit lite model was inferred for the
-							// config default above; re-infer it on the
-							// session's own sender so compaction stays on the
-							// session's endpoint, key, and prompt cache (an
-							// explicit cfg.Lite entry — built from its own
-							// sender — is untouched).
-							if a.LiteSender == prevSender {
-								if lm := app.ImplicitLiteModel(p, m, resolveBaseURL(p, e)); lm != "" {
-									a.LiteSender = llmSender
-									a.LiteModel = lm
-								} else {
-									a.LiteSender, a.LiteModel = nil, ""
-								}
-							}
 							a.Model = m
+							// Compaction's lite model was inferred for the
+							// config default above; re-infer it on the session's
+							// own sender (resumeLite no-ops when the lite is an
+							// explicit cfg.Lite entry).
+							resumeLite(a, prevSender, p, m, e)
 						}
 					} else {
 						a.Model = m
+						resumeLite(a, prevSender, p, m, e)
 					}
+				}
+				// The startup banner (above) printed the config-default
+				// resolution; when a resumed session overrode it, say so under
+				// --verbose so the line matches the wire.
+				if resolveVerbosity(*quietFlag, *verboseFlag).verbose() &&
+					(provName != startProvider || resolvedModel != startModel || entry.BaseURL != startEntry.BaseURL) {
+					fmt.Fprintf(stderr, "octo: resumed session: provider=%s model=%s endpoint=%s\n",
+						provName, resolvedModel, effectiveEndpoint(provName, entry))
 				}
 			}
 			// Recompose from the session's raw user layer so base/project/env

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -381,6 +381,40 @@ func init() {
 	}
 }
 
+// resolveResumedModel resolves the (provider, model, entry) a resumed session
+// should run on, given the session's saved model and the startup resolution
+// for the current config default. A saved session carries its own model —
+// often from a different endpoint than the one the config now defaults to
+// (e.g. created on the kimi endpoint, resumed after the default moved to
+// deepseek) — and sending that model through a sender built for another
+// endpoint misroutes the request (deepseek endpoint + k3-256k → HTTP 400).
+//
+// The returned entry anchors the rebuilt sender; rebuild reports whether it
+// targets a different provider or base URL than the startup entry (the same
+// no-rebuild criterion ensureSender uses: same endpoint → reuse the sender,
+// only the wire model name changes). ok is false when the session model is no
+// longer present in the config (its endpoint was deleted) — the caller then
+// falls back to the current default rather than replaying the stale model.
+// An empty sessionModel passes the startup resolution through untouched.
+func resolveResumedModel(sessionModel, startProvider string, startEntry config.ModelEntry, cfg config.Config) (provider, model string, entry config.ModelEntry, rebuild, ok bool) {
+	if sessionModel == "" {
+		return startProvider, startEntry.Model, startEntry, false, true
+	}
+	// Guard before resolveProviderModel: with an unconfigured model name it
+	// would silently fall back to the current provider (matching on the flag),
+	// reporting ok=true for a model the config no longer carries — the exact
+	// misroute this resolution exists to prevent (mirrors ensureSender).
+	if _, found := cfg.EntryByModel(sessionModel); !found {
+		return "", "", config.ModelEntry{}, false, false
+	}
+	p, m, e, ok := resolveProviderModel("", sessionModel, cfg)
+	if !ok {
+		return "", "", config.ModelEntry{}, false, false
+	}
+	rebuild = p != startProvider || e.BaseURL != startEntry.BaseURL
+	return p, m, e, rebuild, true
+}
+
 // runChat handles `octo [flags] [message]` — every invocation that isn't a
 // named subcommand.
 //
@@ -1011,6 +1045,61 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			a.History = sess.ToHistory()
 			if sess.Model != "" {
 				a.Model = sess.Model
+				// The sender was built for the current config default, but a
+				// saved session carries its own model — often from a different
+				// endpoint (created on the kimi endpoint, resumed after the
+				// default moved to deepseek). Sending a.Model through a sender
+				// built for another endpoint misroutes the request (deepseek
+				// endpoint + k3-256k → HTTP 400). Mirror the server's
+				// senderForSession: re-resolve the session's model to its
+				// config entry, rebuild the sender when the endpoint differs,
+				// and keep the status bar (modelName) on the model actually in
+				// use. A session model that left the config falls back to the
+				// current default so the session stays usable.
+				p, m, e, rebuild, ok := resolveResumedModel(sess.Model, provName, entry, cfg)
+				if !ok {
+					fmt.Fprintf(stderr, "octo: warning: session model %q is no longer configured; resuming on %q\n", sess.Model, resolvedModel)
+					a.Model = resolvedModel
+				} else {
+					prevProvider, prevModel, prevEntry := provName, resolvedModel, entry
+					prevSender := llmSender
+					provName, resolvedModel, entry = p, m, e
+					if rebuild {
+						newSender, serr := buildSender(p, e, stderr, senderTuning{
+							thinkingBudget:  anthropicThinkingBudget(resolvedEffort),
+							reasoningEffort: resolvedEffort,
+							showReasoning:   resolvedShowReasoning,
+						})
+						if serr != nil {
+							// Rebuild failed (missing key, …) — revert to the
+							// default rather than sending the session's model
+							// to the wrong endpoint.
+							provName, resolvedModel, entry = prevProvider, prevModel, prevEntry
+							a.Model = prevModel
+							fmt.Fprintf(stderr, "octo: warning: could not rebuild the sender for the resumed session's model %q (%v); resuming on %q\n", sess.Model, serr, resolvedModel)
+						} else {
+							llmSender = newSender
+							a.SetSender(llmSender)
+							// The implicit lite model was inferred for the
+							// config default above; re-infer it on the
+							// session's own sender so compaction stays on the
+							// session's endpoint, key, and prompt cache (an
+							// explicit cfg.Lite entry — built from its own
+							// sender — is untouched).
+							if a.LiteSender == prevSender {
+								if lm := app.ImplicitLiteModel(p, m, resolveBaseURL(p, e)); lm != "" {
+									a.LiteSender = llmSender
+									a.LiteModel = lm
+								} else {
+									a.LiteSender, a.LiteModel = nil, ""
+								}
+							}
+							a.Model = m
+						}
+					} else {
+						a.Model = m
+					}
+				}
 			}
 			// Recompose from the session's raw user layer so base/project/env
 			// pick up any changes since the session was created. Rerender the

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -382,12 +382,14 @@ func init() {
 }
 
 // resolveResumedModel resolves the (provider, model, entry) a resumed session
-// should run on, given the session's saved model and the startup resolution
-// for the current config default. A saved session carries its own model —
-// often from a different endpoint than the one the config now defaults to
+// should run on, given the session's saved model reference and the startup
+// resolution for the current config default. sessionRef is the session's
+// binding — a bare model id (legacy sessions) or a composite
+// "<endpoint>::<model>" id (a session that recorded a /model switch) — and
+// may come from a different endpoint than the one the config now defaults to
 // (e.g. created on the kimi endpoint, resumed after the default moved to
-// deepseek) — and sending that model through a sender built for another
-// endpoint misroutes the request (deepseek endpoint + k3-256k → HTTP 400).
+// deepseek). Sending that model through a sender built for another endpoint
+// misroutes the request (deepseek endpoint + k3-256k → HTTP 400).
 //
 // The returned entry anchors the rebuilt sender; rebuild reports whether it
 // targets a different provider or base URL than the startup entry (the same
@@ -395,19 +397,19 @@ func init() {
 // only the wire model name changes). ok is false when the session model is no
 // longer present in the config (its endpoint was deleted) — the caller then
 // falls back to the current default rather than replaying the stale model.
-// An empty sessionModel passes the startup resolution through untouched.
-func resolveResumedModel(sessionModel, startProvider string, startEntry config.ModelEntry, cfg config.Config) (provider, model string, entry config.ModelEntry, rebuild, ok bool) {
-	if sessionModel == "" {
+// An empty sessionRef passes the startup resolution through untouched.
+func resolveResumedModel(sessionRef, startProvider string, startEntry config.ModelEntry, cfg config.Config) (provider, model string, entry config.ModelEntry, rebuild, ok bool) {
+	if sessionRef == "" {
 		return startProvider, startEntry.Model, startEntry, false, true
 	}
 	// Guard before resolveProviderModel: with an unconfigured model name it
 	// would silently fall back to the current provider (matching on the flag),
 	// reporting ok=true for a model the config no longer carries — the exact
 	// misroute this resolution exists to prevent (mirrors ensureSender).
-	if _, found := cfg.EntryByModel(sessionModel); !found {
+	if _, found := cfg.EntryByModel(sessionRef); !found {
 		return "", "", config.ModelEntry{}, false, false
 	}
-	p, m, e, ok := resolveProviderModel("", sessionModel, cfg)
+	p, m, e, ok := resolveProviderModel("", sessionRef, cfg)
 	if !ok {
 		return "", "", config.ModelEntry{}, false, false
 	}
@@ -1056,7 +1058,15 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				// and keep the status bar (modelName) on the model actually in
 				// use. A session model that left the config falls back to the
 				// current default so the session stays usable.
-				p, m, e, rebuild, ok := resolveResumedModel(sess.Model, provName, entry, cfg)
+				// Prefer the session's binding (ModelConfig, set by a mid-session
+				// /model switch) over its bare wire model — the binding keeps the
+				// exact endpoint when the same model exists on several ones,
+				// mirroring the server's senderForSession.
+				ref := sess.Model
+				if sess.ModelConfig != "" {
+					ref = sess.ModelConfig
+				}
+				p, m, e, rebuild, ok := resolveResumedModel(ref, provName, entry, cfg)
 				if !ok {
 					fmt.Fprintf(stderr, "octo: warning: session model %q is no longer configured; resuming on %q\n", sess.Model, resolvedModel)
 					a.Model = resolvedModel

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -36,6 +36,123 @@ func TestRunChat_NoArgs_NoStdin_Errors(t *testing.T) {
 	}
 }
 
+// TestResolveResumedModel pins the sender/model resolution for `octo -c`: a
+// resumed session's saved model must re-resolve to its own config entry —
+// rebuilding the sender when it targets a different endpoint than the current
+// config default (otherwise the deepseek sender would send k3-256k → HTTP
+// 400), reusing it when the endpoint matches, and rejecting models that have
+// left the config.
+func TestResolveResumedModel(t *testing.T) {
+	openaiEP := config.Endpoint{
+		ID:       "ep-openai",
+		Provider: "openai",
+		Models:   []config.EndpointModel{{Model: "gpt-4o"}},
+	}
+	deepseekEP := config.Endpoint{
+		ID:       "ep-deepseek",
+		Provider: "deepseek",
+		BaseURL:  "https://api.deepseek.com",
+		Models:   []config.EndpointModel{{Model: "deepseek-v4-flash"}, {Model: "deepseek-v4-pro"}},
+	}
+	kimiEP := config.Endpoint{
+		ID:       "ep-kimi",
+		Provider: "kimi",
+		Models:   []config.EndpointModel{{Model: "k3-256k"}},
+	}
+	relayEP := config.Endpoint{
+		ID:       "ep-deepseek-relay",
+		Provider: "deepseek",
+		BaseURL:  "https://relay.example.com",
+		Models:   []config.EndpointModel{{Model: "deepseek-v4-flash"}},
+	}
+	cfg := config.Config{
+		Endpoints: []config.Endpoint{openaiEP, deepseekEP, kimiEP, relayEP},
+		Default:   "ep-openai::gpt-4o",
+	}
+	openaiEntry := config.ModelEntry{Provider: "openai", Model: "gpt-4o"}
+	deepseekEntry := config.ModelEntry{Provider: "deepseek", Model: "deepseek-v4-pro", BaseURL: "https://api.deepseek.com"}
+
+	tests := []struct {
+		name         string
+		sessionModel string
+		startProv    string
+		startEntry   config.ModelEntry
+		wantProv     string
+		wantModel    string
+		wantRebuild  bool
+		wantOK       bool
+	}{
+		{
+			name:         "session model on another endpoint rebuilds the sender",
+			sessionModel: "deepseek-v4-pro",
+			startProv:    "openai",
+			startEntry:   openaiEntry,
+			wantProv:     "deepseek",
+			wantModel:    "deepseek-v4-pro",
+			wantRebuild:  true,
+			wantOK:       true,
+		},
+		{
+			name:         "same endpoint, different model keeps the sender",
+			sessionModel: "deepseek-v4-pro",
+			startProv:    "deepseek",
+			startEntry:   deepseekEntry,
+			wantProv:     "deepseek",
+			wantModel:    "deepseek-v4-pro",
+			wantRebuild:  false,
+			wantOK:       true,
+		},
+		{
+			name:         "same provider, different base URL rebuilds the sender",
+			sessionModel: "deepseek-v4-flash",
+			startProv:    "deepseek",
+			startEntry:   config.ModelEntry{Provider: "deepseek", Model: "deepseek-v4-flash", BaseURL: "https://relay.example.com"},
+			wantProv:     "deepseek",
+			wantModel:    "deepseek-v4-flash",
+			wantRebuild:  true,
+			wantOK:       true,
+		},
+		{
+			name:         "model deleted from config is rejected",
+			sessionModel: "claude-opus-4-7",
+			startProv:    "openai",
+			startEntry:   openaiEntry,
+			wantOK:       false,
+		},
+		{
+			name:         "empty session model passes the startup resolution through",
+			sessionModel: "",
+			startProv:    "deepseek",
+			startEntry:   deepseekEntry,
+			wantProv:     "deepseek",
+			wantModel:    "deepseek-v4-pro",
+			wantRebuild:  false,
+			wantOK:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, m, e, rebuild, ok := resolveResumedModel(tt.sessionModel, tt.startProv, tt.startEntry, cfg)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if p != tt.wantProv || m != tt.wantModel {
+				t.Errorf("resolved (%q, %q), want (%q, %q)", p, m, tt.wantProv, tt.wantModel)
+			}
+			if rebuild != tt.wantRebuild {
+				t.Errorf("rebuild = %v, want %v", rebuild, tt.wantRebuild)
+			}
+			if e.Model != tt.wantModel {
+				t.Errorf("entry.Model = %q, want %q", e.Model, tt.wantModel)
+			}
+		})
+	}
+}
+
 func TestRunChat_MissingAPIKey(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	t.Setenv("OPENAI_API_KEY", "")

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -73,67 +73,77 @@ func TestResolveResumedModel(t *testing.T) {
 	deepseekEntry := config.ModelEntry{Provider: "deepseek", Model: "deepseek-v4-pro", BaseURL: "https://api.deepseek.com"}
 
 	tests := []struct {
-		name         string
-		sessionModel string
-		startProv    string
-		startEntry   config.ModelEntry
-		wantProv     string
-		wantModel    string
-		wantRebuild  bool
-		wantOK       bool
+		name        string
+		sessionRef  string
+		startProv   string
+		startEntry  config.ModelEntry
+		wantProv    string
+		wantModel   string
+		wantRebuild bool
+		wantOK      bool
 	}{
 		{
-			name:         "session model on another endpoint rebuilds the sender",
-			sessionModel: "deepseek-v4-pro",
-			startProv:    "openai",
-			startEntry:   openaiEntry,
-			wantProv:     "deepseek",
-			wantModel:    "deepseek-v4-pro",
-			wantRebuild:  true,
-			wantOK:       true,
+			name:        "session model on another endpoint rebuilds the sender",
+			sessionRef:  "deepseek-v4-pro",
+			startProv:   "openai",
+			startEntry:  openaiEntry,
+			wantProv:    "deepseek",
+			wantModel:   "deepseek-v4-pro",
+			wantRebuild: true,
+			wantOK:      true,
 		},
 		{
-			name:         "same endpoint, different model keeps the sender",
-			sessionModel: "deepseek-v4-pro",
-			startProv:    "deepseek",
-			startEntry:   deepseekEntry,
-			wantProv:     "deepseek",
-			wantModel:    "deepseek-v4-pro",
-			wantRebuild:  false,
-			wantOK:       true,
+			name:        "same endpoint, different model keeps the sender",
+			sessionRef:  "deepseek-v4-pro",
+			startProv:   "deepseek",
+			startEntry:  deepseekEntry,
+			wantProv:    "deepseek",
+			wantModel:   "deepseek-v4-pro",
+			wantRebuild: false,
+			wantOK:      true,
 		},
 		{
-			name:         "same provider, different base URL rebuilds the sender",
-			sessionModel: "deepseek-v4-flash",
-			startProv:    "deepseek",
-			startEntry:   config.ModelEntry{Provider: "deepseek", Model: "deepseek-v4-flash", BaseURL: "https://relay.example.com"},
-			wantProv:     "deepseek",
-			wantModel:    "deepseek-v4-flash",
-			wantRebuild:  true,
-			wantOK:       true,
+			name:        "same provider, different base URL rebuilds the sender",
+			sessionRef:  "deepseek-v4-flash",
+			startProv:   "deepseek",
+			startEntry:  config.ModelEntry{Provider: "deepseek", Model: "deepseek-v4-flash", BaseURL: "https://relay.example.com"},
+			wantProv:    "deepseek",
+			wantModel:   "deepseek-v4-flash",
+			wantRebuild: true,
+			wantOK:      true,
 		},
 		{
-			name:         "model deleted from config is rejected",
-			sessionModel: "claude-opus-4-7",
-			startProv:    "openai",
-			startEntry:   openaiEntry,
-			wantOK:       false,
+			name:        "composite ref resolves to the bound endpoint",
+			sessionRef:  "ep-deepseek::deepseek-v4-pro",
+			startProv:   "openai",
+			startEntry:  openaiEntry,
+			wantProv:    "deepseek",
+			wantModel:   "deepseek-v4-pro",
+			wantRebuild: true,
+			wantOK:      true,
 		},
 		{
-			name:         "empty session model passes the startup resolution through",
-			sessionModel: "",
-			startProv:    "deepseek",
-			startEntry:   deepseekEntry,
-			wantProv:     "deepseek",
-			wantModel:    "deepseek-v4-pro",
-			wantRebuild:  false,
-			wantOK:       true,
+			name:       "model deleted from config is rejected",
+			sessionRef: "claude-opus-4-7",
+			startProv:  "openai",
+			startEntry: openaiEntry,
+			wantOK:     false,
+		},
+		{
+			name:        "empty session ref passes the startup resolution through",
+			sessionRef:  "",
+			startProv:   "deepseek",
+			startEntry:  deepseekEntry,
+			wantProv:    "deepseek",
+			wantModel:   "deepseek-v4-pro",
+			wantRebuild: false,
+			wantOK:      true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, m, e, rebuild, ok := resolveResumedModel(tt.sessionModel, tt.startProv, tt.startEntry, cfg)
+			p, m, e, rebuild, ok := resolveResumedModel(tt.sessionRef, tt.startProv, tt.startEntry, cfg)
 			if ok != tt.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
 			}

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -79,6 +79,7 @@ func TestResolveResumedModel(t *testing.T) {
 		startEntry  config.ModelEntry
 		wantProv    string
 		wantModel   string
+		wantBaseURL string
 		wantRebuild bool
 		wantOK      bool
 	}{
@@ -109,6 +110,7 @@ func TestResolveResumedModel(t *testing.T) {
 			startEntry:  config.ModelEntry{Provider: "deepseek", Model: "deepseek-v4-flash", BaseURL: "https://relay.example.com"},
 			wantProv:    "deepseek",
 			wantModel:   "deepseek-v4-flash",
+			wantBaseURL: "https://api.deepseek.com",
 			wantRebuild: true,
 			wantOK:      true,
 		},
@@ -158,6 +160,9 @@ func TestResolveResumedModel(t *testing.T) {
 			}
 			if e.Model != tt.wantModel {
 				t.Errorf("entry.Model = %q, want %q", e.Model, tt.wantModel)
+			}
+			if tt.wantBaseURL != "" && e.BaseURL != tt.wantBaseURL {
+				t.Errorf("entry.BaseURL = %q, want %q", e.BaseURL, tt.wantBaseURL)
 			}
 		})
 	}
@@ -945,5 +950,22 @@ func TestRunChat_ResumedPlainSession_NoWarning(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "may make the model emit tool calls as text") {
 		t.Errorf("plain session should not warn; got stderr:\n%s", stderr.String())
+	}
+}
+
+// TestResumeModelRef pins the resume ref selection: a session that recorded a
+// mid-session /model switch (ModelConfig, possibly a composite
+// "<endpoint>::<model>" binding) resumes on that binding; a plain session
+// falls back to its bare wire model.
+func TestResumeModelRef(t *testing.T) {
+	sess := agent.NewSession("deepseek-v4-flash", "")
+	if got := resumeModelRef(sess); got != "deepseek-v4-flash" {
+		t.Errorf("bare session ref = %q, want deepseek-v4-flash", got)
+	}
+	if err := sess.SetModelConfig("ep-b::deepseek-v4-flash", "deepseek-v4-flash"); err != nil {
+		t.Fatalf("SetModelConfig: %v", err)
+	}
+	if got := resumeModelRef(sess); got != "ep-b::deepseek-v4-flash" {
+		t.Errorf("bound session ref = %q, want ep-b::deepseek-v4-flash", got)
 	}
 }

--- a/cmd/octo/model_picker_test.go
+++ b/cmd/octo/model_picker_test.go
@@ -335,6 +335,38 @@ func TestModelPickerView_EmptyWhenInactive(t *testing.T) {
 	}
 }
 
+// TestDispatchModel_PersistsOnSession verifies that /model records the switch
+// on the session (via SetModelConfig) so a later `octo -c` resume honors it —
+// without this the session file keeps the model it was created with, and a
+// mid-session /model switch would be silently forgotten on resume (resuming
+// would re-resolve the creation-time model).
+func TestDispatchModel_PersistsOnSession(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+	writeModelsConfig(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "openai", Models: []config.EndpointModel{{Model: "gpt-4o"}}},
+			{ID: "ep-b", Provider: "deepseek", BaseURL: "https://api.deepseek.com", Models: []config.EndpointModel{{Model: "deepseek-v4-flash"}}},
+		},
+		Default: "ep-a::gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.cfg.session = agent.NewSession("gpt-4o", "")
+
+	// Bare form: the session records the bare wire model.
+	m.dispatchModel("deepseek-v4-flash")
+	if m.cfg.session.Model != "deepseek-v4-flash" || m.cfg.session.ModelConfig != "deepseek-v4-flash" {
+		t.Errorf("session after bare switch = (Model=%q, ModelConfig=%q), want (deepseek-v4-flash, deepseek-v4-flash)",
+			m.cfg.session.Model, m.cfg.session.ModelConfig)
+	}
+
+	// Composite form: the binding keeps the exact endpoint.
+	m.dispatchModel("ep-b::deepseek-v4-flash")
+	if m.cfg.session.ModelConfig != "ep-b::deepseek-v4-flash" {
+		t.Errorf("session ModelConfig after composite switch = %q, want ep-b::deepseek-v4-flash", m.cfg.session.ModelConfig)
+	}
+}
+
 // TestDispatchModel_DefaultFlag verifies that `/model <name> --default` sets
 // the model as default in the persisted config.
 func TestDispatchModel_DefaultFlag(t *testing.T) {

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1290,6 +1290,23 @@ func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
 	// which also set Agent.Model from the resolved entry.
 	m.a.Model = entry.Model
 	m.cfg.modelName = entry.Model
+	// Persist the switch on the session so a later `octo -c` resume honors it —
+	// the session file otherwise keeps the model it was created with (SyncFrom
+	// only syncs history), so a mid-session /model would be silently forgotten
+	// on resume. Mirrors the IM /model path, which persists via SetModelConfig.
+	// The ref is the composite "<endpoint>::<model>" form when the user (or the
+	// picker) addressed an endpoint explicitly, else the bare model id — both
+	// are valid EntryByModel references; the composite keeps the binding exact
+	// when the same model exists on several endpoints.
+	if m.cfg.session != nil {
+		ref := entry.Model
+		if strings.Contains(name, "::") {
+			ref = name
+		}
+		if err := m.cfg.session.SetModelConfig(ref, entry.Model); err != nil {
+			m.println(noticeStyle.Render(fmt.Sprintf("switched to %q but failed to save the session's model: %v", entry.Model, err)))
+		}
+	}
 	// Tool surface may differ per model (e.g. vision vs non-vision).
 	if m.cfg.tools != nil {
 		m.cfg.tools = tools.DefaultToolsFor(entry.Model)


### PR DESCRIPTION
## Problem

Two related bugs made `octo -c <id>` resume sessions on the wrong model:

1. **Resume never rebuilds the sender for the session's model.** `octo -c` overwrites `a.Model` with the session's saved model but keeps the sender built at startup for the **current config default**. When the session's model lives on a different endpoint (e.g. a session created on the Kimi Coding Plan endpoint with `k3-256k`, resumed after the default moved to deepseek), every request goes out on the wrong endpoint carrying the session's model name:

   ```
   error: agent: loop[0]: openai: HTTP 400 (invalid_request_error): The supported API model names are deepseek-v4-pro or deepseek-v4-flash, but you passed k3-256k.
   ```

   The TUI status bar made it worse: it shows `modelName = resolvedModel` (the config default) while the wire actually sends the session's model — display and reality diverge.

2. **The CLI `/model` switch was never persisted.** `dispatchModel` only updated in-memory state (`a.Model` + status bar); it never wrote the session file, whose `Model` field stays at the value the session was **created** with (`SyncFrom` syncs history only). So even after fixing #1, resume faithfully restored the *creation-time* model — a mid-session `/model deepseek-v4-flash` switch was silently forgotten.

The server path (web/IM) already handles both correctly: `senderForSession` (`internal/server/server.go:1538`) resolves sender + model together from the session binding, and the IM `/model` persists via `SetModelConfig` (`internal/channel/manager.go:465`). The CLI missed both halves.

## Fix (two commits on `wt/fix-resume-sender`)

**`c1de1b6f` — rebuild the sender for the resumed session's model**

- New pure function **`resolveResumedModel`** (`cmd/octo/chat.go`) re-resolves the session's saved model to its config entry, reporting whether the sender must be rebuilt (different provider or base URL — the same no-rebuild criterion `ensureSender` uses). It guards with `EntryByModel` first so an unconfigured model is rejected instead of silently falling back to the current provider.
- The `-c` resume branch rebuilds the sender with the session's tuning and updates `provName`/`resolvedModel`/`entry`, so the status bar shows the model actually in use.
- The implicit lite model is re-inferred on the session's own sender after a rebuild, so compaction stays on the session's endpoint/key/prompt cache (an explicit `cfg.Lite` entry is untouched).
- A session model that has left the config, or a failed rebuild (missing key), warns and falls back to the current default so the session stays usable.

**`9af5070b` — persist `/model` switches on the session**

- `dispatchModel` (`cmd/octo/tuirepl_view.go`) now records the switch via `session.SetModelConfig(ref, entry.Model)` — the same API the IM `/model` path uses, which persists immediately (appended `model_config` transcript record / meta rewrite), so the switch survives even without a later turn.
- The recorded ref is the composite `<endpoint>::<model>` form when an endpoint was addressed explicitly (picker accept), else the bare model id.
- Resume now prefers the session's binding (`ModelConfig`) over its bare wire model — matching the server's `senderForSession` — so a composite binding restores the exact endpoint even when the same model exists on several ones.

## Tests

- `TestResolveResumedModel` (`cmd/octo/chat_test.go`): cross-endpoint → rebuild; same endpoint → reuse; same provider different base URL → rebuild; composite ref → resolves to the bound endpoint; model deleted from config → rejected; empty ref → passthrough.
- `TestDispatchModel_PersistsOnSession` (`cmd/octo/model_picker_test.go`): bare switch records the bare model; composite switch records the exact binding.

Verified: `go build ./...`, `go vet ./cmd/octo/`, `gofmt`, full `go test ./cmd/octo/`.