### PR TITLE
refactor(tools): drop Jina proxy from web_fetch

### DIFF
--- a/blog/src/content/posts/en/architecture-deep-dive.md
+++ b/blog/src/content/posts/en/architecture-deep-dive.md
@@ -116,9 +116,7 @@ Guarding on an external file's mtime is inherently strict. What if a command the
 
 ### Pulling the Floor Out from Under SSRF
 
-`web_fetch` can't just `http.Get(userURL)`. That's textbook SSRF (Server-Side Request Forgery). Its answer (`internal/tools/web_fetch.go`) runs every request through one hardened path:
-
-- **The direct path**. It fetches the URL straight up, and **must** follow cross-host redirects (URL shorteners and `www` canonicalization are normal), but it shares the link-local ban and caps the redirect chain at 10 hops so a loop can't hang the agent.
+`web_fetch` can't just `http.Get(userURL)`. That's textbook SSRF (Server-Side Request Forgery). Its answer (`internal/tools/web_fetch.go`) is a single hardened fetch path: it goes straight at the URL, and **must** follow cross-host redirects (URL shorteners and `www` canonicalization are normal for an arbitrary URL), but every hop is dialed through `secureFetchTransport` — which refuses link-local and cloud-metadata addresses — and the chain is capped at 10 hops so a loop can't hang the agent.
 
 The `net.Dialer.Control` hook fires **after** DNS resolution with the concrete IP, so DNS rebinding (a hostname that resolves to a public IP now and `169.254.x.x` / `127.0.0.1` a moment later) is blocked too. Bodies have bounds as well: `WebFetchInlineBytes` (64 KB) is the inline threshold; `WebFetchMaxBytes` (5 MB) is the hard cap; beyond that the body is truncated to a temp file. A big page = summary + head/tail preview + a `read_file` pointer to the rest. Never a wall of text shoved into the model's context.
 

--- a/blog/src/content/posts/en/architecture-deep-dive.md
+++ b/blog/src/content/posts/en/architecture-deep-dive.md
@@ -116,10 +116,9 @@ Guarding on an external file's mtime is inherently strict. What if a command the
 
 ### Pulling the Floor Out from Under SSRF
 
-`web_fetch` can't just `http.Get(userURL)`. That's textbook SSRF (Server-Side Request Forgery). Its answer (`internal/tools/web_fetch.go`) splits requests into **two hardened paths** sharing one `secureFetchTransport`:
+`web_fetch` can't just `http.Get(userURL)`. That's textbook SSRF (Server-Side Request Forgery). Its answer (`internal/tools/web_fetch.go`) runs every request through one hardened path:
 
-- **The Jina proxy path**. Rendering is handed to `r.jina.ai` (Jina AI's page-parsing service), but **cross-host** redirects are refused (a redirect off `r.jina.ai` means being bounced somewhere unexpected), and the connection is cut if the resolved IP is link-local or cloud metadata. When the caller passes custom headers, the request is forced onto the direct path (Jina's outbound headers aren't controllable, so the overrides can't be enforced).
-- **The direct path**. Required for arbitrary URLs, so it **must** follow cross-host redirects (URL shorteners and `www` canonicalization are normal). It shares the link-local ban and caps the redirect chain at 10 hops so a loop can't hang the agent.
+- **The direct path**. It fetches the URL straight up, and **must** follow cross-host redirects (URL shorteners and `www` canonicalization are normal), but it shares the link-local ban and caps the redirect chain at 10 hops so a loop can't hang the agent.
 
 The `net.Dialer.Control` hook fires **after** DNS resolution with the concrete IP, so DNS rebinding (a hostname that resolves to a public IP now and `169.254.x.x` / `127.0.0.1` a moment later) is blocked too. Bodies have bounds as well: `WebFetchInlineBytes` (64 KB) is the inline threshold; `WebFetchMaxBytes` (5 MB) is the hard cap; beyond that the body is truncated to a temp file. A big page = summary + head/tail preview + a `read_file` pointer to the rest. Never a wall of text shoved into the model's context.
 

--- a/blog/src/content/posts/zh/architecture-deep-dive.md
+++ b/blog/src/content/posts/zh/architecture-deep-dive.md
@@ -116,9 +116,7 @@ MCP 工具的 JSON schema 可能非常庞大——配置几十个 MCP 服务器�
 
 ### 抽掉 SSRF 的地板
 
-`web_fetch` 不能直接 `http.Get(userURL)`——那是教科书级的 SSRF（Server-Side Request Forgery，服务端请求伪造）。它的回应（`internal/tools/web_fetch.go`）把每个请求压进**一条加固路径**：
-
-- **直接请求路径**——直接抓取原始 URL，因此**必须**跟随跨主机重定向（URL 短链、`www` 规范化跳转都正常），但共享链路本地封禁，并把重定向链上限设为 10 跳，避免环让 agent 挂起。
+`web_fetch` 不能直接 `http.Get(userURL)`——那是教科书级的 SSRF（Server-Side Request Forgery，服务端请求伪造）。它的回应（`internal/tools/web_fetch.go`）是**一条加固过的抓取路径**：直接打原始 URL，因此**必须**跟随跨主机重定向（对任意 URL 来说，短链、`www` 规范化跳转都是常态），但每一跳都经由 `secureFetchTransport` 拨号——链路本地地址与云元数据端点一律拒绝——并把重定向链上限设为 10 跳，避免环让 agent 挂起。
 
 `net.Dialer.Control` 钩子在 DNS 解析**之后**拿到真实 IP 时触发，所以 DNS 重绑定（一个主机名此刻解析成公网 IP，下一刻就解析成 `169.254.x.x` / `127.0.0.1`）也被拦下。身体也有边界：`WebFetchInlineBytes`（64 KB）是内联阈值；`WebFetchMaxBytes`（5 MB）是硬上限；超出就截断落盘到临时文件。大页面 = 摘要 + 头尾预览 + 指一条 `read_file` 路径给剩余部分，绝不一墙文字糊进模型的 context。
 

--- a/blog/src/content/posts/zh/architecture-deep-dive.md
+++ b/blog/src/content/posts/zh/architecture-deep-dive.md
@@ -116,10 +116,9 @@ MCP 工具的 JSON schema 可能非常庞大——配置几十个 MCP 服务器�
 
 ### 抽掉 SSRF 的地板
 
-`web_fetch` 不能直接 `http.Get(userURL)`——那是教科书级的 SSRF（Server-Side Request Forgery，服务端请求伪造）。它的回应（`internal/tools/web_fetch.go`）把请求拆成**两条加固路径**，共享同一个 `secureFetchTransport`：
+`web_fetch` 不能直接 `http.Get(userURL)`——那是教科书级的 SSRF（Server-Side Request Forgery，服务端请求伪造）。它的回应（`internal/tools/web_fetch.go`）把每个请求压进**一条加固路径**：
 
-- **Jina 代理路径**——把渲染交给 `r.jina.ai`（Jina AI 的网页内容解析服务），但拒绝**跨主机**重定向（离开 `r.jina.ai` 的重定向意味着被弹到意外的地方），在解析后 IP 是链路本地地址/云元数据时直接断连接。调用方传入自定义 header 时强制走直接请求（Jina 的出站 header 不可控，无法执行覆盖）。
-- **直接请求路径**——处理任意 URL 所必须，因此**必须**跟随跨主机重定向（URL 短链、`www` 规范化跳转都正常）。共享链路本地封禁，并把重定向链上限设为 10 跳，避免环让 agent 挂起。
+- **直接请求路径**——直接抓取原始 URL，因此**必须**跟随跨主机重定向（URL 短链、`www` 规范化跳转都正常），但共享链路本地封禁，并把重定向链上限设为 10 跳，避免环让 agent 挂起。
 
 `net.Dialer.Control` 钩子在 DNS 解析**之后**拿到真实 IP 时触发，所以 DNS 重绑定（一个主机名此刻解析成公网 IP，下一刻就解析成 `169.254.x.x` / `127.0.0.1`）也被拦下。身体也有边界：`WebFetchInlineBytes`（64 KB）是内联阈值；`WebFetchMaxBytes`（5 MB）是硬上限；超出就截断落盘到临时文件。大页面 = 摘要 + 头尾预览 + 指一条 `read_file` 路径给剩余部分，绝不一墙文字糊进模型的 context。
 

--- a/internal/skills/defaults/deep-research/SKILL.md
+++ b/internal/skills/defaults/deep-research/SKILL.md
@@ -71,8 +71,8 @@ claim that matters, reach the **primary source** and read it:
 | Product capability / API | Official docs or source, not blog posts |
 | Statistics | The dataset publisher, not the article citing it |
 
-Use `web_fetch` on the source URL to pull the page as clean Markdown (pass the
-raw URL — don't hand-build a `r.jina.ai/` prefix). When the source is behind a
+Use `web_fetch` on the source URL to pull the page (pass the raw URL — it
+fetches directly, no proxy prefix). When the source is behind a
 login, renders via JS, or blocks fetching, switch to `browser` per `web-access`.
 
 When no official source exists, an original report from an authoritative outlet

--- a/internal/skills/defaults/web-access/SKILL.md
+++ b/internal/skills/defaults/web-access/SKILL.md
@@ -50,7 +50,7 @@ metadata:
 | 场景 | 工具 |
 |------|------|
 | 搜索摘要、关键词结果、发现信息来源 | **web_search** |
-| URL 已知，按 prompt 从页面定向提取信息（内部自动走 Jina 转 Markdown，省 token） | **web_fetch**（直接传原始 URL，不要自己拼 `r.jina.ai/` 前缀） |
+| URL 已知，按 prompt 从页面定向提取信息（直接 HTTP 抓取，自带浏览器 UA 和同源 Referer） | **web_fetch**（直接传原始 URL） |
 | URL 已知，需要原始 HTML（meta、JSON-LD 等结构化字段） | **terminal**（curl） |
 | 非公开内容，或已知静态层无效的平台（小红书、公众号等） | **browser**（直接，跳过静态层） |
 | 需要登录态、交互操作，或要像人一样在浏览器内自由导航探索 | **browser** |

--- a/internal/skills/defaults/web-access/SKILL.md
+++ b/internal/skills/defaults/web-access/SKILL.md
@@ -50,12 +50,11 @@ metadata:
 | 场景 | 工具 |
 |------|------|
 | 搜索摘要、关键词结果、发现信息来源 | **web_search** |
-| URL 已知，按 prompt 从页面定向提取信息（直接 HTTP 抓取，自带浏览器 UA 和同源 Referer） | **web_fetch**（直接传原始 URL） |
-| URL 已知，需要原始 HTML（meta、JSON-LD 等结构化字段） | **terminal**（curl） |
+| URL 已知，按 prompt 从页面提取信息，或要页面的原始 HTML（meta、JSON-LD 等结构化字段） | **web_fetch**（直接传原始 URL；直接 HTTP 抓取，自带浏览器 UA 和同源 Referer，返回页面原始文本） |
 | 非公开内容，或已知静态层无效的平台（小红书、公众号等） | **browser**（直接，跳过静态层） |
 | 需要登录态、交互操作，或要像人一样在浏览器内自由导航探索 | **browser** |
 
-`web_search` / `web_fetch` / curl 都不处理登录态。`browser` 不要求 URL 已知——可从任意入口出发，靠页面内搜索、点击、跳转找到目标。
+`web_search` / `web_fetch` 都不处理登录态。`browser` 不要求 URL 已知——可从任意入口出发，靠页面内搜索、点击、跳转找到目标。
 
 ## browser 工具要点
 

--- a/internal/tools/sandbox_network_test.go
+++ b/internal/tools/sandbox_network_test.go
@@ -48,18 +48,14 @@ func TestWebFetch_SandboxAllowsNetwork(t *testing.T) {
 	SetSandbox(&p)
 	defer SetSandbox(nil)
 
-	// Point Jina at a local server so we don't need real network.
+	// Point at a local server so we don't need real network.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("# allowed"))
 	}))
 	defer srv.Close()
 
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = srv.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
 	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com",
+		"url": srv.URL,
 	})
 	if err != nil {
 		t.Fatalf("expected success when network is allowed, got: %v", err)

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -33,7 +33,7 @@ const (
 
 // mcpCatalog returns the deferred MCP tool catalog (the same defs mcpToolDefs
 // would upload in full). A package var so tests can inject a fixed catalog
-// without standing up a live MCP registry — mirrors jinaReaderHostForTest.
+// without standing up a live MCP registry.
 var mcpCatalog = mcpToolDefs
 
 // ── configuration ──────────────────────────────────────────────────────────

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -15,18 +15,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
-	"github.com/open-octo/octo-agent/internal/version"
 )
-
-// JinaReaderHost is the public Jina AI Reader endpoint. Sending a URL via
-// `https://r.jina.ai/<URL>` returns the page rendered to Markdown — handles
-// JavaScript-rendered pages, paywalls (where Jina has access), and most
-// of the noisy chrome a raw curl would dump on the LLM.
-const JinaReaderHost = "https://r.jina.ai/"
-
-// jinaReaderHostForTest is the actual host the tool uses. Tests swap it
-// out to a local httptest server; production reads the const default.
-var jinaReaderHostForTest = JinaReaderHost
 
 // WebFetchMaxBytes is the absolute ceiling on a single fetched body, whether
 // returned inline or spilled to a temp file. It bounds memory and disk for a
@@ -50,17 +39,17 @@ const (
 	webFetchOutlineMaxHeadings = 50
 )
 
-// WebFetchTool fetches a URL and returns its body as Markdown. It prefers
-// the Jina AI Reader proxy for JS-rendered pages and clean HTML-to-Markdown
-// conversion, but falls back to a direct HTTP fetch when the proxy fails.
+// WebFetchTool fetches a URL and returns its body as text via a direct HTTP
+// GET with a browser-like header set. JS-rendered pages come back as their
+// static HTML skeleton; for interactive or login-walled content, use browser.
 type WebFetchTool struct{}
 
 func (WebFetchTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "web_fetch",
-		Description: "Fetch a URL and return its content. Prefers the Jina Reader proxy " +
-			"for JS-rendered pages and clean HTML-to-Markdown conversion; falls back to " +
-			"a direct HTTP fetch when the proxy is unavailable. " +
+		Description: "Fetch a URL and return its content via a direct HTTP GET with a " +
+			"browser-like header set (JS-rendered pages return their static HTML skeleton; " +
+			"for interactive or login-walled content use the browser tool). " +
 			"Responses larger than ~64 KB are saved to a temp file; the tool returns a " +
 			"preview summary (size, content-type, first/last lines) plus the file path. " +
 			"Use read_file or grep on that path to inspect the full content. " +
@@ -69,9 +58,7 @@ func (WebFetchTool) Definition() agent.ToolDefinition {
 			"Public web only — no authentication.\n\n" +
 			"If a URL returns 403/404 even though it works in a browser (hotlink/anti-bot " +
 			"checks), set `referer` — e.g. the page's own origin (https://example.com) or the " +
-			"search engine you found it from. Setting `referer` or `user_agent` forces a direct " +
-			"fetch with those headers (the Jina proxy is skipped, since its outbound headers " +
-			"aren't controllable).",
+			"search engine you found it from — or override `user_agent`.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -81,11 +68,11 @@ func (WebFetchTool) Definition() agent.ToolDefinition {
 				},
 				"referer": map[string]any{
 					"type":        "string",
-					"description": "Optional Referer header. Use when a page 403/404s without one (hotlink protection, anti-bot). Often the page's own origin or the search-result source. Forces a direct fetch (skips the Jina proxy).",
+					"description": "Optional Referer header. Use when a page 403/404s without one (hotlink protection, anti-bot). Often the page's own origin or the search-result source.",
 				},
 				"user_agent": map[string]any{
 					"type":        "string",
-					"description": "Optional User-Agent override. Rarely needed (a realistic browser UA is sent by default). Forces a direct fetch (skips the Jina proxy).",
+					"description": "Optional User-Agent override. Rarely needed (a realistic browser UA is sent by default).",
 				},
 			},
 			"required": []string{"url"},
@@ -102,15 +89,6 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 	if strings.TrimSpace(raw) == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: url is required")
 	}
-	// Strip a mistakenly-passed Jina prefix so both the proxy and fallback
-	// paths operate on the original URL.
-	jinaHost := jinaReaderHostForTest
-	if !strings.HasSuffix(jinaHost, "/") {
-		jinaHost += "/"
-	}
-	if strings.HasPrefix(raw, jinaHost) {
-		raw = strings.TrimPrefix(raw, jinaHost)
-	}
 	u, err := url.Parse(raw)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: parse url: %w", err)
@@ -122,51 +100,17 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 	referer := strings.TrimSpace(stringArg(input, "referer"))
 	userAgent := strings.TrimSpace(stringArg(input, "user_agent"))
 
-	// Custom headers requested: the model wants this page fetched with a
-	// specific Referer/User-Agent (typically to clear a hotlink/anti-bot 403/404).
-	// Go straight to the direct fetch — the Jina proxy's outbound headers aren't
-	// controllable, so it can't honour the override.
-	if referer != "" || userAgent != "" {
-		directCtx, directCancel := context.WithTimeout(ctx, 30*time.Second)
-		out, err := fetchDirect(directCtx, raw, referer, userAgent)
-		directCancel()
-		if err != nil {
-			return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: %w", err)
-		}
-		out.UI = webFetchUI(raw, out.Text)
-		return out, nil
+	// fetchDirect supplies a same-origin Referer and a browser UA by default;
+	// explicit overrides are passed through when the caller needs to clear a
+	// hotlink/anti-bot 403/404.
+	directCtx, directCancel := context.WithTimeout(ctx, 30*time.Second)
+	out, err := fetchDirect(directCtx, raw, referer, userAgent)
+	directCancel()
+	if err != nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: %w", err)
 	}
-
-	// Strategy: try Jina Reader proxy first (better quality), then fall back
-	// to a direct fetch on network-level or 5xx/429 proxy failures.
-	// Jina gets a short 5s timeout so a slow proxy doesn't block the fallback.
-	jinaCtx, jinaCancel := context.WithTimeout(ctx, 5*time.Second)
-	out, jinaErr := fetchViaJina(jinaCtx, raw)
-	jinaCancel()
-	if jinaErr == nil {
-		out.UI = webFetchUI(raw, out.Text)
-		return out, nil
-	}
-
-	// Fallback conditions: network errors (TLS, DNS, timeout), 5xx proxy
-	// errors, or 429 rate-limit. 4xx client errors (e.g. 404) from the proxy
-	// are NOT retried — the proxy correctly reflected an upstream 404.
-	if shouldFallback(jinaErr) {
-		// Give the direct fetch the remaining time up to 30s total. No explicit
-		// referer/UA here — fetchDirect supplies a same-origin Referer and a
-		// browser UA by default.
-		directCtx, directCancel := context.WithTimeout(ctx, 30*time.Second)
-		out, directErr := fetchDirect(directCtx, raw, "", "")
-		directCancel()
-		if directErr == nil {
-			out.UI = webFetchUI(raw, out.Text)
-			return out, nil
-		}
-		// Both failed — surface both errors so the LLM knows what happened.
-		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: jina proxy failed (%v); direct fetch also failed (%v)", jinaErr, directErr)
-	}
-
-	return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: %w", jinaErr)
+	out.UI = webFetchUI(raw, out.Text)
+	return out, nil
 }
 
 // webFetchUI builds the "web_fetch" UI payload. Title and status code are
@@ -178,65 +122,6 @@ func webFetchUI(url, text string) map[string]any {
 		"url":             url,
 		"content_preview": uiHead(text, 4, 300),
 	}
-}
-
-// shouldFallback returns true when a Jina proxy error is worth retrying
-// with a direct fetch. 4xx errors (except 429 rate-limit) are assumed to
-// be legitimate upstream responses and are not retried.
-func shouldFallback(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	// Network-level errors always fallback.
-	if strings.Contains(s, "tls:") ||
-		strings.Contains(s, "x509:") ||
-		strings.Contains(s, "no such host") ||
-		strings.Contains(s, "connection refused") ||
-		strings.Contains(s, "connection reset by peer") ||
-		strings.Contains(s, "timeout") ||
-		strings.Contains(s, "temporary failure") ||
-		strings.Contains(s, "i/o timeout") ||
-		strings.Contains(s, "context deadline exceeded") ||
-		strings.Contains(s, "EOF") {
-		return true
-	}
-	// HTTP 5xx or 429 from the proxy — the proxy itself is struggling.
-	if strings.Contains(s, "HTTP 5") || strings.Contains(s, "HTTP 429") {
-		return true
-	}
-	return false
-}
-
-// fetchViaJina calls the Jina Reader proxy and returns the rendered Markdown.
-func fetchViaJina(ctx context.Context, rawURL string) (agent.ToolResult, error) {
-	// Jina's contract is literal string concatenation: r.jina.ai/<rest>.
-	// Do NOT QueryEscape — Jina parses the rest-of-path itself, and
-	// escaping breaks routing. A `#fragment` in raw is technically lost
-	// here (Jina won't see it), but fragments are never sent to servers
-	// anyway, so this matches normal HTTP semantics.
-	jinaURL := jinaReaderHostForTest + rawURL
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jinaURL, nil)
-	if err != nil {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Accept", "text/markdown,text/plain,*/*")
-	// Identify ourselves so Jina can reach us about issues.
-	req.Header.Set("User-Agent", version.UserAgent())
-
-	resp, err := webFetchHTTPClient().Do(req)
-	if err != nil {
-		return agent.ToolResult{Text: ""}, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return agent.ToolResult{Text: ""}, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	return readBody(resp.Body, rawURL, resp.Header.Get("Content-Type"))
 }
 
 // defaultDirectUserAgent is the browser-like UA sent on direct fetches when the
@@ -528,7 +413,7 @@ func blockedFetchIP(ip net.IP) bool {
 // destinations. The check runs in net.Dialer.Control, which fires AFTER DNS
 // resolution with the concrete remote IP — so a hostname that resolves to a
 // blocked address (DNS rebinding) is refused too, and every redirect hop is
-// re-dialed through the same hook. Shared by both web_fetch clients.
+// re-dialed through the same hook. Used by the web_fetch client.
 func secureFetchTransport() *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
@@ -554,37 +439,11 @@ func secureFetchTransport() *http.Transport {
 	}
 }
 
-// webFetchHTTPClient is the client used for the Jina-proxy path. On top of the
-// shared link-local block it refuses to follow a cross-host 3xx redirect: the
-// proxy always targets r.jina.ai, so a redirect to a different host means it is
-// bouncing us somewhere unexpected — a classic SSRF / data-exfil vector.
-// Same-host redirects (path changes) are still followed. web_search keeps the
-// plain webHTTPClient because search backends legitimately redirect across
-// hosts.
-func webFetchHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: secureFetchTransport(),
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) == 0 {
-				return nil
-			}
-			prev := via[len(via)-1].URL.Host
-			if !strings.EqualFold(req.URL.Host, prev) {
-				return fmt.Errorf("refusing cross-host redirect to %q (from %q); "+
-					"re-issue web_fetch against the final URL if that destination is intended",
-					req.URL.Host, prev)
-			}
-			return nil
-		},
-	}
-}
-
-// directFetchHTTPClient is the client for the direct-fetch fallback. Unlike the
-// proxy client it MUST allow cross-host redirects (URL shorteners, www-canonical
-// hops, http→https on another host are all normal for an arbitrary URL), but it
-// shares the link-local block via secureFetchTransport and caps the redirect
-// chain so a redirect loop can't hang the agent.
+// directFetchHTTPClient is the client used by web_fetch. It MUST allow
+// cross-host redirects (URL shorteners, www-canonical hops, http→https on
+// another host are all normal for an arbitrary URL), but it shares the
+// link-local block via secureFetchTransport and caps the redirect chain so a
+// redirect loop can't hang the agent.
 func directFetchHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout:   30 * time.Second,

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -8,12 +8,11 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 )
 
-// TestWebFetch_CustomHeadersGoDirect verifies that supplying referer/user_agent
-// forces a direct fetch carrying those headers and skips the Jina proxy.
-func TestWebFetch_CustomHeadersGoDirect(t *testing.T) {
+// TestWebFetch_CustomHeadersPassedThrough verifies that supplied referer /
+// user_agent headers reach the destination server.
+func TestWebFetch_CustomHeadersPassedThrough(t *testing.T) {
 	var gotReferer, gotUA string
 	hits := 0
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -24,16 +23,6 @@ func TestWebFetch_CustomHeadersGoDirect(t *testing.T) {
 		_, _ = w.Write([]byte("<html><body>ok</body></html>"))
 	}))
 	defer target.Close()
-
-	// Jina must NOT be called when custom headers are set.
-	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("Jina proxy was called despite custom headers")
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer jina.Close()
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = jina.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
 
 	if _, err := (WebFetchTool{}).Execute(context.Background(), "web_fetch", map[string]any{
 		"url":        target.URL,
@@ -142,20 +131,6 @@ func TestIsTextualContentType(t *testing.T) {
 	}
 }
 
-// withJinaHost swaps JinaReaderHost for the test server URL. Since
-// JinaReaderHost is a const, we test by directly hitting the helper that
-// uses the URL passed in. Instead, we mock at the network layer by setting
-// up an httptest server and rewriting the URL the tool would call.
-//
-// The simpler approach: spin up a server, then call WebFetchTool.Execute
-// with a URL that points at the test server but is shaped like a normal
-// HTTP url. Since the production code does `JinaReaderHost + raw`, we
-// can't easily redirect that without changing the const to a var.
-//
-// We change JinaReaderHost to a var below (see web_fetch.go) — but to
-// keep the test file standalone, we test the simpler case: pointing at
-// the test server directly while exercising the full HTTP path, error
-// handling, and truncation.
 func TestWebFetch_RequiresURL(t *testing.T) {
 	_, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{})
 	if err == nil {
@@ -172,21 +147,15 @@ func TestWebFetch_RejectsNonHTTPScheme(t *testing.T) {
 	}
 }
 
-func TestWebFetch_AgainstHTTPTest(t *testing.T) {
-	// Stand up an httptest server that responds like Jina would — plain
-	// Markdown. Then temporarily redirect JinaReaderHost to it.
+func TestWebFetch_FetchesURL(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/markdown")
 		_, _ = w.Write([]byte("# Hello\n\nthis is markdown"))
 	}))
 	defer srv.Close()
 
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = srv.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
 	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com/article",
+		"url": srv.URL + "/article",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -195,45 +164,16 @@ func TestWebFetch_AgainstHTTPTest(t *testing.T) {
 		t.Errorf("unexpected body: %q", out.Text)
 	}
 	ui, ok := out.UI.(map[string]any)
-	if !ok || ui["type"] != "web_fetch" || ui["url"] != "https://example.com/article" {
+	if !ok || ui["type"] != "web_fetch" || ui["url"] != srv.URL+"/article" {
 		t.Errorf("UI payload = %#v", out.UI)
 	}
 }
 
-func TestWebFetch_RefusesCrossHostRedirect(t *testing.T) {
-	// Destination server (a different host:port than the "jina" entry point).
-	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("secret internal content"))
-	}))
-	defer dest.Close()
-
-	// Entry server stands in for r.jina.ai and 302s us to dest — a different
-	// host. The web_fetch client must refuse to follow.
-	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, dest.URL, http.StatusFound)
-	}))
-	defer entry.Close()
-
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = entry.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
-	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com/x",
-	})
-	if err == nil {
-		t.Fatalf("expected cross-host redirect to be refused; got body %q", out.Text)
-	}
-	if !strings.Contains(err.Error(), "cross-host redirect") {
-		t.Errorf("error should mention cross-host redirect, got %v", err)
-	}
-	if strings.Contains(out.Text, "secret internal content") {
-		t.Errorf("must not have followed the redirect to the destination")
-	}
-}
-
-func TestWebFetch_FollowsSameHostRedirect(t *testing.T) {
-	// A redirect that stays on the same host (path change only) is fine.
+// TestWebFetch_FollowsRedirect verifies the direct client follows both
+// same-host and cross-host redirects (URL shorteners, www-canonical hops,
+// http→https moves are all normal for an arbitrary URL).
+func TestWebFetch_FollowsRedirect(t *testing.T) {
+	// Same-host redirect (path change only) is followed.
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/start" {
@@ -244,18 +184,35 @@ func TestWebFetch_FollowsSameHostRedirect(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = srv.URL + "/start?u=" // shape: <host>/start?u=<rawURL>
-	defer func() { jinaReaderHostForTest = old }()
-
 	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com/x",
+		"url": srv.URL + "/start",
 	})
 	if err != nil {
 		t.Fatalf("same-host redirect should be followed: %v", err)
 	}
 	if !strings.Contains(out.Text, "arrived") {
 		t.Errorf("expected to reach the same-host redirect target, got %q", out.Text)
+	}
+
+	// Cross-host redirect is followed too (URL shorteners are normal).
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("cross-host arrived"))
+	}))
+	defer dest.Close()
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dest.URL, http.StatusFound)
+	}))
+	defer entry.Close()
+
+	out, err = WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
+		"url": entry.URL,
+	})
+	if err != nil {
+		t.Fatalf("cross-host redirect should be followed: %v", err)
+	}
+	if !strings.Contains(out.Text, "cross-host arrived") {
+		t.Errorf("expected the cross-host redirect target, got %q", out.Text)
 	}
 }
 
@@ -265,12 +222,8 @@ func TestWebFetch_HTTPErrorWrapped(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = srv.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
 	_, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com/x",
+		"url": srv.URL,
 	})
 	if err == nil || !strings.Contains(err.Error(), "HTTP 502") {
 		t.Errorf("expected HTTP 502 error, got %v", err)
@@ -285,12 +238,8 @@ func TestWebFetch_Truncates(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = srv.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
 	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com/big",
+		"url": srv.URL + "/big",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -312,12 +261,8 @@ func TestWebFetch_SmallResponseNotSpilled(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = srv.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
 	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com/small",
+		"url": srv.URL + "/small",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -341,12 +286,8 @@ func TestWebFetch_MediumResponseInline(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = srv.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
 	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com/medium",
+		"url": srv.URL + "/medium",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -422,12 +363,8 @@ func TestWebFetch_SpillIncludesOutline(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = srv.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
 	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com/doc",
+		"url": srv.URL + "/doc",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -451,12 +388,8 @@ func TestWebFetch_LargeResponseSpilled(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = srv.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
 	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": "https://example.com/large",
+		"url": srv.URL + "/large",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -482,222 +415,6 @@ func TestWebFetch_LargeResponseSpilled(t *testing.T) {
 	}
 	if string(data) != big {
 		t.Errorf("spill file content mismatch")
-	}
-}
-
-// ───────────────────── fallback tests ─────────────────────
-
-func TestWebFetch_FallsBackOnTLSFailure(t *testing.T) {
-	// Jina proxy returns a TLS error (simulated by a server that closes
-	// immediately, causing a connection error that triggers fallback).
-	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Force a connection reset by hijacking and closing.
-		hj, ok := w.(http.Hijacker)
-		if !ok {
-			t.Fatal("server does not support hijacking")
-		}
-		conn, _, err := hj.Hijack()
-		if err != nil {
-			t.Fatalf("hijack failed: %v", err)
-		}
-		conn.Close()
-	}))
-	defer jina.Close()
-
-	// Direct server serves the real content.
-	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("direct fallback content"))
-	}))
-	defer direct.Close()
-
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = jina.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
-	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": direct.URL + "/page",
-	})
-	if err != nil {
-		t.Fatalf("expected fallback to succeed, got: %v", err)
-	}
-	if !strings.Contains(out.Text, "direct fallback content") {
-		t.Errorf("expected direct fallback content, got: %q", out.Text)
-	}
-}
-
-func TestWebFetch_FallsBackOnHTTP5xx(t *testing.T) {
-	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "jina overloaded", http.StatusServiceUnavailable)
-	}))
-	defer jina.Close()
-
-	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("direct ok"))
-	}))
-	defer direct.Close()
-
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = jina.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
-	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": direct.URL + "/page",
-	})
-	if err != nil {
-		t.Fatalf("expected fallback to succeed, got: %v", err)
-	}
-	if !strings.Contains(out.Text, "direct ok") {
-		t.Errorf("expected direct ok, got: %q", out.Text)
-	}
-}
-
-func TestWebFetch_NoFallbackOnHTTP404(t *testing.T) {
-	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not found", http.StatusNotFound)
-	}))
-	defer jina.Close()
-
-	// Even though direct would succeed, we should NOT fallback on 4xx.
-	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("should not reach here"))
-	}))
-	defer direct.Close()
-
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = jina.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
-	_, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": direct.URL + "/page",
-	})
-	if err == nil {
-		t.Fatal("expected 404 error, got success")
-	}
-	if !strings.Contains(err.Error(), "HTTP 404") {
-		t.Errorf("expected HTTP 404 in error, got: %v", err)
-	}
-}
-
-func TestWebFetch_BothFail(t *testing.T) {
-	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "jina bad", http.StatusBadGateway)
-	}))
-	defer jina.Close()
-
-	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "direct bad", http.StatusInternalServerError)
-	}))
-	defer direct.Close()
-
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = jina.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
-	_, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": direct.URL + "/page",
-	})
-	if err == nil {
-		t.Fatal("expected error when both fail")
-	}
-	if !strings.Contains(err.Error(), "jina proxy failed") {
-		t.Errorf("error should mention jina proxy failure, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "direct fetch also failed") {
-		t.Errorf("error should mention direct fetch failure, got: %v", err)
-	}
-}
-
-func TestWebFetch_FallsBackOnHTTP429(t *testing.T) {
-	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "rate limited", http.StatusTooManyRequests)
-	}))
-	defer jina.Close()
-
-	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("direct after rate limit"))
-	}))
-	defer direct.Close()
-
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = jina.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
-	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": direct.URL + "/page",
-	})
-	if err != nil {
-		t.Fatalf("expected fallback to succeed, got: %v", err)
-	}
-	if !strings.Contains(out.Text, "direct after rate limit") {
-		t.Errorf("expected direct content, got: %q", out.Text)
-	}
-}
-
-func TestWebFetch_FallsBackOnConnectionResetByPeer(t *testing.T) {
-	// Simulate the exact error Jina returns when the upstream resets the TCP
-	// connection — this must trigger the direct-fetch fallback.
-	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hj, ok := w.(http.Hijacker)
-		if !ok {
-			t.Fatal("server does not support hijacking")
-		}
-		conn, _, err := hj.Hijack()
-		if err != nil {
-			t.Fatalf("hijack failed: %v", err)
-		}
-		conn.Close()
-	}))
-	defer jina.Close()
-
-	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("direct after reset"))
-	}))
-	defer direct.Close()
-
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = jina.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
-	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
-		"url": direct.URL + "/page",
-	})
-	if err != nil {
-		t.Fatalf("expected fallback to succeed, got: %v", err)
-	}
-	if !strings.Contains(out.Text, "direct after reset") {
-		t.Errorf("expected direct content, got: %q", out.Text)
-	}
-}
-
-func TestWebFetch_FallsBackOnContextDeadlineExceeded(t *testing.T) {
-	// Jina proxy that sleeps longer than the 5s jina timeout but less than
-	// the total budget, so the fallback has time to succeed.
-	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(6 * time.Second)
-	}))
-	defer jina.Close()
-
-	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("direct after deadline"))
-	}))
-	defer direct.Close()
-
-	old := jinaReaderHostForTest
-	jinaReaderHostForTest = jina.URL + "/"
-	defer func() { jinaReaderHostForTest = old }()
-
-	// Total budget 10s — jina gets 5s, direct gets up to 30s (capped by this 10s).
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	out, err := WebFetchTool{}.Execute(ctx, "web_fetch", map[string]any{
-		"url": direct.URL + "/page",
-	})
-	if err != nil {
-		t.Fatalf("expected fallback to succeed, got: %v", err)
-	}
-	if !strings.Contains(out.Text, "direct after deadline") {
-		t.Errorf("expected direct content, got: %q", out.Text)
 	}
 }
 


### PR DESCRIPTION
## Summary

`web_fetch` previously tried the Jina Reader proxy (`r.jina.ai`) first with a 5s timeout, then fell back to a direct fetch. The proxy fails often enough that every request paid the latency — or failed outright on proxy 4xx — for little gain. **web_fetch now always fetches directly** with a browser-like header set.

## Removed

- `JinaReaderHost` const, `jinaReaderHostForTest` var
- `fetchViaJina`, `shouldFallback` (proxy-failure heuristics)
- The Jina-specific http client with its cross-host redirect refusal
- Jina-prefix strip in `Execute`
- 6 fallback tests + 2 Jina-client redirect tests

## Kept (direct path unchanged)

- Same-origin Referer + browser UA defaults, custom `referer`/`user_agent` overrides
- 10-hop redirect cap, link-local/metadata SSRF block
- Inline/spill thresholds, content-type guards, binary notices

## Docs updated

- `web-access` and `deep-research` skill text
- Architecture deep-dive blog post (en + zh)

## Testing

`go test -race ./...` green except `TestManifestForProfile_FiltersByToolSkills`, a known local-environment noise (counts real `~/.octo/skills`; passes with an isolated HOME — unrelated to this change).

Co-authored-by: octo-agent <no-reply@octo-agent.dev>

## Review follow-ups

- `web-access` routing table: folded the now-meaningless "I need the raw HTML → terminal/curl" row into `web_fetch`, which returns the page's raw text itself post-Jina. Dropped curl from the "no login state" line accordingly.
- Architecture post (en + zh): "one hardened path" was followed by a one-item bullet list. Inlined into the paragraph and named `secureFetchTransport`, which the next paragraph describes.

## Release ordering

**Do not cut a release with this PR but without the HTML cleaner (#2064's implementation).** On its own this measurably regresses `web_fetch`:

- Small pages inline tens of KB of raw HTML (go.dev/blog ≈ 35 KB, HN ≈ 35 KB).
- Large pages spill to a temp file, and `markdownOutline` only recognises ATX markdown headings — its own doc comment says it returns `""` for raw HTML — so the outline is always empty. Wikipedia's Go article (720 KB) yields a preview that is 40 lines of `<!DOCTYPE html><head><script>` plus a file path.
