### PR TITLE
fix(agent): recognize CN-provider context-overflow error strings

### DIFF
--- a/internal/agent/overflow.go
+++ b/internal/agent/overflow.go
@@ -66,7 +66,8 @@ type overflowRecovery struct {
 // contextTooLongError detects whether an error is about exceeding the model's
 // context window. Aligned with Ruby's context_too_long_error?.
 //
-// Coverage (verified against real production error strings):
+// Coverage (verified against real production error strings, except where a
+// phrase's own comment marks it as a defensive generic):
 //
 //	OpenAI:    "This model's maximum context length is 128000 tokens..."
 //	Anthropic: "prompt is too long: 218849 tokens > 200000 maximum"
@@ -104,12 +105,18 @@ func contextTooLongError(err error) bool {
 		// errors, and "max_tokens exceeds the maximum" parameter rejections
 		// must not be classified as context overflow.
 		"exceeded model token limit",
-		// Zhipu bigmodel.cn error code 1261. The message is Chinese-only;
-		// matched against the lowercased error string.
+		// Zhipu bigmodel.cn error code 1261. The message is Chinese-only
+		// ("Prompt 超长" per the official error-code table); matched against
+		// the lowercased error string, with a no-space variant in case the
+		// endpoint omits it.
 		"prompt 超长",
-		// Common Chinese phrasing used by CN-hosted endpoints for the same
-		// condition (e.g. "输入长度超限", "上下文长度超过限制").
-		"长度超限",
+		"prompt超长",
+		// Defensive generics for CN-hosted endpoints (not verified against a
+		// specific production string). Deliberately INPUT-scoped: a bare
+		// "长度超限" would also match "输出长度超限" — the Chinese wording of
+		// an output-side max_tokens rejection, which must not be classified
+		// as context overflow (same trap as the English guard above).
+		"输入长度超限",
 		"上下文长度超过",
 	}
 	for _, p := range strongPhrases {

--- a/internal/agent/overflow.go
+++ b/internal/agent/overflow.go
@@ -18,6 +18,8 @@ var (
 	// OpenAI: "maximum context length is 128000 tokens ... you requested 130000".
 	reMaxContextLen = regexp.MustCompile(`maximum context length is (\d+)`)
 	reRequested     = regexp.MustCompile(`requested (?:about |~)?(\d+)`)
+	// Moonshot/Kimi: "Your request exceeded model token limit: 262144 (requested: 269030)".
+	reTokenLimitRequested = regexp.MustCompile(`token limit:\s*(\d+)\s*\(requested:\s*(\d+)\)`)
 )
 
 // parseOverflowTokens extracts (have, max) token counts from a context-overflow
@@ -44,6 +46,13 @@ func parseOverflowTokens(err error) (have, max int, ok bool) {
 			}
 		}
 	}
+	if m := reTokenLimitRequested.FindStringSubmatch(msg); m != nil {
+		mx, _ := strconv.Atoi(m[1])
+		h, _ := strconv.Atoi(m[2])
+		if h > mx && mx > 0 {
+			return h, mx, true
+		}
+	}
 	return 0, 0, false
 }
 
@@ -63,6 +72,9 @@ type overflowRecovery struct {
 //	Anthropic: "prompt is too long: 218849 tokens > 200000 maximum"
 //	Qwen:      "You passed 117345 input tokens... context length is only 125536"
 //	DeepSeek:  Variants of "context length" / "tokens exceeds"
+//	Kimi:      "Invalid request: Your request exceeded model token limit: 262144 (requested: 269030)"
+//	Zhipu:     "Prompt 超长" (bigmodel.cn error code 1261)
+//	DashScope: "InternalError.Algo.InvalidParameter: Range of input length should be [1, 202752]"
 //	Generic:   "The total number of tokens exceeds the model's maximum context length"
 func contextTooLongError(err error) bool {
 	if err == nil {
@@ -86,6 +98,19 @@ func contextTooLongError(err error) bool {
 		"reduce the length of your",
 		"reduce the length of the prompt",
 		"range of input length",
+		// Moonshot/Kimi (OpenAI protocol): "Your request exceeded model
+		// token limit: 262144 (requested: 269030)". Deliberately the full
+		// phrase — a bare "token limit" would also match rate-limit (TPM)
+		// errors, and "max_tokens exceeds the maximum" parameter rejections
+		// must not be classified as context overflow.
+		"exceeded model token limit",
+		// Zhipu bigmodel.cn error code 1261. The message is Chinese-only;
+		// matched against the lowercased error string.
+		"prompt 超长",
+		// Common Chinese phrasing used by CN-hosted endpoints for the same
+		// condition (e.g. "输入长度超限", "上下文长度超过限制").
+		"长度超限",
+		"上下文长度超过",
 	}
 	for _, p := range strongPhrases {
 		if strings.Contains(msg, p) {

--- a/internal/agent/overflow_test.go
+++ b/internal/agent/overflow_test.go
@@ -60,8 +60,13 @@ func TestContextTooLongError(t *testing.T) {
 		{"dashscope glm", "InternalError.Algo.InvalidParameter: Range of input length should be [1, 202752]", true},
 		{"kimi", "Invalid request: Your request exceeded model token limit: 262144 (requested: 269030)", true},
 		{"zhipu 1261", "Prompt 超长", true},
+		{"zhipu 1261 no space", "Prompt超长", true},
 		{"cn generic length limit", "输入长度超限，请减少输入内容", true},
 		{"cn generic context", "上下文长度超过模型限制", true},
+		// The Chinese wording of an OUTPUT-side max_tokens rejection must
+		// not be classified as context overflow — a bare "长度超限" phrase
+		// would match it.
+		{"cn output length rejection", "输出长度超限，请降低 max_tokens", false},
 		{"unrelated failure", "connection reset by peer", false},
 		// A max_tokens PARAMETER rejection is not a context overflow —
 		// treating it as one dead-ends recovery in a compression loop.

--- a/internal/agent/overflow_test.go
+++ b/internal/agent/overflow_test.go
@@ -22,11 +22,19 @@ func TestParseOverflowTokens(t *testing.T) {
 			130512, 128000, true,
 		},
 		{
+			"kimi", "Invalid request: Your request exceeded model token limit: 262144 (requested: 269030)",
+			269030, 262144, true,
+		},
+		{
 			"not an overflow error", "some unrelated failure",
 			0, 0, false,
 		},
 		{
 			"have not greater than max is rejected", "5 tokens > 9 maximum",
+			0, 0, false,
+		},
+		{
+			"kimi have not greater than max is rejected", "exceeded model token limit: 262144 (requested: 1000)",
 			0, 0, false,
 		},
 	}
@@ -36,6 +44,34 @@ func TestParseOverflowTokens(t *testing.T) {
 			if ok != c.ok || (ok && (have != c.have || max != c.max)) {
 				t.Errorf("parseOverflowTokens(%q) = (%d, %d, %v), want (%d, %d, %v)",
 					c.msg, have, max, ok, c.have, c.max, c.ok)
+			}
+		})
+	}
+}
+
+func TestContextTooLongError(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{"anthropic", "prompt is too long: 218849 tokens > 200000 maximum", true},
+		{"openai", "This model's maximum context length is 128000 tokens", true},
+		{"dashscope glm", "InternalError.Algo.InvalidParameter: Range of input length should be [1, 202752]", true},
+		{"kimi", "Invalid request: Your request exceeded model token limit: 262144 (requested: 269030)", true},
+		{"zhipu 1261", "Prompt 超长", true},
+		{"cn generic length limit", "输入长度超限，请减少输入内容", true},
+		{"cn generic context", "上下文长度超过模型限制", true},
+		{"unrelated failure", "connection reset by peer", false},
+		// A max_tokens PARAMETER rejection is not a context overflow —
+		// treating it as one dead-ends recovery in a compression loop.
+		{"max_tokens rejection", "max_tokens: expected a value <= 32768, but got 65536 instead", false},
+		{"rate limit", "rate limit exceeded, please retry later", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := contextTooLongError(errors.New(c.msg)); got != c.want {
+				t.Errorf("contextTooLongError(%q) = %v, want %v", c.msg, got, c.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

`contextTooLongError` only matches English phrasings (verified against OpenAI / Anthropic / Qwen / DeepSeek production errors). Overflow errors from CN-hosted endpoints are never classified as context overflow, so the recovery pipeline (stale-tool-result reclaim → compaction retry) never runs and the turn fails outright — one of the suspected failure paths in #2118 (huge tool output → overflow → reply destroyed).

Verified real-world strings that currently slip through:

- Zhipu bigmodel.cn error code 1261: `Prompt 超长` (Chinese-only message, [official error-code doc](https://docs.bigmodel.cn/cn/faq/api-code))
- Moonshot/Kimi: `Invalid request: Your request exceeded model token limit: 262144 (requested: 269030)` — contains neither "tokens" + "maximum" nor any strong phrase ([reported in MoonshotAI/kimi-cli#2011](https://github.com/MoonshotAI/kimi-cli/issues/2011))

(DashScope-hosted GLM's `Range of input length should be [1, N]` was already covered by the existing `range of input length` phrase.)

## Fix

- Add strong phrases: `exceeded model token limit` (deliberately the full phrase — a bare "token limit" would also match TPM rate-limit errors), `prompt 超长`, and the generic Chinese phrasings `长度超限` / `上下文长度超过`.
- Teach `parseOverflowTokens` the Kimi `token limit: N (requested: M)` format so Layer-0 reclaim knows the exact deficit and can skip the summarize call when it frees enough.
- Regression tests, including a guard that a `max_tokens` PARAMETER rejection is NOT classified as overflow (misclassifying it would dead-end recovery in a compression loop).

## Testing

`go test -race ./internal/agent/` passes; `gofmt -l` clean.

Part of the follow-up to #2118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)