### PR TITLE
chore: bump version to 1.15.13

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.12"
+var Version = "1.15.13"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch over v1.15.12. Four fixes since:

- **#2109 / #2111** — the #2107 arc: desktop crashes now land in `~/.octo/crash.log` (a GUI process has no usable stderr, so a panic left nothing behind), and the detached goroutines behind a tool call recover instead of taking the whole in-process server down with them.
- **#2110** — the plan is closed out at turn end rather than trusting the model to call `task_update`.
- **#2108** — the permission modal is opaque again.

Plus dependabot #2100/#2104/#2105/#2106.

version.go only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)