### PR TITLE
fix(web): show upgrade progress when upgrade is started outside the badge

### DIFF
--- a/web/src/components/layout/VersionBadge.svelte
+++ b/web/src/components/layout/VersionBadge.svelte
@@ -90,8 +90,11 @@
       // An upgrade can be started elsewhere (the Settings modal's Upgrade
       // button, another client, or before this page loaded) — the broadcasts
       // are the only signal. Enter the upgrading phase and open the popover
-      // so progress is visible no matter who triggered it (#2120).
-      if (phase === 'idle') { phase = 'upgrading'; open = true }
+      // so progress is visible no matter who triggered it (#2120). Drop any
+      // log kept from an earlier failed run; a self-triggered upgrade has
+      // already left idle by the time its broadcasts arrive, so this never
+      // clears its own stream.
+      if (phase === 'idle') { phase = 'upgrading'; logLines = []; open = true }
       logLines = [...logLines, ev.line ?? '']
       queueMicrotask(() => { if (logEl) logEl.scrollTop = logEl.scrollHeight })
     })

--- a/web/src/components/layout/VersionBadge.svelte
+++ b/web/src/components/layout/VersionBadge.svelte
@@ -87,6 +87,11 @@
     // upgrade_log / upgrade_complete are global broadcasts (no session_id); the
     // WS dispatch is by type, so these fire regardless of the active session.
     const offLog = ws.on('upgrade_log', (ev: any) => {
+      // An upgrade can be started elsewhere (the Settings modal's Upgrade
+      // button, another client, or before this page loaded) — the broadcasts
+      // are the only signal. Enter the upgrading phase and open the popover
+      // so progress is visible no matter who triggered it (#2120).
+      if (phase === 'idle') { phase = 'upgrading'; open = true }
       logLines = [...logLines, ev.line ?? '']
       queueMicrotask(() => { if (logEl) logEl.scrollTop = logEl.scrollHeight })
     })

--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -136,9 +136,14 @@
         // — fire it here too and let the badge (always mounted) show live
         // progress via the WS broadcasts it already listens for. Close this
         // modal so the badge's progress popover isn't hidden behind it (#2120).
-        await fetch('/api/version/upgrade', { method: 'POST' })
-        showToast($t('settings.update.started'), 'success')
-        settingsModalOpen.set(false)
+        // 409 = an upgrade is already in flight; its broadcasts drive the
+        // badge, so treat it as started. Any other failure sends no
+        // broadcasts — keep the modal open instead of claiming success.
+        const res = await fetch('/api/version/upgrade', { method: 'POST' })
+        if (res.ok || res.status === 409) {
+          showToast($t('settings.update.started'), 'success')
+          settingsModalOpen.set(false)
+        }
       }
     } finally {
       checkingUpdate = false

--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -134,9 +134,11 @@
       } else {
         // Same endpoint VersionBadge's badge uses (POST /api/version/upgrade)
         // — fire it here too and let the badge (always mounted) show live
-        // progress via the WS broadcasts it already listens for.
+        // progress via the WS broadcasts it already listens for. Close this
+        // modal so the badge's progress popover isn't hidden behind it (#2120).
         await fetch('/api/version/upgrade', { method: 'POST' })
         showToast($t('settings.update.started'), 'success')
+        settingsModalOpen.set(false)
       }
     } finally {
       checkingUpdate = false


### PR DESCRIPTION
## Problem

Fixes #2120.

The web UI has two upgrade entry points, both hitting `POST /api/version/upgrade`:

1. The bottom-left **version badge** popover — sets its own `phase = 'upgrading'` locally, so a progress box appears.
2. The **Settings modal → About → Upgrade** button — fires the request and shows a toast, relying (per its own comment) on the always-mounted VersionBadge to surface progress via the global `upgrade_log` / `upgrade_complete` WS broadcasts.

But VersionBadge's `upgrade_log` handler only accumulated log lines — it never entered the `upgrading` phase, and both the badge spinner and the progress popover are driven by `phase`. So an upgrade started from the Settings modal showed **no progress at all** until completion. That's exactly what the issue reports: progress only appears if you separately click the version badge (whose local phase flip + tolerated 409 happens to reveal the already-accumulated log).

## Fix

- `VersionBadge.svelte`: on the first `upgrade_log` broadcast, if the badge is idle, enter the `upgrading` phase and open the progress popover. This covers the Settings-modal trigger, upgrades started by another client, and pages loaded while an upgrade is already in flight.
- `SettingsModal.svelte`: close the modal after starting an upgrade — the modal scrim (z-index 1000) would otherwise hide the badge popover (z-index 61).

Installer-mode (desktop) flows are untouched; this only affects the in-place `cli` upgrade path.

## Testing

- `svelte-check`: 0 errors
- `vitest run` in `web/`: 225 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)