### PR TITLE
feat: add xAI (Grok) as a first-class vendor preset

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -192,9 +192,17 @@ func contextWindow(model string) int {
 		return 64_000
 
 	// ── XAI Grok ──
+	// Context windows per xAI's model catalogue (docs.x.ai, 2026-07-09):
+	// grok-4.5 = 500k, grok-4.20 / grok-4.3 = 1M, grok-build-0.1 = 256k.
 	case strings.Contains(m, "grok-4.5") || strings.Contains(m, "grok4.5"):
 		return 500_000
+	case strings.Contains(m, "grok-4.20") || strings.Contains(m, "grok4.20"):
+		return 1_000_000
+	case strings.Contains(m, "grok-4.3") || strings.Contains(m, "grok4.3"):
+		return 1_000_000
 	case strings.Contains(m, "grok-4") || strings.Contains(m, "grok4"):
+		return 256_000
+	case strings.Contains(m, "grok-build") || strings.Contains(m, "grokbuild"):
 		return 256_000
 	case strings.Contains(m, "grok"):
 		return 64_000

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -126,6 +126,23 @@ func TestContextWindow(t *testing.T) {
 	if got := contextWindow("x-ai/grok-4.5"); got != 500_000 {
 		t.Errorf("grok-4.5 window = %d, want 500000", got)
 	}
+	if got := contextWindow("grok-4.20"); got != 1_000_000 {
+		t.Errorf("grok-4.20 window = %d, want 1000000", got)
+	}
+	if got := contextWindow("grok-4.20-non-reasoning"); got != 1_000_000 {
+		t.Errorf("grok-4.20-non-reasoning window = %d, want 1000000", got)
+	}
+	if got := contextWindow("grok-4.3"); got != 1_000_000 {
+		t.Errorf("grok-4.3 window = %d, want 1000000", got)
+	}
+	// The OpenRouter-prefixed id resolves by substring and shares the model's
+	// real window — regression pin for the grok-4 (256k) → grok-4.3 (1M) change.
+	if got := contextWindow("x-ai/grok-4.3"); got != 1_000_000 {
+		t.Errorf("x-ai/grok-4.3 window = %d, want 1000000", got)
+	}
+	if got := contextWindow("grok-build-0.1"); got != 256_000 {
+		t.Errorf("grok-build-0.1 window = %d, want 256000", got)
+	}
 	if got := contextWindow("xiaomi/mimo-v2.5"); got != 1_000_000 {
 		t.Errorf("mimo-v2.5 window = %d, want 1000000", got)
 	}

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -140,6 +140,28 @@ var Registry = []Vendor{
 		WebsiteURL:   "https://openrouter.ai/keys",
 	},
 	{
+		ID:             "xai",
+		DisplayName:    "xAI (Grok)",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://api.x.ai",
+		DefaultModel:   "grok-4.5",
+		// All current Grok chat models accept image input (jpg/jpeg, png, up to
+		// 20 MiB) — verified against xAI's model catalogue (docs.x.ai, 2026-07-09).
+		// grok-4.20-multi-agent is excluded: it targets xAI's multi-agent
+		// orchestration API, not a plain OpenAI-compatible chat client.
+		Models: []VendorModel{
+			{ID: "grok-4.5", Vision: true},
+			{ID: "grok-4.20", Vision: true},
+			{ID: "grok-4.20-non-reasoning", Vision: true},
+			{ID: "grok-4.3", Vision: true},
+			{ID: "grok-build-0.1", Vision: true},
+		},
+		LiteModel:    "grok-4.20-non-reasoning",
+		APIKeyEnvVar: "XAI_API_KEY",
+		WebsiteURL:   "https://console.x.ai/",
+	},
+	{
 		ID:             "deepseek",
 		DisplayName:    "DeepSeek",
 		Protocol:       "openai",

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -65,7 +65,7 @@ func TestVendor_KimiCodingPlan_BuildClient_CustomBaseURL(t *testing.T) {
 func TestIsKnownVendor(t *testing.T) {
 	for _, id := range []string{
 		"openrouter", "deepseek", "minimax", "kimi", "kimi-coding-plan",
-		"glm", "openai", "anthropic", "bailian", "mimo", "longcat",
+		"glm", "openai", "anthropic", "bailian", "mimo", "longcat", "xai",
 		ProviderCustom,
 	} {
 		if !IsKnownVendor(id) {
@@ -169,6 +169,62 @@ func TestBuildClient_EmptyBaseURL_UsesVendorEndpoint(t *testing.T) {
 	}
 }
 
+func TestVendor_XAI(t *testing.T) {
+	v := vendorByID("xai")
+	if v == nil {
+		t.Fatal("xai not found in registry")
+	}
+	if v.DisplayName != "xAI (Grok)" {
+		t.Errorf("DisplayName = %q, want xAI (Grok)", v.DisplayName)
+	}
+	if v.Protocol != "openai" {
+		t.Errorf("Protocol = %q, want openai", v.Protocol)
+	}
+	if v.API != "openai-completions" {
+		t.Errorf("API = %q, want openai-completions", v.API)
+	}
+	if v.DefaultBaseURL != "https://api.x.ai" {
+		t.Errorf("DefaultBaseURL = %q, want https://api.x.ai", v.DefaultBaseURL)
+	}
+	if v.DefaultModel != "grok-4.5" {
+		t.Errorf("DefaultModel = %q, want grok-4.5", v.DefaultModel)
+	}
+	if v.APIKeyEnvVar != "XAI_API_KEY" {
+		t.Errorf("APIKeyEnvVar = %q, want XAI_API_KEY", v.APIKeyEnvVar)
+	}
+	if v.LiteModel != "grok-4.20-non-reasoning" {
+		t.Errorf("LiteModel = %q, want grok-4.20-non-reasoning", v.LiteModel)
+	}
+	found := false
+	for _, m := range v.Models {
+		if m.ID == v.LiteModel {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("LiteModel %q must be a member of Models", v.LiteModel)
+	}
+	// All current Grok chat models accept image input (docs.x.ai, 2026-07-09).
+	for _, m := range v.Models {
+		if !m.Vision {
+			t.Errorf("xai model %q: Vision = false, want true", m.ID)
+		}
+	}
+}
+
+func TestVendor_XAI_BuildClient(t *testing.T) {
+	// openai-protocol client with the registry endpoint, no override needed.
+	client, err := buildClient("xai", "sk-dummy", "", "")
+	if err != nil {
+		t.Fatalf("buildClient(xai) error: %v", err)
+	}
+	if c, ok := client.(*openai.Client); !ok {
+		t.Fatalf("buildClient(xai) client type = %T, want *openai.Client", client)
+	} else if c.BaseURL != "https://api.x.ai" {
+		t.Errorf("buildClient(xai) BaseURL = %q, want https://api.x.ai", c.BaseURL)
+	}
+}
+
 func TestVendorEnvVars(t *testing.T) {
 	tests := []struct {
 		id, wantEnv string
@@ -181,6 +237,7 @@ func TestVendorEnvVars(t *testing.T) {
 		{"bailian", "DASHSCOPE_API_KEY"},
 		{"mimo", "MIMO_API_KEY"},
 		{"longcat", "LONGCAT_API_KEY"},
+		{"xai", "XAI_API_KEY"},
 	}
 	for _, tc := range tests {
 		got := VendorAPIKeyEnvVar(tc.id)
@@ -255,8 +312,12 @@ func TestVendorModelVision(t *testing.T) {
 		{"kimi", "kimi-k2.6", true, true},       // MoonViT multimodal
 		{"openai", "o3-mini", false, true},      // no image input
 		{"openai", "o4-mini", true, true},
-		{"bailian", "not-a-model", false, false}, // unknown model
-		{"bogus", "whatever", false, false},      // unknown vendor
+		{"xai", "grok-4.5", true, true},
+		{"xai", "grok-4.20", true, true},
+		{"xai", "grok-build-0.1", true, true},
+		{"xai", "grok-4.20-multi-agent", false, false}, // excluded from catalogue
+		{"bailian", "not-a-model", false, false},       // unknown model
+		{"bogus", "whatever", false, false},            // unknown vendor
 		{ProviderCustom, "anything", false, false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## What

Add xAI (Grok) as a first-class vendor preset in `internal/app/provider.go`'s Registry. Picking **xAI** in `octo config` or the Web settings panel now fills in the base URL, the API-key env var, and a Grok model dropdown — no more Custom vendor + hand-typed OpenAI endpoint.

Changes:
- **`internal/app/provider.go`** — new `xai` vendor entry: `Protocol: "openai"`, `DefaultBaseURL: https://api.x.ai`, 5-model catalogue, `LiteModel: grok-4.20-non-reasoning`, `APIKeyEnvVar: XAI_API_KEY`, key page link to `https://console.x.ai/`.
- **`internal/agent/compaction.go`** — Grok context windows corrected/added to match the xAI catalogue (see below).
- **`internal/app/provider_test.go`**, **`internal/agent/compaction_test.go`** — tests pinning the new vendor fields, base URL, env var, vision flags, and context windows.

CLI (`octo config`), completion, and the Web settings panel all derive from `app.Registry`, so no other code changes were needed. No new i18n keys were required — vendor labels flow straight from the registry `DisplayName` (the Web provider dropdown renders `p.name` directly), matching how every other vendor label works.

## Docs verified (xAI official)

Checked against **https://docs.x.ai** on **2026-08-09** (model pages show "Last updated: July 9, 2026"; model catalogue data taken from the site's published model registry):

- **Base URL**: `https://api.x.ai` — official OpenAI-SDK example uses `base_url="https://api.x.ai/v1"`; octo stores the host only and appends the protocol path, so the entry uses `https://api.x.ai`.
- **Vision flags**: the xAI model catalogue lists `inputModalities: ["TEXT", "IMAGE"]` for **all** current chat models (docs also state image input: jpg/jpeg, png, up to 20 MiB, unlimited count). Hence `Vision: true` for every catalogue entry. `grok-4.20-multi-agent` is **excluded** deliberately: it targets xAI's multi-agent orchestration API rather than a plain OpenAI-compatible chat client.
- **Context windows** (catalogue `maxPromptLength`):
  - `grok-4.5` → 500,000 (unchanged; was already correct)
  - `grok-4.20` → 1,000,000 (was mis-classified under `grok-4` = 256k)
  - `grok-4.3` → 1,000,000 (was mis-classified under `grok-4` = 256k)
  - `grok-build-0.1` (alias `grok-code-fast-1`, the code model) → 256,000 (was falling through to `grok` = 64k)
- **OpenAI compatibility for the parts octo uses**:
  - **Streaming SSE**: supported — official SDK/curl streaming examples use `stream=true` with `text/event-stream`.
  - **Tool calls**: supported — function calling is enabled on all listed models; client-side function tools return `tool_calls` for the caller to execute (docs "Tool Use").
  - **`stream_options.include_usage`**: **supported** — xAI's docs explicitly show `stream_options: {"include_usage": true}` and state usage is included in the final chunk (with empty `choices`), which matches how octo's OpenAI adapter consumes it. No wire-format or adapter changes needed.

## Smoke test

Not run — no xAI API key available in this environment. **Smoke test pending manual execution** with a real key: create an endpoint with vendor `xai`, send a chat turn, and confirm the usage/token accounting shows up. The code paths involved (registry lookup → openai client build → streaming) are covered by unit tests; only the live-API round trip is unverified.

## Notes

- No unrelated changes bundled. If a wire-format incompatibility with xAI surfaces during smoke testing, it will be tracked separately.
- `make test` (race), `make vet`, `make fmt-check` all green locally.

Closes #1872
