### PR TITLE
fix(web): render link labels from parsed inline tokens

### DIFF
--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -78,6 +78,36 @@ describe('renderMarkdown: tables', () => {
   })
 })
 
+describe('renderMarkdown: link labels (#2088)', () => {
+  it('renders bold inside a link label instead of leaking asterisks', () => {
+    const out = renderMarkdown('See [**PR #123**](https://example.com)')
+    expect(out).toContain('href="https://example.com"')
+    expect(out).toContain('<strong>PR #123</strong>')
+    expect(out).not.toContain('**')
+  })
+
+  it('renders inline code inside a link label instead of leaking backticks', () => {
+    const out = renderMarkdown('Open [`foo.ts`](https://example.com/foo)')
+    expect(out).toContain('<code>foo.ts</code>')
+    expect(out).not.toContain('`')
+  })
+
+  it('sanitizes dangerous HTML in link labels', () => {
+    // Inline HTML in the label now flows through parseInline like everywhere
+    // else in the document; the final DOMPurify pass is what keeps it safe.
+    const out = renderMarkdown('[a <img src=x onerror=alert(1)> c](https://example.com)')
+    expect(out).not.toContain('onerror')
+    const out2 = renderMarkdown('[x <script>alert(1)</script>](https://example.com)')
+    expect(out2).not.toContain('<script>')
+  })
+
+  it('still blanks unsafe hrefs', () => {
+    const out = renderMarkdown('[click](javascript:alert(1))')
+    expect(out).not.toContain('javascript:')
+    expect(out).toContain('>click</a>')
+  })
+})
+
 describe('renderMarkdown: renderer installed once (#2089)', () => {
   it('does not re-wrap the global renderer methods on every render', () => {
     // marked.use() wraps already-installed renderer methods in a new closure

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -62,11 +62,14 @@ renderer.code = function ({ text: codeText, lang }: { text: string; lang?: strin
 </div>`
 }
 
-renderer.link = function ({ href, title, text }: { href: string; title?: string | null; text: string }) {
+renderer.link = function ({ href, title, tokens }: Tokens.Link) {
   // Only allow safe URL schemes; strip everything else.
   const safe = isSafeHref(href)
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : ""
-  return `<a href="${safe ? escapeHtml(href) : ""}"${titleAttr} target="_blank" rel="noopener">${escapeHtml(text)}</a>`
+  // Render the label from the token's parsed inline children — token.text is
+  // the raw markdown source (same bug class as blockquote below), so escaping
+  // it leaked literal ** and backticks into every formatted link label.
+  return `<a href="${safe ? escapeHtml(href) : ""}"${titleAttr} target="_blank" rel="noopener">${this.parser.parseInline(tokens)}</a>`
 }
 
 // Render the quote's children, don't interpolate token.text — that field is


### PR DESCRIPTION
## Problem

Fixes #2088.

The custom `renderer.link` escaped and interpolated `token.text`, which in marked v18 is the **raw markdown source** of the link body (parsed inline children live in `token.tokens`). Any link label with emphasis or inline code — `[\`foo.ts\`](url)`, `[**PR #123**](url)`, both common in agent output — rendered with literal backticks and asterisks. This is the same bug class the codebase already documented and fixed for `renderer.blockquote` in the same file.

## Fix

Mirror the blockquote fix: render the label via `this.parser.parseInline(tokens)`. The href scheme whitelist (`isSafeHref`) is unchanged. Inline HTML in a label now flows through like everywhere else in the document, with the final DOMPurify pass sanitizing it — covered by a new test asserting `onerror`/`<script>` payloads in labels are stripped.

## Stacked on #2127

Based on `fix-2089-marked-use-leak` because both PRs touch the same `renderer.link` function (#2127 hoists it to module scope). Merge #2127 first; GitHub will retarget this PR to `main` automatically. **Do not merge this one before #2127.**

## Testing

- New tests: bold label, inline-code label (both **verified red before the fix**), plus sanitization of dangerous HTML in labels and the unsafe-href blank-out.
- `vitest run` in `web/`: 230 tests pass
- `svelte-check`: 0 errors (2 pre-existing CSS warnings in unrelated views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)