### PR TITLE
chore: bump version to 1.15.10

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.9"
+var Version = "1.15.10"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the v1.15.10 patch release. Ships everything merged since v1.15.9:

- #2069 — projects: session groups that share one working directory
- #2071 — broadcast session-group changes so all tabs stay in sync
- #2068 — vision helper: let text-only models see images
- #2067 — web_fetch: convert fetched HTML to readable Markdown
- #2065 — web_fetch: drop Jina proxy
- #2058 — web: hide Save to Light App for artifacts already in the Light Apps dir
- #2061 — landing: restore hero octopus logo
- #2059/#2060/#2062/#2063/#2064 — docs & copy tweaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)