### PR TITLE
fix: address review follow-ups from the v1.15.11 fixes

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -473,10 +473,14 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		model = req.Model
 		// The web modal sends a config entry id; the session binds to that
 		// entry so its turns run on the entry's sender. A non-matching value
-		// stays a raw model string on the default sender.
+		// stays a raw model string on the default sender. The binding stores
+		// the id AS RECEIVED: collapsing a composite "<endpoint>::<model>" id
+		// to the bare model name (as this once did) loses the endpoint half,
+		// so a later EntryByModel re-resolution could land on a DIFFERENT
+		// endpoint exposing the same model name.
 		if cfg, err := config.Load(); err == nil {
 			if e, ok := cfg.EntryByModel(req.Model); ok {
-				modelConfig = e.Model
+				modelConfig = req.Model
 				if e.Model != "" {
 					model = e.Model
 				}
@@ -1278,7 +1282,10 @@ func (s *Server) handleUpdateSessionModel(w http.ResponseWriter, r *http.Request
 	var model string
 	if entry, ok := cfg.EntryByModel(req.ModelID); ok {
 		model = entry.Model
-		err = sess.SetModelConfig(entry.Model, entry.Model)
+		// Bind with the id AS RECEIVED — a composite "<endpoint>::<model>"
+		// id must survive verbatim, or re-resolving the bare model name
+		// later could land on a different endpoint exposing the same model.
+		err = sess.SetModelConfig(req.ModelID, entry.Model)
 	} else if req.ModelID == "default" {
 		// Legacy id for "the default entry". Unbind so the session follows
 		// whatever the default is at turn time.

--- a/internal/server/model_binding_endpoint_test.go
+++ b/internal/server/model_binding_endpoint_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/config"
+)
+
+// Two endpoints exposing the SAME model name: binding a session to the
+// non-default one must survive verbatim as the composite id. Collapsing it to
+// the bare model name (as both write paths once did) made every later
+// EntryByModel re-resolution land on whichever endpoint scans first — the
+// session silently ran on the wrong endpoint/key.
+func sameModelTwoEndpointsConfig(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	seed := config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-official", Provider: "kimi", BaseURL: "https://official.example", APIKey: "sk-a", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
+			{ID: "ep-proxy", Provider: "custom", BaseURL: "https://proxy.example", APIKey: "sk-b", Models: []config.EndpointModel{{Model: "kimi-k2.6"}}},
+		},
+		Default: "ep-official::kimi-k2.6",
+	}
+	if err := seed.Save(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHandleUpdateSessionModel_CompositeIDKeepsEndpoint(t *testing.T) {
+	sameModelTwoEndpointsConfig(t)
+
+	sess := agent.NewSession("kimi-k2.6", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	payload, _ := json.Marshal(updateSessionModelRequest{ModelID: "ep-proxy::kimi-k2.6"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+sess.ID+"/model", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	got, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ModelConfig != "ep-proxy::kimi-k2.6" {
+		t.Fatalf("ModelConfig = %q, want the composite id ep-proxy::kimi-k2.6", got.ModelConfig)
+	}
+	cfg, _ := config.Load()
+	entry, ok := cfg.EntryByModel(got.ModelConfig)
+	if !ok || entry.BaseURL != "https://proxy.example" {
+		t.Fatalf("re-resolved entry = (%+v, %v), want the ep-proxy endpoint", entry, ok)
+	}
+}
+
+func TestHandleCreateSession_CompositeIDKeepsEndpoint(t *testing.T) {
+	sameModelTwoEndpointsConfig(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/sessions", `{"model":"ep-proxy::kimi-k2.6"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/sessions = %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Session struct {
+			ID    string `json:"id"`
+			Model string `json:"model"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Session.Model != "kimi-k2.6" {
+		t.Errorf("display model = %q, want the bare model name kimi-k2.6", resp.Session.Model)
+	}
+
+	sess, err := agent.LoadSession(resp.Session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.ModelConfig != "ep-proxy::kimi-k2.6" {
+		t.Fatalf("ModelConfig = %q, want the composite id ep-proxy::kimi-k2.6", sess.ModelConfig)
+	}
+	cfg, _ := config.Load()
+	entry, ok := cfg.EntryByModel(sess.ModelConfig)
+	if !ok || entry.BaseURL != "https://proxy.example" {
+		t.Fatalf("re-resolved entry = (%+v, %v), want the ep-proxy endpoint", entry, ok)
+	}
+}

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -366,9 +366,10 @@ func (m *BackgroundManager) Start(ctx context.Context, command string, mode Back
 		return "", fmt.Errorf("background: invalid mode %q (want %q or %q)", mode, BgModeAsync, BgModeInteractive)
 	}
 
-	bgCtx, cancel := context.WithCancel(context.Background())
-	// WithWorkingDir no-ops on "" — an unstamped caller keeps the process CWD.
-	bgCtx = WithWorkingDir(bgCtx, WorkingDir(ctx))
+	// WithoutCancel keeps every ctx value (working dir today, whatever
+	// shellCommand consumes tomorrow) while severing the caller's
+	// cancellation/deadline, so only the WithCancel below can kill the process.
+	bgCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	cmd, err := shellCommand(bgCtx, command)
 	if err != nil {
 		cancel()

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -686,9 +686,15 @@
   // otherwise freezes at page load, so an endpoint/model configured in
   // Settings never appeared (and rows for since-edited endpoints kept stale
   // composite ids that no longer resolve) until a full reload (#2066).
+  // The sequence guard drops out-of-order responses — reopening the menu
+  // quickly fires overlapping fetches, and a slow first response must not
+  // overwrite a newer one.
+  let modelsFetchSeq = 0
   async function refreshModels() {
+    const seq = ++modelsFetchSeq
     try {
       const ep = await api.getEndpoints()
+      if (seq !== modelsFetchSeq) return
       const flat: { id: string; model: string; endpoint: string }[] = []
       for (const e of ep.endpoints) {
         for (const m of e.models) {

--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -90,7 +90,12 @@
       permissionMode   = cfg.permission_mode ?? 'interactive'
       showReasoningVal = cfg.show_reasoning ?? true
       coauthorVal      = cfg.coauthor ?? true
-      workspaceDir        = cfg.workspace_dir ?? ''
+      // Legacy installer-seeded "auto" resolves to the same default as ""
+      // (see tools.ResolveWorkspaceDir) — show it as the empty input with
+      // the resolved-default placeholder, not as a literal "auto" the user
+      // would mistake for a real path.
+      const wd = cfg.workspace_dir ?? ''
+      workspaceDir        = wd.trim().toLowerCase() === 'auto' ? '' : wd
       workspaceDirDefault = cfg.workspace_dir_default ?? ''
       if (cfg.language) language = cfg.language
       setLocale(cfg.language === 'zh' || cfg.language === 'zh-TW' ? 'zh' : 'en')

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -246,7 +246,13 @@ export const agenticSessions = new Set<string>()
 export async function createNewSession(agentProfile?: string): Promise<void> {
   const opts: api.CreateSessionOpts = { source: 'manual' }
   if (agentProfile) opts.agent_profile = agentProfile
+  // A model picked on the blank new-chat view rides pendingModel until a
+  // session exists — honor it here too, or the sidebar "+" would silently
+  // discard the pick that ChatView.ensureActiveSession applies on send.
+  const pending = get(pendingModel)
+  if (pending) opts.model = pending
   const sess = await api.createSession(opts)
+  if (pending) pendingModel.set('')
   sessions.update(ss => [sess, ...ss])
   activeSessionId.set(sess.id)
   view.set('chat')


### PR DESCRIPTION
Post-merge review of #2077/#2078/#2079 surfaced five follow-ups; all fixed here.

## Changes

1. **`BackgroundManager.Start` carries all ctx values** — derive the process context via `context.WithoutCancel(ctx)` instead of hand-copying only the working-dir value. Every present and future ctx stamp flows to `shellCommand`, while the caller's cancellation/deadline stays severed (lifecycle semantics unchanged — async/interactive processes still outlive the turn; Kill/KillAll unchanged).

2. **Session model bindings store the id as received** (the pre-existing bug the review surfaced). Both write paths — `POST /api/sessions` and `PATCH /api/sessions/{id}/model` — collapsed a composite `<endpoint>::<model>` id to the bare model name. With two endpoints exposing the same model name (e.g. an official endpoint and a proxy both serving `kimi-k2.6`), every later `EntryByModel` re-resolution of the bare name landed on whichever endpoint scans first — the session silently ran on the wrong endpoint/key. `EntryByModel` has been composite-aware on the read side all along (its doc comment even describes composite ids in "new session files"); this aligns the write side. Bare ids still round-trip unchanged, so legacy session files are unaffected. Regression tests cover both paths with a same-model two-endpoint config.

3. **`refreshModels` sequence guard** — reopening the composer model menu quickly fires overlapping fetches; a slow stale response can no longer overwrite a newer list.

4. **Sidebar "+" honors the pending model pick** — `createNewSession` now consumes `pendingModel` the same way `ChatView.ensureActiveSession` does, instead of silently discarding a model picked on the blank new-chat view.

5. **Settings shows legacy `workspace_dir: auto` as empty** — the input renders the empty value with the resolved-default placeholder, matching what `ResolveWorkspaceDir` actually does with `"auto"` since #2077, instead of a literal "auto" that reads like a real path.

## Verification

- `go test -race ./...` passes; `gofmt`/`go vet` clean.
- New regression tests: `TestHandleUpdateSessionModel_CompositeIDKeepsEndpoint`, `TestHandleCreateSession_CompositeIDKeepsEndpoint`.
- `svelte-check` 0 errors; web `vitest` 214 passed; `make web-build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)