### PR TITLE
fix(web): stop /goal and /reload hanging a pending user bubble forever

### DIFF
--- a/web/src/lib/inlineSlash.test.ts
+++ b/web/src/lib/inlineSlash.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { inlineSlashCommand } from './inlineSlash'
+
+describe('inlineSlashCommand', () => {
+  it('recognises the no-arg commands, case-insensitively and around whitespace', () => {
+    expect(inlineSlashCommand('/clear')).toBe('clear')
+    expect(inlineSlashCommand('  /compact  ')).toBe('compact')
+    expect(inlineSlashCommand('/RELOAD')).toBe('reload')
+  })
+
+  it('recognises /goal with and without arguments', () => {
+    expect(inlineSlashCommand('/goal')).toBe('goal')
+    expect(inlineSlashCommand('/goal ')).toBe('goal')
+    expect(inlineSlashCommand('/goal ship the release')).toBe('goal')
+    expect(inlineSlashCommand('/goal pause')).toBe('goal')
+  })
+
+  // The server matches /goal case-sensitively (the ToLower switch covers only
+  // the no-arg three), so "/Goal x" falls through to the model there.
+  it('leaves /goal case-sensitive, like the server', () => {
+    expect(inlineSlashCommand('/Goal ship it')).toBeNull()
+  })
+
+  it('rejects anything the server would hand to the model', () => {
+    expect(inlineSlashCommand('/goalpost matters')).toBeNull()
+    expect(inlineSlashCommand('/clear the deck')).toBeNull()
+    expect(inlineSlashCommand('/loop 5m check CI')).toBeNull()
+    expect(inlineSlashCommand('what does /goal do?')).toBeNull()
+    expect(inlineSlashCommand('')).toBeNull()
+  })
+
+  // Attachments take the message off the inline path server-side (the switch is
+  // guarded on there being no blocks and no notes), so it runs as a real turn
+  // and does get a history_user_message echo.
+  it('is off when the message carries files', () => {
+    expect(inlineSlashCommand('/goal ship it', true)).toBeNull()
+    expect(inlineSlashCommand('/compact', true)).toBeNull()
+  })
+})

--- a/web/src/lib/inlineSlash.ts
+++ b/web/src/lib/inlineSlash.ts
@@ -1,0 +1,29 @@
+// Slash commands the server applies inline in wsUserMessage — they mutate the
+// session and return before any turn starts, so the text never enters history
+// and no history_user_message is ever broadcast for it.
+//
+// That absence is what the caller cares about: send()'s optimistic user bubble
+// is retired by that echo, and its pendingSends entry is retired by the same
+// event. Left in place for an inline command, the bubble spins forever and the
+// stale queue entry is shifted out by the NEXT message's confirmation, so that
+// one is mis-classified (steer vs fresh) and its own bubble is never de-duped.
+//
+// The matching mirrors internal/server/ws_handlers.go exactly: /clear, /compact
+// and /reload are case-insensitive exact matches; /goal is case-sensitive and
+// takes arguments. Attachments take the message off the inline path server-side.
+export type InlineSlashCommand = 'clear' | 'compact' | 'reload' | 'goal'
+
+export function inlineSlashCommand(text: string, hasFiles = false): InlineSlashCommand | null {
+  if (hasFiles) return null
+  const trimmed = text.trim()
+  switch (trimmed.toLowerCase()) {
+    case '/clear':
+      return 'clear'
+    case '/compact':
+      return 'compact'
+    case '/reload':
+      return 'reload'
+  }
+  if (trimmed === '/goal' || trimmed.startsWith('/goal ')) return 'goal'
+  return null
+}

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -59,6 +59,7 @@
   import { renderMarkdown, escapeHtml, setupCopyButtons } from '../lib/markdown'
   import { t, tr, pickLocalized } from '../lib/i18n'
   import { insertPendingSend } from '../lib/pendingSendOrder'
+  import { inlineSlashCommand } from '../lib/inlineSlash'
   import { exportModeStore, selectedMessagesStore } from '../lib/exportStore'
   import { filenameStem } from '../lib/filename'
   import DOMPurify from 'dompurify'
@@ -1977,6 +1978,17 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   }
 
   // ── send message ───────────────────────────────────────────────────────────
+  // The previous turn's leftovers, cleared before anything that can start the
+  // next one: finished sub-agents, the thinking buffer, the error banner, and
+  // the follow-up suggestion (it belongs to a conversation that has now moved
+  // on and must not re-render when this turn ends).
+  function clearLastTurnUi(sid: string) {
+    turnError = null
+    clearDoneSubAgents(sid)
+    chatThinking.update(tt => ({ ...tt, [sid]: '' }))
+    chatSuggestion.update(s => ({ ...s, [sid]: '' }))
+  }
+
   async function send(text: string, files?: any[], queued = false) {
     if (!text.trim() && !(files && files.length)) return
     const sid = await ensureActiveSession()
@@ -1986,18 +1998,34 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     // the sub-agents panel and thinking buffer belong to the turn in flight.
     const wasStreaming = get(chatStreaming)[sid] ?? false
     const steering = wasStreaming
+
+    // Server-inline commands (/clear, /compact, /reload, /goal …) are applied
+    // by the server and never enter history, so no history_user_message ever
+    // comes back for them. Everything that echo retires — the optimistic
+    // bubble, its pendingSends entry, the ghost steer — has to be skipped, or
+    // it hangs there forever. The server speaks for these itself: a goal_notice
+    // line, a history_reload, a toast.
+    const inline = inlineSlashCommand(text, !!(files && files.length))
+    if (inline) {
+      if (!steering) {
+        clearLastTurnUi(sid)
+        // Only /compact is a long server-side job with no other busy signal
+        // (its own session_update idle clears this again). /goal may start a
+        // continuation turn, whose events flip streaming on for real; the rest
+        // finish in a single round-trip. Claiming "streaming" for those would
+        // stick — nothing would ever flip it back.
+        if (inline === 'compact') chatStreaming.update(s => ({ ...s, [sid]: true }))
+      }
+      ws.sendMessage(sid, text, files, false, false)
+      pinToBottom()
+      return
+    }
+
     if (!steering) {
-      // A fresh turn starts: clear the previous turn's finished sub-agents and
-      // thinking buffer, clear the error banner, clear any stale follow-up
-      // suggestion from the last turn (it belongs to a conversation that has now
-      // moved on and must not re-render when this turn ends), and flip the
-      // session into streaming.
-      turnError = null
+      // A fresh turn starts.
+      clearLastTurnUi(sid)
       // Remember what started this turn so turn_error can hand it back.
       turnInput.set(sid, { text, files })
-      clearDoneSubAgents(sid)
-      chatThinking.update(tt => ({ ...tt, [sid]: '' }))
-      chatSuggestion.update(s => ({ ...s, [sid]: '' }))
       chatStreaming.update(s => ({ ...s, [sid]: true }))
     }
     // Queueing only means anything mid-turn: idle there is no turn to wait for,


### PR DESCRIPTION
## Problem

The server applies `/clear`, `/compact`, `/reload` and `/goal` inline in `wsUserMessage` and returns before any turn starts, so their text never enters history and **no `history_user_message` is ever broadcast for it**.

`send()` doesn't know that. It renders the optimistic user bubble and registers a `pendingSends` entry for every message, and both are retired by that echo.

- `/clear`, `/compact` — invisible: the `history_reload` they trigger wipes the transcript (bubble included) and their `session_update idle` clears the streaming flag.
- `/goal` — since #2084 gave it a real continuation turn, typing a goal in the web composer leaves the bubble spinning next to the goal's own notices. This is the reported symptom.
- `/reload` — sends neither, so it has always left both the bubble and the "thinking" indicator stuck.

The stale queue entry is the quieter half: it is shifted out by the **next** message's confirmation, so that message is classified by the wrong entry's `wasStreaming` (steer vs fresh turn) and its own bubble is never de-duped.

## Fix

A new `inlineSlashCommand()` helper mirrors the server's matching (`/clear`, `/compact`, `/reload` case-insensitive and exact; `/goal` case-sensitive with arguments; attachments take the message off the inline path). `send()` skips the bubble, the `pendingSends` entry and the ghost steer for those — the server speaks for them itself (a `goal_notice` line, a `history_reload`, a toast).

The previous turn's UI leftovers are still cleared, since `/goal` can start a turn; that block is extracted into `clearLastTurnUi` so both paths share it. The optimistic streaming flag is kept only for `/compact` — the one long server-side job with no other busy signal, which closes with its own `session_update idle`.

## Verification

Isolated walkthrough (fake `HOME`, a local stub OpenAI endpoint, headless Chrome over CDP):

- `/goal <objective>` → `.pending-spinner` count **0**, no residual bubble, goal notices and the continuation turn render normally.
- A plain message right after → confirmed bubble (`pending: false`) within 400 ms.
- `web/` suite: 219 tests pass; `svelte-check`: 0 errors.

## Not in scope

- `sendMobile` has the same defect. Fixing it alone would leave `/goal` with no feedback at all on mobile (no `goal_notice` handler there), so it rides a follow-up.
- A separate, pre-existing bug found while verifying this: the turn's own initial `history_user_message` is broadcast before the stream writer exists and is never buffered for replay, so a client that subscribes moments later (the composer creating the session on first send) never sees it — one permanently pending bubble, and a `pendingSends` FIFO that stays off by one for the rest of that tab's session. Reproduced identically on unmodified `main`; follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)