### PR TITLE
fix(goal): name a web session started by /goal from its objective

### DIFF
--- a/internal/agent/goal.go
+++ b/internal/agent/goal.go
@@ -188,10 +188,17 @@ func (s *Session) startGoalLocked(objective string, tokenBudget int64) Goal {
 	// not billed to the fresh goal. Cleared unconsumed at the next turn start.
 	s.goalSkipNextTokenDelta = true
 	records := []sessionRecord{{Type: "goal", Goal: s.Goal}}
-	if s.Title == "" || s.Title == "*Octo Agent" {
+	if IsAutoNamePlaceholder(s.Title) {
 		// Seed the title from the objective (the Codex thread-preview
 		// behavior). It needs its own record — a "goal" record doesn't carry
 		// the title, so without one the seed would vanish on reload.
+		//
+		// IsAutoNamePlaceholder is THE placeholder predicate: hand-rolling the
+		// check here missed the web frontend's "Session N" name, so a session
+		// started by "/goal <objective>" from the browser went unnamed — and
+		// the ordinary title path can't rescue it either, since the turn that
+		// kick starts carries only the hidden <goal_context> prompt, which
+		// FirstUserSnippet strips to nothing.
 		s.Title = goalTitle(objective)
 		records = append(records, sessionRecord{Type: "title", Title: s.Title})
 	}

--- a/internal/agent/goal_test.go
+++ b/internal/agent/goal_test.go
@@ -50,6 +50,33 @@ func TestCreateGoal(t *testing.T) {
 	}
 }
 
+// TestCreateGoal_SeedsTitleOverEveryPlaceholder: the objective must name a
+// session whatever placeholder it was born with. The web frontend's "Session
+// N" was the gap — the seed check was hand-rolled ("" or "*Octo Agent") and
+// missed it, so a browser session started by "/goal <objective>" stayed
+// unnamed. The ordinary title path can't cover for it: the turn that command
+// kicks off carries only the hidden <goal_context> prompt, which strips to
+// nothing. A title the user chose is never overwritten.
+func TestCreateGoal_SeedsTitleOverEveryPlaceholder(t *testing.T) {
+	for _, tc := range []struct{ title, want string }{
+		{"", "ship the release"},
+		{"*Octo Agent", "ship the release"},
+		{"Session 7", "ship the release"},
+		{"my own name", "my own name"},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			s := NewSession("m", "")
+			s.Title = tc.title
+			if _, err := s.CreateGoal("ship the release", 0); err != nil {
+				t.Fatalf("CreateGoal: %v", err)
+			}
+			if s.Title != tc.want {
+				t.Errorf("title = %q, want %q", s.Title, tc.want)
+			}
+		})
+	}
+}
+
 func TestCreateGoal_RejectsBadInput(t *testing.T) {
 	s := NewSession("m", "")
 	if _, err := s.CreateGoal("   ", 0); err == nil {

--- a/internal/server/goal.go
+++ b/internal/server/goal.go
@@ -152,12 +152,21 @@ func (s *Server) wsGoalCommand(sessionID, args string) {
 		s.broadcastGoalNotice(sessionID, "command", fmt.Sprintf("/goal: %v", err), "error")
 		return
 	}
+	titleBefore := sess.Title
 	reply, start := agent.GoalCommand(sess, args)
 	level := "info"
 	if len(reply) > 6 && (reply[:6] == "/goal:" || reply[:6] == "/goal ") {
 		level = "error"
 	}
 	s.broadcastGoalNotice(sessionID, "command", reply, level)
+	// Creating or replacing a goal seeds a placeholder-named session's title
+	// from the objective (startGoalLocked, which also persists it). Tell the
+	// sidebar: without this the rename would only surface on the next refetch,
+	// so a session started by "/goal …" would look unnamed for as long as the
+	// tab stayed open.
+	if sess.Title != titleBefore {
+		s.broadcastSessionRenamed(sessionID, sess.Title)
+	}
 	if g, ok := sess.GoalSnapshot(); ok {
 		s.broadcastGoalUpdated(sessionID, g)
 	} else {
@@ -235,6 +244,7 @@ func (s *Server) handleUpdateSessionGoal(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	titleBefore := sess.Title
 	var g agent.Goal
 	var err error
 	switch {
@@ -265,6 +275,10 @@ func (s *Server) handleUpdateSessionGoal(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	s.broadcastGoalUpdated(sess.ID, g)
+	// Same objective-seeded rename as the composer's /goal (see wsGoalCommand).
+	if sess.Title != titleBefore {
+		s.broadcastSessionRenamed(sess.ID, sess.Title)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"goal": g})
 }
 

--- a/internal/server/goal_test.go
+++ b/internal/server/goal_test.go
@@ -265,6 +265,39 @@ func waitEventType(t *testing.T, conn *wsConn, typ string) map[string]any {
 	return nil
 }
 
+// TestWSGoalCommand_NamesPlaceholderSessionFromObjective is the regression
+// guard for a browser session started by "/goal <objective>" staying unnamed:
+// the objective seeds the title, the sidebar is told live, and the seed
+// survives the reload. Web sessions are born as "Session N", which the goal
+// seed's hand-rolled placeholder check used to miss — and nothing else could
+// name them, since the turn the command kicks off carries only the hidden
+// continuation prompt.
+func TestWSGoalCommand_NamesPlaceholderSessionFromObjective(t *testing.T) {
+	srv, sess := goalTestServer(t)
+	sess.Title = "Session 4" // the web frontend's auto-assigned name
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
+	// Registered but not subscribed: session_renamed is a global broadcast.
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.wsHub.register <- conn
+	srv.sender = &goalRoundSender{}
+
+	srv.wsGoalCommand(sess.ID, "ship the 1.16 release")
+	waitGoalTurnIdle(t, srv, sess.ID)
+
+	if ev := waitEventType(t, conn, "session_renamed"); ev["name"] != "ship the 1.16 release" {
+		t.Errorf("rename name = %v, want the objective", ev["name"])
+	}
+	loaded, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Title != "ship the 1.16 release" {
+		t.Errorf("persisted Title = %q, want the objective", loaded.Title)
+	}
+}
+
 // The web's answer to the TUI's "● Goal …" scrollback: the command's reply
 // lands in the transcript, and the continuation turn it kicks announces itself
 // — without that line the turn's output would read as unprompted, since the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3037,8 +3037,15 @@ func (s *Server) handleChannelGoal(ad channel.Adapter, ev channel.InboundEvent, 
 		ad.SendText(ev.ChatID, "Goals are unavailable for this session.", ev.MessageID)
 		return
 	}
+	titleBefore := store.Title
 	reply, start := agent.GoalCommand(store, args)
 	ad.SendText(ev.ChatID, reply, ev.MessageID)
+	// The objective seeds a placeholder-named session's title (startGoalLocked).
+	// IM has no session list of its own, but the web sidebar lists IM sessions
+	// too — tell it, the same as wsGoalCommand does.
+	if store.Title != titleBefore {
+		s.broadcastSessionRenamed(store.ID, store.Title)
+	}
 	if start == agent.GoalStartNone {
 		return
 	}


### PR DESCRIPTION
## Problem

A session started in the browser with `/goal <objective>` kept its placeholder name (`Session N`) forever — no title was ever generated.

Two mechanisms failed at once:

1. **The goal seed missed the web placeholder.** `startGoalLocked` already seeds the title from the objective, but hand-rolled the check as `Title == "" || Title == "*Octo Agent"`. Web sessions are created as `Session N`, so the seed never fired for them. `IsAutoNamePlaceholder` is the canonical predicate — its own doc says every surface must agree on it.

2. **The ordinary title path can't cover for it.** `/goal` never enters the transcript; the turn it kicks off carries only the hidden continuation prompt, which is wrapped in `<goal_context>`. `FirstUserSnippet` runs `StripSystemReminders` first, so it comes up empty and the generation gate skips every goal turn.

TUI and IM sessions are born as `*Octo Agent` and were unaffected — only the browser hit this.

## Fix

- `startGoalLocked` uses `IsAutoNamePlaceholder`. A title the user chose is still never overwritten.
- The rename is broadcast: `wsGoalCommand`, `PUT /api/sessions/{id}/goal` and the IM `/goal` handler each emit `session_renamed` when the objective renamed the session, so the sidebar updates live rather than on the next refetch. The web session list covers IM sessions too, which is why the IM handler broadcasts as well.

## Tests

- `TestCreateGoal_SeedsTitleOverEveryPlaceholder` — table over `""` / `*Octo Agent` / `Session 7` / a user-chosen name.
- `TestWSGoalCommand_NamesPlaceholderSessionFromObjective` — end-to-end: a `Session 4` session runs `/goal`, the rename lands on the wire, and the title survives the reload.

Both fail against the pre-fix code (`title = "Session 7", want …`; rename broadcast times out).

`go test ./...` and `go test -race` on the touched packages are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
