### PR TITLE
fix(web): place newly created group sessions at the top of the group

### DIFF
--- a/internal/server/session_groups.go
+++ b/internal/server/session_groups.go
@@ -378,10 +378,11 @@ func createSessionGroupNamed(name string) (sessionGroup, error) {
 	return g, nil
 }
 
-// addSessionToGroup appends a session ID to a group, enforcing single
-// membership (the session is first removed from every other group, matching
-// handleSetSessionGroup). Returns an error if the target group no longer
-// exists.
+// addSessionToGroup prepends a session ID to a group — a newly created
+// session shows at the top of its group, matching the newest-first session
+// list — enforcing single membership (the session is first removed from every
+// other group, matching handleSetSessionGroup). Returns an error if the
+// target group no longer exists.
 func addSessionToGroup(groupID, sessionID string) error {
 	groupMu.Lock()
 	defer groupMu.Unlock()
@@ -399,7 +400,7 @@ func addSessionToGroup(groupID, sessionID string) error {
 		}
 		groups[i].SessionIDs = ids
 		if groups[i].ID == groupID {
-			groups[i].SessionIDs = append(groups[i].SessionIDs, sessionID)
+			groups[i].SessionIDs = append([]string{sessionID}, groups[i].SessionIDs...)
 			found = true
 		}
 	}

--- a/internal/server/session_groups_test.go
+++ b/internal/server/session_groups_test.go
@@ -178,17 +178,38 @@ func TestAddSessionToGroup_PrependsNewest(t *testing.T) {
 			t.Fatalf("addSessionToGroup(%s): %v", sid, err)
 		}
 	}
-	groups, _ := loadSessionGroups()
-	want := []string{"s-new", "s-mid", "s-old"}
-	got := groups[0].SessionIDs
-	if len(got) != len(want) {
-		t.Fatalf("SessionIDs = %v, want %v", got, want)
+	assertGroupOrder(t, gid, []string{"s-new", "s-mid", "s-old"})
+
+	// Re-adding an existing member moves it to the top (filter + prepend).
+	if err := addSessionToGroup(gid, "s-old"); err != nil {
+		t.Fatalf("addSessionToGroup(s-old again): %v", err)
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("SessionIDs = %v, want %v", got, want)
+	assertGroupOrder(t, gid, []string{"s-old", "s-new", "s-mid"})
+}
+
+// assertGroupOrder reloads the registry from disk and asserts the group's
+// SessionIDs exactly match want, in order.
+func assertGroupOrder(t *testing.T, gid string, want []string) {
+	t.Helper()
+	groups, err := loadSessionGroups()
+	if err != nil {
+		t.Fatalf("loadSessionGroups: %v", err)
+	}
+	for _, g := range groups {
+		if g.ID != gid {
+			continue
 		}
+		if len(g.SessionIDs) != len(want) {
+			t.Fatalf("SessionIDs = %v, want %v", g.SessionIDs, want)
+		}
+		for i := range want {
+			if g.SessionIDs[i] != want[i] {
+				t.Fatalf("SessionIDs = %v, want %v", g.SessionIDs, want)
+			}
+		}
+		return
 	}
+	t.Fatalf("group %s not found", gid)
 }
 
 func TestSessionGroups_Delete(t *testing.T) {

--- a/internal/server/session_groups_test.go
+++ b/internal/server/session_groups_test.go
@@ -166,6 +166,31 @@ func TestSessionGroups_SingleMembership(t *testing.T) {
 	}
 }
 
+func TestAddSessionToGroup_PrependsNewest(t *testing.T) {
+	srv := groupTestServer(t)
+	_, out := doGroupReq(t, srv, http.MethodPost, "/api/session-groups", map[string]any{"name": "G"})
+	gid := out["group"].(map[string]any)["id"].(string)
+
+	// Newly created sessions land at the top of their group, newest first —
+	// matching the sidebar's newest-first session list.
+	for _, sid := range []string{"s-old", "s-mid", "s-new"} {
+		if err := addSessionToGroup(gid, sid); err != nil {
+			t.Fatalf("addSessionToGroup(%s): %v", sid, err)
+		}
+	}
+	groups, _ := loadSessionGroups()
+	want := []string{"s-new", "s-mid", "s-old"}
+	got := groups[0].SessionIDs
+	if len(got) != len(want) {
+		t.Fatalf("SessionIDs = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("SessionIDs = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestSessionGroups_Delete(t *testing.T) {
 	srv := groupTestServer(t)
 	_, out := doGroupReq(t, srv, http.MethodPost, "/api/session-groups", map[string]any{"name": "Temp"})

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -267,7 +267,7 @@ export async function createSessionInGroup(groupId: string): Promise<void> {
   const sess = await api.createSession({ source: 'manual', group_id: groupId })
   sessions.update(ss => [sess, ...ss])
   sessionGroups.update(gs =>
-    gs.map(g => (g.id === groupId ? { ...g, session_ids: [...g.session_ids, sess.id] } : g)),
+    gs.map(g => (g.id === groupId ? { ...g, session_ids: [sess.id, ...g.session_ids] } : g)),
   )
   activeSessionId.set(sess.id)
   view.set('chat')


### PR DESCRIPTION
## Problem

Creating a session from a group's "+" button appends it to the end of the group's `session_ids`, so the new session renders at the **bottom** of the group in the sidebar — inconsistent with the newest-first ordering used everywhere else in the session list.

## Fix

- `addSessionToGroup` (server) now **prepends** the session ID. This covers both the sidebar per-group "+" flow (`POST /api/sessions` with `group_id`) and task-run sessions filed under their task group — both are "newly created session enters a group", so newest-first applies to both.
- `createSessionInGroup` (web) patches the local group store with the same prepend so the sidebar shows the new session at the top without a refetch.
- Moving an **existing** session into a group (`PUT /api/sessions/{id}/group`, sidebar "move to group") keeps the append behavior — unchanged.

## Tests

- New `TestAddSessionToGroup_PrependsNewest` asserts newest-first order after successive adds.
- `go test -race ./internal/server/` (group/pin/create-session tests), `go vet`, `gofmt` clean.
- `svelte-check`: 0 errors; `vitest`: 225 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)