### PR TITLE
fix(web): install the marked custom renderer once at module scope

### DIFF
--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { marked } from 'marked'
 import { renderMarkdown } from './markdown'
 
 describe('renderMarkdown: blockquote contents', () => {
@@ -74,5 +75,24 @@ describe('renderMarkdown: tables', () => {
     expect(out).toContain('<td>a|b</td>')
     // The escaped pipe must not create a spurious second column.
     expect(out.match(/<td>/g)).toHaveLength(1)
+  })
+})
+
+describe('renderMarkdown: renderer installed once (#2089)', () => {
+  it('does not re-wrap the global renderer methods on every render', () => {
+    // marked.use() wraps already-installed renderer methods in a new closure
+    // per call; installing per render grew an unbounded wrapper chain. With a
+    // single module-scope install, the installed method references must stay
+    // identical across renders.
+    renderMarkdown('warm-up **render**')
+    const installed = (marked.defaults as any).renderer
+    const before = { code: installed.code, link: installed.link, blockquote: installed.blockquote, table: installed.table }
+    for (let i = 0; i < 5; i++) renderMarkdown(`render pass ${i} with \`code\` and [a link](https://example.com)`)
+    const after = (marked.defaults as any).renderer
+    expect(after).toBe(installed)
+    expect(after.code).toBe(before.code)
+    expect(after.link).toBe(before.link)
+    expect(after.blockquote).toBe(before.blockquote)
+    expect(after.table).toBe(before.table)
   })
 })

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -31,6 +31,73 @@ export function escapeHtml(s: string): string {
     .replace(/'/g, "&#39;")
 }
 
+function isSafeHref(href: string): boolean {
+  if (!href) return false
+  const lower = href.trim().toLowerCase()
+  return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("mailto:") || lower.startsWith("tel:")
+}
+
+// Custom renderer, installed ONCE at module scope. marked.use() re-wraps the
+// already-installed renderer methods in a fresh closure layer on every call,
+// so installing per render() grew an unbounded wrapper chain on the global
+// marked instance — a monotonic memory leak in streaming chat views (#2089).
+// None of the overrides capture per-call state, so a single install is
+// semantically identical.
+const renderer = new Renderer()
+
+renderer.code = function ({ text: codeText, lang }: { text: string; lang?: string }) {
+  const language = lang && hljs.getLanguage(lang) ? lang : "plaintext"
+  let highlighted: string
+  if (language !== "plaintext") {
+    highlighted = hljs.highlight(codeText, { language }).value
+  } else {
+    highlighted = escapeHtml(codeText)
+  }
+  return `<div class="code-block">
+  <div class="code-header">
+    <span class="code-lang">${escapeHtml(language)}</span>
+    <button class="copy-btn">Copy</button>
+  </div>
+  <pre><code class="hljs language-${escapeHtml(language)}">${highlighted}</code></pre>
+</div>`
+}
+
+renderer.link = function ({ href, title, text }: { href: string; title?: string | null; text: string }) {
+  // Only allow safe URL schemes; strip everything else.
+  const safe = isSafeHref(href)
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : ""
+  return `<a href="${safe ? escapeHtml(href) : ""}"${titleAttr} target="_blank" rel="noopener">${escapeHtml(text)}</a>`
+}
+
+// Render the quote's children, don't interpolate token.text — that field is
+// the raw markdown source, so `> quoted **bold**` reached the DOM with the
+// asterisks intact and every link, inline code span and nested list inside a
+// quote came out as literal text. The default renderer parses token.tokens;
+// this override exists only to add the md-bq class, so it has to do the same.
+renderer.blockquote = function ({ tokens }: Tokens.Blockquote) {
+  return `<blockquote class="md-bq">${this.parser.parse(tokens)}</blockquote>`
+}
+
+// Wrap marked's default table in a horizontal-scroll container so wide
+// tables don't blow out the flex bubble / .md-content column. The table
+// itself stays a real <table> (reusing the default tablecell/tablerow), so
+// thead/tbody columns keep aligning and per-cell alignment survives.
+renderer.table = function (token: Tokens.Table) {
+  let header = ""
+  for (const cell of token.header) header += this.tablecell(cell)
+  header = this.tablerow({ text: header })
+  let body = ""
+  for (const row of token.rows) {
+    let cells = ""
+    for (const cell of row) cells += this.tablecell(cell)
+    body += this.tablerow({ text: cells })
+  }
+  if (body) body = `<tbody>${body}</tbody>`
+  return `<div class="table-scroll"><table><thead>${header}</thead>${body}</table></div>`
+}
+
+marked.use({ renderer })
+
 export function renderMarkdown(text: string, showReasoning = true): string {
   if (!text) return ""
 
@@ -45,72 +112,10 @@ export function renderMarkdown(text: string, showReasoning = true): string {
     return `${PLACEHOLDER}${index}\x00`
   })
 
-  // 3. Set up custom renderer
-  const renderer = new Renderer()
-
-  renderer.code = function ({ text: codeText, lang }: { text: string; lang?: string }) {
-    const language = lang && hljs.getLanguage(lang) ? lang : "plaintext"
-    let highlighted: string
-    if (language !== "plaintext") {
-      highlighted = hljs.highlight(codeText, { language }).value
-    } else {
-      highlighted = escapeHtml(codeText)
-    }
-    return `<div class="code-block">
-  <div class="code-header">
-    <span class="code-lang">${escapeHtml(language)}</span>
-    <button class="copy-btn">Copy</button>
-  </div>
-  <pre><code class="hljs language-${escapeHtml(language)}">${highlighted}</code></pre>
-</div>`
-  }
-
-  renderer.link = function ({ href, title, text }: { href: string; title?: string | null; text: string }) {
-    // Only allow safe URL schemes; strip everything else.
-    const safe = isSafeHref(href)
-    const titleAttr = title ? ` title="${escapeHtml(title)}"` : ""
-    return `<a href="${safe ? escapeHtml(href) : ""}"${titleAttr} target="_blank" rel="noopener">${escapeHtml(text)}</a>`
-  }
-
-  function isSafeHref(href: string): boolean {
-    if (!href) return false
-    const lower = href.trim().toLowerCase()
-    return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("mailto:") || lower.startsWith("tel:")
-  }
-
-  // Render the quote's children, don't interpolate token.text — that field is
-  // the raw markdown source, so `> quoted **bold**` reached the DOM with the
-  // asterisks intact and every link, inline code span and nested list inside a
-  // quote came out as literal text. The default renderer parses token.tokens;
-  // this override exists only to add the md-bq class, so it has to do the same.
-  renderer.blockquote = function ({ tokens }: Tokens.Blockquote) {
-    return `<blockquote class="md-bq">${this.parser.parse(tokens)}</blockquote>`
-  }
-
-  // Wrap marked's default table in a horizontal-scroll container so wide
-  // tables don't blow out the flex bubble / .md-content column. The table
-  // itself stays a real <table> (reusing the default tablecell/tablerow), so
-  // thead/tbody columns keep aligning and per-cell alignment survives.
-  renderer.table = function (token: Tokens.Table) {
-    let header = ""
-    for (const cell of token.header) header += this.tablecell(cell)
-    header = this.tablerow({ text: header })
-    let body = ""
-    for (const row of token.rows) {
-      let cells = ""
-      for (const cell of row) cells += this.tablecell(cell)
-      body += this.tablerow({ text: cells })
-    }
-    if (body) body = `<tbody>${body}</tbody>`
-    return `<div class="table-scroll"><table><thead>${header}</thead>${body}</table></div>`
-  }
-
-  marked.use({ renderer })
-
-  // 3. Parse remaining text with marked
+  // 2. Parse remaining text with marked
   const renderedMain = marked.parse(textWithPlaceholders) as string
 
-  // 2. Build think block HTML for each segment
+  // 3. Build think block HTML for each segment
   const thinkBlocks = thinkSegments.map((segment) => {
     const renderedSegment = DOMPurify.sanitize(marked.parse(segment) as string)
     return `<details class="think-block"><summary class="think-summary"><iconify-icon icon="ant-design:bulb-outlined" width="13"></iconify-icon>Thoughts</summary><div class="think-body">${renderedSegment}</div></details>`


### PR DESCRIPTION
## Problem

Fixes #2089.

`marked.use({ renderer })` was called inside `renderMarkdown()`, which runs per streaming `text_delta`. marked v18's `use()` reuses the already-installed renderer object and re-wraps each overridden method in a new closure (`r[o] = (...p) => { let c = u.apply(r, p); return c === false ? a.apply(r, p) : c }`), so every render added ~4 closure layers to the module-global `marked` instance, pinned forever by `marked.defaults.renderer`. Behavior stayed correct (outermost wrapper wins), but memory grew monotonically with the app's lifetime render count and was never released until page reload.

## Fix

Hoist the renderer construction (`code` / `link` / `blockquote` / `table` overrides, plus the `isSafeHref` helper) and the single `marked.use({ renderer })` call to module scope. None of the overrides capture per-call state — `showReasoning` only affects the `<think>`-block extraction, which stays inside `renderMarkdown` — so a one-time install is semantically identical.

## Testing

- New regression test: the installed renderer method references on `marked.defaults.renderer` must stay identical across repeated `renderMarkdown` calls. **Verified red against the previous code** (the per-call `use()` replaced the methods every render), green with the fix.
- `vitest run` in `web/`: 226 tests pass
- `svelte-check`: 0 errors (2 pre-existing CSS warnings in unrelated views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)