### PR TITLE
fix(goal): hold the continuation loop while async work is in flight

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -2262,8 +2262,12 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 
 	// Idle with nothing queued: an active goal keeps going. The session owns
 	// the policy (status, zero-progress suppression); user input always won
-	// above by reaching the queue/inbox branches first.
-	if err == nil {
+	// above by reaching the queue/inbox branches first. Async work this turn is
+	// waiting on holds the loop back — continuing on top of it only buys a turn
+	// that says "still waiting" and bills for it, and the completion note
+	// (bgExitMsg / subAgentNoteMsg) starts its own turn whose end lands back
+	// here.
+	if err == nil && !tools.PendingAsyncWork(tools.DefaultBackgroundManager(), m.cfg.subAgentMgr) {
 		if prompt, ok := m.goalContinuationKick(false); ok {
 			return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(prompt, ""))
 		}

--- a/internal/server/goal.go
+++ b/internal/server/goal.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/tools"
 )
 
 // steerPending reports whether user steer input is queued for the session,
@@ -15,6 +16,18 @@ func (s *Server) steerPending(sessionID string) bool {
 	s.steerMu.Lock()
 	defer s.steerMu.Unlock()
 	return len(s.steerQueues[sessionID]) > 0
+}
+
+// goalWorkPending reports whether the session has async work in flight that
+// the goal-continuation kick must wait for — a one-shot background process or
+// a running async sub-agent. Continuing on top of one only buys a turn that
+// says "still waiting" and bills for it; the completion hook starts its own
+// turn, and that turn's end re-enters the continuation check.
+func (s *Server) goalWorkPending(sessionID string) bool {
+	return tools.PendingAsyncWork(
+		tools.SessionBackgroundManager(sessionID),
+		tools.SessionSubAgentManager(sessionID, nil),
+	)
 }
 
 // broadcastGoalUpdated pushes the goal snapshot to the session's subscribers.

--- a/internal/server/goal_test.go
+++ b/internal/server/goal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/agentprofile"
 	"github.com/open-octo/octo-agent/internal/channel"
+	"github.com/open-octo/octo-agent/internal/tools"
 )
 
 // goalRoundSender replies (or errs) per main-loop round, recording each call's
@@ -626,5 +627,42 @@ func TestChannelTurn_BudgetCrossingSendsNotice(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected a budget-reached notice, got %v", ad.texts())
+	}
+}
+
+// The continuation loop must sit out while an async background task the turn is
+// waiting on is still running. Its only other guard is zero token progress, and
+// a "still waiting" turn bills real tokens — so without this the loop spins
+// unbounded until the task finishes.
+func TestGoalWorkPending_AsyncBackgroundTask(t *testing.T) {
+	srv := &Server{}
+	const sid = "sess-goal-work-pending"
+	mgr := tools.SessionBackgroundManager(sid)
+	t.Cleanup(func() { tools.CloseSessionBackgroundManager(sid) })
+
+	if srv.goalWorkPending(sid) {
+		t.Fatal("an idle session must not hold the continuation loop back")
+	}
+	if _, err := mgr.Start(context.Background(), "sleep 30", tools.BgModeAsync); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !srv.goalWorkPending(sid) {
+		t.Error("a running async task must hold the continuation loop back")
+	}
+}
+
+// An interactive background process (a service or REPL) may never exit, so it
+// must not park the goal.
+func TestGoalWorkPending_IgnoresInteractiveProcess(t *testing.T) {
+	srv := &Server{}
+	const sid = "sess-goal-work-interactive"
+	mgr := tools.SessionBackgroundManager(sid)
+	t.Cleanup(func() { tools.CloseSessionBackgroundManager(sid) })
+
+	if _, err := mgr.Start(context.Background(), "sleep 30", tools.BgModeInteractive); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if srv.goalWorkPending(sid) {
+		t.Error("an interactive process must not hold the continuation loop back")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3366,6 +3366,9 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
+	// Declared out here so the goal-continuation gate at the end of the turn
+	// chain can see this chat's in-flight async sub-agents.
+	var subMgr *tools.SubAgentManager
 	if s.cfg.Tools {
 		// Session-scoped tracker (same "im:"+sess.Key identity used for the
 		// background/workflow managers below) so a file read_file'd in one chat
@@ -3391,7 +3394,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 			}
 			return tools.WithoutGoalTools(tools.DefaultToolsForCtx(ctx, sess.Agent.Model))
 		})
-		subMgr := tools.NewSubAgentManager(spawner)
+		subMgr = tools.NewSubAgentManager(spawner)
 		// A background sub-agent finishes after this turn's chain ends; its
 		// result reaches the model via the agent Inbox + an idle follow-up turn,
 		// the same channel every background process and workflow completion uses
@@ -3534,7 +3537,8 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// Steer messages that arrived after the turn's final inbox drain chain
 	// into follow-up turns (web runAgentTurnLoop parity), and an active goal
 	// keeps the chain going with hidden continuation prompts once the inbox
-	// is dry (user input always drains first). Still inside BeginRun, so no
+	// is dry (user input always drains first) and no async work this turn is
+	// waiting on is still in flight. Still inside BeginRun, so no
 	// new turn can interleave. Persist after each chained turn — one crash
 	// must cost at most one turn, not the whole chain. A chained error stops
 	// the chain (its rollback already dropped the steer message; looping
@@ -3543,7 +3547,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		next := ""
 		if items := sess.Agent.Inbox.Drain(); len(items) > 0 {
 			next = strings.Join(agent.Texts(items), "\n\n")
-		} else if goalsOn {
+		} else if goalsOn && !tools.PendingAsyncWork(tools.SessionBackgroundManager("im:"+string(sess.Key)), subMgr) {
 			if prompt, ok := goalStore.GoalContinuation(); ok {
 				next = prompt
 			}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1177,8 +1177,9 @@ func (s *Server) runAgentTurnLoop(sess *agent.Session, initialContent string, bl
 		// prompt so the chain below starts the follow-up turn. User steers
 		// queued meanwhile take priority — GoalContinuation is only consulted
 		// when the queue is empty, and its own guards (status, zero-progress
-		// suppression) decide whether the loop keeps going.
-		if s.goalsEnabled.Load() && !s.steerPending(sess.ID) {
+		// suppression) decide whether the loop keeps going. Async work the turn
+		// is waiting on holds the loop back too — see goalWorkPending.
+		if s.goalsEnabled.Load() && !s.steerPending(sess.ID) && !s.goalWorkPending(sess.ID) {
 			if prompt, ok := sess.GoalContinuation(); ok {
 				s.enqueueSteer(sess.ID, agent.InboxItem{Text: prompt})
 				// The prompt is hidden (StripSystemReminders drops the

--- a/internal/tools/pending_work.go
+++ b/internal/tools/pending_work.go
@@ -1,0 +1,40 @@
+package tools
+
+// PendingAsyncWork reports whether the session has async work in flight that a
+// turn is legitimately waiting on: a one-shot background process (BgModeAsync)
+// or a running async sub-agent. Both push a completion note to the model when
+// they finish, so the turn that would answer "still waiting" has nothing to add
+// until then.
+//
+// Transports use it to hold back the goal-continuation loop, whose only other
+// guard — zero token progress — cannot catch this: each "still waiting" turn
+// bills real tokens, so the loop would spin unbounded until the work finishes.
+// The wait is safe because the completion hooks (BackgroundManager.SetOnExit,
+// SubAgentManager.SetOnExit) start their own turn, whose end re-enters the
+// continuation check.
+//
+// Interactive background processes are deliberately excluded: a service or REPL
+// (octo serve, rails c) may never exit, and parking the goal on one would stall
+// it forever. Sub-agents are counted by Busy, not by presence: ListRunning
+// reports every agent that hasn't exited, and one that finished its round stays
+// there indefinitely so a later turn can Continue it — treating those as
+// in-flight would stall the goal just as badly.
+//
+// Either manager may be nil (a transport with no such manager wired).
+func PendingAsyncWork(bg *BackgroundManager, sub *SubAgentManager) bool {
+	if bg != nil {
+		for _, info := range bg.ListRunning() {
+			if info.Mode == BgModeAsync {
+				return true
+			}
+		}
+	}
+	if sub != nil {
+		for _, info := range sub.ListRunning() {
+			if info.Busy {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/tools/pending_work_test.go
+++ b/internal/tools/pending_work_test.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPendingAsyncWork_NothingWired(t *testing.T) {
+	if PendingAsyncWork(nil, nil) {
+		t.Error("no managers wired must not report pending work")
+	}
+	if PendingAsyncWork(NewBackgroundManager(), NewSubAgentManager(&fakeSpawner{})) {
+		t.Error("idle managers must not report pending work")
+	}
+}
+
+// An interactive background process is a service or REPL that may never exit.
+// Counting one would park the goal-continuation loop forever, so only async
+// one-shot tasks hold it back.
+func TestPendingAsyncWork_IgnoresInteractive(t *testing.T) {
+	m := NewBackgroundManager()
+	defer m.KillAll()
+	if _, err := m.Start(context.Background(), "sleep 30", BgModeInteractive); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if PendingAsyncWork(m, nil) {
+		t.Error("an interactive process must not count as pending async work")
+	}
+}
+
+func TestPendingAsyncWork_AsyncProcess(t *testing.T) {
+	m := NewBackgroundManager()
+	defer m.KillAll()
+	id, err := m.Start(context.Background(), "sleep 30", BgModeAsync)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !PendingAsyncWork(m, nil) {
+		t.Fatal("a running async process must count as pending async work")
+	}
+
+	// Once it exits the loop is free again — the completion note is what
+	// carries the goal forward from here.
+	m.Kill(id)
+	waitFor(t, "async process to stop counting", func() bool { return !PendingAsyncWork(m, nil) })
+}
+
+// A sub-agent that finished its round stays in ListRunning so a later turn can
+// Continue it. Only a busy one is work in flight — counting the idle ones would
+// park the goal loop for the rest of the session.
+func TestPendingAsyncWork_RunningSubAgent(t *testing.T) {
+	sp := &blockingSpawner{release: make(chan struct{})}
+	m := NewSubAgentManager(sp)
+	if _, err := m.Start(SpawnRequest{Description: "d", Prompt: "p"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !PendingAsyncWork(nil, m) {
+		t.Fatal("a busy sub-agent must count as pending async work")
+	}
+
+	close(sp.release)
+	waitFor(t, "finished sub-agent to stop counting", func() bool { return !PendingAsyncWork(nil, m) })
+	if len(m.ListRunning()) == 0 {
+		t.Error("test setup: the finished agent should still be listed, so this proves Busy is what's checked")
+	}
+}


### PR DESCRIPTION
## Problem

The goal-continuation loop fires at every turn end, and its only spin guard is zero token progress (`Session.GoalContinuation`, `internal/agent/goal.go`). That guard cannot see the case the user hit: the model is waiting on an async background task or sub-agent, so every continuation turn answers *"still waiting"* — and bills real tokens for it. `TokensUsed` keeps climbing, the guard never fires, and the loop spins for as long as the work runs.

## Fix

Gate all three continuation points on the new `tools.PendingAsyncWork`:

- `cmd/octo/tuirepl.go` — TUI `handleTurnFinished`
- `internal/server/ws_handlers.go` — web `runAgentTurnLoop` (via `Server.goalWorkPending`)
- `internal/server/server.go` — IM's turn chain

Waiting is safe because the completion hooks (`BackgroundManager.SetOnExit`, `SubAgentManager.SetOnExit`) already start their own turn, and that turn's end re-enters the continuation check. No timeout fallback — the wake-up path is closed, so a timeout would be a knob for a case that cannot happen.

## Two things that deliberately do NOT count as work in flight

- **Interactive background processes.** A service or REPL (`octo serve`, `rails c`) may never exit; parking the goal on one would stall it for good.
- **Sub-agents that are listed but idle.** `SubAgentManager.ListRunning()` reports every agent that hasn't *exited*, and a successfully finished one stays there indefinitely so a later turn can `Continue` it. Checking list length would have parked the goal for the rest of the session — the check is on `Busy`.

A user-initiated start (`/goal`, `/goal resume`, the web idle kick) is not gated: the user just asked for it, and the turn-end gate takes over from there.

## Tests

`internal/tools/pending_work_test.go` (async counts, interactive doesn't, busy-vs-listed sub-agent) and two `internal/server/goal_test.go` cases covering the web wiring. `go test -race` green on tools / server / cmd/octo / agent / channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)