### PR TITLE
fix(tools): terminal commands now run in the session working directory

### DIFF
--- a/internal/server/turn_workingdir_test.go
+++ b/internal/server/turn_workingdir_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+)
+
+// cwdProbeSender drives one real tool turn: round 1 asks the terminal to
+// print the shell's cwd, round 2 captures the tool_result it got back.
+type cwdProbeSender struct {
+	mu         sync.Mutex
+	round      int
+	toolResult string
+}
+
+func (s *cwdProbeSender) SendMessages(_ context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	return agent.Reply{Content: "side-call"}, nil
+}
+
+func (s *cwdProbeSender) StreamMessages(_ context.Context, _, _ string, _ []agent.Message, _ int, _ func(string), _ func(string)) (agent.Reply, error) {
+	return agent.Reply{Content: "side-call"}, nil
+}
+
+func (s *cwdProbeSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition) (agent.Reply, error) {
+	return agent.Reply{Content: "side-call"}, nil
+}
+
+func (s *cwdProbeSender) StreamMessagesWithTools(_ context.Context, _, _ string, msgs []agent.Message, _ int, _ []agent.ToolDefinition, _ func(string), _ agent.ToolInputDeltaFunc, _ agent.ThinkingDeltaFunc) (agent.Reply, error) {
+	s.mu.Lock()
+	s.round++
+	round := s.round
+	s.mu.Unlock()
+	if round == 1 {
+		cmd := "pwd"
+		if runtime.GOOS == "windows" {
+			cmd = "(Get-Location).Path"
+		}
+		return agent.Reply{
+			Blocks: []agent.ContentBlock{
+				agent.NewToolUseBlock("tu1", "terminal", map[string]any{"command": cmd}),
+			},
+			StopReason: "tool_use",
+		}, nil
+	}
+	s.mu.Lock()
+	for _, m := range msgs {
+		for _, b := range m.Blocks {
+			if b.Type == "tool_result" {
+				s.toolResult = b.Result
+			}
+		}
+	}
+	s.mu.Unlock()
+	return agent.Reply{Content: "done"}, nil
+}
+
+// TestDoAgentTurn_TerminalRunsInSessionWorkingDir is the end-to-end guard for
+// the field bug where the composer chip and the system prompt showed the
+// session's working directory while every shell command ran in the serve
+// process's cwd (its launch directory): the terminal tool routes all commands
+// through BackgroundManager.Start, which used to build the shell from a bare
+// context.Background() and so dropped the WithWorkingDir stamp. Drives the
+// REAL turn path — doAgentTurn → buildAgent → prepareToolTurn → terminal.
+func TestDoAgentTurn_TerminalRunsInSessionWorkingDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sender := &cwdProbeSender{}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+	srv.sender = sender
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]queuedTurn)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Title = "fixed title" // suppress the async title side-call
+	if err := sess.SetPermissionMode("auto"); err != nil {
+		t.Fatal(err)
+	}
+	srv.applyDefaultWorkspaceDir(sess)
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	want := filepath.Join(tmp, "Octo")
+	if sess.WorkingDir != want {
+		t.Fatalf("precondition: seeded WorkingDir = %q, want %q", sess.WorkingDir, want)
+	}
+
+	srv.doAgentTurn(sess, "where are you", nil, nil)
+
+	got := strings.TrimSpace(sender.toolResult)
+	gotReal, _ := filepath.EvalSymlinks(got)
+	wantReal, _ := filepath.EvalSymlinks(want)
+	if gotReal == "" || gotReal != wantReal {
+		procCwd, _ := filepath.Abs(".")
+		t.Errorf("shell ran in %q, want session working dir %q (process cwd %q)", got, want, procCwd)
+	}
+}

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -354,13 +354,22 @@ func WithVisible(v bool) StartOption {
 // its background id. Output streams into a capped buffer; the process is killed
 // if its context is cancelled (Kill / KillAll). The mode argument determines
 // whether the process is an async one-shot task or an interactive service/REPL.
-func (m *BackgroundManager) Start(command string, mode BackgroundMode, opts ...StartOption) (string, error) {
+//
+// ctx contributes VALUES only — most importantly the working directory stamped
+// by WithWorkingDir, so the command runs where the session's tools run (the
+// per-session dir, a sub-agent's worktree, a cron task's directory) instead of
+// the server process's cwd. The child's lifecycle is deliberately NOT tied to
+// ctx's cancellation: async/interactive processes must survive the turn that
+// started them, so the process runs under its own cancel (Kill / KillAll).
+func (m *BackgroundManager) Start(ctx context.Context, command string, mode BackgroundMode, opts ...StartOption) (string, error) {
 	if mode != BgModeAsync && mode != BgModeInteractive {
 		return "", fmt.Errorf("background: invalid mode %q (want %q or %q)", mode, BgModeAsync, BgModeInteractive)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cmd, err := shellCommand(ctx, command)
+	bgCtx, cancel := context.WithCancel(context.Background())
+	// WithWorkingDir no-ops on "" — an unstamped caller keeps the process CWD.
+	bgCtx = WithWorkingDir(bgCtx, WorkingDir(ctx))
+	cmd, err := shellCommand(bgCtx, command)
 	if err != nil {
 		cancel()
 		return "", err

--- a/internal/tools/background_listrunning_test.go
+++ b/internal/tools/background_listrunning_test.go
@@ -1,13 +1,14 @@
 package tools
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
 
 func TestBackgroundManager_ListRunning(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("sleep 2", BgModeAsync)
+	id, err := m.Start(context.Background(), "sleep 2", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -35,7 +36,7 @@ func TestBackgroundManager_ListRunning(t *testing.T) {
 
 func TestBackgroundManager_ListRunning_ExcludesExited(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("echo done", BgModeAsync)
+	id, err := m.Start(context.Background(), "echo done", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -58,7 +59,7 @@ func TestRunningBackground_DefaultManagerDelegates(t *testing.T) {
 // started with visible=false do not appear in ListRunning until Promoted.
 func TestBackgroundManager_ListRunning_ExcludesInvisible(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("sleep 2", BgModeAsync, WithVisible(false))
+	id, err := m.Start(context.Background(), "sleep 2", BgModeAsync, WithVisible(false))
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/tools/background_onexit_test.go
+++ b/internal/tools/background_onexit_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"runtime"
 	"strings"
 	"testing"
@@ -34,7 +35,7 @@ func TestBackgroundManager_OnExitHookFires(t *testing.T) {
 		}
 	})
 
-	id, err := m.Start("echo hi-from-bg", BgModeAsync)
+	id, err := m.Start(context.Background(), "echo hi-from-bg", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -83,7 +84,7 @@ func TestBackgroundManager_OnExitHookFires(t *testing.T) {
 // leaves the original poll-only behaviour intact — Start/Read still work.
 func TestBackgroundManager_NoHookByDefault(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("echo plain", BgModeAsync)
+	id, err := m.Start(context.Background(), "echo plain", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -115,7 +116,7 @@ func TestBackgroundManager_OnExitNotFiredForInvisibleProcess(t *testing.T) {
 	})
 
 	// Start invisible (visible=false), exactly like the sync path does.
-	id, err := m.Start("echo sync-done", BgModeAsync, WithVisible(false))
+	id, err := m.Start(context.Background(), "echo sync-done", BgModeAsync, WithVisible(false))
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -150,7 +151,7 @@ func TestBackgroundManager_OnExitFiresAfterPromote(t *testing.T) {
 	})
 
 	// Start invisible, then promote before it finishes.
-	id, err := m.Start("sleep 0.1", BgModeAsync, WithVisible(false))
+	id, err := m.Start(context.Background(), "sleep 0.1", BgModeAsync, WithVisible(false))
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/tools/background_orphan_test.go
+++ b/internal/tools/background_orphan_test.go
@@ -3,6 +3,7 @@
 package tools
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"syscall"
@@ -16,7 +17,7 @@ import (
 // (the direct child / group leader) is SIGKILLed instead of the whole group.
 func startWithBackgroundChild(t *testing.T, mgr *BackgroundManager) (id string, childPID int) {
 	t.Helper()
-	id, err := mgr.Start("sleep 60 & echo $! ; wait", BgModeAsync)
+	id, err := mgr.Start(context.Background(), "sleep 60 & echo $! ; wait", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -33,7 +33,7 @@ func waitFor(t *testing.T, what string, fn func() bool) {
 
 func TestBackgroundManager_RunsAndReportsExit(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("echo hello", BgModeAsync)
+	id, err := m.Start(context.Background(), "echo hello", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestBackgroundManager_RunsAndReportsExit(t *testing.T) {
 
 func TestBackgroundManager_IncrementalRead(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("echo one; sleep 0.3; echo two", BgModeAsync)
+	id, err := m.Start(context.Background(), "echo one; sleep 0.3; echo two", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestBackgroundManager_IncrementalRead(t *testing.T) {
 
 func TestBackgroundManager_Kill(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("sleep 30", BgModeAsync)
+	id, err := m.Start(context.Background(), "sleep 30", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/tools/bgnotify_test.go
+++ b/internal/tools/bgnotify_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -119,15 +120,15 @@ func TestFormatBgNote_NoNudgeForKilled(t *testing.T) {
 func TestFormatBgNoteWithSummary_SkipsFinishedAndSelf(t *testing.T) {
 	mgr := NewBackgroundManager()
 	// Launch three processes; we will simulate bg_1 finishing.
-	_, err := mgr.Start("echo one", BgModeAsync)
+	_, err := mgr.Start(context.Background(), "echo one", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start bg_1: %v", err)
 	}
-	_, err = mgr.Start("sleep 60", BgModeAsync)
+	_, err = mgr.Start(context.Background(), "sleep 60", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start bg_2: %v", err)
 	}
-	_, err = mgr.Start("node server.js", BgModeInteractive)
+	_, err = mgr.Start(context.Background(), "node server.js", BgModeInteractive)
 	if err != nil {
 		t.Fatalf("Start bg_3: %v", err)
 	}

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -248,7 +248,7 @@ func (t TerminalTool) ExecuteStream(
 	// Skipped for sub-agents (see subAgent above) — the requested async/
 	// interactive mode is ignored and the command runs synchronously instead.
 	if useBg && !subAgent {
-		id, err := t.managerFor(ctx).Start(command, bgMode)
+		id, err := t.managerFor(ctx).Start(ctx, command, bgMode)
 		if err != nil {
 			return agent.ToolResult{Text: ""}, err
 		}
@@ -337,7 +337,7 @@ func (t TerminalTool) ExecuteStream(
 	}
 
 	mgr := t.managerFor(ctx)
-	id, err := mgr.Start(command, BgModeAsync, WithOnLine(onLine), WithVisible(false))
+	id, err := mgr.Start(ctx, command, BgModeAsync, WithOnLine(onLine), WithVisible(false))
 	if err != nil {
 		return agent.ToolResult{Text: ""}, err
 	}

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -635,7 +635,7 @@ func main() {
 		t.Fatalf("go build helper: %v\n%s", err, buildOut)
 	}
 
-	id, err := mgr.Start(bin, BgModeInteractive)
+	id, err := mgr.Start(context.Background(), bin, BgModeInteractive)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -682,7 +682,7 @@ func TestTerminalInputTool_ExitedProcess(t *testing.T) {
 	inputTool := TerminalInputTool{mgr: mgr}
 
 	// Start a trivial command that exits immediately.
-	id, err := mgr.Start("echo done", BgModeInteractive)
+	id, err := mgr.Start(context.Background(), "echo done", BgModeInteractive)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/tools/workdir_resolve_test.go
+++ b/internal/tools/workdir_resolve_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -38,5 +40,77 @@ func TestFileTools_HonorWorkingDir(t *testing.T) {
 	}
 	if res.Text == "" {
 		t.Error("read_file returned empty for the working-dir-relative path")
+	}
+}
+
+// printCwdCommand returns a shell command that prints the shell's current
+// working directory on the platform shell shellCommand selects (POSIX sh vs
+// PowerShell).
+func printCwdCommand() string {
+	if runtime.GOOS == "windows" {
+		return "(Get-Location).Path"
+	}
+	return "pwd"
+}
+
+// sameDir compares two directory paths after symlink resolution (macOS
+// t.TempDir lives under /var/folders → /private/var/folders).
+func sameDir(a, b string) bool {
+	ra, err1 := filepath.EvalSymlinks(a)
+	rb, err2 := filepath.EvalSymlinks(b)
+	if err1 != nil || err2 != nil {
+		return a == b
+	}
+	return ra == rb
+}
+
+// TestTerminalTool_SyncHonorsWorkingDir is the terminal-side counterpart of
+// TestFileTools_HonorWorkingDir — and the regression guard for the field bug
+// where every serve-side shell command ran in the server process's cwd: the
+// synchronous path routes through BackgroundManager.Start, which used to
+// build its shell from a bare context.Background(), dropping the
+// WithWorkingDir stamp that buildAgent/prepareToolTurn thread through the
+// turn ctx.
+func TestTerminalTool_SyncHonorsWorkingDir(t *testing.T) {
+	dir := t.TempDir()
+	ctx := WithWorkingDir(context.Background(), dir)
+
+	res, err := TerminalTool{mgr: NewBackgroundManager()}.Execute(ctx, "terminal", map[string]any{
+		"command": printCwdCommand(),
+	})
+	if err != nil {
+		t.Fatalf("terminal: %v", err)
+	}
+	got := strings.TrimSpace(res.Text)
+	if !sameDir(got, dir) {
+		procCwd, _ := os.Getwd()
+		t.Errorf("sync terminal ran in %q, want the ctx working dir %q (process cwd %q)", got, dir, procCwd)
+	}
+}
+
+// Background (async/interactive) launches must honor the stamp too — they
+// share BackgroundManager.Start with the sync path. Only the working-dir
+// VALUE crosses; lifecycle stays detached from the turn ctx (asserted by
+// TestBackgroundServerLifecycle and friends).
+func TestBackgroundManager_StartHonorsCtxWorkingDir(t *testing.T) {
+	dir := t.TempDir()
+	ctx := WithWorkingDir(context.Background(), dir)
+
+	m := NewBackgroundManager()
+	id, err := m.Start(ctx, printCwdCommand(), BgModeAsync)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var out string
+	waitFor(t, "process to exit", func() bool {
+		o, s, found, _, _ := m.Read(id)
+		out += o
+		return found && strings.HasPrefix(s, "exited")
+	})
+	got := strings.TrimSpace(out)
+	if !sameDir(got, dir) {
+		procCwd, _ := os.Getwd()
+		t.Errorf("background command ran in %q, want the ctx working dir %q (process cwd %q)", got, dir, procCwd)
 	}
 }

--- a/internal/tools/workspacedir.go
+++ b/internal/tools/workspacedir.go
@@ -3,19 +3,23 @@ package tools
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ResolveWorkspaceDir turns the config workspace_dir value into the directory
 // path a newly created web session should default its WorkingDir to.
 //
-//   - "" (unset) -> ~/Octo, the discoverable default for every user. Not
-//     created here — the caller MkdirAll's it lazily the first time a
-//     session actually needs it.
+//   - "" (unset) and the legacy "auto" -> ~/Octo, the discoverable default
+//     for every user. Not created here — the caller MkdirAll's it lazily the
+//     first time a session actually needs it. "auto" was the pre-#1986 magic
+//     string; the Windows/macOS installers seeded it into fresh configs, so
+//     it must keep resolving to the default rather than becoming a literal
+//     relative path named "auto".
 //   - anything else -> an explicit override, with a leading "~" expanded to
 //     the user's home directory.
 func ResolveWorkspaceDir(raw string) (string, error) {
-	if raw != "" {
-		return expandHome(raw), nil
+	if v := strings.TrimSpace(raw); v != "" && !strings.EqualFold(v, "auto") {
+		return expandHome(v), nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/tools/workspacedir_test.go
+++ b/internal/tools/workspacedir_test.go
@@ -55,14 +55,22 @@ func setTestHomeDir(t *testing.T) string {
 	return tmp
 }
 
-// A literal value equal to the old magic keyword is now just an ordinary
-// relative path override — "auto" is no longer special-cased.
-func TestResolveWorkspaceDir_LiteralNamedAuto(t *testing.T) {
-	got, err := ResolveWorkspaceDir("auto")
-	if err != nil {
-		t.Fatalf("ResolveWorkspaceDir(\"auto\") error = %v, want nil", err)
-	}
-	if got != "auto" {
-		t.Fatalf("ResolveWorkspaceDir(\"auto\") = %q, want %q", got, "auto")
+// The legacy "auto" keyword resolves to the same default as "". #1986 made it
+// a literal relative path, but the Windows/macOS installers had been seeding
+// `workspace_dir: auto` into every fresh config since before that change —
+// those configs would otherwise root every new session at the literal
+// directory "auto" under the server's process cwd.
+func TestResolveWorkspaceDir_LegacyAutoResolvesToDefault(t *testing.T) {
+	home := setTestHomeDir(t)
+	want := filepath.Join(home, "Octo")
+
+	for _, raw := range []string{"auto", "Auto", " auto "} {
+		got, err := ResolveWorkspaceDir(raw)
+		if err != nil {
+			t.Fatalf("ResolveWorkspaceDir(%q) error = %v, want nil", raw, err)
+		}
+		if got != want {
+			t.Fatalf("ResolveWorkspaceDir(%q) = %q, want %q", raw, got, want)
+		}
 	}
 }

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -27,15 +27,13 @@ if [ -f "$res/uv" ]; then
   chmod +x "$octo_bin_dir/uv"
 fi
 
-# Seed ~/.octo/config.yml (workspace_dir: auto) only on a genuinely fresh
-# install; never overwrite an existing user config.
+# No config.yml seeding: an absent/empty workspace_dir already resolves to
+# ~/Octo (the pre-#1986 "auto" magic string is gone). The dir is still needed
+# for the uninstall helper below.
 config_dir="$HOME/.octo"
-config_path="$config_dir/config.yml"
-if [ ! -f "$config_path" ]; then
+if [ ! -d "$config_dir" ]; then
   mkdir -p "$config_dir"
   chmod 700 "$config_dir"
-  printf 'workspace_dir: auto\n' > "$config_path"
-  chmod 600 "$config_path"
 fi
 
 # Uninstall helper (a .pkg has no native uninstaller). Leaves ~/.octo data.

--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -121,22 +121,6 @@ begin
   RegWriteExpandStringValue(HKEY_CURRENT_USER, EnvKey, 'Path', Path);
 end;
 
-// WriteDefaultConfigIfMissing seeds ~/.octo/config.yml with workspace_dir: auto
-// on a genuinely fresh install; never overwrites an existing user config.
-procedure WriteDefaultConfigIfMissing;
-var
-  ConfigDir, ConfigPath: string;
-begin
-  ConfigDir := ExpandConstant('{%USERPROFILE}') + '\.octo';
-  ConfigPath := ConfigDir + '\config.yml';
-  if FileExists(ConfigPath) then
-    exit;
-  if not DirExists(ConfigDir) then
-    if not CreateDir(ConfigDir) then
-      exit;
-  SaveStringToFile(ConfigPath, 'workspace_dir: auto' + #13#10, False);
-end;
-
 // SeedUvToOctoBin copies the bundled uv into ~/.octo/bin so the CLI has Python
 // tooling immediately (the app also self-provisions this on first launch).
 procedure SeedUvToOctoBin;
@@ -230,7 +214,6 @@ begin
   begin
     AddToPath;
     EnsurePowerShell7;
-    WriteDefaultConfigIfMissing;
     SeedUvToOctoBin;
     LaunchApp;
   end;


### PR DESCRIPTION
## Problem

Every terminal command in `octo serve` — synchronous, `run_in_background: async`, and `interactive` — ran in the **serve process's cwd** instead of the session's working directory. The composer chip, the system prompt's env context, and the file tools (`read_file`/`write_file`/`edit_file`/`glob`/`grep`) all correctly followed the per-session directory, so the model *believed* it was in `~/Octo` while its shell was actually wherever the serve process happened to be launched from (a `D:\wwwroot\...` terminal, the Windows installer's `{app}` shortcut dir, …).

Field reports reproduced this on Windows, Linux, and macOS (v1.15.6 and v1.15.10).

## Root cause

`BackgroundManager.Start` built its shell from a bare `context.Background()`, dropping the `tools.WithWorkingDir` stamp that `buildAgent`/`prepareToolTurn` thread through the turn ctx — and the synchronous terminal path also routes through `Start` (hidden background process, for output streaming + timeout reaping). So the stamp never reached `shellCommand`/`cmd.Dir` on any terminal path. The bug has existed since per-session working directories were introduced (#1036) but was invisible in the CLI, where the process cwd *is* the expected working dir. Worktree-isolated sub-agents and cron `task.Directory` terminal commands were equally affected.

`Start` now takes the caller's ctx and copies the working-directory **value** into the process's own context. Lifecycle is deliberately unchanged: async/interactive processes must survive the turn that started them, so cancellation still never flows from the turn ctx (the process keeps its own cancel for Kill/KillAll).

## Related installer/config drift, same field reports

The Windows (`octo.iss`) and macOS (`postinstall`) installers seeded fresh configs with `workspace_dir: auto` — a magic string whose special-casing #1986 removed. Since v1.15.2 it resolved as a **literal relative path** `"auto"`: new sessions were seeded with `working_dir: "auto"`, the model saw `Working directory: auto`, and shells landed in `<process cwd>/auto`.

- `ResolveWorkspaceDir` now maps the legacy `"auto"` (trimmed, case-insensitive) back to the `~/Octo` default, for the configs already in the field.
- Both installers stop seeding it — an absent/empty value already means `~/Octo`.

## Tests

- `TestDoAgentTurn_TerminalRunsInSessionWorkingDir` — end-to-end through the real turn loop (`doAgentTurn` → `buildAgent` → `prepareToolTurn` → terminal): `pwd` must land in the session's seeded working dir. This is the test that reproduced the field bug (red on main before the fix).
- `TestTerminalTool_SyncHonorsWorkingDir` / `TestBackgroundManager_StartHonorsCtxWorkingDir` — tool-level guards for the sync and background paths (the terminal-side counterparts of `TestFileTools_HonorWorkingDir`).
- `TestResolveWorkspaceDir_LegacyAutoResolvesToDefault` — replaces `TestResolveWorkspaceDir_LiteralNamedAuto`, which asserted the (unintentionally harmful) literal behavior.
- Full `go test -race ./...` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
