### PR TITLE
fix(web): reword zh workflows.desc copy

### DIFF
--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1198,7 +1198,7 @@ export const zh: Record<string, string> = {
   "skills.export_zip": "导出为 .zip",
   "skills.use": "在新对话中使用",
   "workflows.title": "工作流",
-  "workflows.desc": "串联技能的可复用已保存工作流 — 运行、编辑或导出",
+  "workflows.desc": "将技能串联为可复用工作流 — 运行、编辑或导出",
   "workflows.create": "新建工作流",
   "workflows.show_system": "显示内置工作流",
   "workflows.col_name": "工作流",


### PR DESCRIPTION
## Summary

Reword the Chinese copy for the workflows panel description (web UI only):

- Before: `串联技能的可复用已保存工作流 — 运行、编辑或导出`
- After: `将技能串联为可复用工作流 — 运行、编辑或导出`

The old copy stacked two attributives (`可复用已保存`) ahead of the noun and read stiffly, like a machine translation. The new phrasing puts `可复用` as a result attribute and drops the redundant `已保存` (saved is implied by the term 工作流).

## Tests

- `npx svelte-check`: 0 errors.