### PR TITLE
chore(deps): bump js-yaml from 4.3.0 to 4.3.1 in /docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3889,9 +3889,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Bumps transitive `js-yaml` in `docs/package-lock.json` from 4.3.0 to 4.3.1.

Resolves Dependabot alert #63 — [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj): quadratic CPU consumption in `!!omap` resolution (DoS, CVSS 7.5). The blog copy of the same dependency was already bumped by #2070; docs is the last remaining manifest.

No production code paths parse untrusted YAML here — js-yaml is a build-time transitive dep of astro — but bumping clears the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)