### PR TITLE
fix(web): make the permission modal opaque

### DIFF
--- a/web/src/components/overlays/ConfirmModal.svelte
+++ b/web/src/components/overlays/ConfirmModal.svelte
@@ -140,7 +140,12 @@
 }
 .modal {
   width: 100%; max-width: 480px;
-  background: var(--warning-bg);
+  /* #2103: --warning-bg is a translucent tint meant for badges and notices
+     that already sit on an opaque surface. As a floating panel's background
+     it left the whole dialog at 16% opacity, so the chat behind it bled
+     through the very content being approved. Layer the tint over an opaque
+     surface instead — same warm colour, nothing shows through. */
+  background: linear-gradient(var(--warning-bg), var(--warning-bg)), var(--bg-container);
   border: 1px solid var(--warning-border);
   border-radius: 12px;
   overflow: hidden;
@@ -182,6 +187,10 @@
 /* #1105: edit_file preview — same classification/coloring ToolGroup.svelte
    uses for the post-execution diff card, scoped to this modal's spacing. */
 .diff-block {
+  /* #2103: its own surface, so the half-opaque add/rm line fills blend with
+     the neutral container the way they do in ToolGroup's diff card, not with
+     the modal's orange tint. */
+  background: var(--bg-container);
   border: 1px solid var(--border); border-radius: 6px;
   overflow: hidden; overflow-y: auto; max-height: 220px;
   font-size: 12px; line-height: 1.6;

--- a/web/src/components/overlays/ConfirmModal.svelte
+++ b/web/src/components/overlays/ConfirmModal.svelte
@@ -172,7 +172,11 @@
 }
 .desc {
   margin: 0;
-  font-size: 13px; line-height: 1.6; color: var(--text-secondary);
+  /* #2103: full-strength text, not --text-secondary. This line says what is
+     about to be approved, and against the tinted panel the secondary grey
+     lands at ~3.2:1 (light) / ~3.6:1 (dark) — under the 4.5:1 AA floor for
+     13px. The rest of the modal's greys are chrome; this one is content. */
+  font-size: 13px; line-height: 1.6; color: var(--text);
 }
 .terminal {
   margin: 0; padding: 10px 12px;


### PR DESCRIPTION
## Problem

The web permission modal renders half see-through, so the chat behind it bleeds through the content the user is being asked to approve.

`ConfirmModal`'s panel used `--warning-bg` as its background. That token is a translucent tint (`rgba(255,149,0,0.16)`) meant for badges and inline notices that already sit on an opaque surface — used as a floating panel's background it leaves the whole dialog at 16% opacity. Behind the backdrop scrim (45% light / 60% dark), roughly 46% / 34% of the underlying content's contrast still reaches the dialog's own 13px text. Every other overlay in the web UI (`AuthGate`, `SettingsModal`, `QuestionModal`, `CommandPalette`, `FolderPickerModal`, …) uses the opaque `--bg-container`; this modal was the only exception.

That also explains the reporter's "sometimes". The transparency is constant; whether it hurts depends on

- **what happens to be behind the dialog** — blank whitespace is invisible, a dark terminal block or a red traceback is not; and
- **the request type** — command / input approvals render their payload into `.terminal`, which has an opaque `--terminal-bg`, so only the header and footer were see-through. Edit approvals go through `.diff-block`, which had no surface of its own, so the page underneath bled straight in between the +/- lines under review.

## Fix

- `.modal` — layer the warning tint over `--bg-container` instead of using it as the background. Same warm colour, nothing shows through.
- `.diff-block` — give it its own surface, so the half-opaque add/rm fills land on a neutral container rather than on the modal's orange tint. (`ToolGroup`'s diff card ends up neutral implicitly, by inheriting its card's `--bg-container`; here the panel is tinted, so it has to be explicit.) Not strictly required once the panel is opaque — it keeps the +/- colours accurate and makes the block read as an embedded content surface, the same role `.terminal` already plays in this modal.

- `.desc` — promote from `--text-secondary` to `--text`. Against the tinted panel the secondary grey lands at ~3.2:1 (light) / ~3.6:1 (dark), under the 4.5:1 WCAG AA floor for 13px, which left the line naming what you are approving as the faintest content in the dialog. Now 14.8:1 / 9.4:1. (Pre-existing, not introduced here — but it serves the same "can't read what I'm approving" complaint, so it's fixed alongside rather than left behind.)

No behavioural change; CSS only.

## Verification

- `svelte-check` clean, `npm run build` clean; confirmed the layered background survives into the emitted CSS.
- Rendered the modal over the reporter's exact scenario (a diff approval on top of a Python traceback) before and after, in **both** themes: before is unreadable in the same way as the screenshot in the issue, after is fully opaque.
- Swept the rest of the web UI for the same mistake — every other translucent `--*-bg` usage is on an element that already sits on an opaque parent, so this modal was the only one affected. The mobile approval flow (`mobile/ApprovalDetail.svelte`) is a full-screen route with no scrim, unaffected.
- No tests touch this component (web tests are all pure-logic under `lib/`, no render or CSS snapshots), so there is nothing to add or update.

Fixes #2103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
