### PR TITLE
feat(server,web): broadcast session-group changes so all tabs stay in sync

### DIFF
--- a/dev-docs/projects-design.md
+++ b/dev-docs/projects-design.md
@@ -173,6 +173,12 @@ type updateSessionGroupRequest struct {
 - **Composer 的 cwd chip**：会话属于项目时显示项目目录，且**置为只读**，点击提示「由项目〈名字〉统一管理」。这一条不能省——否则用户改了没反应，就是一次静默失效。
 - **拖入 / 移出项目**：复用现有的 `PUT /api/sessions/{id}/group`。移入后工作目录立刻显示为项目目录，移出后回落到会话自己的值。
 
+## 多 tab 同步
+
+registry 的每次成功写盘（分组增删改、成员移动、pin、项目目录/notes 编辑）都会全局广播 `session_groups_changed`，钩在唯一写点 `saveRegistry` 上（`notifyGroupsChanged`，Server `initWS` 时装配）——而不是散在每个 handler 里，这样 cron 的编程式写入和将来的新写路径都不会漏。事件**不带 payload**：客户端收到后重新拉 `GET /api/session-groups`，registry 的形状不用在客户端镜像一份。
+
+没有它，一个 tab 里改掉的项目目录在其它 tab 里保持陈旧——sidebar 头和 composer chip（从 groups store 派生）会误报工具实际运行的位置。执行侧永远正确（解析在服务端），这纯粹是显示同步。发起方 tab 自己也会收到广播并重拉一次，幂等无害。
+
 ## 测试要点
 
 - 解析优先级三种组合：有项目、无项目有会话值、两者都无。

--- a/internal/server/projects_test.go
+++ b/internal/server/projects_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -423,6 +424,81 @@ func TestProject_CreateSessionInUnknownGroup(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("unknown group: status %d, want 404: %s", rec.Code, rec.Body.String())
 	}
+}
+
+// TestProject_RegistryWritesNotifyTabs: every registry write must fire the
+// groups-changed notification — it is what keeps other tabs' sidebar headers
+// and composer chips from lying about where a project's tools run. Hooked at
+// saveRegistry, so one test can sweep every write path.
+func TestProject_RegistryWritesNotifyTabs(t *testing.T) {
+	srv := groupTestServer(t)
+	projectDir := t.TempDir()
+	sess := saveSessionWithDir(t, "")
+
+	notified := 0
+	prev := notifyGroupsChanged
+	notifyGroupsChanged = func() { notified++ }
+	t.Cleanup(func() { notifyGroupsChanged = prev })
+
+	steps := []struct {
+		name string
+		do   func() *httptest.ResponseRecorder
+	}{
+		{"create project", func() *httptest.ResponseRecorder {
+			rec, _ := doGroupReq(t, srv, http.MethodPost, "/api/session-groups", map[string]any{"name": "Work", "working_dir": projectDir})
+			return rec
+		}},
+		{"move session in", func() *httptest.ResponseRecorder {
+			gid := projectIDByName(t, srv, "Work")
+			rec, _ := doGroupReq(t, srv, http.MethodPut, "/api/sessions/"+sess.ID+"/group", map[string]any{"group_id": gid})
+			return rec
+		}},
+		{"edit notes", func() *httptest.ResponseRecorder {
+			gid := projectIDByName(t, srv, "Work")
+			rec, _ := doGroupReq(t, srv, http.MethodPatch, "/api/session-groups/"+gid, map[string]any{"notes": "n"})
+			return rec
+		}},
+		{"pin session", func() *httptest.ResponseRecorder {
+			rec, _ := doGroupReq(t, srv, http.MethodPut, "/api/sessions/"+sess.ID+"/pin", map[string]any{"pinned": true})
+			return rec
+		}},
+		{"delete group", func() *httptest.ResponseRecorder {
+			gid := projectIDByName(t, srv, "Work")
+			rec, _ := doGroupReq(t, srv, http.MethodDelete, "/api/session-groups/"+gid, nil)
+			return rec
+		}},
+	}
+	for _, step := range steps {
+		before := notified
+		if rec := step.do(); rec.Code != http.StatusOK {
+			t.Fatalf("%s: status %d: %s", step.name, rec.Code, rec.Body.String())
+		}
+		if notified <= before {
+			t.Errorf("%s: registry write did not notify", step.name)
+		}
+	}
+}
+
+// projectIDByName finds a group id by name via the list endpoint.
+func projectIDByName(t *testing.T, srv *Server, name string) string {
+	t.Helper()
+	rec, _ := doGroupReq(t, srv, http.MethodGet, "/api/session-groups", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list groups: status %d", rec.Code)
+	}
+	var resp struct {
+		Groups []sessionGroup `json:"groups"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, g := range resp.Groups {
+		if g.Name == name {
+			return g.ID
+		}
+	}
+	t.Fatalf("group %q not found", name)
+	return ""
 }
 
 // TestProject_ListReportsProjectFields makes sure the Web UI can tell a project

--- a/internal/server/session_groups.go
+++ b/internal/server/session_groups.go
@@ -90,6 +90,22 @@ type groupFile struct {
 	PinnedSessionIDs []string       `json:"pinned_session_ids,omitempty"`
 }
 
+// notifyGroupsChanged, when set (Server.New), is called after every successful
+// registry write so open Web/desktop tabs can refetch the groups snapshot —
+// without it, a project's working directory changed in one tab stays stale in
+// every other until reload, and a stale project directory misleads about
+// where a session's tools run. One hook at the single write point
+// (saveRegistry) rather than a broadcast per HTTP handler: the programmatic
+// writers (cron's group helpers, create-session-in-group) are covered too,
+// and no future write path can forget it. Called under groupMu — the hub's
+// buffered events channel makes that non-blocking in practice, same as every
+// other broadcast issued under a lock.
+//
+// Package-level like groupMu/regCache: the registry is per-~/.octo process
+// state, and the last Server to start owns the notification. A no-op when nil
+// (tests that never construct a Server).
+var notifyGroupsChanged func()
+
 // groupMu serialises read-modify-write cycles on the registry within this
 // process — the common case, since a given ~/.octo is normally served by one
 // process. It does NOT coordinate across processes: if `octo serve` and the
@@ -157,6 +173,9 @@ func saveRegistry(gf groupFile) error {
 		return fmt.Errorf("session groups: write %s: %w", path, err)
 	}
 	invalidateRegistryCache()
+	if notifyGroupsChanged != nil {
+		notifyGroupsChanged()
+	}
 	return nil
 }
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -2280,6 +2280,14 @@ func (s *Server) initWS() {
 	s.interrupts = make(map[string]context.CancelFunc)
 	s.confirmations = make(map[string]chan string)
 	s.liveStates = make(map[string]*sessionLiveState)
+	// Every registry write (group/pin/project edits, from any writer) tells
+	// all connected tabs to refetch the groups snapshot — see
+	// notifyGroupsChanged's doc comment for why this is hooked at the write
+	// point rather than in each handler.
+	hub := s.wsHub
+	notifyGroupsChanged = func() {
+		hub.broadcast("", wsEventSessionGroupsChanged{Type: "session_groups_changed"})
+	}
 }
 
 // toolDefsFor returns tool definitions for the given model.

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -212,6 +212,15 @@ type wsEventSessionCreated struct {
 	SessionID string `json:"session_id"`
 }
 
+// wsEventSessionGroupsChanged is broadcast globally after every session-group
+// registry write (group create/rename/delete/reorder, membership moves, pins,
+// project directory/notes edits). It deliberately carries no payload: clients
+// refetch GET /api/session-groups, so there is no second copy of the registry
+// shape to keep in sync.
+type wsEventSessionGroupsChanged struct {
+	Type string `json:"type"`
+}
+
 type wsEventRequestFeedback struct {
 	Type string `json:"type"`
 	// SessionID is required: the ws-dispatcher drops any event whose session_id

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, sessions, sessionGroups, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell, panelContent, cmdkOpen, settingsModalOpen, createNewSession, isDesktopShell } from './lib/stores'
+  import { view, sessions, sessionGroups, pinnedSessions, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell, panelContent, cmdkOpen, settingsModalOpen, createNewSession, isDesktopShell } from './lib/stores'
   import MobileApp from './mobile/MobileApp.svelte'
   import { ws, wsState } from './lib/ws'
   import { notificationsEnabled } from './lib/notifications'
@@ -231,6 +231,21 @@
     ws.on('session_created', () => {
       refreshSessionsFromServer()
       api.listSessionGroups().then(org => sessionGroups.set(org.groups)).catch(() => { /* non-critical */ })
+    })
+
+    // The group registry changed — in this tab or another (a group edit, a
+    // membership move, a pin, a project's working directory or notes). The
+    // groups snapshot is otherwise fetched once at sidebar mount, so without
+    // this a project directory retargeted in one tab stays stale in every
+    // other: the sidebar header keeps the old path and the composer chip of
+    // member sessions (which derives from the groups store) misleads about
+    // where tools actually run. The event carries no payload by design —
+    // refetch, so there's no registry shape to mirror client-side.
+    ws.on('session_groups_changed', () => {
+      api.listSessionGroups().then(org => {
+        sessionGroups.set(org.groups)
+        pinnedSessions.set(org.pinned)
+      }).catch(() => { /* non-critical; next mount refetches */ })
     })
 
     // session_activity is a lightweight global signal (unlike


### PR DESCRIPTION
## What

Follow-up to #2069, closing the known gap it documented: a project's working directory changed in one tab stayed stale in every other open tab until reload.

Every successful group-registry write now broadcasts a global `session_groups_changed` WS event. Open tabs refetch `GET /api/session-groups` — previously fetched only once, at sidebar mount — so the sidebar's project header and the composer's read-only dir chip (both derived from the groups store) follow the change immediately.

## Why now, when group-rename staleness never warranted it

Execution was always correct — resolution is server-side. But the project directory is a statement about **where a session's tools run**; a UI that misreports that is worse than a stale group name.

## Design

- **Hooked at the single write point** (`saveRegistry`), not per HTTP handler: covers the programmatic writers too (cron's group helpers, create-session-in-group), and no future write path can forget it. Wired in `initWS` via a package-level `notifyGroupsChanged` — same lifecycle as the registry's other package state (`groupMu`, `regCache`).
- **No payload by design**: clients refetch, so there's no second copy of the registry shape to keep in sync. Same pattern as the existing `session_created` handler, which already refetches groups.
- Pins ride along: they live in the same registry file, so pin changes now sync across tabs too.
- The initiating tab also receives the broadcast and refetches once — idempotent.

## Testing

- `TestProject_RegistryWritesNotifyTabs` sweeps five write paths (create project, move session in, edit notes, pin, delete group) and asserts each fires the notification.
- `go test -race ./internal/server/`, `make vet`, `make fmt-check`, `svelte-check` (0 errors), `vitest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)