### PR TITLE
chore: bump version to 1.15.12

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.11"
+var Version = "1.15.12"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the v1.15.12 patch release (ships the `octo serve stop` guard from #2085 and everything since v1.15.11).