### PR TITLE
fix(agent): persist the streamed partial reply when a turn dies on an error

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1120,7 +1120,7 @@ func (a *Agent) runLoop(
 				continue
 			}
 
-			if a.keepPartialReply(roundText) {
+			if a.keepPartialReply(handler, roundText, "") {
 				// The words the user watched stream in are persisted — even a
 				// first-round failure must not roll them (and the user input)
 				// back into oblivion.
@@ -1153,8 +1153,12 @@ func (a *Agent) runLoop(
 			a.describeImages(ctx, handler, emsgs)
 			// The escalated retry re-streams the whole reply; drop the
 			// truncated attempt's text so a failure here keeps only the
-			// retry's partial, not both concatenated.
+			// retry's partial, not both concatenated. Snapshot it first:
+			// if the retry dies having streamed nothing, the truncated
+			// attempt's fully-streamed text is still the best partial to keep.
+			truncatedText := ""
 			if roundText != nil {
+				truncatedText = roundText.String()
 				roundText.Reset()
 			}
 			escalated, eerr := send(ctx, emsgs, a.MaxTokensEscalate)
@@ -1171,8 +1175,9 @@ func (a *Agent) runLoop(
 				// Claude 3 caps at 4096). Keep the truncated reply and fall
 				// through to the graceful stop below.
 			default:
-				if a.keepPartialReply(roundText) {
-					// Persisted the escalated attempt's partial — no rollback.
+				if a.keepPartialReply(handler, roundText, truncatedText) {
+					// Persisted the escalated attempt's partial (or the
+					// truncated first attempt's text) — no rollback.
 				} else if i == 0 {
 					a.History.TruncateTo(baseHistoryLen)
 					a.inputRolledBack = true
@@ -1417,18 +1422,28 @@ const partialReplyNote = "[Reply interrupted by an error — the text above is i
 // failing round as an assistant message. Without it, a turn that dies on an
 // unrecoverable send error discards everything the user watched arrive: the
 // text was never appended to history, so it survives only in the live view
-// and vanishes on the next transcript reload. Returns false when there is
-// nothing worth keeping (no streaming accumulator, or the round died before
-// any text arrived), in which case the caller applies its normal rollback.
-func (a *Agent) keepPartialReply(roundText *strings.Builder) bool {
-	if roundText == nil {
-		return false
+// and vanishes on the next transcript reload. fallback covers the escalation
+// path, where the accumulator was reset for the retry but the truncated
+// first attempt had streamed a complete text worth keeping. Returns false
+// when there is nothing worth keeping, in which case the caller applies its
+// normal rollback.
+func (a *Agent) keepPartialReply(handler EventHandler, roundText *strings.Builder, fallback string) bool {
+	partial := ""
+	if roundText != nil {
+		partial = strings.TrimSpace(roundText.String())
 	}
-	partial := strings.TrimSpace(roundText.String())
+	if partial == "" {
+		partial = strings.TrimSpace(fallback)
+	}
 	if partial == "" {
 		return false
 	}
 	a.History.Append(NewAssistantMessage(partial + "\n\n" + partialReplyNote))
+	// The live view already rendered the partial via deltas — deliver the
+	// marker too, so the bubble on screen matches what history persisted.
+	if handler != nil {
+		handler(AgentEvent{Kind: EventTextDelta, Text: "\n\n" + partialReplyNote})
+	}
 	return true
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -842,8 +842,9 @@ func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinitio
 	}
 
 	// Buffered send + nil handler: runLoop runs the same dispatch/history
-	// machinery as the streaming path but emits no events.
-	return a.runLoop(ctx, userInput, tools, executor, nil,
+	// machinery as the streaming path but emits no events. No roundText —
+	// a buffered send that errors has streamed nothing worth keeping.
+	return a.runLoop(ctx, userInput, tools, executor, nil, nil,
 		func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error) {
 			return ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, maxTokens, tools)
 		})
@@ -879,8 +880,20 @@ func (a *Agent) RunStream(
 
 	// onChunk adapts text deltas from provider streams into EventTextDelta
 	// events. Nil-safe; empty deltas are silently dropped.
+	//
+	// roundText mirrors every delta of the CURRENT provider round: when the
+	// round dies on an unrecoverable error, the text the user already watched
+	// stream in is persisted as a partial reply (see keepPartialReply) instead
+	// of existing only in the dying view. runLoop resets it before each round
+	// — retries (overflow recovery, stream stalls, escalation) re-stream from
+	// scratch, so carrying the failed attempt's text would double it.
+	var roundText strings.Builder
 	onChunk := func(delta string) {
-		if handler == nil || delta == "" {
+		if delta == "" {
+			return
+		}
+		roundText.WriteString(delta)
+		if handler == nil {
 			return
 		}
 		handler(AgentEvent{Kind: EventTextDelta, Text: delta})
@@ -923,13 +936,13 @@ func (a *Agent) RunStream(
 
 	// Try ToolStreamingSender first, then fall back to ToolSender (buffered).
 	if tss, ok := sender.(ToolStreamingSender); ok {
-		return a.runLoop(ctx, userInput, tools, executor, handler,
+		return a.runLoop(ctx, userInput, tools, executor, handler, &roundText,
 			func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error) {
 				return tss.StreamMessagesWithTools(ctx, a.Model, a.System, msgs, maxTokens, tools, onChunk, onToolDelta, onThinking)
 			})
 	}
 	if ts, ok := sender.(ToolSender); ok {
-		return a.runLoop(ctx, userInput, tools, executor, handler,
+		return a.runLoop(ctx, userInput, tools, executor, handler, &roundText,
 			func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error) {
 				reply, err := ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, maxTokens, tools)
 				if err == nil && reply.Content != "" {
@@ -962,6 +975,7 @@ func (a *Agent) runLoop(
 	tools []ToolDefinition,
 	executor ToolExecutor,
 	handler EventHandler,
+	roundText *strings.Builder,
 	send func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error),
 ) (Reply, error) {
 	// Goal accounting brackets the whole turn: the baseline reset pins the
@@ -1070,6 +1084,12 @@ func (a *Agent) runLoop(
 		msgs := a.History.Snapshot()
 		a.describeImages(ctx, handler, msgs)
 
+		// Each provider round streams its own text from scratch — a retry of
+		// this round (overflow recovery, stream stall) re-streams, so the
+		// accumulator must not carry the failed attempt's text.
+		if roundText != nil {
+			roundText.Reset()
+		}
 		reply, err := send(ctx, msgs, a.MaxTokens)
 		if err != nil {
 			// Interrupt during the provider call: finalize cleanly rather than
@@ -1100,7 +1120,11 @@ func (a *Agent) runLoop(
 				continue
 			}
 
-			if i == 0 {
+			if a.keepPartialReply(roundText) {
+				// The words the user watched stream in are persisted — even a
+				// first-round failure must not roll them (and the user input)
+				// back into oblivion.
+			} else if i == 0 {
 				a.History.TruncateTo(baseHistoryLen)
 				a.inputRolledBack = true
 			}
@@ -1127,6 +1151,12 @@ func (a *Agent) runLoop(
 			// first attempt, so this costs no helper calls.
 			emsgs := a.History.Snapshot()
 			a.describeImages(ctx, handler, emsgs)
+			// The escalated retry re-streams the whole reply; drop the
+			// truncated attempt's text so a failure here keeps only the
+			// retry's partial, not both concatenated.
+			if roundText != nil {
+				roundText.Reset()
+			}
 			escalated, eerr := send(ctx, emsgs, a.MaxTokensEscalate)
 			switch {
 			case eerr == nil:
@@ -1141,7 +1171,9 @@ func (a *Agent) runLoop(
 				// Claude 3 caps at 4096). Keep the truncated reply and fall
 				// through to the graceful stop below.
 			default:
-				if i == 0 {
+				if a.keepPartialReply(roundText) {
+					// Persisted the escalated attempt's partial — no rollback.
+				} else if i == 0 {
 					a.History.TruncateTo(baseHistoryLen)
 					a.inputRolledBack = true
 				}
@@ -1374,6 +1406,30 @@ func (a *Agent) finishInterrupted(handler EventHandler) (Reply, error) {
 	// before finishInterrupted is reached) so the UI shows how many iterations
 	// completed before the interrupt.
 	return reply, context.Canceled
+}
+
+// partialReplyNote caps a partial reply persisted by keepPartialReply, so
+// both the user and the model (on the next turn) can see the text is
+// incomplete rather than mistaking it for a finished answer.
+const partialReplyNote = "[Reply interrupted by an error — the text above is incomplete.]"
+
+// keepPartialReply persists the text the model already streamed in the
+// failing round as an assistant message. Without it, a turn that dies on an
+// unrecoverable send error discards everything the user watched arrive: the
+// text was never appended to history, so it survives only in the live view
+// and vanishes on the next transcript reload. Returns false when there is
+// nothing worth keeping (no streaming accumulator, or the round died before
+// any text arrived), in which case the caller applies its normal rollback.
+func (a *Agent) keepPartialReply(roundText *strings.Builder) bool {
+	if roundText == nil {
+		return false
+	}
+	partial := strings.TrimSpace(roundText.String())
+	if partial == "" {
+		return false
+	}
+	a.History.Append(NewAssistantMessage(partial + "\n\n" + partialReplyNote))
+	return true
 }
 
 // TakeBackInterrupted undoes an interrupt that produced no output: when

--- a/internal/agent/partial_reply_test.go
+++ b/internal/agent/partial_reply_test.go
@@ -126,3 +126,39 @@ func TestRunStream_PartialReplyKeptOnLaterRoundError(t *testing.T) {
 		t.Error("a later-round failure must never report the input rolled back")
 	}
 }
+
+// TestRunStream_TruncatedTextKeptWhenEscalationFails: the accumulator is
+// reset before the escalated retry, but the truncated first attempt streamed
+// a complete text the user watched arrive — when the retry dies having
+// streamed nothing, that snapshot must be the partial that gets kept.
+func TestRunStream_TruncatedTextKeptWhenEscalationFails(t *testing.T) {
+	send := &perCallStreamingSender{
+		fakeToolSender: fakeToolSender{
+			replies: []Reply{{Content: "truncated answer", StopReason: StopReasonMaxTokens}},
+			errs:    []error{nil, errors.New("boom")},
+		},
+		chunksPerCall: [][]string{{"truncated answer"}}, // escalated retry streams nothing
+	}
+	a := New(send, "m")
+	a.MaxTokens = 100
+	a.MaxTokensEscalate = 200
+
+	if _, err := a.RunStream(context.Background(), "hi", dummyOverflowTools, &fakeExecutor{}, nil); err == nil {
+		t.Fatal("expected the escalated turn to fail")
+	}
+
+	msgs := a.History.Snapshot()
+	last := msgs[len(msgs)-1]
+	if last.Role != RoleAssistant {
+		t.Fatalf("last message role = %q, want assistant", last.Role)
+	}
+	if !strings.Contains(last.Content, "truncated answer") {
+		t.Errorf("truncated attempt's text was not kept, got: %q", last.Content)
+	}
+	if !strings.Contains(last.Content, partialReplyNote) {
+		t.Errorf("kept text is not marked incomplete, got: %q", last.Content)
+	}
+	if a.InputRolledBack() {
+		t.Error("input must not be rolled back when the truncated text was kept")
+	}
+}

--- a/internal/agent/partial_reply_test.go
+++ b/internal/agent/partial_reply_test.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// perCallStreamingSender streams a scripted set of text chunks on EVERY call
+// (indexed by call number), unlike fakeToolStreamingSender which replays only
+// on the first. Needed to exercise the per-round reset of the partial-reply
+// accumulator: round N's failure must persist round N's text only.
+type perCallStreamingSender struct {
+	fakeToolSender
+	chunksPerCall [][]string
+}
+
+func (f *perCallStreamingSender) StreamMessagesWithTools(
+	_ context.Context, _, _ string, _ []Message, _ int,
+	_ []ToolDefinition,
+	onChunk func(string),
+	_ ToolInputDeltaFunc,
+	_ ThinkingDeltaFunc,
+) (Reply, error) {
+	if f.calls < len(f.chunksPerCall) && onChunk != nil {
+		for _, c := range f.chunksPerCall[f.calls] {
+			onChunk(c)
+		}
+	}
+	return f.nextReply()
+}
+
+// TestRunStream_PartialReplyKeptOnFirstRoundError: a first-round send that
+// streamed text before dying must persist that text as a partial reply and
+// must NOT roll the user message back — the words the user watched arrive
+// would otherwise vanish from history (and, after the rollback-triggered
+// transcript reload, from the screen too).
+func TestRunStream_PartialReplyKeptOnFirstRoundError(t *testing.T) {
+	send := &perCallStreamingSender{
+		fakeToolSender: fakeToolSender{errs: []error{errors.New("boom")}},
+		chunksPerCall:  [][]string{{"Hello, ", "wor"}},
+	}
+	a := New(send, "m")
+
+	if _, err := a.RunStream(context.Background(), "hi", dummyOverflowTools, &fakeExecutor{}, nil); err == nil {
+		t.Fatal("expected the turn to fail")
+	}
+
+	msgs := a.History.Snapshot()
+	if len(msgs) != 2 {
+		t.Fatalf("history has %d messages, want 2 (user + partial assistant)", len(msgs))
+	}
+	last := msgs[1]
+	if last.Role != RoleAssistant {
+		t.Fatalf("last message role = %q, want assistant", last.Role)
+	}
+	if !strings.Contains(last.Content, "Hello, wor") {
+		t.Errorf("partial reply text missing, got: %q", last.Content)
+	}
+	if !strings.Contains(last.Content, partialReplyNote) {
+		t.Errorf("partial reply is not marked incomplete, got: %q", last.Content)
+	}
+	if a.InputRolledBack() {
+		t.Error("input must not be reported rolled back when the partial reply was kept")
+	}
+}
+
+// TestRunStream_NoPartialStillRollsBackFirstRound pins the pre-existing
+// contract: a first-round failure that streamed nothing rolls history back
+// past the user message so a retry doesn't duplicate it.
+func TestRunStream_NoPartialStillRollsBackFirstRound(t *testing.T) {
+	send := &perCallStreamingSender{
+		fakeToolSender: fakeToolSender{errs: []error{errors.New("boom")}},
+	}
+	a := New(send, "m")
+
+	if _, err := a.RunStream(context.Background(), "hi", dummyOverflowTools, &fakeExecutor{}, nil); err == nil {
+		t.Fatal("expected the turn to fail")
+	}
+	if n := a.History.Len(); n != 0 {
+		t.Errorf("history has %d messages, want 0 (rolled back)", n)
+	}
+	if !a.InputRolledBack() {
+		t.Error("input_rolled_back must stay true when there was no partial to keep")
+	}
+}
+
+// TestRunStream_PartialReplyKeptOnLaterRoundError: when round 1 dies, only
+// round 1's streamed text is persisted — the accumulator must reset between
+// rounds, or round 0's (already appended) text would be duplicated into the
+// partial.
+func TestRunStream_PartialReplyKeptOnLaterRoundError(t *testing.T) {
+	send := &perCallStreamingSender{
+		fakeToolSender: fakeToolSender{
+			replies: []Reply{{
+				StopReason: "tool_use",
+				Content:    "round zero text",
+				Blocks:     []ContentBlock{NewToolUseBlock("c1", "bash", map[string]any{"command": "ls"})},
+			}},
+			errs: []error{nil, errors.New("boom")},
+		},
+		chunksPerCall: [][]string{{"round zero text"}, {"round one partial"}},
+	}
+	a := New(send, "m")
+
+	if _, err := a.RunStream(context.Background(), "hi", dummyOverflowTools, &fakeExecutor{}, nil); err == nil {
+		t.Fatal("expected the turn to fail")
+	}
+
+	msgs := a.History.Snapshot()
+	last := msgs[len(msgs)-1]
+	if last.Role != RoleAssistant {
+		t.Fatalf("last message role = %q, want assistant", last.Role)
+	}
+	if !strings.Contains(last.Content, "round one partial") {
+		t.Errorf("round 1 partial missing, got: %q", last.Content)
+	}
+	if strings.Contains(last.Content, "round zero text") {
+		t.Errorf("round 0 text leaked into the partial (accumulator not reset): %q", last.Content)
+	}
+	if !strings.Contains(last.Content, partialReplyNote) {
+		t.Errorf("partial reply is not marked incomplete, got: %q", last.Content)
+	}
+	if a.InputRolledBack() {
+		t.Error("a later-round failure must never report the input rolled back")
+	}
+}

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -292,8 +292,9 @@ func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (r
 	// When the manager stamped an event sink into ctx (TUI live panel), stream
 	// the child's tool-level activity to it. Only tool_started/tool_error are
 	// forwarded — not per-token text — to keep event volume sane with several
-	// sub-agents running at once. No sink (headless) => nil handler =>
-	// RunStream behaves exactly like Run.
+	// sub-agents running at once. No sink (headless) => nil handler => no
+	// events; unlike Run, a nil-handler RunStream still keeps a streamed
+	// partial reply in history when a round dies on an error.
 	var handler agent.EventHandler
 	if sink := tools.SubAgentEventSink(ctx); sink != nil {
 		handler = func(ev agent.AgentEvent) {


### PR DESCRIPTION
## Problem

When a send fails mid-stream, everything the model already streamed exists only in the live view: the failed round's text was never appended to history, so it vanishes on the next transcript reload. Worse, a first-round failure rolls the whole turn back and broadcasts `history_reload`, wiping the words the user just watched arrive off the screen entirely — the "该次回答被销毁" (reply destroyed) experience reported in #2118.

## Fix

- `RunStream` mirrors each round's text deltas into an accumulator; `runLoop` resets it before every provider round, since retries (overflow recovery, transient stream stalls, max-tokens escalation) re-stream from scratch — carrying the failed attempt's text would double it.
- On an unrecoverable send error, the accumulated text is appended to history as an assistant message capped with an explicit marker: `[Reply interrupted by an error — the text above is incomplete.]` — so both the user and the model (on the next turn) can see it is partial. The server's existing error-path `sess.Save()` then persists it, and the existing transcript replay renders it after a refresh.
- A first-round failure that kept a partial no longer rolls back the user message and reports `input_rolled_back=false`, so the web UI neither restores the composer nor reloads the (unshrunk) transcript — the bubble simply stays. One that streamed nothing keeps the existing rollback contract, verified by a regression test.

No server or frontend changes needed: the only consumer of `InputRolledBack` is the composer-restore hint, whose semantics ("the typed text is gone from both places") now correctly report false when the message was kept.

## Testing

Three new tests: first-round failure keeps partial + skips rollback; no-partial first-round failure still rolls back (pre-existing contract); later-round failure persists only the failing round's text (accumulator reset). `go test -race` passes for `internal/agent`, `internal/server`, `internal/tools`; `gofmt -l` clean.

Part of the follow-up to #2118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)