### PR TITLE
fix(tools): recover panics in detached goroutines, and settle their work

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/hooks"
+	"github.com/open-octo/octo-agent/internal/panics"
 )
 
 // Sender is the minimal slice of provider.Provider the Agent depends on:
@@ -1800,6 +1801,19 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
+				// Only the parallel branch needs this: the serial one below runs
+				// on the turn's own goroutine, where the caller's recover (the
+				// server's recoverTurn) still applies. Here a panicking tool
+				// would kill the process — and the desktop build hosts the
+				// server in it. An empty slot is not an option either: every
+				// tool_use must come back with a tool_result or the next request
+				// is malformed, so the panic is reported as this call's failure.
+				defer func() {
+					if err := panics.Error(recover(), "tool call", "tool", calls[i].block.Name); err != nil && resultSlices[i] == nil {
+						resultSlices[i] = toolResultBlocks(calls[i].block.ID, ToolResult{}, err)
+						emit(calls[i].block.Name, resultSlices[i])
+					}
+				}()
 				res, err := executor.Execute(ctx, calls[i].block.Name, calls[i].block.Input)
 				resultSlices[i] = toolResultBlocks(calls[i].block.ID, res, err)
 				emit(calls[i].block.Name, resultSlices[i])

--- a/internal/agent/dispatch_panic_test.go
+++ b/internal/agent/dispatch_panic_test.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// panicExecutor panics instead of running a tool.
+type panicExecutor struct{}
+
+func (panicExecutor) Execute(context.Context, string, map[string]any) (ToolResult, error) {
+	panic("tool exploded")
+}
+
+// TestDispatchTools_ParallelPanicBecomesToolResult covers the parallel branch,
+// which is the only one that runs a tool off the turn's own goroutine — the
+// caller's recover can't reach it, and the desktop build hosts the server
+// in-process, so a panicking tool used to close the app.
+//
+// Filling the slot matters as much as surviving: a tool_use with no matching
+// tool_result makes the *next* request malformed, so the failure would come
+// back from the provider one turn later, far from its cause.
+func TestDispatchTools_ParallelPanicBecomesToolResult(t *testing.T) {
+	blocks := []ContentBlock{
+		{Type: "tool_use", ID: "t1", Name: "read_file"},
+		{Type: "tool_use", ID: "t2", Name: "read_file"},
+	}
+
+	out, err := dispatchTools(context.Background(), panicExecutor{}, blocks, nil, nil)
+	if err != nil {
+		t.Fatalf("dispatchTools: %v", err)
+	}
+	if len(out) != len(blocks) {
+		t.Fatalf("got %d result blocks for %d calls: %+v", len(out), len(blocks), out)
+	}
+	for i, b := range out {
+		if b.Type != "tool_result" {
+			t.Errorf("block %d is %q, want tool_result", i, b.Type)
+		}
+		if !b.IsError {
+			t.Errorf("block %d should be an error result", i)
+		}
+		if !strings.Contains(b.Result, "panicked") {
+			t.Errorf("block %d should report the panic, got %q", i, b.Result)
+		}
+	}
+	if out[0].ToolUseID != "t1" || out[1].ToolUseID != "t2" {
+		t.Errorf("results lost their tool_use ids / order: %q, %q", out[0].ToolUseID, out[1].ToolUseID)
+	}
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/open-octo/octo-agent/internal/panics"
 )
 
 // defaultCallTimeout bounds a single request/response when the caller's context
@@ -419,7 +421,14 @@ func (c *Client) receiveLoop() {
 			fn := c.onNotification
 			c.notifyMu.Unlock()
 			if fn != nil {
-				go fn(msg.Method)
+				// The handler is caller-supplied and runs detached, with
+				// nothing above it to recover — a server that fires a
+				// notification mid-tool-call could otherwise take the whole
+				// process down.
+				go func() {
+					defer func() { _ = panics.Error(recover(), "mcp notification handler", "method", msg.Method) }()
+					fn(msg.Method)
+				}()
 			}
 		}
 		// Server-initiated request: ignored — see the doc comment above.

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -144,6 +144,19 @@ func (c *Connection) refreshSurfaces(method string) {
 	c.refreshing = true
 	c.refreshMu.Unlock()
 
+	// refreshing is what gates every later refresh; leaving it set would
+	// collapse them all into a pending flag nobody ever acts on, so this
+	// connection's tool list would silently freeze at whatever it last saw.
+	// The recover above this one (the notification goroutine) logs the panic.
+	defer func() {
+		if r := recover(); r != nil {
+			c.refreshMu.Lock()
+			c.refreshing = false
+			c.refreshMu.Unlock()
+			panic(r)
+		}
+	}()
+
 	for {
 		c.refreshOnce(method)
 

--- a/internal/panics/panics.go
+++ b/internal/panics/panics.go
@@ -1,0 +1,45 @@
+// Package panics turns a recovered panic into a logged error, for the detached
+// goroutines that run a tool call's work.
+//
+// Those goroutines have no request scope above them to recover — no net/http
+// handler, no agent turn — and the desktop app hosts the whole server in its
+// own process. An unrecovered panic in one therefore doesn't just fail a tool
+// call: it closes the user's window and takes every other session with it,
+// historically without leaving so much as a stack trace behind (which is why
+// ~/.octo/crash.log exists — see internal/crashlog).
+//
+// Recovering on its own is not enough. Most of these goroutines are the only
+// thing that will ever mark their work finished — delivering a result the
+// script blocks on, closing a channel a caller waits on, clearing a busy flag,
+// recording an exit status — so a bare recover would trade a crash for a
+// permanent hang: harder to diagnose, and just as fatal to the session. That
+// half belongs to the caller: use the returned error to settle whatever the
+// goroutine was responsible for.
+package panics
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+)
+
+// Error logs a recovered panic with its stack and returns it as an error,
+// or nil when r is nil (no panic in flight).
+//
+// It takes the recovered value instead of calling recover() itself, because
+// recover only works when called *directly* by a deferred function — a helper
+// that hid the call inside itself would silently never recover anything:
+//
+//	defer func() {
+//		if err := panics.Error(recover(), "what this goroutine does"); err != nil {
+//			// settle whatever this goroutine owns
+//		}
+//	}()
+func Error(r any, what string, attrs ...any) error {
+	if r == nil {
+		return nil
+	}
+	slog.Error("recovered panic in detached goroutine",
+		append([]any{"what", what, "panic", r, "stack", string(debug.Stack())}, attrs...)...)
+	return fmt.Errorf("%s panicked: %v", what, r)
+}

--- a/internal/panics/panics.go
+++ b/internal/panics/panics.go
@@ -5,8 +5,7 @@
 // handler, no agent turn — and the desktop app hosts the whole server in its
 // own process. An unrecovered panic in one therefore doesn't just fail a tool
 // call: it closes the user's window and takes every other session with it,
-// historically without leaving so much as a stack trace behind (which is why
-// ~/.octo/crash.log exists — see internal/crashlog).
+// historically without leaving so much as a stack trace behind.
 //
 // Recovering on its own is not enough. Most of these goroutines are the only
 // thing that will ever mark their work finished — delivering a result the

--- a/internal/panics/panics_test.go
+++ b/internal/panics/panics_test.go
@@ -1,0 +1,31 @@
+package panics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestError_ReportsAndStopsThePanic(t *testing.T) {
+	var got error
+	func() {
+		// The documented usage: recover() stays in the deferred function, and
+		// its value is handed to the helper. A version of Error that called
+		// recover() itself would never fire here — the panic below would escape
+		// and take the test binary with it.
+		defer func() { got = Error(recover(), "unit under test", "id", 7) }()
+		panic("boom")
+	}()
+
+	if got == nil {
+		t.Fatal("Error returned nil for a real panic")
+	}
+	if !strings.Contains(got.Error(), "boom") || !strings.Contains(got.Error(), "unit under test") {
+		t.Errorf("error should name both the panic and the goroutine, got: %v", got)
+	}
+}
+
+func TestError_NilWhenNoPanic(t *testing.T) {
+	if err := Error(nil, "unit under test"); err != nil {
+		t.Errorf("Error(nil) = %v, want nil", err)
+	}
+}

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -424,6 +424,15 @@ func (m *BackgroundManager) Start(ctx context.Context, command string, mode Back
 		// panic unwinds, or the waiter below would block on it forever.
 		defer func() { _ = panics.Error(recover(), "background process reader", "id", id) }()
 		defer close(readerDone)
+		// What this goroutine really owns is draining pr. cmd.Stdout is an
+		// *io.PipeWriter, so os/exec copies into it from a goroutine of its own
+		// that cmd.Wait blocks on — a reader that stops without closing its end
+		// leaves that copy blocked on an undrained pipe forever, and with it
+		// Wait, finish, the exit notification, and the child process itself.
+		// Closing pr fails the copy instead, which is how the panic surfaces as
+		// an exit status rather than a task stuck on "running". Redundant on the
+		// normal path, where the scan ends at EOF.
+		defer pr.Close()
 		scanner := bufio.NewScanner(pr)
 		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 		for scanner.Scan() {

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/open-octo/octo-agent/internal/panics"
 )
 
 // maxBgOutputBytes caps how much output is retained per background process.
@@ -418,6 +420,9 @@ func (m *BackgroundManager) Start(ctx context.Context, command string, mode Back
 
 	// Reader: forward combined output into the capped buffer.
 	go func() {
+		// Registered first so it runs last: readerDone is still closed as the
+		// panic unwinds, or the waiter below would block on it forever.
+		defer func() { _ = panics.Error(recover(), "background process reader", "id", id) }()
 		defer close(readerDone)
 		scanner := bufio.NewScanner(pr)
 		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
@@ -436,11 +441,22 @@ func (m *BackgroundManager) Start(ctx context.Context, command string, mode Back
 	// Waiter: wait for the process, close pipe so the reader sees EOF,
 	// then wait for the reader to drain before firing onExit.
 	go func() {
+		finished := false
+		// Until finish runs, the process reads as "running" to every status
+		// query and to the exit-notification path — so a panic before it has
+		// to record an exit itself, or the task hangs in the UI forever. The
+		// caller-supplied onExit hook below is the reachable panic source.
+		defer func() {
+			if err := panics.Error(recover(), "background process waiter", "id", id); err != nil && !finished {
+				p.finish(err)
+			}
+		}()
 		err := cmd.Wait()
 		_ = pw.Close()
 		_ = stdinW.Close() // close stdin so any blocked reads on the process side get EOF
 		<-readerDone       // ensures reader flushed all pipe data
 		p.finish(err)
+		finished = true
 
 		m.mu.Lock()
 		hook := m.onExit

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/browser"
 	"github.com/open-octo/octo-agent/internal/config"
+	"github.com/open-octo/octo-agent/internal/panics"
 )
 
 // browserSession holds the per-session Chrome connection, reused across tool
@@ -337,8 +338,11 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 		// stall the reconnect — wait up to 3s for it to finish, then move on.
 		closeDone := make(chan struct{})
 		go func() {
+			// Deferred so a panicking close still releases the wait below
+			// immediately instead of parking the reconnect for the full 3s.
+			defer close(closeDone)
+			defer func() { _ = panics.Error(recover(), "browser session close") }()
 			closeSession(browserSession.b, nil)
-			close(closeDone)
 		}()
 		select {
 		case <-closeDone:

--- a/internal/tools/memory_backend.go
+++ b/internal/tools/memory_backend.go
@@ -10,6 +10,7 @@ import (
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/hooks"
 	"github.com/open-octo/octo-agent/internal/memorybackend"
+	"github.com/open-octo/octo-agent/internal/panics"
 )
 
 // activeMemoryBackend, when non-nil, backs the `memory_recall` tool and the
@@ -145,6 +146,9 @@ func RegisterMemoryBackendHooks(e *hooks.Engine) {
 		// lands in long-term memory and can't resurface via memory_recall.
 		content = agent.StripSystemReminders(content)
 		go func() {
+			// Fire-and-forget: nothing waits on this, so logging the panic is
+			// the whole obligation.
+			defer func() { _ = panics.Error(recover(), "memory backend store") }()
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			_ = b.Store(ctx, content)

--- a/internal/tools/recover_test.go
+++ b/internal/tools/recover_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -140,7 +141,10 @@ func waitAgentIdle(t *testing.T, mgr *SubAgentManager, id string) {
 	}
 }
 
-func TestWorkflowManager_PanickingAgentFinishesRun(t *testing.T) {
+// Named for what it actually covers: the panic happens in the goroutine
+// internal/workflow spawns per agent() call, not in the manager's run
+// goroutine, so this pins the workflow runtime's own settle path.
+func TestWorkflow_PanickingAgentReachesScriptAndFinishes(t *testing.T) {
 	m := NewWorkflowManager()
 
 	id, err := m.Start(WorkflowRunRequest{
@@ -179,6 +183,90 @@ func TestWorkflowManager_PanickingAgentFinishesRun(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
+}
+
+// The manager's own run goroutine, whose reachable panic source is the
+// completion hook it calls after the run has finished.
+func TestWorkflowManager_PanickingDoneHookSurvives(t *testing.T) {
+	m := NewWorkflowManager()
+	m.SetOnDone(func(WorkflowNotification) { panic("done hook exploded") })
+
+	id, err := m.Start(WorkflowRunRequest{
+		Description: "hookboom",
+		Script:      `"ok"`,
+		Agent: func(context.Context, string, workflow.AgentOptions) workflow.AgentResult {
+			return workflow.AgentResult{Reply: "unused"}
+		},
+		JournalDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		snap, ok := m.Read(id)
+		if !ok {
+			t.Fatalf("run %s disappeared", id)
+		}
+		if snap.Status != "running" {
+			// The hook panics after finish, so the result must be intact — the
+			// notification is what failed, not the run.
+			if snap.Status != "done" {
+				t.Errorf("status = %q, want done", snap.Status)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("run never finished")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestBackgroundManager_PanickingOutputHandlerStillExits(t *testing.T) {
+	m := NewBackgroundManager()
+
+	// The output handler panics on the first line, with plenty of output still
+	// to come. Draining the pipe is what this goroutine really owns: cmd.Stdout
+	// is an *io.PipeWriter, so os/exec copies into it from its own goroutine and
+	// Wait blocks on that copy — a reader that dies without closing its end
+	// leaves the copy blocked forever, and with it Wait, finish, and the exit
+	// notification. That is the crash-turned-hang this whole change exists to
+	// avoid, so it gets a regression test of its own.
+	id, err := m.Start(context.Background(), unfinishedOutputCommand(), BgModeAsync,
+		WithOnLine(func(string) { panic("output handler exploded") }))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	deadline := time.Now().Add(hookTimeout())
+	for {
+		_, status, found, _, _ := m.Read(id)
+		if !found {
+			t.Fatalf("process %s disappeared", id)
+		}
+		if status != "running" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("process still running: the reader died without releasing the pipe, so cmd.Wait never returned")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// unfinishedOutputCommand returns a shell command that emits a line, pauses,
+// then emits another. The pause is what makes the test deterministic: the
+// reader panics on the first line while the second is still unwritten, so the
+// copy goroutine is guaranteed to be mid-Write against a pipe nobody drains.
+// Sheer volume works too, but only past whatever buffering happens to be in
+// play — 2000 lines slipped through and passed against the broken code.
+func unfinishedOutputCommand() string {
+	if runtime.GOOS == "windows" {
+		return "Write-Output a; Start-Sleep -Seconds 1; Write-Output b"
+	}
+	return "echo a; sleep 1; echo b"
 }
 
 func TestBackgroundManager_PanickingExitHookSurvives(t *testing.T) {

--- a/internal/tools/recover_test.go
+++ b/internal/tools/recover_test.go
@@ -1,0 +1,213 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/open-octo/octo-agent/internal/workflow"
+)
+
+// The goroutines in this package have no request scope above them to recover,
+// and the desktop app runs the server in-process — so a panic in any of them
+// used to take the whole app down. These tests pin both halves of the fix: the
+// process survives, AND whatever the goroutine was responsible for settling
+// gets settled, because a recover that skipped that would turn each crash into
+// a hang.
+
+// panicSpawner panics instead of running an agent.
+type panicSpawner struct{}
+
+func (panicSpawner) Spawn(context.Context, SpawnRequest) (SpawnResult, error) {
+	panic("spawner exploded")
+}
+
+func (panicSpawner) Continue(context.Context, string, string) (SpawnResult, error) {
+	panic("continue exploded")
+}
+
+func TestRunSync_PanickingSpawnerReturnsError(t *testing.T) {
+	mgr := NewSubAgentManager(panicSpawner{})
+	mgr.SetSynchronous(true)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := mgr.RunSync(context.Background(), SpawnRequest{Description: "boom"})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		// The tool call must come back with the failure, not with a nil error.
+		if err == nil {
+			t.Fatal("RunSync returned no error after the spawner panicked")
+		}
+		if !strings.Contains(err.Error(), "panicked") {
+			t.Errorf("error should name the panic, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunSync never returned: the panic became a hang")
+	}
+
+	// The sync slot must have been released too, or the next sub-agent call
+	// would block forever behind the dead one.
+	second := make(chan struct{})
+	go func() {
+		_, _ = mgr.RunSync(context.Background(), SpawnRequest{Description: "after"})
+		close(second)
+	}()
+	select {
+	case <-second:
+	case <-time.After(10 * time.Second):
+		t.Fatal("a later RunSync blocked: the concurrency slot leaked")
+	}
+}
+
+func TestStart_PanickingSpawnerClearsBusy(t *testing.T) {
+	mgr := NewSubAgentManager(panicSpawner{})
+
+	id, err := mgr.Start(SpawnRequest{Description: "boom"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// setDone is the only thing that ever clears the busy flag; the goal loop's
+	// idle check reads it, so an agent stuck "working" wedges more than the UI.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		_, status, found := mgr.Read(id)
+		if !found {
+			t.Fatalf("agent %s disappeared", id)
+		}
+		if status != "running" {
+			if !strings.Contains(status, "panicked") {
+				t.Errorf("status should report the panic, got %q", status)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("agent still reports running: the panic left it busy forever")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if running := mgr.ListRunning(); len(running) != 0 {
+		t.Errorf("ListRunning still reports %d agent(s) after the panic", len(running))
+	}
+}
+
+func TestSend_PanickingContinueClearsBusy(t *testing.T) {
+	// Spawn succeeds, then the follow-up message panics — the path a user hits
+	// by replying to a sub-agent that is already parked.
+	mgr := NewSubAgentManager(&spawnOKContinuePanicSpawner{})
+
+	id, err := mgr.Start(SpawnRequest{Description: "ok"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitAgentIdle(t, mgr, id)
+
+	if err := mgr.Send(id, "hello"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	waitAgentIdle(t, mgr, id)
+}
+
+// spawnOKContinuePanicSpawner completes a spawn normally but panics on the
+// follow-up round.
+type spawnOKContinuePanicSpawner struct{}
+
+func (*spawnOKContinuePanicSpawner) Spawn(context.Context, SpawnRequest) (SpawnResult, error) {
+	return SpawnResult{AgentID: "c1", Reply: "hi"}, nil
+}
+
+func (*spawnOKContinuePanicSpawner) Continue(context.Context, string, string) (SpawnResult, error) {
+	panic("continue exploded")
+}
+
+func waitAgentIdle(t *testing.T, mgr *SubAgentManager, id string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, status, found := mgr.Read(id); found && status != "running" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("agent stayed busy: the panic was recovered but never settled")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestWorkflowManager_PanickingAgentFinishesRun(t *testing.T) {
+	m := NewWorkflowManager()
+
+	id, err := m.Start(WorkflowRunRequest{
+		Description: "boom",
+		Script:      `agent("x")`,
+		Agent: func(context.Context, string, workflow.AgentOptions) workflow.AgentResult {
+			panic("agent exploded")
+		},
+		JournalDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Polling rather than Wait on purpose: finish is what closes the channel
+	// Wait blocks on, and Wait's own cancellation path waits on that same
+	// channel — so a regression here would hang the test binary instead of
+	// failing it.
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		snap, ok := m.Read(id)
+		if !ok {
+			t.Fatalf("run %s disappeared", id)
+		}
+		if snap.Status != "running" {
+			// A failed agent() is an ordinary outcome for a script — it comes
+			// back as an "[agent error] …" string (runtime.go) — so the panic
+			// must arrive that way too, rather than as a lost token.
+			if !strings.Contains(snap.Output, "panicked") && !strings.Contains(snap.ErrMsg, "panicked") {
+				t.Errorf("panic never reached the script; output=%q errMsg=%q", snap.Output, snap.ErrMsg)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("run never finished: nothing would ever release a Wait on it")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestBackgroundManager_PanickingExitHookSurvives(t *testing.T) {
+	m := NewBackgroundManager()
+	m.SetOnExit(func(BgExit) { panic("hook exploded") })
+
+	id, err := m.Start(context.Background(), "echo hi", BgModeAsync)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// The hook fires after the exit is recorded, so the process must still be
+	// observable as finished — and the manager must still be usable.
+	deadline := time.Now().Add(hookTimeout())
+	for {
+		_, status, found, _, _ := m.Read(id)
+		if !found {
+			t.Fatalf("process %s disappeared", id)
+		}
+		if status != "running" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("process never reported an exit after the hook panicked")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if _, err := m.Start(context.Background(), "echo again", BgModeAsync); err != nil {
+		t.Fatalf("manager unusable after a panicking hook: %v", err)
+	}
+}

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/open-octo/octo-agent/internal/panics"
 )
 
 // maxSubAgentResultBytes caps how much result text is retained per async sub-agent.
@@ -374,6 +376,18 @@ func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnR
 	done := make(chan outcome, 1)
 
 	go func() {
+		var o outcome
+		// The select below blocks on `done` while holding a sync-concurrency
+		// slot, so the outcome has to be delivered even when the spawner
+		// panics: recovering without sending would turn a crash into a tool
+		// call that never returns and a slot that is never released.
+		defer func() {
+			if err := panics.Error(recover(), "sub-agent spawn", "agent_id", id); err != nil {
+				o = outcome{err: err}
+				a.setDone(err, "")
+			}
+			done <- o
+		}()
 		res, err := m.spawner.Spawn(spawnCtx, req)
 		if err == nil {
 			a.mu.Lock()
@@ -386,7 +400,7 @@ func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnR
 			stopReason = res.StopReason
 		}
 		a.setDone(err, stopReason)
-		done <- outcome{res: res, err: err}
+		o = outcome{res: res, err: err}
 	}()
 
 	select {
@@ -409,6 +423,10 @@ func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnR
 		m.mu.Unlock()
 
 		go func() {
+			// Registered first so it runs last: the async-budget release below
+			// still happens while the panic unwinds. The exit notification hook
+			// is caller-supplied, which is what makes this reachable.
+			defer func() { _ = panics.Error(recover(), "sub-agent background wait", "agent_id", id) }()
 			defer func() {
 				m.mu.Lock()
 				m.activeAsync--
@@ -605,6 +623,16 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 	}
 
 	go func() {
+		settled := false
+		// Registered first so it runs last, after the defers below have
+		// released the async budget and cleared the live panel. Nothing else
+		// ever clears this agent's busy flag — the goal loop's idle check reads
+		// it — so a panic before setDone has to settle the agent itself.
+		defer func() {
+			if err := panics.Error(recover(), "sub-agent spawn", "agent_id", id); err != nil && !settled {
+				agent.setDone(err, "")
+			}
+		}()
 		defer func() {
 			m.mu.Lock()
 			m.activeAsync--
@@ -625,6 +653,7 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 			stopReason = res.StopReason
 		}
 		agent.setDone(err, stopReason)
+		settled = true
 
 		m.mu.Lock()
 		hook := m.onExit
@@ -690,6 +719,16 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 		return
 	}
 
+	// Send marks the agent busy before launching this, and setDone below is the
+	// only thing that ever clears it — so a panicking Continue would leave the
+	// agent permanently "working" to the UI and to the goal loop's idle check.
+	settled := false
+	defer func() {
+		if err := panics.Error(recover(), "sub-agent continue", "agent_id", agentID); err != nil && !settled {
+			agent.setDone(err, "")
+		}
+	}()
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Replace the agent's cancel so Kill targets the current operation. Call the
@@ -731,6 +770,7 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 		stopReason = res.StopReason
 	}
 	agent.setDone(err, stopReason)
+	settled = true
 
 	m.mu.Lock()
 	hook := m.onExit

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -624,15 +624,9 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 
 	go func() {
 		settled := false
-		// Registered first so it runs last, after the defers below have
-		// released the async budget and cleared the live panel. Nothing else
-		// ever clears this agent's busy flag — the goal loop's idle check reads
-		// it — so a panic before setDone has to settle the agent itself.
-		defer func() {
-			if err := panics.Error(recover(), "sub-agent spawn", "agent_id", id); err != nil && !settled {
-				agent.setDone(err, "")
-			}
-		}()
+		// Outermost, so it also covers the defers below — sink is
+		// caller-supplied and can panic in its own right.
+		defer func() { _ = panics.Error(recover(), "sub-agent cleanup", "agent_id", id) }()
 		defer func() {
 			m.mu.Lock()
 			m.activeAsync--
@@ -643,6 +637,15 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 			// clears the live-panel entry, even on spawn error.
 			defer sink(SubAgentEvent{Kind: "done"})
 		}
+		// Innermost, so it runs before the "done" event above: nothing else ever
+		// clears this agent's busy flag — the goal loop's idle check reads it —
+		// and the event carries the stop reason read off that same state, so the
+		// agent has to be settled before the panel is told it finished.
+		defer func() {
+			if err := panics.Error(recover(), "sub-agent spawn", "agent_id", id); err != nil && !settled {
+				agent.setDone(err, "")
+			}
+		}()
 		res, err := m.spawner.Spawn(ctx, req)
 		stopReason := ""
 		if err == nil {
@@ -719,15 +722,7 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 		return
 	}
 
-	// Send marks the agent busy before launching this, and setDone below is the
-	// only thing that ever clears it — so a panicking Continue would leave the
-	// agent permanently "working" to the UI and to the goal loop's idle check.
 	settled := false
-	defer func() {
-		if err := panics.Error(recover(), "sub-agent continue", "agent_id", agentID); err != nil && !settled {
-			agent.setDone(err, "")
-		}
-	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -754,6 +749,24 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 		ctx = WithSubAgentEventSink(ctx, sink)
 		sink(SubAgentEvent{Kind: "started"})
 	}
+
+	// Send marks the agent busy before launching this round, and setDone below
+	// is the only thing that ever clears it — so a panicking Continue would
+	// leave the agent permanently "working" to the UI and to the goal loop's
+	// idle check. The round's context and its live-panel entry are this
+	// goroutine's to release too; registered here rather than at the top of the
+	// function because both only exist from this point on.
+	defer func() {
+		err := panics.Error(recover(), "sub-agent continue", "agent_id", agentID)
+		if err == nil || settled {
+			return
+		}
+		cancel()
+		agent.setDone(err, "")
+		if sink != nil {
+			sink(SubAgentEvent{Kind: "done"})
+		}
+	}()
 
 	// Continue addresses the child by its Spawner-side id, not the manager's
 	// agent_N handle — the two id spaces are distinct.

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/panics"
 )
 
 // TerminalTimeout is the DEFAULT wait for a synchronous command when the call
@@ -311,6 +312,10 @@ func (t TerminalTool) ExecuteStream(
 	if progress != nil {
 		progressCh = make(chan string, 128)
 		go func() {
+			// A panicking progress handler costs this command its live output —
+			// senders drop lines once nobody is receiving (the select below
+			// falls through to default) — but it must not cost the process.
+			defer func() { _ = panics.Error(recover(), "terminal progress handler") }()
 			for line := range progressCh {
 				progress(line)
 			}

--- a/internal/tools/workflow_manager.go
+++ b/internal/tools/workflow_manager.go
@@ -285,9 +285,10 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 		finished := false
 		// finish closes the channel Wait blocks on, and Wait's own cancellation
 		// path waits on it too — so a panic that skipped it would leave a
-		// foreground workflow_start blocked with no way out. The Log/Progress
-		// callbacks below run inside workflow.Run and reach a caller-supplied
-		// event sink, which is what makes this reachable.
+		// foreground workflow_start blocked with no way out. What's reachable
+		// here is the emit and hook calls after the run itself: a panic inside
+		// workflow.Run's own host functions never gets this far, because wazero
+		// recovers those and returns them as a Call error instead.
 		defer func() {
 			if err := panics.Error(recover(), "workflow run", "run_id", id); err != nil && !finished {
 				run.finish("", "", err.Error(), time.Now())

--- a/internal/tools/workflow_manager.go
+++ b/internal/tools/workflow_manager.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/open-octo/octo-agent/internal/panics"
 	"github.com/open-octo/octo-agent/internal/workflow"
 )
 
@@ -281,6 +282,17 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 	}
 
 	go func() {
+		finished := false
+		// finish closes the channel Wait blocks on, and Wait's own cancellation
+		// path waits on it too — so a panic that skipped it would leave a
+		// foreground workflow_start blocked with no way out. The Log/Progress
+		// callbacks below run inside workflow.Run and reach a caller-supplied
+		// event sink, which is what makes this reachable.
+		defer func() {
+			if err := panics.Error(recover(), "workflow run", "run_id", id); err != nil && !finished {
+				run.finish("", "", err.Error(), time.Now())
+			}
+		}()
 		defer func() {
 			m.mu.Lock()
 			m.active--
@@ -310,6 +322,7 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 			errMsg = err.Error()
 		}
 		run.finish(res.Output, res.RunID, errMsg, time.Now())
+		finished = true
 
 		status := "done"
 		if errMsg != "" {

--- a/internal/workflow/runtime.go
+++ b/internal/workflow/runtime.go
@@ -403,6 +403,9 @@ func (b *backend) agentStart(_ context.Context, mod api.Module, ptr, length, mpt
 		// Replayed from journal: deliver without calling Agent.
 		ce := b.cached[seq]
 		go func() {
+			// delivered is set before the call, not after: the only statement
+			// here that can panic is deliver itself, and re-entering it would
+			// double-count usage and append a second journal entry for this seq.
 			delivered := false
 			defer func() {
 				if err := panics.Error(recover(), "workflow agent() replay", "token", tok); err != nil && !delivered {
@@ -417,8 +420,8 @@ func (b *backend) agentStart(_ context.Context, mod api.Module, ptr, length, mpt
 				res.InputTokens = ce.InputTokens
 				res.OutputTokens = ce.OutputTokens
 			}
-			b.deliver(tok, res)
 			delivered = true
+			b.deliver(tok, res)
 		}()
 		return tok
 	}
@@ -478,6 +481,7 @@ func (b *backend) skillStart(_ context.Context, mod api.Module, nptr, nlen, pptr
 		// Replayed from journal: deliver the stored outputs without re-running.
 		ce := b.cached[seq]
 		go func() {
+			// Set before the call — see the agent() replay above.
 			delivered := false
 			defer func() {
 				if err := panics.Error(recover(), "workflow skill() replay", "token", tok); err != nil && !delivered {
@@ -492,8 +496,8 @@ func (b *backend) skillStart(_ context.Context, mod api.Module, nptr, nlen, pptr
 				res.InputTokens = ce.InputTokens
 				res.OutputTokens = ce.OutputTokens
 			}
-			b.deliver(tok, res)
 			delivered = true
+			b.deliver(tok, res)
 		}()
 		return tok
 	}

--- a/internal/workflow/runtime.go
+++ b/internal/workflow/runtime.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/open-octo/octo-agent/internal/panics"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
@@ -402,6 +403,12 @@ func (b *backend) agentStart(_ context.Context, mod api.Module, ptr, length, mpt
 		// Replayed from journal: deliver without calling Agent.
 		ce := b.cached[seq]
 		go func() {
+			delivered := false
+			defer func() {
+				if err := panics.Error(recover(), "workflow agent() replay", "token", tok); err != nil && !delivered {
+					b.deliver(tok, AgentResult{Err: err})
+				}
+			}()
 			var res AgentResult
 			if ce.ErrMsg != "" {
 				res.Err = errors.New(ce.ErrMsg)
@@ -411,22 +418,33 @@ func (b *backend) agentStart(_ context.Context, mod api.Module, ptr, length, mpt
 				res.OutputTokens = ce.OutputTokens
 			}
 			b.deliver(tok, res)
+			delivered = true
 		}()
 		return tok
 	}
 
 	go func() {
+		// The script is blocked on this token until deliver runs, and the run
+		// isn't finished until the script returns — so a panicking Agent has to
+		// deliver a failure, or the whole workflow (and any Wait on it) hangs.
+		delivered := false
+		settle := func(res AgentResult) { delivered = true; b.deliver(tok, res) }
+		defer func() {
+			if err := panics.Error(recover(), "workflow agent() call", "token", tok); err != nil && !delivered {
+				b.deliver(tok, AgentResult{Err: err})
+			}
+		}()
 		if b.sem != nil {
 			select {
 			case b.sem <- struct{}{}:
 				defer func() { <-b.sem }()
 			case <-b.ctx.Done():
-				b.deliver(tok, AgentResult{Err: b.ctx.Err()})
+				settle(AgentResult{Err: b.ctx.Err()})
 				return
 			}
 		}
 		res := b.opt.Agent(b.ctx, prompt, opts)
-		b.deliver(tok, res)
+		settle(res)
 	}()
 	return tok
 }
@@ -460,6 +478,12 @@ func (b *backend) skillStart(_ context.Context, mod api.Module, nptr, nlen, pptr
 		// Replayed from journal: deliver the stored outputs without re-running.
 		ce := b.cached[seq]
 		go func() {
+			delivered := false
+			defer func() {
+				if err := panics.Error(recover(), "workflow skill() replay", "token", tok); err != nil && !delivered {
+					b.deliver(tok, AgentResult{Err: err})
+				}
+			}()
 			var res AgentResult
 			if ce.ErrMsg != "" {
 				res.Err = errors.New(ce.ErrMsg)
@@ -469,25 +493,34 @@ func (b *backend) skillStart(_ context.Context, mod api.Module, nptr, nlen, pptr
 				res.OutputTokens = ce.OutputTokens
 			}
 			b.deliver(tok, res)
+			delivered = true
 		}()
 		return tok
 	}
 
 	go func() {
+		// Same contract as agent() above: deliver or the script waits forever.
+		delivered := false
+		settle := func(res AgentResult) { delivered = true; b.deliver(tok, res) }
+		defer func() {
+			if err := panics.Error(recover(), "workflow skill() call", "token", tok); err != nil && !delivered {
+				b.deliver(tok, AgentResult{Err: err})
+			}
+		}()
 		if b.sem != nil {
 			select {
 			case b.sem <- struct{}{}:
 				defer func() { <-b.sem }()
 			case <-b.ctx.Done():
-				b.deliver(tok, AgentResult{Err: b.ctx.Err()})
+				settle(AgentResult{Err: b.ctx.Err()})
 				return
 			}
 		}
 		if b.opt.Skill == nil {
-			b.deliver(tok, AgentResult{Err: errors.New("skill() is not available in this run")})
+			settle(AgentResult{Err: errors.New("skill() is not available in this run")})
 			return
 		}
-		b.deliver(tok, b.opt.Skill(b.ctx, name, params, schema))
+		settle(b.opt.Skill(b.ctx, name, params, schema))
 	}()
 	return tok
 }


### PR DESCRIPTION
Follow-up to #2109 (which makes a crash *reportable*); this one stops a whole class of them.

Relates to #2107.

## The gap

Every goroutine behind a tool call ran with no `recover` above it. Nothing in their stack can catch a panic — they're detached from the request that started them, so there's no `net/http` handler and no agent turn in the way (the interactive turn path *does* have one, `recoverTurn`). The desktop app hosts the server in-process, so a single panicking tool call closed the user's window and took every other session down with it.

Sites: sub-agent spawn (sync + async) and follow-up messages, background process reader and waiter, workflow runs, the `agent()` / `skill()` calls inside a workflow, the terminal progress pump, browser session close, memory-backend store.

## Why a plain `recover` would have been the wrong fix

Most of these goroutines are the only thing that ever marks their work finished. Recovering without settling that trades a crash for a permanent hang — quieter, harder to diagnose, just as fatal to the session:

| goroutine | what only it can settle | cost of skipping it |
|---|---|---|
| `RunSync` spawn | send on `done` | tool call never returns; sync-concurrency slot leaks |
| `Start` spawn, `runContinue` | `setDone` (clears `busy`) | sub-agent shows "working" forever; the goal loop's idle check reads that flag |
| background waiter | `p.finish` | task reads "running" forever |
| workflow run | `run.finish` | closes the channel `Wait` blocks on — and `Wait`'s *cancellation* path waits on the same channel, so there is no way out |
| workflow `agent()` / `skill()` | `deliver(tok, …)` | the script parks on the token, and the run with it |

So each site recovers **and** settles what it owns, surfacing the panic as that path's ordinary failure: an errored outcome, a recorded exit status, an `"[agent error] …"` string the script can read.

## `internal/panics`

The shared helper takes the recovered value instead of calling `recover()` itself:

```go
defer func() {
    if err := panics.Error(recover(), "what this goroutine does"); err != nil {
        // settle whatever this goroutine owns
    }
}()
```

`recover()` only works when called *directly* by a deferred function. The first version of this change hid that call inside the helper, which silently disabled every single recover — the tests caught it immediately, which is the main argument for having written them first.

It lives in its own package because `internal/tools` imports `internal/workflow`, so the workflow runtime can't import back.

## Scope note

The workflow runtime's own goroutines (`internal/workflow/runtime.go`) were found the same way: after `internal/tools` was fully covered, the workflow test *still* crashed the suite, because `agent()` runs the caller's function in a goroutine of its own that nothing in `tools` can wrap.

Deliberately untouched: `detached.go`'s `go cmd.Wait()`, which calls nothing but stdlib.

## Tests

Five, each pinning both halves — the process survives, and the work gets settled:

- `RunSync` with a panicking spawner returns an error (not nil, not never), and a later `RunSync` still gets a slot.
- `Start` with a panicking spawner leaves the agent reporting the panic rather than stuck busy, and out of `ListRunning`.
- `Send` with a panicking `Continue` clears busy too.
- A panicking workflow `agent()` reaches the script as an `"[agent error] … panicked: …"` result instead of parking the run. Polls the snapshot rather than calling `Wait`, so a regression fails the test instead of hanging the binary.
- A panicking background exit hook still leaves the process observably exited and the manager usable.

`go test ./...` green; `-race` green on `internal/tools` and `internal/workflow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
