### PR TITLE
fix(agent): sanitize control bytes, ANSI escapes, and invalid UTF-8 in tool results

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2002,7 +2002,10 @@ func (a *Agent) applyPostToolUse(ctx context.Context, uses, results []ContentBlo
 		p.ToolName = u.Name
 		p.ToolInput = u.Input
 		p.ToolResult = rb.Result
-		if extra := a.Hooks.Inject(ctx, p); extra != "" {
+		// Hook output is external script stdout appended AFTER the
+		// toolResultBlocks chokepoint — sanitize it here too, or it would
+		// reintroduce the very bytes the chokepoint just scrubbed.
+		if extra := sanitizeToolResultText(a.Hooks.Inject(ctx, p)); extra != "" {
 			if rb.Result == "" {
 				rb.Result = extra
 			} else {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1959,13 +1959,15 @@ func canParallelize(calls []toolCall) bool {
 
 // toolResultBlocks builds a slice of content blocks from a ToolResult.
 // The first element is always the tool_result block; any additional blocks
-// (e.g. images) from the result are appended after it.
+// (e.g. images) from the result are appended after it. Text is sanitized
+// (control bytes, invalid UTF-8, ANSI escapes) before the size backstop so
+// the 40 KB cap holds on the bytes that actually enter history.
 func toolResultBlocks(id string, result ToolResult, err error) []ContentBlock {
 	if err != nil {
-		return []ContentBlock{NewToolResultBlock(id, microCompact(err.Error()), true)}
+		return []ContentBlock{NewToolResultBlock(id, microCompact(sanitizeToolResultText(err.Error())), true)}
 	}
 	blocks := make([]ContentBlock, 0, 1+len(result.Blocks))
-	rb := NewToolResultBlock(id, microCompact(result.Text), false)
+	rb := NewToolResultBlock(id, microCompact(sanitizeToolResultText(result.Text)), false)
 	rb.UI = result.UI
 	blocks = append(blocks, rb)
 	blocks = append(blocks, result.Blocks...)

--- a/internal/agent/sanitize.go
+++ b/internal/agent/sanitize.go
@@ -23,7 +23,9 @@ var ansiEscape = regexp.MustCompile(`\x1b(?:\[[0-9;:?<=>]*[ -/]*[@-~]|\][^\x07\x
 //     not information, and once the ESC byte is replaced below they would
 //     degrade into "�[31m" noise.
 //   - Remaining C0 control bytes other than \t, \n, \r — plus DEL — are
-//     replaced with U+FFFD.
+//     replaced with U+FFFD. Correctly-encoded C1 controls (U+0080–U+009F)
+//     are deliberately left alone: they are valid UTF-8 and harmless on the
+//     JSON wire, while a raw C1 byte is invalid UTF-8 and caught below.
 //   - Invalid UTF-8 is coerced to U+FFFD here, eagerly, so history matches
 //     the bytes actually sent.
 //

--- a/internal/agent/sanitize.go
+++ b/internal/agent/sanitize.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// ansiEscape matches well-formed ANSI escape sequences: CSI sequences
+// (colors, cursor movement — ESC [ params final-byte) and OSC sequences
+// (window titles, hyperlinks — ESC ] payload terminated by BEL or ST).
+var ansiEscape = regexp.MustCompile(`\x1b(?:\[[0-9;:?<=>]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\))`)
+
+// sanitizeToolResultText makes tool output safe for the JSON wire and useful
+// to the model. Commands that dump binary data (analyzing an executable,
+// catting an image) fill the result with NUL and other control bytes and with
+// invalid UTF-8 — strict backends reject a literal NUL (\u0000) in JSON
+// strings, and Go's json.Marshal silently coerces invalid UTF-8 at encode
+// time, leaving the persisted session and the wire disagreeing about what
+// the model saw.
+//
+//   - Well-formed ANSI escape sequences are stripped: they carry styling,
+//     not information, and once the ESC byte is replaced below they would
+//     degrade into "�[31m" noise.
+//   - Remaining C0 control bytes other than \t, \n, \r — plus DEL — are
+//     replaced with U+FFFD.
+//   - Invalid UTF-8 is coerced to U+FFFD here, eagerly, so history matches
+//     the bytes actually sent.
+//
+// The common case (clean text) is detected with a single byte scan and
+// returned unchanged.
+func sanitizeToolResultText(s string) string {
+	if !needsSanitize(s) {
+		return s
+	}
+	if strings.IndexByte(s, 0x1b) >= 0 {
+		s = ansiEscape.ReplaceAllString(s, "")
+	}
+	s = strings.ToValidUTF8(s, "�")
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return r
+		}
+		if r < 0x20 || r == 0x7f {
+			return '�'
+		}
+		return r
+	}, s)
+}
+
+// needsSanitize reports whether s contains a control byte (other than \t, \n,
+// \r), DEL, or invalid UTF-8. A pure byte scan: control bytes and UTF-8
+// validity are both decidable without decoding runes.
+func needsSanitize(s string) bool {
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b < 0x20 && b != '\t' && b != '\n' && b != '\r' {
+			return true
+		}
+		if b == 0x7f {
+			return true
+		}
+	}
+	return !utf8.ValidString(s)
+}

--- a/internal/agent/sanitize_test.go
+++ b/internal/agent/sanitize_test.go
@@ -18,6 +18,9 @@ func TestSanitizeToolResultText(t *testing.T) {
 		{"tab newline cr kept", "a\tb\nc\rd", "a\tb\nc\rd"},
 		{"csi color stripped", "\x1b[31mred\x1b[0m plain", "red plain"},
 		{"csi cursor stripped", "\x1b[2Kline", "line"},
+		{"csi with intermediate byte stripped", "\x1b[4 qcursor", "cursor"},
+		// Correctly-encoded C1 controls are valid UTF-8 and pass through.
+		{"encoded c1 kept", "a\u0085b", "a\u0085b"},
 		{"osc bel stripped", "\x1b]0;title\x07body", "body"},
 		{"osc st stripped", "\x1b]8;;https://x\x1b\\link\x1b]8;;\x1b\\", "link"},
 		{"bare esc replaced", "a\x1bb", "a�b"},

--- a/internal/agent/sanitize_test.go
+++ b/internal/agent/sanitize_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeToolResultText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"clean text unchanged", "hello 世界\nsecond line\ttabbed\r\n", "hello 世界\nsecond line\ttabbed\r\n"},
+		{"nul replaced", "MZ\x00\x00PE header", "MZ��PE header"},
+		{"c0 controls replaced", "a\x01b\x02c", "a�b�c"},
+		{"del replaced", "a\x7fb", "a�b"},
+		{"tab newline cr kept", "a\tb\nc\rd", "a\tb\nc\rd"},
+		{"csi color stripped", "\x1b[31mred\x1b[0m plain", "red plain"},
+		{"csi cursor stripped", "\x1b[2Kline", "line"},
+		{"osc bel stripped", "\x1b]0;title\x07body", "body"},
+		{"osc st stripped", "\x1b]8;;https://x\x1b\\link\x1b]8;;\x1b\\", "link"},
+		{"bare esc replaced", "a\x1bb", "a�b"},
+		{"unterminated osc leaves replaced esc", "a\x1b]0;title", "a�]0;title"},
+		// A run of invalid bytes collapses to ONE replacement char —
+		// strings.ToValidUTF8 semantics, and less noise for the model.
+		{"invalid utf8 coerced", "ok\xff\xfebad", "ok�bad"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sanitizeToolResultText(c.in); got != c.want {
+				t.Errorf("sanitizeToolResultText(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestToolResultBlocks_SanitizesBinaryGarbage pins the integration point: a
+// tool result carrying binary bytes must enter history sanitized, on both the
+// success and the error path.
+func TestToolResultBlocks_SanitizesBinaryGarbage(t *testing.T) {
+	blocks := toolResultBlocks("tu_1", ToolResult{Text: "ELF\x00\x00\x01\x02"}, nil)
+	if got := blocks[0].Result; strings.ContainsRune(got, 0) {
+		t.Errorf("success path kept a NUL byte: %q", got)
+	}
+
+	blocks = toolResultBlocks("tu_2", ToolResult{}, errBinary("fail\x00ure"))
+	if got := blocks[0].Result; strings.ContainsRune(got, 0) {
+		t.Errorf("error path kept a NUL byte: %q", got)
+	}
+}
+
+type errBinary string
+
+func (e errBinary) Error() string { return string(e) }
+
+// TestSanitizeThenCompact_CapHolds ensures sanitization runs before the size
+// backstop: replacing single junk bytes with the 3-byte U+FFFD must not push
+// the stored result past ToolResultMaxBytes.
+func TestSanitizeThenCompact_CapHolds(t *testing.T) {
+	junk := strings.Repeat("x\x01", ToolResultMaxBytes) // expands ~2x when sanitized
+	blocks := toolResultBlocks("tu_3", ToolResult{Text: junk}, nil)
+	if n := len(blocks[0].Result); n > ToolResultMaxBytes {
+		t.Errorf("stored result is %d bytes, want <= %d", n, ToolResultMaxBytes)
+	}
+}


### PR DESCRIPTION
## Problem

A command that dumps binary data (e.g. running a Python script to analyze an executable — the #2118 scenario) fills its tool result with NUL and other C0 control bytes and invalid UTF-8:

- Strict backends reject a literal NUL (`\u0000`) inside JSON strings with a 400, failing the whole turn — and since that error is not a context-overflow, no recovery runs and the reply is destroyed.
- Go's `json.Marshal` silently coerces invalid UTF-8 to U+FFFD at encode time, so the persisted session disagrees with the bytes actually sent to the model.

## Fix

Sanitize at the `toolResultBlocks` chokepoint (the single place every tool result — success and error path — enters history), **before** the 40 KB `microCompact` backstop so the cap holds on the stored bytes:

- Strip well-formed ANSI CSI/OSC escape sequences: they carry styling, not information, and once the ESC byte is replaced they would degrade into visible `�[31m` noise.
- Replace remaining C0 control bytes (other than tab/newline/CR) plus DEL with U+FFFD.
- Coerce invalid UTF-8 to U+FFFD eagerly, so history matches the wire.

Clean text — the overwhelmingly common case — is detected with a single byte scan and returned unchanged, no allocation.

## Testing

New unit tests cover each byte class, the ANSI forms (CSI, OSC+BEL, OSC+ST, bare/unterminated ESC), both integration paths, and a guard that sanitization's 1→3-byte expansion cannot push a stored result past `ToolResultMaxBytes`. `go test -race ./internal/agent/` passes; `gofmt -l` clean.

Part of the follow-up to #2118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)