### PR TITLE
chore: bump version to 1.15.9

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.8"
+var Version = "1.15.9"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bumps the octo version from 1.15.8 to 1.15.9 in `internal/version/version.go`. Single-line change; `go test ./internal/version/` passes.