### PR TITLE
feat(web): hide Save to Light App for artifacts already in the Light Apps dir

### DIFF
--- a/internal/server/lightapps_handlers.go
+++ b/internal/server/lightapps_handlers.go
@@ -31,13 +31,15 @@ type lightAppManifest struct {
 }
 
 // handleListLightApps lists all Light Apps by scanning ~/.octo/light-apps/ for
-// subdirectories containing a valid manifest.json.
+// subdirectories containing a valid manifest.json. The response also carries
+// the directory itself, so the web UI can tell whether a session artifact
+// already lives inside it (and skip the redundant "Save to Light App" action).
 func (s *Server) handleListLightApps(w http.ResponseWriter, r *http.Request) {
 	dir := lightAppsDir()
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			writeJSON(w, http.StatusOK, map[string]any{"apps": []lightAppManifest{}})
+			writeJSON(w, http.StatusOK, map[string]any{"apps": []lightAppManifest{}, "dir": dir})
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "list_lightapps_failed")
@@ -68,7 +70,7 @@ func (s *Server) handleListLightApps(w http.ResponseWriter, r *http.Request) {
 	if apps == nil {
 		apps = []lightAppManifest{}
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"apps": apps})
+	writeJSON(w, http.StatusOK, map[string]any{"apps": apps, "dir": dir})
 }
 
 // handleGetLightApp returns the full manifest and index.html content for a

--- a/internal/server/lightapps_handlers_test.go
+++ b/internal/server/lightapps_handlers_test.go
@@ -35,12 +35,18 @@ func TestListLightApps_EmptyDir(t *testing.T) {
 	if w.Code != 200 {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	var out struct{ Apps []lightAppManifest }
+	var out struct {
+		Apps []lightAppManifest
+		Dir  string
+	}
 	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
 		t.Fatal(err)
 	}
 	if len(out.Apps) != 0 {
 		t.Errorf("expected 0 apps, got %d", len(out.Apps))
+	}
+	if want := filepath.Join(home, ".octo", "light-apps"); out.Dir != want {
+		t.Errorf("expected dir %q, got %q", want, out.Dir)
 	}
 }
 
@@ -56,7 +62,10 @@ func TestListLightApps_WithApps(t *testing.T) {
 	if w.Code != 200 {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	var out struct{ Apps []lightAppManifest }
+	var out struct {
+		Apps []lightAppManifest
+		Dir  string
+	}
 	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
 		t.Fatal(err)
 	}
@@ -65,6 +74,9 @@ func TestListLightApps_WithApps(t *testing.T) {
 	}
 	if out.Apps[0].Name != "CSV Tool" || out.Apps[0].Slug != "csv-tool" {
 		t.Errorf("unexpected app: %+v", out.Apps[0])
+	}
+	if want := filepath.Join(home, ".octo", "light-apps"); out.Dir != want {
+		t.Errorf("expected dir %q, got %q", want, out.Dir)
 	}
 }
 

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -2,7 +2,7 @@
   import { artifacts, panelContent, artifactSel, artifactView, artifactModalOpen, lightappSel, lightapps, lightappHTML, showToast } from '../lib/stores'
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact, imagePreviewError } from '../lib/artifact-actions'
-  import { hydrateArtifact, lightAppSource } from '../lib/artifacts'
+  import { hydrateArtifact, lightAppSource, pathIsInside } from '../lib/artifacts'
   import * as api from '../lib/api'
 
   // ── Session artifacts (existing) ──────────────────────────────────────────
@@ -86,9 +86,11 @@
   // "Save to Light App" is pointless for a file that already lives inside the
   // Light Apps directory (a Light App's own index.html, or a file beside it).
   // The directory itself is server-side knowledge (~/.octo/light-apps), so it
-  // is fetched once, lazily, only once an HTML artifact is showing. A failed
-  // lookup must not hide a working action, so the button stays visible until
-  // the directory is actually known.
+  // is fetched once, lazily, while the session panel shows an HTML artifact.
+  // A failed lookup must not hide a working action, so the button stays
+  // visible until the directory is actually known — and the attempt resets,
+  // so a transient failure is retried on the next artifact switch instead of
+  // disabling the feature for the rest of the session.
   let laDir = $state<string | null>(null)
   let laDirAttempted = $state(false)
 
@@ -99,25 +101,20 @@
       laDir = await api.getLightAppsDir()
     } catch {
       laDir = ''
+      laDirAttempted = false
     }
   }
 
-  // Path comparison is normalized: separators unified, trailing slashes
-  // stripped, case folded — Windows paths are case-insensitive, and the
-  // server's filepath.Join and the artifact path from the transcript may
-  // differ in spelling.
-  function isInsideLaDir(p: string): boolean {
-    if (!laDir) return false
-    const norm = (s: string) => s.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
-    const dir = norm(laDir)
-    const path = norm(p)
-    return path.startsWith(dir + '/')
-  }
-
-  const curIsLightApp = $derived(curIsHTML && isInsideLaDir(cur?.path ?? ''))
+  const curIsLightApp = $derived(curIsHTML && pathIsInside(cur?.path ?? '', laDir ?? ''))
 
   $effect(() => {
-    if (curIsHTML) void ensureLaDir()
+    if ($panelContent === 'session' && curIsHTML) void ensureLaDir()
+  })
+
+  // The Save dialog must not outlive the button: once the lookup settles and
+  // the artifact turns out to be inside the Light Apps directory, close it.
+  $effect(() => {
+    if (curIsLightApp) saveToLADialog = false
   })
 
   // ── Light Apps (new) ──────────────────────────────────────────────────────

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -82,6 +82,44 @@
 
   const curIsHTML = $derived(cur?.type === 'HTML')
 
+  // ── Already-a-Light-App detection ──────────────────────────────────────────
+  // "Save to Light App" is pointless for a file that already lives inside the
+  // Light Apps directory (a Light App's own index.html, or a file beside it).
+  // The directory itself is server-side knowledge (~/.octo/light-apps), so it
+  // is fetched once, lazily, only once an HTML artifact is showing. A failed
+  // lookup must not hide a working action, so the button stays visible until
+  // the directory is actually known.
+  let laDir = $state<string | null>(null)
+  let laDirAttempted = $state(false)
+
+  async function ensureLaDir() {
+    if (laDir !== null || laDirAttempted) return
+    laDirAttempted = true
+    try {
+      laDir = await api.getLightAppsDir()
+    } catch {
+      laDir = ''
+    }
+  }
+
+  // Path comparison is normalized: separators unified, trailing slashes
+  // stripped, case folded — Windows paths are case-insensitive, and the
+  // server's filepath.Join and the artifact path from the transcript may
+  // differ in spelling.
+  function isInsideLaDir(p: string): boolean {
+    if (!laDir) return false
+    const norm = (s: string) => s.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+    const dir = norm(laDir)
+    const path = norm(p)
+    return path.startsWith(dir + '/')
+  }
+
+  const curIsLightApp = $derived(curIsHTML && isInsideLaDir(cur?.path ?? ''))
+
+  $effect(() => {
+    if (curIsHTML) void ensureLaDir()
+  })
+
   // ── Light Apps (new) ──────────────────────────────────────────────────────
   let laLoading = $state(false)
   let laAttempted = $state(false)
@@ -304,7 +342,7 @@
           <iconify-icon icon="ant-design:download-outlined" width="14"></iconify-icon>
           {$t('artifacts.download')}
         </button>
-        {#if curIsHTML}
+        {#if curIsHTML && !curIsLightApp}
           <button class="wbtn" disabled={!cur.loaded || cur.loadFailed} onclick={openSaveToLA}>
             <iconify-icon icon="ant-design:save-outlined" width="14"></iconify-icon>
             {$t('artifacts.save_to_lightapp')}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -775,9 +775,27 @@ export interface LightAppDetail {
   html: string
 }
 
+// The list response also carries the Light Apps directory itself — the web UI
+// uses it to detect session artifacts that already live inside it.
+export interface LightAppList {
+  apps: LightApp[]
+  dir: string
+}
+
 export async function listLightApps(): Promise<LightApp[]> {
-  const d = await request<{ apps: LightApp[] }>('/api/light-apps')
+  const d = await request<LightAppList>('/api/light-apps')
   return d.apps ?? []
+}
+
+// Absolute path of the Light Apps directory (~/.octo/light-apps). Cached so
+// repeated lookups (per artifact selection) cost one request per session.
+let lightAppsDirCache: string | null = null
+
+export async function getLightAppsDir(): Promise<string> {
+  if (lightAppsDirCache) return lightAppsDirCache
+  const d = await request<LightAppList>('/api/light-apps')
+  lightAppsDirCache = d.dir || ''
+  return lightAppsDirCache
 }
 
 export async function getLightApp(slug: string): Promise<LightAppDetail> {

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { get } from 'svelte/store'
 import { artifacts, artifactSel, panelContent } from './stores'
-import { lightAppSource, observeArtifact, hydrateArtifact, resetArtifacts } from './artifacts'
+import { lightAppSource, observeArtifact, hydrateArtifact, resetArtifacts, pathIsInside } from './artifacts'
 
 // Nothing a preview document references can authenticate: the srcdoc iframe has
 // no allow-same-origin, so its subresource requests are cross-site and the
@@ -705,5 +705,45 @@ describe('installArtifactThemeRefresh — theme switch busts baked previews', ()
     // to rebuild it, so resetting it would strand a permanent spinner.
     expect(get(artifacts)[1].loaded).toBe(true)
     expect(get(artifacts)[1].src).toBe('/api/x.png')
+  })
+})
+
+describe('pathIsInside — Light Apps directory detection', () => {
+  const LA_DIR = '/Users/qiao/.octo/light-apps'
+
+  it('matches files inside the directory, including nested ones', () => {
+    expect(pathIsInside(`${LA_DIR}/my-app/index.html`, LA_DIR)).toBe(true)
+    expect(pathIsInside(`${LA_DIR}/my-app/sub/asset.js`, LA_DIR)).toBe(true)
+  })
+
+  it('rejects siblings that merely share a prefix', () => {
+    expect(pathIsInside('/Users/qiao/.octo/light-apps2/x.html', LA_DIR)).toBe(false)
+    expect(pathIsInside('/Users/qiao/.octo/light-apps.js', LA_DIR)).toBe(false)
+    expect(pathIsInside('/Users/qiao/.octo/light-apps-other/x.html', LA_DIR)).toBe(false)
+  })
+
+  it('rejects unrelated paths and relative paths', () => {
+    expect(pathIsInside('/Users/qiao/Downloads/report.html', LA_DIR)).toBe(false)
+    expect(pathIsInside('my-app/index.html', LA_DIR)).toBe(false)
+    expect(pathIsInside('', LA_DIR)).toBe(false)
+  })
+
+  it('normalizes backslashes (Windows)', () => {
+    expect(pathIsInside('C:\\Users\\qiao\\.octo\\light-apps\\my-app\\index.html', 'C:\\Users\\qiao\\.octo\\light-apps')).toBe(true)
+    expect(pathIsInside('C:\\Users\\qiao\\.octo\\light-apps2\\x.html', 'C:\\Users\\qiao\\.octo\\light-apps')).toBe(false)
+  })
+
+  it('folds case so Windows drive letters and spelling differences match', () => {
+    expect(pathIsInside('/Users/QIAO/.OCTO/Light-Apps/my-app/index.html', LA_DIR)).toBe(true)
+    expect(pathIsInside('C:/Users/Qiao/.octo/light-apps/my-app/index.html', 'c:\\users\\qiao\\.octo\\light-apps')).toBe(true)
+  })
+
+  it('tolerates a trailing slash on either side', () => {
+    expect(pathIsInside(`${LA_DIR}/my-app/index.html`, `${LA_DIR}/`)).toBe(true)
+    expect(pathIsInside(`${LA_DIR}/my-app/index.html/`, LA_DIR)).toBe(true)
+  })
+
+  it('matches nothing when the directory is unknown', () => {
+    expect(pathIsInside(`${LA_DIR}/my-app/index.html`, '')).toBe(false)
   })
 })

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -392,6 +392,19 @@ function cleanPath(p: string): string {
   return (norm.startsWith('/') ? '/' : '') + out.join('/')
 }
 
+// True when `path` lives inside `dir` — used to detect artifacts that already
+// sit in the Light Apps directory, where "Save to Light App" is pointless.
+// Both sides are normalized before comparing: separators unified, trailing
+// slashes stripped, case folded. Windows paths are case-insensitive, and the
+// server's filepath.Join and a transcript path may spell the same directory
+// differently (C:\Users vs c:/users). An empty `dir` (unknown) matches
+// nothing, so callers keep showing the action when the lookup failed.
+export function pathIsInside(path: string, dir: string): boolean {
+  if (!dir) return false
+  const norm = (s: string) => s.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+  return norm(path).startsWith(norm(dir) + '/')
+}
+
 function blobToDataURL(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()


### PR DESCRIPTION
## Summary

The artifacts panel shows a **Save to Light App** action for every HTML artifact. When the file already lives inside `~/.octo/light-apps` — a Light App's own `index.html`, or a file beside it — the action is pointless: saving would either `409` on the existing slug or duplicate the app.

This PR hides the button for those artifacts.

## Changes

- **`internal/server/lightapps_handlers.go`**: `GET /api/light-apps` now also returns the Light Apps directory (`dir`), the one piece of information the browser cannot derive on its own.
- **`web/src/lib/api.ts`**: new `LightAppList` type + `getLightAppsDir()` (cached after first call).
- **`web/src/components/ArtifactsPanel.svelte`**: when an HTML artifact is showing, fetch the directory once; derive `curIsLightApp` by normalizing the artifact path (unified separators, stripped trailing slashes, case-folded for Windows) and checking it starts with the directory; the Save button renders only when `curIsHTML && !curIsLightApp`.

## Behavior notes

- The directory is fetched lazily only while an HTML artifact is showing (one request per session, cached).
- If the lookup fails (offline, old server), the button stays visible — hiding a working action because the directory was unknowable would be worse.
- The check covers anything under the directory (subdirectory files included), not just a byte-exact `index.html` match.

## Tests

- Extended `TestListLightApps_EmptyDir` / `TestListLightApps_WithApps` to assert the `dir` field.
- `go test ./internal/server/` passes; `npx svelte-check` reports 0 errors; `npm run build` passes.