### PR TITLE
fix(web): keep the composer model picker healthy after Settings changes

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -4,7 +4,7 @@
   import {
     running, activeSessionId, chatStreaming, sessions, sessionGroups,
     chatContextUsage, chatWorkingDir, chatPermMode, chatReasoningEffort, chatShowReasoning, showToast, chatGoal, chatModel,
-    globalPermissionMode, nativeShell, activeAgent, view, settingsModalOpen,
+    globalPermissionMode, nativeShell, activeAgent, pendingModel, view, settingsModalOpen,
   } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
@@ -565,7 +565,16 @@
 
   // Session meta chips — pull live values from per-session stores, fall back
   // to the session record, then to sensible defaults.
-  let modelName = $derived($chatModel[sid] || currentSession?.model || currentSession?.model_id || '—')
+  // No session yet → show the pending pick (composite "<endpoint>::<model>"
+  // id; display just the model half) that ensureActiveSession will apply.
+  let modelName = $derived(
+    $chatModel[sid] || currentSession?.model || currentSession?.model_id
+    || ($pendingModel ? $pendingModel.split('::').pop() : '') || '—',
+  )
+  // A pending pick belongs to the blank new-chat view only. Once a session is
+  // active (auto-created — which consumed it — or picked/created any other
+  // way), drop any leftover so it can't leak into a later blank view.
+  $effect(() => { if (sid) pendingModel.set('') })
   // "" (off) is a legitimate resolved value, not "no data yet" — only fall
   // back to the bootstrap default when neither source has reported anything
   // at all (?? only skips null/undefined, not ""). That default is 'off':
@@ -673,7 +682,11 @@
   const reasoningLevels = ['off', 'low', 'medium', 'high', 'xhigh', 'max']
   const showReasoningIcon = $derived(showReasoning ? 'ant-design:eye-outlined' : 'ant-design:eye-invisible-outlined')
 
-  onMount(async () => {
+  // Loaded at mount AND re-fetched every time the model menu opens: the list
+  // otherwise freezes at page load, so an endpoint/model configured in
+  // Settings never appeared (and rows for since-edited endpoints kept stale
+  // composite ids that no longer resolve) until a full reload (#2066).
+  async function refreshModels() {
     try {
       const ep = await api.getEndpoints()
       const flat: { id: string; model: string; endpoint: string }[] = []
@@ -683,7 +696,11 @@
         }
       }
       models = flat
-    } catch { /* leave empty */ }
+    } catch { /* keep the previous list */ }
+  }
+
+  onMount(async () => {
+    await refreshModels()
     try { skills = await api.listSkills() } catch { /* leave empty */ }
     try { agents = await api.listAgents() } catch { /* leave empty */ }
     try { workflows = await api.listWorkflows() } catch { /* leave empty */ }
@@ -697,7 +714,14 @@
 
   async function pickModel(m: { id: string; model: string; endpoint: string }) {
     modelMenu = false
-    if (!sid) return
+    if (!sid) {
+      // No session yet: remember the pick for the session about to be
+      // auto-created (ensureActiveSession in ChatView), mirroring pickAgent.
+      // Silently returning here made the menu look broken (#2066).
+      pendingModel.set(m.id)
+      queueMicrotask(() => textareaEl?.focus())
+      return
+    }
     try {
       // m.id is the composite id "<endpoint>::<model>" — the backend's
       // handleUpdateSessionModel resolves it via cfg.EntryByModel (composite-
@@ -1111,7 +1135,7 @@
       {/if}
       <div class="meta-row">
         <div class="picker">
-          <button class="meta-chip" onclick={(e) => { e.stopPropagation(); const open = modelMenu; closeMenus(); modelMenu = !open }}>
+          <button class="meta-chip" onclick={(e) => { e.stopPropagation(); const open = modelMenu; closeMenus(); modelMenu = !open; if (!open) void refreshModels() }}>
             <iconify-icon icon="ant-design:robot-outlined" width="13"></iconify-icon>
             <span class="mono">{modelName}</span>
             <iconify-icon icon="lucide:chevron-down" width="12"></iconify-icon>

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -13,6 +13,12 @@ export const view = writable('chat')
 // The currently active agent profile ID. Default is the code-defined default
 // agent; switching to a profile routes sessions to its isolated session pool.
 export const activeAgent = writable<string>('default')
+// Model picked in the composer BEFORE any session exists (composite
+// "<endpoint>::<model>" id, '' = server default). Consumed once by
+// ChatView.ensureActiveSession when it auto-creates the session — without
+// this, picking a model on the blank new-chat view was a silent no-op
+// (#2066).
+export const pendingModel = writable<string>('')
 export const sidebar = writable('full')
 export const cmdkOpen = writable(false)
 // Drives the MCP import-JSON modal. Adding a single server and editing an

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -5,6 +5,7 @@
   import {
     activeSessionId,
     activeAgent,
+    pendingModel,
     sessions,
     chatMessages,
     chatStreaming,
@@ -1925,7 +1926,13 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     const existing = get(activeSessionId)
     if (existing) return existing
     try {
-      const created = await api.createSession({ source: 'manual', agent_profile: get(activeAgent) }) as any
+      // A model picked in the composer before any session existed rides the
+      // pendingModel store (composite "<endpoint>::<model>" id — the create
+      // handler resolves it via cfg.EntryByModel); consumed here so it only
+      // applies to the session it was picked for.
+      const model = get(pendingModel)
+      const created = await api.createSession({ source: 'manual', agent_profile: get(activeAgent), ...(model ? { model } : {}) }) as any
+      if (model) pendingModel.set('')
       const newSess = created.session ?? created
       sessions.update(ss => [newSess, ...ss])
       activeSessionId.set(newSess.id)


### PR DESCRIPTION
## Problem

After configuring a model/endpoint in Settings, the chat composer's model menu could look broken: items render but selecting them does nothing, or the just-configured model never shows up (#2066, v1.15.3, desktop webview).

## Root causes (two, both in the composer)

1. **Stale list.** The endpoint/model list was fetched once in `onMount`. A model added or edited in Settings never appeared in the menu — and rows for since-edited endpoints kept stale `<endpoint>::<model>` composite ids that no longer resolve server-side — until a full page reload.

2. **Silent no-op on the blank new-chat view.** `pickModel` began with `if (!sid) return`: with no session created yet (the state you're in right after first configuring models), clicking a menu item closed the menu and did nothing — no request, no toast, no chip change. Exactly "visually present but functionally unselectable".

## Fix

1. Extract the list load into `refreshModels()` and re-fetch every time the menu opens (one cheap `GET /api/config/endpoints` per open), so Settings changes are always reflected.

2. Mirror the `activeAgent` pattern for the pre-session case: a `pendingModel` store remembers the composite id, the chip displays it, and `ChatView.ensureActiveSession` passes it to `POST /api/sessions` — whose handler already resolves composite ids via `cfg.EntryByModel`. The pending pick is consumed on creation and cleared whenever any session becomes active, so it cannot leak into a later blank view.

## Verification

- `svelte-check`: 0 errors; `vitest` (web/): 214 passed; `make web-build` compiles.

Fixes #2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)