### PR TITLE
fix(tasks): close the plan out at turn end instead of trusting the model

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -334,6 +334,23 @@ type Agent struct {
 	// so runLoop can detect when the model is stuck repeating the same call(s).
 	// Guarded by the implicit serialisation of runLoop (single goroutine).
 	recentToolCalls [][]toolCallFingerprint
+
+	// TurnEndReminder, when set, is consulted at the moment a turn would end:
+	// the model answered in prose and nothing else is pending. A non-empty
+	// return is appended as a user message and the loop runs one more round, so
+	// the model can act on it before the turn really closes; "" ends the turn.
+	//
+	// It is the seam for harness-side end-of-turn bookkeeping the model tends
+	// to forget — today the task-checklist guard (tools.PendingTaskReminder),
+	// which catches a plan left with an in_progress task after the model has
+	// already reported the work done. The agent layer stays ignorant of what
+	// is being checked; the ctx is the running turn's, so a ctx-scoped store
+	// (server / IM) resolves the same way the tools do.
+	//
+	// Fired at most once per turn: a model that ignores the reminder must not
+	// be able to hold the turn open. Wired only on top-level agents — a
+	// sub-agent shares the parent's checklist and must not report on it.
+	TurnEndReminder func(ctx context.Context) string
 }
 
 // toolCallFingerprint is a lightweight hash of a single tool-use block.
@@ -982,6 +999,7 @@ func (a *Agent) runLoop(
 	streamStalls := 0      // transient mid-stream stalls re-issued for the current round
 	truncationResumes := 0 // layer-2 resume-and-chunk budget
 	escalateExhausted := false
+	reminded := false // TurnEndReminder already fired this turn
 	a.turnIterations = 0
 	for i := 0; limit == unlimitedTurns || i < limit; i++ {
 		a.turnIterations = i + 1
@@ -1234,6 +1252,21 @@ func (a *Agent) runLoop(
 		// once-only — it fires only when we actually return below.
 		if a.Inbox.HasPending() {
 			continue
+		}
+
+		// End-of-turn bookkeeping the model forgot (a task left in_progress
+		// after it reported the work done). Inject the reminder as a user
+		// message and run one more round so it can fix the record inside this
+		// turn — the once-per-turn latch keeps a model that ignores it from
+		// holding the turn open.
+		// (Skipped on the last allowed iteration: the extra round would run out
+		// of loop budget and turn a clean finish into a max-turns stop.)
+		if !reminded && a.TurnEndReminder != nil && (limit == unlimitedTurns || i+1 < limit) {
+			if note := a.TurnEndReminder(ctx); note != "" {
+				reminded = true
+				a.History.Append(NewUserMessage(note))
+				continue
+			}
 		}
 
 		if handler != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -339,6 +339,9 @@ type Agent struct {
 	// the model answered in prose and nothing else is pending. A non-empty
 	// return is appended as a user message and the loop runs one more round, so
 	// the model can act on it before the turn really closes; "" ends the turn.
+	// toolsUsed carries the tool names dispatched so far this turn, so a
+	// reminder can scope itself to turns that actually touched what it guards
+	// instead of re-billing a round-trip on every turn of the session.
 	//
 	// It is the seam for harness-side end-of-turn bookkeeping the model tends
 	// to forget — today the task-checklist guard (tools.PendingTaskReminder),
@@ -350,7 +353,7 @@ type Agent struct {
 	// Fired at most once per turn: a model that ignores the reminder must not
 	// be able to hold the turn open. Wired only on top-level agents — a
 	// sub-agent shares the parent's checklist and must not report on it.
-	TurnEndReminder func(ctx context.Context) string
+	TurnEndReminder func(ctx context.Context, toolsUsed []string) string
 }
 
 // toolCallFingerprint is a lightweight hash of a single tool-use block.
@@ -1000,6 +1003,15 @@ func (a *Agent) runLoop(
 	truncationResumes := 0 // layer-2 resume-and-chunk budget
 	escalateExhausted := false
 	reminded := false // TurnEndReminder already fired this turn
+	// reminderCarry holds the answer the model had already delivered when the
+	// turn-end reminder fired, while the extra round runs. If that round
+	// answers in prose too (no tool call in between), both texts belong to one
+	// unbroken stretch of assistant speech: every UI streamed them into the
+	// same block, so the final Reply — which the web transport broadcasts as
+	// the block's settled content — has to carry both or the answer the user
+	// just read gets overwritten by the bookkeeping line. A tool call in
+	// between opens a new block, so it clears the carry.
+	reminderCarry := ""
 	a.turnIterations = 0
 	for i := 0; limit == unlimitedTurns || i < limit; i++ {
 		a.turnIterations = i + 1
@@ -1025,6 +1037,16 @@ func (a *Agent) runLoop(
 					a.History.Append(Message{Role: RoleUser, Blocks: blocks})
 				} else {
 					a.History.Append(NewUserMessage(it.Text))
+				}
+			}
+			// A steer the user can see (every UI hides pure injected context —
+			// same StripSystemReminders test they render by) puts a message
+			// between the two halves of a carried reply, so they are no longer
+			// one block and must not be re-joined. See reminderCarry.
+			for _, it := range steerItems {
+				if strings.TrimSpace(StripSystemReminders(it.Text)) != "" || len(it.Blocks) > 0 {
+					reminderCarry = ""
+					break
 				}
 			}
 			if handler != nil {
@@ -1173,6 +1195,10 @@ func (a *Agent) runLoop(
 
 		if reply.StopReason == "tool_use" {
 			a.History.Append(NewToolUseMessage(reply.Blocks))
+			// A tool call ends the current stretch of assistant speech (every
+			// UI starts a new block after it), so a carried pre-reminder answer
+			// stops being part of what the final reply settles.
+			reminderCarry = ""
 
 			// ── Duplicate-tool-call loop detection ──
 			// If the model keeps issuing the exact same tool_use batch, it is
@@ -1259,13 +1285,28 @@ func (a *Agent) runLoop(
 		// message and run one more round so it can fix the record inside this
 		// turn — the once-per-turn latch keeps a model that ignores it from
 		// holding the turn open.
-		// (Skipped on the last allowed iteration: the extra round would run out
-		// of loop budget and turn a clean finish into a max-turns stop.)
-		if !reminded && a.TurnEndReminder != nil && (limit == unlimitedTurns || i+1 < limit) {
-			if note := a.TurnEndReminder(ctx); note != "" {
+		//
+		// Skipped in two cases: on the last allowed iteration, where the extra
+		// round would run out of loop budget and turn a clean finish into a
+		// max-turns stop; and once the turn is cancelled, where spending
+		// another provider round-trip would only widen the window in which an
+		// interrupt lands on top of an answer the model already delivered.
+		if !reminded && a.TurnEndReminder != nil && ctx.Err() == nil && (limit == unlimitedTurns || i+1 < limit) {
+			if note := a.TurnEndReminder(ctx, a.turnTools); note != "" {
 				reminded = true
+				reminderCarry = content
 				a.History.Append(NewUserMessage(note))
 				continue
+			}
+		}
+
+		// Re-attach the pre-reminder answer (see reminderCarry): this reply is
+		// the tail of a block the user has already been reading the head of.
+		if reminderCarry != "" {
+			if reply.Content != "" {
+				reply.Content = reminderCarry + "\n\n" + reply.Content
+			} else {
+				reply.Content = reminderCarry
 			}
 		}
 

--- a/internal/agent/turn_end_reminder_test.go
+++ b/internal/agent/turn_end_reminder_test.go
@@ -10,6 +10,14 @@ import (
 // guard lives) when tools and an executor are present.
 var reminderTools = []ToolDefinition{{Name: "noop", Description: "noop"}}
 
+// constReminder is a TurnEndReminder that always asks for one more round.
+func constReminder(note string, fired *int) func(context.Context, []string) string {
+	return func(context.Context, []string) string {
+		*fired++
+		return note
+	}
+}
+
 // A non-empty TurnEndReminder buys one more round: the note lands as a user
 // message and the model gets to act on it before the turn returns.
 func TestRunLoop_TurnEndReminder_InjectsAndContinues(t *testing.T) {
@@ -19,7 +27,7 @@ func TestRunLoop_TurnEndReminder_InjectsAndContinues(t *testing.T) {
 	}}
 	a := New(send, "m")
 	calls := 0
-	a.TurnEndReminder = func(context.Context) string {
+	a.TurnEndReminder = func(context.Context, []string) string {
 		calls++
 		if calls == 1 {
 			return "<system-reminder>task #2 still in_progress</system-reminder>"
@@ -27,12 +35,8 @@ func TestRunLoop_TurnEndReminder_InjectsAndContinues(t *testing.T) {
 		return ""
 	}
 
-	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
-	if err != nil {
+	if _, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{}); err != nil {
 		t.Fatalf("Run: %v", err)
-	}
-	if reply.Content != "marked #2 completed" {
-		t.Errorf("reply = %q, want the post-reminder reply", reply.Content)
 	}
 	if send.calls != 2 {
 		t.Errorf("sender calls = %d, want 2", send.calls)
@@ -49,11 +53,129 @@ func TestRunLoop_TurnEndReminder_InjectsAndContinues(t *testing.T) {
 	}
 }
 
+// The reminder's extra round continues a stretch of assistant speech the user
+// is already reading, so the final Reply must carry the pre-reminder answer as
+// well — the web transport broadcasts Reply.Content as the settled content of
+// that block, and dropping the head would erase the answer on screen.
+func TestRunLoop_TurnEndReminder_ReplyKeepsPreReminderAnswer(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{Content: "the answer", StopReason: "end_turn"},
+		{Content: "noted", StopReason: "end_turn"},
+	}}
+	a := New(send, "m")
+	fired := 0
+	a.TurnEndReminder = onceReminder(&fired)
+
+	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if want := "the answer\n\nnoted"; reply.Content != want {
+		t.Errorf("Content = %q, want %q", reply.Content, want)
+	}
+	// History keeps them as the two separate assistant turns they really were.
+	var assistants []string
+	for _, m := range a.History.Snapshot() {
+		if m.Role == RoleAssistant {
+			assistants = append(assistants, m.Content)
+		}
+	}
+	if len(assistants) != 2 || assistants[0] != "the answer" || assistants[1] != "noted" {
+		t.Errorf("history assistant messages = %q, want the two replies unmerged", assistants)
+	}
+}
+
+// A tool call in between opens a new block on every UI, so the pre-reminder
+// answer is no longer part of what this reply settles — re-attaching it would
+// render the answer twice.
+func TestRunLoop_TurnEndReminder_ToolCallDropsTheCarry(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{Content: "the answer", StopReason: "end_turn"},
+		{StopReason: "tool_use", Blocks: []ContentBlock{{Type: "tool_use", ID: "t1", Name: "noop", Input: map[string]any{}}}},
+		{Content: "marked it completed", StopReason: "end_turn"},
+	}}
+	a := New(send, "m")
+	fired := 0
+	a.TurnEndReminder = onceReminder(&fired)
+
+	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "marked it completed" {
+		t.Errorf("Content = %q, want only the post-tool reply", reply.Content)
+	}
+}
+
+// A visible steer lands between the two halves, so they are no longer one
+// block on screen and must not be re-joined.
+func TestRunLoop_TurnEndReminder_VisibleSteerDropsTheCarry(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{Content: "the answer", StopReason: "end_turn"},
+		{Content: "noted", StopReason: "end_turn"},
+		{Content: "ok, and about that", StopReason: "end_turn"},
+	}}
+	a := New(send, "m")
+	fired := 0
+	a.TurnEndReminder = onceReminder(&fired)
+	// The steer arrives while the reminder round is in flight.
+	send.onCall = func(idx int) {
+		if idx == 1 {
+			a.Inbox.Enqueue("wait, one more thing")
+		}
+	}
+
+	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.Contains(reply.Content, "the answer") {
+		t.Errorf("Content = %q, want the carry dropped after a visible steer", reply.Content)
+	}
+}
+
+// A pure <system-reminder> steer (a background-process completion note) is
+// invisible on every surface, so it does not break the block up.
+func TestRunLoop_TurnEndReminder_InvisibleSteerKeepsTheCarry(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{Content: "the answer", StopReason: "end_turn"},
+		{Content: "noted", StopReason: "end_turn"},
+		{Content: "and the background job finished", StopReason: "end_turn"},
+	}}
+	a := New(send, "m")
+	fired := 0
+	a.TurnEndReminder = onceReminder(&fired)
+	send.onCall = func(idx int) {
+		if idx == 1 {
+			a.Inbox.Enqueue("<system-reminder>bg job done</system-reminder>")
+		}
+	}
+
+	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(reply.Content, "the answer") {
+		t.Errorf("Content = %q, want the carried answer kept", reply.Content)
+	}
+}
+
+// onceReminder fires the reminder exactly on its first call.
+func onceReminder(fired *int) func(context.Context, []string) string {
+	return func(context.Context, []string) string {
+		*fired++
+		if *fired == 1 {
+			return "<system-reminder>close the plan</system-reminder>"
+		}
+		return ""
+	}
+}
+
 // An empty return ends the turn as usual — no extra round-trip.
 func TestRunLoop_TurnEndReminder_EmptyEndsTurn(t *testing.T) {
 	send := &fakeToolSender{replies: []Reply{{Content: "all done", StopReason: "end_turn"}}}
 	a := New(send, "m")
-	a.TurnEndReminder = func(context.Context) string { return "" }
+	a.TurnEndReminder = func(context.Context, []string) string { return "" }
 
 	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
 	if err != nil {
@@ -67,6 +189,28 @@ func TestRunLoop_TurnEndReminder_EmptyEndsTurn(t *testing.T) {
 	}
 }
 
+// The reminder is handed the tools this turn dispatched, so a guard can scope
+// itself to turns that touched what it watches.
+func TestRunLoop_TurnEndReminder_SeesToolsUsed(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{StopReason: "tool_use", Blocks: []ContentBlock{{Type: "tool_use", ID: "t1", Name: "task_update", Input: map[string]any{}}}},
+		{Content: "done", StopReason: "end_turn"},
+	}}
+	a := New(send, "m")
+	var got []string
+	a.TurnEndReminder = func(_ context.Context, toolsUsed []string) string {
+		got = append([]string(nil), toolsUsed...)
+		return ""
+	}
+
+	if _, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(got) != 1 || got[0] != "task_update" {
+		t.Errorf("toolsUsed = %v, want [task_update]", got)
+	}
+}
+
 // A model that ignores the reminder must not be able to hold the turn open:
 // the guard fires at most once per turn.
 func TestRunLoop_TurnEndReminder_FiresOncePerTurn(t *testing.T) {
@@ -76,10 +220,7 @@ func TestRunLoop_TurnEndReminder_FiresOncePerTurn(t *testing.T) {
 	}}
 	a := New(send, "m")
 	fired := 0
-	a.TurnEndReminder = func(context.Context) string {
-		fired++
-		return "<system-reminder>nag</system-reminder>"
-	}
+	a.TurnEndReminder = constReminder("<system-reminder>nag</system-reminder>", &fired)
 
 	if _, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{}); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -110,10 +251,7 @@ func TestRunLoop_TurnEndReminder_SkippedAtTurnLimit(t *testing.T) {
 	a := New(send, "m")
 	a.MaxTurns = 1
 	fired := 0
-	a.TurnEndReminder = func(context.Context) string {
-		fired++
-		return "<system-reminder>nag</system-reminder>"
-	}
+	a.TurnEndReminder = constReminder("<system-reminder>nag</system-reminder>", &fired)
 
 	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
 	if err != nil {
@@ -124,5 +262,27 @@ func TestRunLoop_TurnEndReminder_SkippedAtTurnLimit(t *testing.T) {
 	}
 	if reply.Content != "all done" {
 		t.Errorf("reply = %q", reply.Content)
+	}
+}
+
+// A cancelled turn must not spend another provider round-trip: that only widens
+// the window in which the interrupt lands on top of an answer already given.
+func TestRunLoop_TurnEndReminder_SkippedWhenCancelled(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{{Content: "all done", StopReason: "end_turn"}}}
+	a := New(send, "m")
+	fired := 0
+	a.TurnEndReminder = constReminder("<system-reminder>nag</system-reminder>", &fired)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	send.onCall = func(int) { cancel() } // turn is cancelled by the time the reply lands
+
+	if _, err := a.Run(ctx, "go", reminderTools, &fakeExecutor{}); err != nil && err != context.Canceled {
+		t.Fatalf("Run: %v", err)
+	}
+	if fired != 0 {
+		t.Errorf("reminder fired %d times on a cancelled turn, want 0", fired)
+	}
+	if send.calls != 1 {
+		t.Errorf("sender calls = %d, want 1", send.calls)
 	}
 }

--- a/internal/agent/turn_end_reminder_test.go
+++ b/internal/agent/turn_end_reminder_test.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// reminderTools is a one-tool catalog: Run only enters runLoop (where the
+// guard lives) when tools and an executor are present.
+var reminderTools = []ToolDefinition{{Name: "noop", Description: "noop"}}
+
+// A non-empty TurnEndReminder buys one more round: the note lands as a user
+// message and the model gets to act on it before the turn returns.
+func TestRunLoop_TurnEndReminder_InjectsAndContinues(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{Content: "all done", StopReason: "end_turn"},
+		{Content: "marked #2 completed", StopReason: "end_turn"},
+	}}
+	a := New(send, "m")
+	calls := 0
+	a.TurnEndReminder = func(context.Context) string {
+		calls++
+		if calls == 1 {
+			return "<system-reminder>task #2 still in_progress</system-reminder>"
+		}
+		return ""
+	}
+
+	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "marked #2 completed" {
+		t.Errorf("reply = %q, want the post-reminder reply", reply.Content)
+	}
+	if send.calls != 2 {
+		t.Errorf("sender calls = %d, want 2", send.calls)
+	}
+	msgs := a.History.Snapshot()
+	var injected bool
+	for _, m := range msgs {
+		if m.Role == RoleUser && strings.Contains(m.Content, "still in_progress") {
+			injected = true
+		}
+	}
+	if !injected {
+		t.Errorf("reminder was not appended to history: %+v", msgs)
+	}
+}
+
+// An empty return ends the turn as usual — no extra round-trip.
+func TestRunLoop_TurnEndReminder_EmptyEndsTurn(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{{Content: "all done", StopReason: "end_turn"}}}
+	a := New(send, "m")
+	a.TurnEndReminder = func(context.Context) string { return "" }
+
+	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "all done" {
+		t.Errorf("reply = %q", reply.Content)
+	}
+	if send.calls != 1 {
+		t.Errorf("sender calls = %d, want 1", send.calls)
+	}
+}
+
+// A model that ignores the reminder must not be able to hold the turn open:
+// the guard fires at most once per turn.
+func TestRunLoop_TurnEndReminder_FiresOncePerTurn(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{Content: "all done", StopReason: "end_turn"},
+		{Content: "still all done", StopReason: "end_turn"},
+	}}
+	a := New(send, "m")
+	fired := 0
+	a.TurnEndReminder = func(context.Context) string {
+		fired++
+		return "<system-reminder>nag</system-reminder>"
+	}
+
+	if _, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if fired != 1 {
+		t.Errorf("reminder fired %d times, want 1", fired)
+	}
+	if send.calls != 2 {
+		t.Errorf("sender calls = %d, want 2", send.calls)
+	}
+
+	// The latch re-arms for the next turn.
+	send.replies = append(send.replies,
+		Reply{Content: "second turn", StopReason: "end_turn"},
+		Reply{Content: "second turn, nagged", StopReason: "end_turn"})
+	if _, err := a.Run(context.Background(), "again", reminderTools, &fakeExecutor{}); err != nil {
+		t.Fatalf("Run (2nd turn): %v", err)
+	}
+	if fired != 2 {
+		t.Errorf("reminder fired %d times across two turns, want 2", fired)
+	}
+}
+
+// On the last allowed iteration the guard stands down: spending the final round
+// on bookkeeping would turn a clean finish into a max-turns stop.
+func TestRunLoop_TurnEndReminder_SkippedAtTurnLimit(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{{Content: "all done", StopReason: "end_turn"}}}
+	a := New(send, "m")
+	a.MaxTurns = 1
+	fired := 0
+	a.TurnEndReminder = func(context.Context) string {
+		fired++
+		return "<system-reminder>nag</system-reminder>"
+	}
+
+	reply, err := a.Run(context.Background(), "go", reminderTools, &fakeExecutor{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if fired != 0 {
+		t.Errorf("reminder fired %d times at the turn limit, want 0", fired)
+	}
+	if reply.Content != "all done" {
+		t.Errorf("reply = %q", reply.Content)
+	}
+}

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -109,9 +109,9 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 	}
 	if enableTasks {
 		tools.SetTaskStore(tasks.New())
-		// Close the loop on the checklist: a turn that ends with the plan's last
-		// step still in_progress gets one reminder to file the closing
-		// task_update before it really ends.
+		// Close the loop on the checklist: a turn that worked the plan and then
+		// ends with its last step still in_progress gets one reminder to file
+		// the closing task_update before it really ends.
 		a.TurnEndReminder = tools.PendingTaskReminder
 		prev := cleanup
 		cleanup = func() {

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -109,10 +109,15 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 	}
 	if enableTasks {
 		tools.SetTaskStore(tasks.New())
+		// Close the loop on the checklist: a turn that ends with the plan's last
+		// step still in_progress gets one reminder to file the closing
+		// task_update before it really ends.
+		a.TurnEndReminder = tools.PendingTaskReminder
 		prev := cleanup
 		cleanup = func() {
 			prev()
 			tools.SetTaskStore(nil)
+			a.TurnEndReminder = nil
 		}
 	}
 

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -23,6 +23,9 @@ func TestWireTools_SetsUpEnvAndCleansUp(t *testing.T) {
 	if tools.ActiveTaskStore() == nil {
 		t.Error("WireTools(enableTasks=true) should install a task store")
 	}
+	if a.TurnEndReminder == nil {
+		t.Error("WireTools(enableTasks=true) should wire the turn-end task guard")
+	}
 	if env.SubAgentMgr == nil {
 		t.Error("WireTools should return a sub-agent manager")
 	}
@@ -53,6 +56,9 @@ func TestWireTools_SetsUpEnvAndCleansUp(t *testing.T) {
 	if tools.ActiveTaskStore() != nil {
 		t.Error("cleanup should reset the task store")
 	}
+	if a.TurnEndReminder != nil {
+		t.Error("cleanup should reset the turn-end task guard")
+	}
 	// After cleanup, the sub_agent tool should no longer be advertised.
 	for _, d := range env.ToolsFor(context.Background()) {
 		if d.Name == "sub_agent" {
@@ -71,6 +77,9 @@ func TestWireTools_TasksDisabled(t *testing.T) {
 
 	if tools.ActiveTaskStore() != nil {
 		t.Error("WireTools(enableTasks=false) must not install a task store")
+	}
+	if a.TurnEndReminder != nil {
+		t.Error("WireTools(enableTasks=false) must not wire the turn-end task guard")
 	}
 	if tools.ActiveSpawner() == nil {
 		t.Error("spawner should still be registered when tasks are disabled")

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -477,6 +477,25 @@ func TestAgentSpawner_ChildStartsFresh(t *testing.T) {
 	}
 }
 
+// A child must not inherit the parent's turn-end guard: the task checklist is
+// the parent's, and a sub-agent ending its round is not the plan closing.
+func TestAgentSpawner_ChildHasNoTurnEndReminder(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	parent.TurnEndReminder = func(context.Context, []string) string {
+		return "<system-reminder>close the plan</system-reminder>"
+	}
+
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
+	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{Prompt: "go"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if sp.reg.m[onlyChildID(t, sp)].agent.TurnEndReminder != nil {
+		t.Error("a child must not carry the parent's turn-end reminder")
+	}
+}
+
 // onlyChildID returns the single registered child id, failing if there isn't
 // exactly one.
 func onlyChildID(t *testing.T, sp *Spawner) string {

--- a/internal/app/toolenv.go
+++ b/internal/app/toolenv.go
@@ -24,14 +24,20 @@ type ToolEnvCallbacks struct {
 // Contracts:
 //   - It does NOT read or write Agent.Gate. Callers set a.Gate before or after
 //     this call.
+//   - It DOES set Agent.TurnEndReminder, the only Agent field it writes: the
+//     guard belongs to the per-session task store this function stamps in, and
+//     it makes a turn that ends with the plan's last step still in_progress
+//     spend one extra provider round-trip filing the closing task_update.
+//     cleanup clears it.
 //   - It does NOT call config.Load() or permission.New(). It performs no local
 //     file I/O.
 //   - It does NOT handle process-global browser state (SetBrowserVision etc.) or
 //     workflow-discovery-cwd state. See dev-docs/octoagent-pkg-design.md.
 //   - It does NOT register or use an MCP registry.
 //
-// The returned cleanup function is currently a no-op but is reserved for future
-// resource release. It does NOT destroy the session-scoped managers (sub-agent,
+// The returned cleanup function clears Agent.TurnEndReminder and is otherwise
+// reserved for future resource release. It does NOT destroy the session-scoped
+// managers (sub-agent,
 // background, workflow), because those are cached by sessionID and reused across
 // turns. Callers manage session lifecycle resources themselves.
 func NewSessionToolEnv(
@@ -48,10 +54,10 @@ func NewSessionToolEnv(
 	// tasks.New() here is why the panel used to vanish). Callers that want a plan
 	// reset between turns do it via CloseSessionTaskStore before this call.
 	ctx = tools.WithTaskStore(ctx, tools.SessionTaskStore(sessionID))
-	// Turn-end guard over that same store: a plan left with an in_progress task
-	// after the model reported the work done gets one reminder to file the
-	// closing task_update. It resolves the store from the turn's ctx, so it
-	// reads exactly what the task_* tools just wrote.
+	// Turn-end guard over that same store: a turn that worked the plan and left
+	// a task in_progress after reporting the work done gets one reminder to
+	// file the closing task_update. It resolves the store from the turn's ctx,
+	// so it reads exactly what the task_* tools just wrote.
 	a.TurnEndReminder = tools.PendingTaskReminder
 
 	mkSpawner := func() tools.Spawner {
@@ -77,6 +83,6 @@ func NewSessionToolEnv(
 	}
 	ctx = tools.WithWorkflowManager(ctx, wfMgr)
 
-	cleanup := func() {}
+	cleanup := func() { a.TurnEndReminder = nil }
 	return ctx, executor, mgr, cleanup
 }

--- a/internal/app/toolenv.go
+++ b/internal/app/toolenv.go
@@ -48,6 +48,11 @@ func NewSessionToolEnv(
 	// tasks.New() here is why the panel used to vanish). Callers that want a plan
 	// reset between turns do it via CloseSessionTaskStore before this call.
 	ctx = tools.WithTaskStore(ctx, tools.SessionTaskStore(sessionID))
+	// Turn-end guard over that same store: a plan left with an in_progress task
+	// after the model reported the work done gets one reminder to file the
+	// closing task_update. It resolves the store from the turn's ctx, so it
+	// reads exactly what the task_* tools just wrote.
+	a.TurnEndReminder = tools.PendingTaskReminder
 
 	mkSpawner := func() tools.Spawner {
 		return NewSpawner(a, executor, func(ctx context.Context) []agent.ToolDefinition {

--- a/internal/app/toolenv_test.go
+++ b/internal/app/toolenv_test.go
@@ -25,13 +25,13 @@ func TestNewSessionToolEnv_WiresTurnEndTaskGuard(t *testing.T) {
 	a := agent.New(sender{p: &mockProvider{}}, "claude-haiku-4-5")
 	executor := tools.NewDefaultRegistry()
 	ctx, _, _, cleanup := NewSessionToolEnv(context.Background(), a, sid, executor, ToolEnvCallbacks{})
-	defer cleanup()
 
 	if a.TurnEndReminder == nil {
 		t.Fatal("NewSessionToolEnv should wire the turn-end task guard")
 	}
+	planTools := []string{"task_update"}
 	// Quiet while the plan is empty…
-	if got := a.TurnEndReminder(ctx); got != "" {
+	if got := a.TurnEndReminder(ctx, planTools); got != "" {
 		t.Errorf("empty plan should not fire the guard, got %q", got)
 	}
 	// …and it reads the same session store the task_* tools write to.
@@ -44,7 +44,13 @@ func TestNewSessionToolEnv_WiresTurnEndTaskGuard(t *testing.T) {
 	if _, err := store.Update(id, tasks.UpdateField{Status: &st}); err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if got := a.TurnEndReminder(ctx); got == "" {
+	if got := a.TurnEndReminder(ctx, planTools); got == "" {
 		t.Error("a task left in_progress should fire the guard")
+	}
+	// …and cleanup takes it back off, so an SDK caller reusing one agent across
+	// sessions doesn't inherit a stale guard.
+	cleanup()
+	if a.TurnEndReminder != nil {
+		t.Error("cleanup should clear the turn-end task guard")
 	}
 }

--- a/internal/app/toolenv_test.go
+++ b/internal/app/toolenv_test.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/tasks"
+	"github.com/open-octo/octo-agent/internal/tools"
+)
+
+// The session tool env owns the per-session task store, so it also owns the
+// guard that closes the checklist out at turn end — otherwise a web/SDK turn
+// would leave a finished plan showing an in_progress step.
+func TestNewSessionToolEnv_WiresTurnEndTaskGuard(t *testing.T) {
+	const sid = "sess-turn-end-guard"
+	t.Cleanup(func() {
+		tools.CloseSessionTaskStore(sid)
+		tools.CloseSessionSubAgentManager(sid)
+		tools.CloseSessionBackgroundManager(sid)
+		tools.CloseSessionWorkflowManager(sid)
+		tools.SetTaskStore(nil)
+	})
+
+	a := agent.New(sender{p: &mockProvider{}}, "claude-haiku-4-5")
+	executor := tools.NewDefaultRegistry()
+	ctx, _, _, cleanup := NewSessionToolEnv(context.Background(), a, sid, executor, ToolEnvCallbacks{})
+	defer cleanup()
+
+	if a.TurnEndReminder == nil {
+		t.Fatal("NewSessionToolEnv should wire the turn-end task guard")
+	}
+	// Quiet while the plan is empty…
+	if got := a.TurnEndReminder(ctx); got != "" {
+		t.Errorf("empty plan should not fire the guard, got %q", got)
+	}
+	// …and it reads the same session store the task_* tools write to.
+	store := tools.SessionTaskStore(sid)
+	id, err := store.Create("ship it", "", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	st := tasks.InProgress
+	if _, err := store.Update(id, tasks.UpdateField{Status: &st}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := a.TurnEndReminder(ctx); got == "" {
+		t.Error("a task left in_progress should fire the guard")
+	}
+}

--- a/internal/server/channel_task_guard_test.go
+++ b/internal/server/channel_task_guard_test.go
@@ -35,7 +35,8 @@ func TestHandleChannelMessage_WiresTurnEndTaskGuard(t *testing.T) {
 	if sess.Agent.TurnEndReminder == nil {
 		t.Fatal("handleChannelMessage must wire the turn-end task guard")
 	}
-	if got := sess.Agent.TurnEndReminder(context.Background()); got != "" {
+	planTools := []string{"task_update"}
+	if got := sess.Agent.TurnEndReminder(context.Background(), planTools); got != "" {
 		t.Errorf("empty plan should not fire the guard, got %q", got)
 	}
 
@@ -50,7 +51,7 @@ func TestHandleChannelMessage_WiresTurnEndTaskGuard(t *testing.T) {
 	// The guard resolves the store from the turn's ctx — the same stamping the
 	// handler does — so an unfinished plan is what the next turn ends against.
 	ctx := tools.WithTaskStore(context.Background(), sess.Tasks)
-	if got := sess.Agent.TurnEndReminder(ctx); got == "" {
+	if got := sess.Agent.TurnEndReminder(ctx, planTools); got == "" {
 		t.Error("a task left in_progress should fire the guard")
 	}
 }

--- a/internal/server/channel_task_guard_test.go
+++ b/internal/server/channel_task_guard_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/agentprofile"
+	"github.com/open-octo/octo-agent/internal/channel"
+	"github.com/open-octo/octo-agent/internal/tasks"
+	"github.com/open-octo/octo-agent/internal/tools"
+)
+
+// The IM path builds its tool environment by hand instead of going through
+// app.NewSessionToolEnv, so the turn-end task guard has to be wired there
+// explicitly — this pins that it is, and that it reads the session's own task
+// store (the one the task_* tools write to across messages in this chat).
+func TestHandleChannelMessage_WiresTurnEndTaskGuard(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func(*agentprofile.Profile) *agent.Agent {
+		return agent.New(&stubSender{}, "stub-model")
+	}, channel.BindByChat)
+	ad := &fullFakeAdapter{}
+
+	// Own chat id: sessions are keyed by chat, and the shared "c1" used by the
+	// other channel tests would carry their state into this one.
+	ev := channel.InboundEvent{Platform: "fake", ChatID: "c-taskguard", UserID: "u1", MessageID: "m1", Text: "hello"}
+	sess := srv.channelMgr.GetOrCreateSession(ev, nil)
+	if sess.Agent.TurnEndReminder != nil {
+		t.Fatal("the session factory must not pre-wire the guard")
+	}
+
+	srv.handleChannelMessage(context.Background(), ad, ev, nil)
+
+	if sess.Agent.TurnEndReminder == nil {
+		t.Fatal("handleChannelMessage must wire the turn-end task guard")
+	}
+	if got := sess.Agent.TurnEndReminder(context.Background()); got != "" {
+		t.Errorf("empty plan should not fire the guard, got %q", got)
+	}
+
+	id, err := sess.Tasks.Create("ship it", "", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	st := tasks.InProgress
+	if _, err := sess.Tasks.Update(id, tasks.UpdateField{Status: &st}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	// The guard resolves the store from the turn's ctx — the same stamping the
+	// handler does — so an unfinished plan is what the next turn ends against.
+	ctx := tools.WithTaskStore(context.Background(), sess.Tasks)
+	if got := sess.Agent.TurnEndReminder(ctx); got == "" {
+		t.Error("a task left in_progress should fire the guard")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3471,6 +3471,12 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		// The task store lives on the session, so the task list persists
 		// across messages in this chat.
 		ctx = tools.WithTaskStore(ctx, sess.Tasks)
+		// Same turn-end guard the CLI and web turns get (app.WireTools /
+		// app.NewSessionToolEnv): a plan whose last step is still in_progress
+		// when the model stops talking earns one reminder to file the closing
+		// task_update. This path builds its tool env by hand, so it has to wire
+		// the guard itself.
+		sess.Agent.TurnEndReminder = tools.PendingTaskReminder
 		// Per-chat background manager: completions are surfaced to the model
 		// via the Inbox and also trigger idle follow-up turns above.
 		ctx = tools.WithBackgroundManager(ctx, tools.SessionBackgroundManager("im:"+string(sess.Key)))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3472,10 +3472,10 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		// across messages in this chat.
 		ctx = tools.WithTaskStore(ctx, sess.Tasks)
 		// Same turn-end guard the CLI and web turns get (app.WireTools /
-		// app.NewSessionToolEnv): a plan whose last step is still in_progress
-		// when the model stops talking earns one reminder to file the closing
-		// task_update. This path builds its tool env by hand, so it has to wire
-		// the guard itself.
+		// app.NewSessionToolEnv): a turn that worked the plan and left its last
+		// step in_progress earns one reminder to file the closing task_update.
+		// This path builds its tool env by hand, so it has to wire the guard
+		// itself.
 		sess.Agent.TurnEndReminder = tools.PendingTaskReminder
 		// Per-chat background manager: completions are surfaced to the model
 		// via the Inbox and also trigger idle follow-up turns above.

--- a/internal/tools/task_guard.go
+++ b/internal/tools/task_guard.go
@@ -15,17 +15,41 @@ import (
 // forgets the closing task_update — leaving the plan panel showing "1/2 done"
 // against a reply that says everything is finished.
 //
-// It fires only when nothing is left pending: an in_progress task with pending
-// work queued behind it is a plan the model is legitimately in the middle of
-// (it commonly stops there to ask the user something), and nagging about it
-// would cost an extra round-trip on every such turn. With the queue empty, the
-// model believes it is on the final step — ending the turn there is exactly
-// the case this guard exists for.
+// Two conditions keep it from billing round-trips it hasn't earned:
+//
+//   - The turn must have touched the plan itself. An unfinished plan survives
+//     across turns by design (only a fully-completed one is cleared), and the
+//     reminder explicitly allows the model to answer "that task really isn't
+//     done". Without this check, one task the model refuses to close would tax
+//     every later turn in the session — including turns about something else
+//     entirely. It also keeps the reminder from naming task_update at a turn
+//     where the active profile never advertised it.
+//   - Nothing may be left pending. An in_progress task with work still queued
+//     behind it is a plan the model is mid-way through, not one it is closing.
+//
+// Neither condition can tell "finished the last step but forgot to file it"
+// (the bug) from "stopped on the last step to ask the user something" (fine) —
+// nothing observable separates those, so the second case costs one extra
+// round-trip. The reminder is worded to keep that case cheap: acknowledge and
+// stop, don't restate the question.
 //
 // Returns "" when there is nothing to remind about, which ends the turn
 // normally. The reminder is a <system-reminder>, so no UI renders it.
-func PendingTaskReminder(ctx context.Context) string {
+func PendingTaskReminder(ctx context.Context, toolsUsed []string) string {
+	if !touchedPlan(toolsUsed) {
+		return ""
+	}
 	return pendingTaskReminder(resolveTaskStore(ctx))
+}
+
+// touchedPlan reports whether any task_* tool ran during the turn.
+func touchedPlan(toolsUsed []string) bool {
+	for _, name := range toolsUsed {
+		if strings.HasPrefix(name, "task_") {
+			return true
+		}
+	}
+	return false
 }
 
 func pendingTaskReminder(store TaskStore) string {

--- a/internal/tools/task_guard.go
+++ b/internal/tools/task_guard.go
@@ -1,0 +1,61 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/open-octo/octo-agent/internal/tasks"
+)
+
+// PendingTaskReminder is the agent's TurnEndReminder for the task checklist: it
+// catches a plan whose last steps are still marked in_progress at the moment
+// the model stops talking. The model is told to "update status as you go", but
+// after a long tool-heavy turn it routinely reports "all done" in prose and
+// forgets the closing task_update — leaving the plan panel showing "1/2 done"
+// against a reply that says everything is finished.
+//
+// It fires only when nothing is left pending: an in_progress task with pending
+// work queued behind it is a plan the model is legitimately in the middle of
+// (it commonly stops there to ask the user something), and nagging about it
+// would cost an extra round-trip on every such turn. With the queue empty, the
+// model believes it is on the final step — ending the turn there is exactly
+// the case this guard exists for.
+//
+// Returns "" when there is nothing to remind about, which ends the turn
+// normally. The reminder is a <system-reminder>, so no UI renders it.
+func PendingTaskReminder(ctx context.Context) string {
+	return pendingTaskReminder(resolveTaskStore(ctx))
+}
+
+func pendingTaskReminder(store TaskStore) string {
+	if store == nil {
+		return ""
+	}
+	var inProgress []tasks.Task
+	for _, t := range store.List() {
+		switch t.Status {
+		case tasks.Pending:
+			return "" // still work queued — the plan is mid-flight, not closing
+		case tasks.InProgress:
+			inProgress = append(inProgress, t)
+		}
+	}
+	if len(inProgress) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("<system-reminder>\n")
+	b.WriteString("Your turn is about to end with these tasks still marked in_progress:\n")
+	for _, t := range inProgress {
+		fmt.Fprintf(&b, "  #%d %s\n", t.ID, t.Subject)
+	}
+	b.WriteString("If you finished the work, call task_update to mark each one completed " +
+		"(status `deleted` if it no longer applies) so the plan the user sees matches what " +
+		"you just reported. If a task genuinely isn't done, leave it as is. Either way this " +
+		"is bookkeeping, not a new question for the user — do not repeat your answer; reply " +
+		"with at most one short line.\n")
+	b.WriteString("</system-reminder>")
+	return b.String()
+}

--- a/internal/tools/task_guard_test.go
+++ b/internal/tools/task_guard_test.go
@@ -38,7 +38,7 @@ func TestPendingTaskReminder(t *testing.T) {
 		{"mid-plan: work still queued behind the active task", []tasks.Status{tasks.InProgress, tasks.Pending}, false},
 		{"nothing started yet", []tasks.Status{tasks.Pending, tasks.Pending}, false},
 		{"no plan at all", nil, false},
-		{"dropped tasks don't count as queued work", []tasks.Status{tasks.Deleted, tasks.InProgress}, true},
+		{"a dropped task is not queued work", []tasks.Status{tasks.Deleted, tasks.InProgress}, true},
 		{"several tasks left open", []tasks.Status{tasks.InProgress, tasks.InProgress}, true},
 	}
 	for _, tc := range cases {
@@ -82,11 +82,41 @@ func TestPendingTaskReminder_NilStore(t *testing.T) {
 // dispatch to, so the guard reads what they just wrote.
 func TestPendingTaskReminder_ResolvesCtxStore(t *testing.T) {
 	SetTaskStore(nil)
-	if got := PendingTaskReminder(context.Background()); got != "" {
+	t.Cleanup(func() { SetTaskStore(nil) })
+	planTools := []string{"task_update"}
+	if got := PendingTaskReminder(context.Background(), planTools); got != "" {
 		t.Fatalf("unconfigured session = %q, want empty", got)
 	}
 	ctx := WithTaskStore(context.Background(), mkTaskStore(t, tasks.InProgress))
-	if got := PendingTaskReminder(ctx); got == "" {
+	if got := PendingTaskReminder(ctx, planTools); got == "" {
 		t.Error("ctx-scoped store with an in_progress task should fire")
+	}
+}
+
+// An unfinished plan survives across turns, and the model is allowed to answer
+// "that task really isn't done" — so a turn that never touched the plan must
+// not re-bill a round-trip for it, however many turns later it is.
+func TestPendingTaskReminder_OnlyOnTurnsThatTouchedThePlan(t *testing.T) {
+	SetTaskStore(nil)
+	t.Cleanup(func() { SetTaskStore(nil) })
+	ctx := WithTaskStore(context.Background(), mkTaskStore(t, tasks.InProgress))
+
+	for _, tc := range []struct {
+		name      string
+		toolsUsed []string
+		want      bool
+	}{
+		{"no tools at all", nil, false},
+		{"unrelated work", []string{"read_file", "terminal"}, false},
+		{"the plan was updated", []string{"terminal", "task_update"}, true},
+		{"the plan was created", []string{"task_create"}, true},
+		{"the plan was only read", []string{"task_list"}, true},
+		{"a lookalike tool name", []string{"tasks_of_mine"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := PendingTaskReminder(ctx, tc.toolsUsed) != ""; got != tc.want {
+				t.Errorf("fired = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/tools/task_guard_test.go
+++ b/internal/tools/task_guard_test.go
@@ -1,0 +1,92 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/tasks"
+)
+
+// mkTaskStore builds a store whose tasks land in the given statuses, in order.
+func mkTaskStore(t *testing.T, statuses ...tasks.Status) *tasks.Store {
+	t.Helper()
+	s := tasks.New()
+	for i, st := range statuses {
+		id, err := s.Create("task "+string(rune('A'+i)), "", "")
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if st == tasks.Pending {
+			continue
+		}
+		if _, err := s.Update(id, tasks.UpdateField{Status: &st}); err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+	}
+	return s
+}
+
+func TestPendingTaskReminder(t *testing.T) {
+	cases := []struct {
+		name     string
+		statuses []tasks.Status
+		want     bool
+	}{
+		{"the reported bug: last step left in_progress", []tasks.Status{tasks.Completed, tasks.InProgress}, true},
+		{"plan fully closed", []tasks.Status{tasks.Completed, tasks.Completed}, false},
+		{"mid-plan: work still queued behind the active task", []tasks.Status{tasks.InProgress, tasks.Pending}, false},
+		{"nothing started yet", []tasks.Status{tasks.Pending, tasks.Pending}, false},
+		{"no plan at all", nil, false},
+		{"dropped tasks don't count as queued work", []tasks.Status{tasks.Deleted, tasks.InProgress}, true},
+		{"several tasks left open", []tasks.Status{tasks.InProgress, tasks.InProgress}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pendingTaskReminder(mkTaskStore(t, tc.statuses...))
+			if (got != "") != tc.want {
+				t.Fatalf("reminder = %q, want fired=%v", got, tc.want)
+			}
+			if got == "" {
+				return
+			}
+			if !strings.HasPrefix(got, "<system-reminder>") || !strings.HasSuffix(got, "</system-reminder>") {
+				t.Errorf("reminder is not a system-reminder span: %q", got)
+			}
+			if !strings.Contains(got, "task_update") {
+				t.Errorf("reminder doesn't name the tool to call: %q", got)
+			}
+		})
+	}
+}
+
+// The in_progress tasks are named so the model doesn't have to call task_list
+// to find out which ones the guard means.
+func TestPendingTaskReminder_NamesTheOpenTasks(t *testing.T) {
+	got := pendingTaskReminder(mkTaskStore(t, tasks.Completed, tasks.InProgress))
+	if !strings.Contains(got, "#2 task B") {
+		t.Errorf("reminder should name task #2: %q", got)
+	}
+	if strings.Contains(got, "task A") {
+		t.Errorf("reminder should not list the completed task: %q", got)
+	}
+}
+
+func TestPendingTaskReminder_NilStore(t *testing.T) {
+	if got := pendingTaskReminder(nil); got != "" {
+		t.Errorf("nil store = %q, want empty", got)
+	}
+}
+
+// The exported entry point resolves the same per-turn store the task_* tools
+// dispatch to, so the guard reads what they just wrote.
+func TestPendingTaskReminder_ResolvesCtxStore(t *testing.T) {
+	SetTaskStore(nil)
+	if got := PendingTaskReminder(context.Background()); got != "" {
+		t.Fatalf("unconfigured session = %q, want empty", got)
+	}
+	ctx := WithTaskStore(context.Background(), mkTaskStore(t, tasks.InProgress))
+	if got := PendingTaskReminder(ctx); got == "" {
+		t.Error("ctx-scoped store with an in_progress task should fire")
+	}
+}

--- a/pkg/octoagent/toolenv/toolenv.go
+++ b/pkg/octoagent/toolenv/toolenv.go
@@ -71,15 +71,19 @@ func WithWorkflowEvents(
 //
 // Contracts:
 //   - It does NOT read or write a.Gate. Set a.Gate before or after this call.
+//   - It DOES set a.TurnEndReminder, the only Agent field it writes: a turn
+//     that ends with the session plan's last task still in_progress spends one
+//     extra provider round-trip prompting the model to file the closing
+//     task_update. cleanup clears it.
 //   - It does NOT call config.Load() or permission.New(). It performs no local
 //     file I/O.
 //   - It does NOT handle process-global browser state (SetBrowserVision etc.) or
 //     workflow-discovery-cwd state.
 //   - It does NOT register or use an MCP registry.
 //
-// The returned cleanup function is reserved for future resource release and is
-// currently a no-op. It does NOT destroy session-scoped managers, which are
-// cached by sessionID and reused across turns.
+// The returned cleanup function clears a.TurnEndReminder and is otherwise
+// reserved for future resource release. It does NOT destroy session-scoped
+// managers, which are cached by sessionID and reused across turns.
 func WireForSession(
 	ctx context.Context,
 	a *octoagent.Agent,


### PR DESCRIPTION
Fixes #2102.

## The problem

A multi-step turn routinely ends with the model reporting "all done" in prose while the last task is still marked `in_progress`. The system prompt already tells it to update status as it goes, but after a long tool-heavy turn the closing `task_update` is exactly the thing that gets dropped — so the plan panel shows `1/2 done` against a reply that says everything is finished.

Users can't backstop this themselves: the `Stop` hook is side-effect only, its stdout is discarded, so nothing a hook prints can reach the model.

## The fix

A turn-end seam in the agent loop. `Agent.TurnEndReminder` is consulted at the moment a turn would return — the model answered in prose, the inbox is empty, `EventTurnDone` is about to fire. A non-empty return is appended as a user message and the loop runs one more round, so the model can fix the record *inside* the same turn.

Three guards:

- **Fires at most once per turn.** A model that ignores the reminder must not be able to hold the turn open.
- **Stands down on the last allowed iteration.** Spending the final round on bookkeeping would turn a clean finish into a `max-turns` stop.
- **The agent layer stays ignorant of what is checked.** The ctx handed to the callback is the running turn's, so a ctx-scoped store resolves the same way the tools do.

`tools.PendingTaskReminder` is the first user of that seam: it names the tasks still marked `in_progress` and asks for the closing `task_update` (or `deleted`, if the task no longer applies).

**It fires only when nothing is pending.** An `in_progress` task with work still queued behind it is a plan the model is legitimately in the middle of — it commonly stops there to ask the user something — and nagging about that would cost an extra round-trip on every such turn. With the queue empty, the model believes it is on the final step, which is exactly the case this guard exists for.

The note is a `<system-reminder>`, so no UI renders it (a user message that strips to empty is skipped by web replay and the TUI alike).

## Wiring

All three transports, since each builds its tool environment differently:

| Transport | Site |
|---|---|
| CLI | `app.WireTools` (only when tasks are enabled; cleared on cleanup) |
| Web / SDK | `app.NewSessionToolEnv` (covers all three `prepareToolTurn` callers) |
| IM | `runChannelTurns` — this path assembles its tool env by hand |

Sub-agents are deliberately left out: they share the parent's checklist and must not report on it.

## Not done

The issue floats an "auto-mark it completed if the reminder is ignored" fallback. Marking a task done that the model never confirmed replaces a stale panel with a lying one, which is worse than the bug. No config knob either — the guard only costs a round-trip when there is an `in_progress` task and nothing pending, which is too narrow to be worth a setting.

## Tests

- `internal/agent/turn_end_reminder_test.go` — injects and continues / empty return ends the turn / once per turn and re-arms next turn / stands down at the turn limit.
- `internal/tools/task_guard_test.go` — 7-case status table (including the reported 1-done-1-in_progress shape and the mid-plan case that must stay quiet), only open tasks are named, ctx-store resolution.
- One wiring assertion per transport (`app/bootstrap_test.go` extended, new `app/toolenv_test.go` and `server/channel_task_guard_test.go`).

`go test -race ./...`, `go vet ./...`, `gofmt -l .` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
