### PR TITLE
fix(mobile): skip the optimistic echo for server-inline slash commands

### DIFF
--- a/web/src/lib/inlineSlash.test.ts
+++ b/web/src/lib/inlineSlash.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { inlineSlashCommand } from './inlineSlash'
+
+describe('inlineSlashCommand', () => {
+  it('recognises the no-arg commands, case-insensitively and around whitespace', () => {
+    expect(inlineSlashCommand('/clear')).toBe('clear')
+    expect(inlineSlashCommand('  /compact  ')).toBe('compact')
+    expect(inlineSlashCommand('/RELOAD')).toBe('reload')
+  })
+
+  it('recognises /goal with and without arguments', () => {
+    expect(inlineSlashCommand('/goal')).toBe('goal')
+    expect(inlineSlashCommand('/goal ')).toBe('goal')
+    expect(inlineSlashCommand('/goal ship the release')).toBe('goal')
+    expect(inlineSlashCommand('/goal pause')).toBe('goal')
+  })
+
+  // The server matches /goal case-sensitively (the ToLower switch covers only
+  // the no-arg three), so "/Goal x" falls through to the model there.
+  it('leaves /goal case-sensitive, like the server', () => {
+    expect(inlineSlashCommand('/Goal ship it')).toBeNull()
+  })
+
+  it('rejects anything the server would hand to the model', () => {
+    expect(inlineSlashCommand('/goalpost matters')).toBeNull()
+    expect(inlineSlashCommand('/clear the deck')).toBeNull()
+    expect(inlineSlashCommand('/loop 5m check CI')).toBeNull()
+    expect(inlineSlashCommand('what does /goal do?')).toBeNull()
+    expect(inlineSlashCommand('')).toBeNull()
+  })
+
+  // Attachments take the message off the inline path server-side (the switch is
+  // guarded on there being no blocks and no notes), so it runs as a real turn
+  // and does get a history_user_message echo.
+  it('is off when the message carries files', () => {
+    expect(inlineSlashCommand('/goal ship it', true)).toBeNull()
+    expect(inlineSlashCommand('/compact', true)).toBeNull()
+  })
+})

--- a/web/src/lib/inlineSlash.ts
+++ b/web/src/lib/inlineSlash.ts
@@ -1,0 +1,29 @@
+// Slash commands the server applies inline in wsUserMessage — they mutate the
+// session and return before any turn starts, so the text never enters history
+// and no history_user_message is ever broadcast for it.
+//
+// That absence is what the caller cares about: send()'s optimistic user bubble
+// is retired by that echo, and its pendingSends entry is retired by the same
+// event. Left in place for an inline command, the bubble spins forever and the
+// stale queue entry is shifted out by the NEXT message's confirmation, so that
+// one is mis-classified (steer vs fresh) and its own bubble is never de-duped.
+//
+// The matching mirrors internal/server/ws_handlers.go exactly: /clear, /compact
+// and /reload are case-insensitive exact matches; /goal is case-sensitive and
+// takes arguments. Attachments take the message off the inline path server-side.
+export type InlineSlashCommand = 'clear' | 'compact' | 'reload' | 'goal'
+
+export function inlineSlashCommand(text: string, hasFiles = false): InlineSlashCommand | null {
+  if (hasFiles) return null
+  const trimmed = text.trim()
+  switch (trimmed.toLowerCase()) {
+    case '/clear':
+      return 'clear'
+    case '/compact':
+      return 'compact'
+    case '/reload':
+      return 'reload'
+  }
+  if (trimmed === '/goal' || trimmed.startsWith('/goal ')) return 'goal'
+  return null
+}

--- a/web/src/mobile/chatWiring.ts
+++ b/web/src/mobile/chatWiring.ts
@@ -16,6 +16,7 @@ import { ws } from '../lib/ws'
 import { tr } from '../lib/i18n'
 import * as api from '../lib/api'
 import { observeArtifact, resetArtifacts } from '../lib/artifacts'
+import { inlineSlashCommand } from '../lib/inlineSlash'
 import {
   chatMessages,
   chatStreaming,
@@ -91,6 +92,20 @@ export function loadMobileHistory(sid: string): Promise<void> {
 export function sendMobile(sid: string, text: string, files?: unknown[]) {
   const t = text.trim()
   if (!t) return
+  // Server-inline commands never enter history, so no history_user_message
+  // comes back to reconcile the echo — it would spin forever. Mobile has no
+  // slash menu, so these only arrive typed by hand, but /reload and /goal do
+  // reach here. /compact keeps the optimistic busy flag: it is a long
+  // server-side job that closes with its own session_update idle, which the
+  // handler below already listens for. What the others report is the server's
+  // own doing (a history_reload, a toast); goal notices have no mobile surface
+  // yet, which is a separate gap, not something a spinner should paper over.
+  const inline = inlineSlashCommand(t, !!(files && files.length))
+  if (inline) {
+    if (inline === 'compact') chatStreaming.update(s => ({ ...s, [sid]: true }))
+    ws.sendMessage(sid, t, files)
+    return
+  }
   addChatMsg(sid, {
     id: uid('u'), type: 'user', content: t, createdAt: Date.now(),
     streaming: false, pending: true, tools: [], todos: [], images: [],

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -59,6 +59,7 @@
   import { renderMarkdown, escapeHtml, setupCopyButtons } from '../lib/markdown'
   import { t, tr, pickLocalized } from '../lib/i18n'
   import { insertPendingSend } from '../lib/pendingSendOrder'
+  import { inlineSlashCommand } from '../lib/inlineSlash'
   import { exportModeStore, selectedMessagesStore } from '../lib/exportStore'
   import { filenameStem } from '../lib/filename'
   import DOMPurify from 'dompurify'
@@ -1977,6 +1978,17 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
   }
 
   // ── send message ───────────────────────────────────────────────────────────
+  // The previous turn's leftovers, cleared before anything that can start the
+  // next one: finished sub-agents, the thinking buffer, the error banner, and
+  // the follow-up suggestion (it belongs to a conversation that has now moved
+  // on and must not re-render when this turn ends).
+  function clearLastTurnUi(sid: string) {
+    turnError = null
+    clearDoneSubAgents(sid)
+    chatThinking.update(tt => ({ ...tt, [sid]: '' }))
+    chatSuggestion.update(s => ({ ...s, [sid]: '' }))
+  }
+
   async function send(text: string, files?: any[], queued = false) {
     if (!text.trim() && !(files && files.length)) return
     const sid = await ensureActiveSession()
@@ -1986,18 +1998,34 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     // the sub-agents panel and thinking buffer belong to the turn in flight.
     const wasStreaming = get(chatStreaming)[sid] ?? false
     const steering = wasStreaming
+
+    // Server-inline commands (/clear, /compact, /reload, /goal …) are applied
+    // by the server and never enter history, so no history_user_message ever
+    // comes back for them. Everything that echo retires — the optimistic
+    // bubble, its pendingSends entry, the ghost steer — has to be skipped, or
+    // it hangs there forever. The server speaks for these itself: a goal_notice
+    // line, a history_reload, a toast.
+    const inline = inlineSlashCommand(text, !!(files && files.length))
+    if (inline) {
+      if (!steering) {
+        clearLastTurnUi(sid)
+        // Only /compact is a long server-side job with no other busy signal
+        // (its own session_update idle clears this again). /goal may start a
+        // continuation turn, whose events flip streaming on for real; the rest
+        // finish in a single round-trip. Claiming "streaming" for those would
+        // stick — nothing would ever flip it back.
+        if (inline === 'compact') chatStreaming.update(s => ({ ...s, [sid]: true }))
+      }
+      ws.sendMessage(sid, text, files, false, false)
+      pinToBottom()
+      return
+    }
+
     if (!steering) {
-      // A fresh turn starts: clear the previous turn's finished sub-agents and
-      // thinking buffer, clear the error banner, clear any stale follow-up
-      // suggestion from the last turn (it belongs to a conversation that has now
-      // moved on and must not re-render when this turn ends), and flip the
-      // session into streaming.
-      turnError = null
+      // A fresh turn starts.
+      clearLastTurnUi(sid)
       // Remember what started this turn so turn_error can hand it back.
       turnInput.set(sid, { text, files })
-      clearDoneSubAgents(sid)
-      chatThinking.update(tt => ({ ...tt, [sid]: '' }))
-      chatSuggestion.update(s => ({ ...s, [sid]: '' }))
       chatStreaming.update(s => ({ ...s, [sid]: true }))
     }
     // Queueing only means anything mid-turn: idle there is no turn to wait for,


### PR DESCRIPTION
Stacked on #2096 — based there so the diff stays to one file; retarget to `main` once #2096 merges.

## Problem

`sendMobile` marks every send with a pending bubble and a streaming flag, and both only clear when the server echoes the message back as `history_user_message`. The server-inline commands never enter history, so no echo ever comes — the same defect #2096 fixes on desktop.

Mobile handles `history_reload` and `session_update idle`, so:

| command | mobile today |
|---|---|
| `/clear`, `/compact` | fine — covered by `history_reload` + idle |
| `/reload` | bubble and "thinking" stuck for good |
| `/goal` | bubble and "thinking" stuck for good, **and no feedback at all** |

Reachability is lower than desktop: the mobile composer is a plain textarea with no slash menu, so these only arrive typed by hand.

## Fix

Reuse `inlineSlashCommand` from #2096, with the same `/compact` carve-out (a long server-side job whose only busy signal is that flag, cleared by its own `session_update idle`).

`/goal` stays silent on mobile — there is no `goal_notice` handler and the `chatGoal` snapshot feeds no UI. That gap predates this and deserves its own change; a spinner that never stops is not a stand-in for feedback.

## Verification

`svelte-check` 0 errors, `web/` suite 219 tests pass. No behavioural walkthrough: the mobile shell has no way to reach these commands other than typing them, and the changed branch is the one #2096 already exercised on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
