### PR TITLE
fix(tui): clear completed task plan at the start of each new turn

### DIFF
--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -67,7 +67,8 @@ func runTurn(ctx context.Context, a *agent.Agent, cfg replConfig, sink ViewSink,
 	// instead of piling onto old, done ones (same semantics as the server's
 	// prepareToolTurn). An incomplete plan carries over so the agent keeps
 	// working on it. No-op when tasks are disabled (nil store), empty, or
-	// only-deleted (nothing to close).
+	// only-deleted (nothing to close). Turns are serialized (one turn
+	// goroutine at a time), so this read-then-swap is safe.
 	if tools.AllTasksComplete(tools.ActiveTaskStore()) {
 		tools.SetTaskStore(tasks.New())
 	}

--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/tasks"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
 
@@ -61,6 +62,15 @@ type TurnStats struct {
 // sink; the caller owns input reading, slash-command dispatch, the turn's
 // cancellable context, and the save/loop decision based on the returned error.
 func runTurn(ctx context.Context, a *agent.Agent, cfg replConfig, sink ViewSink, line string) (agent.Reply, error) {
+	// Clear-and-rebuild: a fully-completed plan is closed, so drop it before
+	// this turn's tools run — the new turn's tasks then start a fresh plan
+	// instead of piling onto old, done ones (same semantics as the server's
+	// prepareToolTurn). An incomplete plan carries over so the agent keeps
+	// working on it. No-op when tasks are disabled (nil store), empty, or
+	// only-deleted (nothing to close).
+	if tools.AllTasksComplete(tools.ActiveTaskStore()) {
+		tools.SetTaskStore(tasks.New())
+	}
 	// Scope the turn's tools-layer per-session state (the replay-secret cache)
 	// to this CLI session. With no session (a nil cfg.session, e.g. an
 	// ephemeral one-shot) the cache degrades to process-level — correct,

--- a/cmd/octo/turncore_tasks_test.go
+++ b/cmd/octo/turncore_tasks_test.go
@@ -38,8 +38,15 @@ func TestRunTurn_ClearsCompletedPlanAtStart(t *testing.T) {
 
 // TestRunTurn_KeepsIncompletePlan verifies an unfinished plan carries over to
 // the next turn — the agent keeps working on it instead of losing progress.
+// The fixture is a partially-done plan (one completed + one pending), the
+// trickiest case: it must NOT be cleared.
 func TestRunTurn_KeepsIncompletePlan(t *testing.T) {
 	store := tasks.New()
+	doneID, _ := store.Create("done task", "", "")
+	done := tasks.Completed
+	if _, err := store.Update(doneID, tasks.UpdateField{Status: &done}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
 	store.Create("pending task", "", "")
 	tools.SetTaskStore(store)
 	t.Cleanup(func() { tools.SetTaskStore(nil) })
@@ -50,7 +57,36 @@ func TestRunTurn_KeepsIncompletePlan(t *testing.T) {
 		t.Fatalf("runTurn: %v", err)
 	}
 	items := tools.ActiveTaskStore().List()
-	if len(items) != 1 || items[0].Subject != "pending task" {
-		t.Errorf("incomplete plan should carry over, got %+v", items)
+	if len(items) != 2 {
+		t.Fatalf("partially-done plan should carry over untouched, got %d tasks: %+v", len(items), items)
+	}
+	for _, want := range []string{"done task", "pending task"} {
+		found := false
+		for _, it := range items {
+			if it.Subject == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("plan lost task %q; got %+v", want, items)
+		}
+	}
+}
+
+// TestRunTurn_NoopWithoutTaskStore guards the disabled-session invariant
+// end-to-end: when no store is registered (nil), a turn must leave it nil —
+// the clear-and-rebuild must never enable task tracking.
+func TestRunTurn_NoopWithoutTaskStore(t *testing.T) {
+	tools.SetTaskStore(nil)
+	t.Cleanup(func() { tools.SetTaskStore(nil) })
+
+	cs := &capturingSender{stubSender: stubSender{reply: "ok"}}
+	a := agent.New(cs, "m")
+	if _, err := runTurn(context.Background(), a, replConfig{a: a}, noopSink{}, "next"); err != nil {
+		t.Fatalf("runTurn: %v", err)
+	}
+	if tools.ActiveTaskStore() != nil {
+		t.Error("disabled session (nil store) must stay nil — the clear must not enable task tracking")
 	}
 }

--- a/cmd/octo/turncore_tasks_test.go
+++ b/cmd/octo/turncore_tasks_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/tasks"
+	"github.com/open-octo/octo-agent/internal/tools"
+)
+
+// TestRunTurn_ClearsCompletedPlanAtStart verifies the TUI-side clear-and-rebuild
+// (mirroring the server's prepareToolTurn): a fully-completed plan is dropped
+// when the next turn starts, so the new turn's tasks build a fresh list instead
+// of piling onto old, done ones. Without this, the accumulated task list grows
+// unboundedly across turns.
+func TestRunTurn_ClearsCompletedPlanAtStart(t *testing.T) {
+	store := tasks.New()
+	id, _ := store.Create("a", "", "")
+	done := tasks.Completed
+	if _, err := store.Update(id, tasks.UpdateField{Status: &done}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	tools.SetTaskStore(store)
+	t.Cleanup(func() { tools.SetTaskStore(nil) })
+
+	cs := &capturingSender{stubSender: stubSender{reply: "ok"}}
+	a := agent.New(cs, "m")
+	if _, err := runTurn(context.Background(), a, replConfig{a: a}, noopSink{}, "next"); err != nil {
+		t.Fatalf("runTurn: %v", err)
+	}
+	if got := tools.ActiveTaskStore(); got == nil {
+		t.Fatal("task store should remain active after the clear")
+	} else if items := got.List(); len(items) != 0 {
+		t.Errorf("completed plan should be cleared at turn start, got %d tasks: %+v", len(items), items)
+	}
+}
+
+// TestRunTurn_KeepsIncompletePlan verifies an unfinished plan carries over to
+// the next turn — the agent keeps working on it instead of losing progress.
+func TestRunTurn_KeepsIncompletePlan(t *testing.T) {
+	store := tasks.New()
+	store.Create("pending task", "", "")
+	tools.SetTaskStore(store)
+	t.Cleanup(func() { tools.SetTaskStore(nil) })
+
+	cs := &capturingSender{stubSender: stubSender{reply: "ok"}}
+	a := agent.New(cs, "m")
+	if _, err := runTurn(context.Background(), a, replConfig{a: a}, noopSink{}, "continue"); err != nil {
+		t.Fatalf("runTurn: %v", err)
+	}
+	items := tools.ActiveTaskStore().List()
+	if len(items) != 1 || items[0].Subject != "pending task" {
+		t.Errorf("incomplete plan should carry over, got %+v", items)
+	}
+}

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/tasks"
@@ -25,18 +26,34 @@ type TaskStore interface {
 // advertisement in DefaultTools. Set by cmd/octo at REPL start with a fresh
 // per-session Store. Nil → task_create / task_update / task_list don't
 // appear in the catalog (single-turn mode and unattended runs).
-var activeTasks TaskStore
+//
+// Guarded by a mutex: SetTaskStore runs at startup, but the store is read
+// from turn goroutines (the TUI's runTurn clear-and-rebuild, taskListView
+// renders) that can outlive the goroutine that set it, and tests swap stores
+// between runs — an unsynchronized pointer is a data race under -race.
+var (
+	activeTasksMu sync.RWMutex
+	activeTasks   TaskStore
+)
 
 // SetTaskStore registers the store the task_* tools delegate to. Pass nil to
 // disable; the three tools then drop out of DefaultTools.
-func SetTaskStore(s TaskStore) { activeTasks = s }
+func SetTaskStore(s TaskStore) {
+	activeTasksMu.Lock()
+	activeTasks = s
+	activeTasksMu.Unlock()
+}
 
 // ActiveTaskStore returns the currently registered store, or nil. Used by
 // cmd/octo's /tasks REPL command (and the post-tool summary line) without
 // going through a LLM-driven tool call.
-func ActiveTaskStore() TaskStore { return activeTasks }
+func ActiveTaskStore() TaskStore {
+	activeTasksMu.RLock()
+	defer activeTasksMu.RUnlock()
+	return activeTasks
+}
 
-func tasksEnabled() bool { return activeTasks != nil }
+func tasksEnabled() bool { return ActiveTaskStore() != nil }
 
 // taskStoreCtxKey carries a per-turn TaskStore so the task_* tools dispatch to
 // it instead of the process-global activeTasks. A request/response transport
@@ -64,7 +81,7 @@ func resolveTaskStore(ctx context.Context) TaskStore {
 	if s := taskStoreFromContext(ctx); s != nil {
 		return s
 	}
-	return activeTasks
+	return ActiveTaskStore()
 }
 
 // ============================================================================


### PR DESCRIPTION
## Problem

The TUI's task store is process-global (`app.WireTools` sets it once at REPL start) and was never reset between turns. Every new round's `task_create` calls piled onto the previous rounds' completed tasks, so with each turn the pinned (Ctrl+T) task panel grew unboundedly and was all stale history. The web side already fixed this — the server clears a fully-completed plan at the start of every turn (`prepareToolTurn`'s clear-and-rebuild, `internal/server/handlers_prepare_toolturn.go:131`) — the TUI needs to align.

## Change

Mirror the server's clear-and-rebuild in the CLI's single turn entry point, `runTurn` (`cmd/octo/turncore.go`): at the start of each turn, if the previous plan is fully completed (`tools.AllTasksComplete`), swap in a fresh store (`tools.SetTaskStore(tasks.New())`) so this turn's tasks build a new list.

- An **incomplete plan carries over** unchanged — the agent keeps working on the same tasks (same semantics as the server).
- No-op for a nil/empty/only-deleted store.
- Turns are serialized (one turn goroutine at a time), so the read-then-swap is safe — same invariant the server relies on.
- One-shot mode (`runOnce`) runs exactly one turn per process with a fresh store, so the clear is a no-op there; the TUI is the only multi-turn CLI path affected.

While landing this, the new read of the global store from turn goroutines exposed a **latent data race**: `tools.activeTasks` was an unsynchronized package-level pointer — `SetTaskStore` (startup, and test cleanup) could race with `ActiveTaskStore` reads from TUI turn goroutines that outlive their spawning test. Guarded the slot with an `RWMutex` (also applied to `tasksEnabled` and `resolveTaskStore`'s direct read). `go test -race` was previously green only because no turn-goroutine path read the store; this makes it robust.

## Verification

- `go test -race ./cmd/octo/ ./internal/tools/ ./internal/app/ ./internal/server/` — all pass
- `go vet` / `gofmt` clean
- New tests (`cmd/octo/turncore_tasks_test.go`):
  - `TestRunTurn_ClearsCompletedPlanAtStart` — all-complete store → cleared after the turn
  - `TestRunTurn_KeepsIncompletePlan` — partially-done plan (one completed + one pending) survives the turn untouched
  - `TestRunTurn_NoopWithoutTaskStore` — a nil store stays nil across a turn (disabled-session invariant)