### PR TITLE
fix(web): persist the Settings language choice to the server config

### DIFF
--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -207,6 +207,19 @@
     }
   }
 
+  // Persist the language like every other config-backed field in this modal.
+  // The $effect below already applies it to the live locale store; without
+  // this PUT the choice only lived in memory and a refresh reverted to the
+  // server's stored language (#2076). FirstRunSetup persists through the same
+  // endpoint.
+  async function saveLanguage(v: string) {
+    try {
+      await api.updateLanguage(v)
+    } catch (e: any) {
+      showToast(e.message ?? 'Failed to update language', 'error')
+    }
+  }
+
   function close() {
     settingsModalOpen.set(false)
   }
@@ -275,7 +288,7 @@
               <span class="setl">{$t('settings.language')}</span>
               <span class="setd">{$t('settings.language_desc')}</span>
             </div>
-            <select class="sinput" bind:value={language}>
+            <select class="sinput" bind:value={language} onchange={() => saveLanguage(language)}>
               {#each langOptions as o}
                 <option value={o.value}>{o.label}</option>
               {/each}


### PR DESCRIPTION
## Problem

Switching the web UI language to Chinese in Settings reverted to English on every page refresh (#2076).

## Root cause

Language persistence is server-side by design: `App.svelte` applies `cfg.language` from `GET /api/config` on load, and `PUT /api/config/language` stores it. But the Settings modal's language select only ran `setLocale()` on the in-memory store — nothing ever called the PUT. The endpoint's sole caller was FirstRunSetup, so the wizard's choice stuck while the Settings choice evaporated on refresh. The persist call was lost when Settings moved from a page to the modal.

## Fix

Save on change like every other config-backed field in the modal (reasoning effort, permission mode, workspace dir): an explicit `saveLanguage` handler calling `api.updateLanguage` with a failure toast, wired to the select's `onchange`. The option values are exactly the `'en'`/`'zh'` the backend validates. The existing `$effect` keeps applying the choice to the live locale store, so the immediate-switch behavior is unchanged.

## Verification

- `svelte-check`: 0 errors; `vitest` (web/): 214 passed; `make web-build` compiles.

Fixes #2076

🤖 Generated with [Claude Code](https://claude.com/claude-code)