### PR TITLE
chore: bump version to 1.15.14

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.13"
+var Version = "1.15.14"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release carrying #2116 (collapsible sessions in the web sidebar) and #2115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)