### PR TITLE
chore: bump version to 1.15.11

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.10"
+var Version = "1.15.11"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release with three fixes:

- #2077 — terminal commands now run in the session working directory (serve-side shells previously inherited the server process's cwd on every path: sync, async, interactive; worktree sub-agents and cron task directories were equally affected). Also restores the legacy `workspace_dir: auto` → `~/Octo` mapping and stops the Windows/macOS installers from seeding it.
- #2078 — the Settings language choice is persisted to the server config, so it survives a page refresh (fixes #2076).
- #2079 — the composer model picker refreshes its endpoint/model list on open and supports picking a model before the first session exists (fixes #2066).

🤖 Generated with [Claude Code](https://claude.com/claude-code)