### PR TITLE
fix(web): read ev.result in Markdown transcript export tool results

### DIFF
--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1685,7 +1685,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
           if (type === 'tool_call') {
             lines.push(`- **Tool call**: ${ev.tool_name ?? ev.name ?? 'unknown'}`, '')
           } else {
-            lines.push(`- **Tool result**: ${typeof ev.content === 'string' ? ev.content.slice(0, 500) : '(non-text result)'}`, '')
+            lines.push(`- **Tool result**: ${typeof ev.result === 'string' ? ev.result.slice(0, 500) : '(non-text result)'}`, '')
           }
         } else {
           omittedToolEvents = true


### PR DESCRIPTION
## Problem

Fixes #2091.

Exporting a chat transcript to Markdown with "include tools" enabled emitted `(non-text result)` for 100% of tool results. The export branch read `ev.content`, but the server only ever sends `ev.result` for `tool_result` events — both the history-replay path (`internal/server/handlers.go`) and the live WS path (`internal/server/ws_handlers.go`) build `{type: "tool_result", result: …, tool_id: …}` with no `content` key — so the `typeof ev.content === 'string'` check was always false and the ternary always took the fallback.

## Fix

Read `ev.result` instead, matching the same file's history-replay path (`updateToolResult(sid, ev.tool_id, ev.result, …)`). The `(non-text result)` placeholder now only fires when the field is genuinely absent or non-text. One-line change.

## Testing

- `svelte-check`: 0 errors (2 pre-existing CSS warnings in unrelated views)
- `vitest run` in `web/`: 225 tests pass
- Verified server-side both event-building paths send `result` as a string (`agent.StripRemindersForDisplay(b.Result)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)