### PR TITLE
fix(web): don't send into a session before anything is subscribed to it

### DIFF
--- a/web/src/lib/pendingSendOrder.test.ts
+++ b/web/src/lib/pendingSendOrder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { insertPendingSend, pendingSendInsertIndex } from './pendingSendOrder'
+import { insertPendingSend, pendingSendInsertIndex, takeConfirmedSend } from './pendingSendOrder'
 
 type Entry = { id: string; queued?: boolean }
 
@@ -65,5 +65,54 @@ describe('insertPendingSend', () => {
     const q: Entry[] = [queued('Q1')]
     insertPendingSend(q, steer('S2'))
     expect(ids(q)).toEqual(['S2', 'Q1'])
+  })
+})
+
+describe('takeConfirmedSend', () => {
+  type Send = { pendingId: string; text: string; queued?: boolean }
+  const send = (id: string, text: string): Send => ({ pendingId: id, text })
+
+  it('retires the head when it is the message confirmed', () => {
+    const q = [send('a', 'first'), send('b', 'second')]
+    const { meta, dropped } = takeConfirmedSend(q, 'first')
+    expect(meta?.pendingId).toBe('a')
+    expect(dropped).toEqual([])
+    expect(q.map(m => m.pendingId)).toEqual(['b'])
+  })
+
+  it('ignores whitespace the server trimmed off', () => {
+    const q = [send('a', '  padded  ')]
+    expect(takeConfirmedSend(q, 'padded').meta?.pendingId).toBe('a')
+  })
+
+  // The desync this exists for: 'a' never got a confirmation, so a plain
+  // shift() would hand 'a' back for 'second' and stay one entry ahead forever.
+  it('re-anchors past entries whose confirmation never arrived', () => {
+    const q = [send('a', 'first'), send('b', 'second'), send('c', 'third')]
+    const { meta, dropped } = takeConfirmedSend(q, 'second')
+    expect(meta?.pendingId).toBe('b')
+    expect(dropped.map(m => m.pendingId)).toEqual(['a'])
+    expect(q.map(m => m.pendingId)).toEqual(['c'])
+  })
+
+  it('matches the earliest of two identical messages', () => {
+    const q = [send('a', 'same'), send('b', 'same')]
+    expect(takeConfirmedSend(q, 'same').meta?.pendingId).toBe('a')
+    expect(q.map(m => m.pendingId)).toEqual(['b'])
+  })
+
+  // Content the client can't match (an attachment-only send the server
+  // re-rendered, an older server): behave exactly as the old shift() did.
+  it('falls back to the head when nothing matches', () => {
+    const q = [send('a', 'first'), send('b', 'second')]
+    const { meta, dropped } = takeConfirmedSend(q, 'something else entirely')
+    expect(meta?.pendingId).toBe('a')
+    expect(dropped).toEqual([])
+    expect(q.map(m => m.pendingId)).toEqual(['b'])
+  })
+
+  it('reports nothing for an empty queue', () => {
+    const q: Send[] = []
+    expect(takeConfirmedSend(q, 'anything')).toEqual({ meta: undefined, dropped: [] })
   })
 })

--- a/web/src/lib/pendingSendOrder.ts
+++ b/web/src/lib/pendingSendOrder.ts
@@ -27,3 +27,30 @@ export function insertPendingSend<T extends PendingSendLike>(queue: T[], entry: 
   queue.splice(pendingSendInsertIndex(queue, entry.queued === true), 0, entry)
   return queue
 }
+
+export interface ConfirmableSend extends PendingSendLike {
+  pendingId: string
+  text: string
+}
+
+// Which entry a history_user_message confirms, and which entries it proves
+// will never be confirmed.
+//
+// A plain shift() assumes every send gets exactly one confirmation. One that
+// goes missing — a WS gap, a send that raced its own subscription — leaves the
+// queue permanently one entry ahead, and from then on every confirmation is
+// read against the wrong entry: steers are misread as fresh turns, ghosts are
+// never dropped, and bubbles are duplicated instead of de-duped. Matching on
+// the text the server echoed back re-anchors the queue, so a single lost
+// confirmation costs one stale entry rather than the rest of the session.
+//
+// Falls back to the head when nothing matches, which is what shift() did.
+export function takeConfirmedSend<T extends ConfirmableSend>(
+  queue: T[],
+  content: string,
+): { meta?: T; dropped: T[] } {
+  const want = content.trim()
+  const found = queue.findIndex(m => m.text.trim() === want)
+  const removed = queue.splice(0, (found >= 0 ? found : 0) + 1)
+  return { meta: removed[removed.length - 1], dropped: removed.slice(0, -1) }
+}

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -162,7 +162,7 @@ export const chatWorkflows = writable<Record<string, WorkflowRunState[]>>({})
 // old hand-written UI's Sessions.setPendingMessage → ws "subscribed" flush, so
 // the agentic-first panels invoke a skill in a fresh chat instead of opening a
 // blank session or popping a form.
-export const pendingPrompt = writable<{ sessionId: string; content: string } | null>(null)
+export const pendingPrompt = writable<{ sessionId: string; content: string; files?: any[] } | null>(null)
 
 // Permission/question modals
 // Keyed by sessionId so a second session's confirmation doesn't clobber a

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -58,7 +58,7 @@
   import { observeArtifact, resetArtifacts } from '../lib/artifacts'
   import { renderMarkdown, escapeHtml, setupCopyButtons } from '../lib/markdown'
   import { t, tr, pickLocalized } from '../lib/i18n'
-  import { insertPendingSend } from '../lib/pendingSendOrder'
+  import { insertPendingSend, takeConfirmedSend } from '../lib/pendingSendOrder'
   import { inlineSlashCommand } from '../lib/inlineSlash'
   import { exportModeStore, selectedMessagesStore } from '../lib/exportStore'
   import { filenameStem } from '../lib/filename'
@@ -486,7 +486,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       const pend = get(pendingPrompt)
       if (pend && pend.sessionId === sid) {
         pendingPrompt.set(null)
-        send(pend.content)
+        send(pend.content, pend.files)
       }
     }))
 
@@ -843,8 +843,15 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       const createdAt = (ev as any).created_at ?? Date.now()
       const images = (ev as any).images ?? []
       const queue = pendingSends.get(sid)
-      const meta = queue?.shift()
+      // Entries ahead of the confirmed one never got a confirmation of their
+      // own. Retiring them here — instead of letting the queue stay short —
+      // keeps one lost confirmation from misreading every send after it.
+      const { meta, dropped } = takeConfirmedSend(queue ?? [], content)
       if (queue && queue.length === 0) pendingSends.delete(sid)
+      if (dropped.length) {
+        const stale = new Set(dropped.map(d => d.pendingId))
+        pendingSteers = { ...pendingSteers, [sid]: pendingSteers[sid]?.filter(s => !stale.has(s.pendingId)) ?? [] }
+      }
       // Trust the FIFO queue to decide whether this confirmation belongs to a
       // steer. If the queue is empty (e.g. page refresh), any pendingSteers are
       // orphaned UI state from before the refresh; don't guess by content and
@@ -1024,9 +1031,13 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       chatProgress.update(p => ({ ...p, [sid]: null }))
       // A turn that ends without an assistant_message (interrupt / error) would
       // otherwise leave the live bubble's streaming caret blinking forever, so
-      // clear any lingering per-message streaming flags here.
+      // clear any lingering per-message streaming flags here. Same for a user
+      // bubble still marked pending: its confirmation is broadcast at turn
+      // start, so by the time the turn ends it either arrived or never will —
+      // a spinner that outlives its own turn is only ever a lie.
       chatMessages.update(m => {
-        const msgs = (m[sid] || []).map((x: any) => (x.streaming ? { ...x, streaming: false } : x))
+        const msgs = (m[sid] || []).map((x: any) =>
+          x.streaming || x.pending ? { ...x, streaming: false, pending: false } : x)
         return { ...m, [sid]: msgs }
       })
       // Close open tool groups AND mark any still-spinning tools done — a
@@ -1952,13 +1963,15 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     }
   }
 
-  // ensureActiveSession returns the active session id, creating one first if
-  // none is active — e.g. right after deleting the session that was open.
+  // ensureActiveSession returns the session to send into, creating one first
+  // if none is active — e.g. right after deleting the session that was open.
   // Mirrors Sidebar's "+" new-session flow so typing into that empty state
-  // and hitting send works instead of silently dropping the message.
-  async function ensureActiveSession(): Promise<string | null> {
+  // and hitting send works instead of silently dropping the message. `created`
+  // reports whether this call is what created it: the caller must not send
+  // straight into a session it just created (see send()).
+  async function ensureActiveSession(): Promise<{ id: string; created: boolean } | null> {
     const existing = get(activeSessionId)
-    if (existing) return existing
+    if (existing) return { id: existing, created: false }
     try {
       // A model picked in the composer before any session existed rides the
       // pendingModel store (composite "<endpoint>::<model>" id — the create
@@ -1970,7 +1983,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       const newSess = created.session ?? created
       sessions.update(ss => [newSess, ...ss])
       activeSessionId.set(newSess.id)
-      return newSess.id
+      return { id: newSess.id, created: true }
     } catch (e: any) {
       showToast(e.message, 'error')
       return null
@@ -1991,8 +2004,21 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
   async function send(text: string, files?: any[], queued = false) {
     if (!text.trim() && !(files && files.length)) return
-    const sid = await ensureActiveSession()
-    if (!sid) return
+    const active = await ensureActiveSession()
+    if (!active) return
+    const sid = active.id
+    if (active.created) {
+      // Nothing is subscribed to a session that existed a millisecond ago: the
+      // effect above only issues the subscribe once this call returns. Sending
+      // now would have the server broadcast this message's confirmation to an
+      // empty room, and a turn's own history_user_message — unlike the steers
+      // that follow it — is not in the replay buffer, so a later subscribe
+      // never sees it. The bubble would spin for good and the queue would sit
+      // one entry ahead for the rest of the tab's life. Hand the text to the
+      // flush-on-subscribe path the panel-opened sessions already use.
+      pendingPrompt.set({ sessionId: sid, content: text, files })
+      return
+    }
     // Steering: a message sent while a turn is already running rides the
     // running turn's Inbox on the server. It must NOT reset the live UI —
     // the sub-agents panel and thinking buffer belong to the turn in flight.


### PR DESCRIPTION
Found while verifying #2096. Same family — an optimistic bubble that never gets reconciled — but a different cause, and it reproduces identically on unmodified `main`.

## Problem

A turn's opening `history_user_message` is broadcast in `doAgentTurn` before the stream writer exists (`ws_handlers.go:1405`) and is never buffered for replay — unlike the steer confirmations that follow it, which are (`:2248`). Any client that subscribes after that instant never learns the message was accepted.

The composer walks straight into that. `ensureActiveSession` creates the session and `send()` fires immediately, while the subscribe is still queued behind the effect that reacts to the session becoming active (`loadHistory(sid).then(() => ws.subscribe(sid))` — a REST round-trip). So the very first message of a composer-created session — an empty workbench, or the state right after deleting the open session — is broadcast to an empty room.

The visible half is one bubble that spins forever. The worse half: its `pendingSends` entry is never retired, so the FIFO stays one ahead for the rest of that tab's session and **every later confirmation is read against the wrong entry** — steers misread as fresh turns, their ghost bubbles never dropped, messages rendered twice (once pending, once confirmed). A reload clears it because the queue lives in memory; nothing else does.

### Reproduction (deterministic)

Fake `HOME`, a stub OpenAI endpoint pacing one word per second, headless Chrome over CDP:

| step | before | after |
|---|---|---|
| send the first message into a fresh session | bubble `pending` forever | confirmed in ~4 s |
| steer that turn | ghost never clears | ghost clears at turn end |
| send once more after the turn | two bubbles (one pending, one confirmed) | one bubble |

Trigger boundary, all measured: composer-created session ❌ · "New Session" button then type ✅ · second and later messages ✅ · after a reload ✅.

## Fix

Cause outward:

- `ensureActiveSession` reports whether it created the session, and `send()` hands that first message to the flush-on-subscribe path (`pendingPrompt`) that panel-opened sessions already use, instead of racing the subscribe. `pendingPrompt` gains a `files` field so an attachment isn't dropped on that path.
- `takeConfirmedSend` matches the confirmation against the queue's text rather than blindly shifting, so a confirmation lost some other way (a WS gap) costs one stale entry instead of every entry after it. The re-anchoring drops the stranded ghosts with it.
- A user bubble still pending when the turn completes is un-pended alongside the streaming-caret cleanup already there: the confirmation is broadcast at turn start, so by turn end it either arrived or never will.

The server side is left alone deliberately. Buffering the opening message for replay is the other obvious fix, but the REST history already serves it during the turn (it sits below the watermark), so a replay would double-render it for every client that loads history *after* the persist — the common mid-turn refresh. Fixing the ordering costs nothing and has no such edge.

## Side effect worth noting

`/goal` as the very first message of a fresh session used to lose its `goal_notice` lines to the same empty room. It now shows "Goal set" and "Goal starts" as intended.

## Verification

- The walkthrough above, on this branch vs unmodified `main`.
- `/goal` first-message and the steer regression re-run after rebasing onto #2096 + #2097.
- `web/` suite 225 tests pass (6 new for `takeConfirmedSend`, including the desync case, whitespace, duplicate text, and the no-match fallback); `svelte-check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
