### PR TITLE
fix(web): guard slash-menu against stale async mcp-tool fetch

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -485,7 +485,13 @@
     }
   }
 
+  // Generation guard (like modelsFetchSeq): the mcp-tool branch awaits a
+  // fetch mid-keystroke-stream, and a stale invocation resuming after the
+  // user deleted the trigger or switched servers must not re-open its menu.
+  let slashInputSeq = 0
+
   async function handleSlashInput() {
+    const seq = ++slashInputSeq
     const normalized = normalizeSlash(text)
     if (normalized !== text) text = normalized
     const parsed = parseSlashInput(text)
@@ -514,6 +520,7 @@
     }
     if (parsed.mode === 'mcp-tool' && parsed.serverName) {
       await maybeLoadMcpTools(parsed.serverName)
+      if (seq !== slashInputSeq) return
       showSlashMenu('mcp-tools', parsed.query, parsed.serverName)
       return
     }


### PR DESCRIPTION
## Problem

Fixes #2092.

`handleSlashInput()` fires unawaited on every keystroke, and its `mcp-tool` branch suspends on `await maybeLoadMcpTools(...)` (a network fetch on the first open of each server). While a stale invocation is suspended, the user can delete the trigger text (a later invocation hides the menu) or type a different server name (a later invocation shows that server's menu). When the stale call resumes it unconditionally calls `showSlashMenu(...)` with its captured values — re-opening a phantom menu with the wrong server's tools; selecting a row then replaces the composer's current text with a stale command.

## Fix

Add a generation counter `slashInputSeq`, incremented at the top of every `handleSlashInput()` invocation; after the `await`, bail out if a newer invocation has run. This is the same pattern `refreshModels()` already uses in this file (`modelsFetchSeq`) for the same overlapping-fetch problem. The `await` in the mcp-tool branch is the only suspension point in the function, so the single post-await check covers all races.

## Testing

- `svelte-check`: 0 errors (2 pre-existing CSS warnings in unrelated views)
- `vitest run` in `web/`: 225 tests pass
- No component-level test added: the repo has no Svelte component test setup (all web tests are lib-level pure functions), and the sibling `modelsFetchSeq` guard is likewise untested; adding a component-testing framework for this would be a new dependency out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)