### PR TITLE
fix(tools): refuse binary file content in read_file via NUL sniff

### DIFF
--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -58,7 +58,8 @@ func (ReadFileTool) Definition() agent.ToolDefinition {
 			"has been read; do not call read_file again for the same path. " +
 			"Absolute paths are preferred; relative paths resolve against the current " +
 			"working directory. Refuses binary extensions (executables, archives, " +
-			"PDFs, DBs) and blocking device files (/dev/random, /dev/tty etc). " +
+			"PDFs, DBs), files whose content is binary or UTF-16 (use the terminal " +
+			"tool for those), and blocking device files (/dev/random, /dev/tty etc). " +
 			"Image files (.png, .jpg, .jpeg, .gif, .webp, .bmp, .tiff, .heic, .ico) " +
 			"are returned as image content for multimodal model consumption, or a " +
 			"refusal if the active model does not accept image input.",
@@ -148,7 +149,7 @@ func (ReadFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 	// them yields NUL-laced garbage lines the model can't use — refuse and
 	// point at the terminal tool instead.
 	if reason, serr := sniffBinaryPrefix(f); serr != nil {
-		return agent.ToolResult{}, fmt.Errorf("read_file: %q: %w", path, serr)
+		return agent.ToolResult{}, fmt.Errorf("read_file: %s: %w", path, serr)
 	} else if reason != "" {
 		return agent.ToolResult{}, fmt.Errorf("read_file: refusing to read %s — %s", path, reason)
 	}
@@ -410,12 +411,15 @@ func sniffBinaryPrefix(f *os.File) (reason string, err error) {
 	}
 	buf = buf[:n]
 
+	// BOM check first, not nested under the NUL check: UTF-16 text that is
+	// pure non-ASCII (e.g. CJK-only with no newline in the first 512 bytes)
+	// has no NUL byte, but the BOM still identifies it.
+	if bytes.HasPrefix(buf, []byte{0xff, 0xfe}) || bytes.HasPrefix(buf, []byte{0xfe, 0xff}) {
+		return "file is UTF-16 encoded text (BOM detected); read_file only handles UTF-8/ASCII. " +
+			"Convert it via the terminal tool first (e.g. iconv -f utf-16 -t utf-8, or PowerShell " +
+			"Get-Content <file> | Set-Content -Encoding utf8 <out>)", nil
+	}
 	if bytes.IndexByte(buf, 0) >= 0 {
-		if bytes.HasPrefix(buf, []byte{0xff, 0xfe}) || bytes.HasPrefix(buf, []byte{0xfe, 0xff}) {
-			return "file is UTF-16 encoded text (BOM detected); read_file only handles UTF-8/ASCII. " +
-				"Convert it via the terminal tool first (e.g. iconv -f utf-16 -t utf-8, or PowerShell " +
-				"Get-Content <file> | Set-Content -Encoding utf8 <out>)", nil
-		}
 		return "file content looks binary (NUL byte in the first 512 bytes); read_file only handles text. " +
 			"Use the terminal tool to inspect binary files (e.g. file, strings, xxd, or a script)", nil
 	}

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -2,8 +2,10 @@ package tools
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,6 +142,16 @@ func (ReadFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 		return agent.ToolResult{}, fmt.Errorf("read_file: open %q: %w", path, err)
 	}
 	defer f.Close()
+
+	// Content sniff: the extension check above misses binaries with an
+	// unknown or missing extension (./a.out, a PNG saved as .txt). Reading
+	// them yields NUL-laced garbage lines the model can't use — refuse and
+	// point at the terminal tool instead.
+	if reason, serr := sniffBinaryPrefix(f); serr != nil {
+		return agent.ToolResult{}, fmt.Errorf("read_file: %q: %w", path, serr)
+	} else if reason != "" {
+		return agent.ToolResult{}, fmt.Errorf("read_file: refusing to read %s — %s", path, reason)
+	}
 
 	// Larger initial buffer than bufio.Scanner's 64KiB default so long
 	// lines (minified JS, base64 blobs) don't trip MaxScanTokenSize.
@@ -376,6 +388,42 @@ func isLikelyBinaryPath(absPath string) string {
 		return reason + " (read_file only handles text)"
 	}
 	return ""
+}
+
+// sniffPrefixBytes is how much of the file the content sniff examines. 512
+// bytes matches net/http.DetectContentType's window: enough to catch any
+// real binary format's header without a meaningful read cost.
+const sniffPrefixBytes = 512
+
+// sniffBinaryPrefix reads the first sniffPrefixBytes of f and reports a
+// refusal reason when the content is not text read_file can serve: a NUL
+// byte in the prefix marks a binary (every common binary format has one
+// early; UTF-8/ASCII text never does). UTF-16 text — NUL-laced by encoding,
+// not by nature — gets its own message pointing at a terminal conversion
+// instead of being lumped in with executables. The reader is rewound to the
+// start on success so the caller's scanner sees the whole file.
+func sniffBinaryPrefix(f *os.File) (reason string, err error) {
+	buf := make([]byte, sniffPrefixBytes)
+	n, rerr := io.ReadFull(f, buf)
+	if rerr != nil && rerr != io.EOF && rerr != io.ErrUnexpectedEOF {
+		return "", fmt.Errorf("sniff: %w", rerr)
+	}
+	buf = buf[:n]
+
+	if bytes.IndexByte(buf, 0) >= 0 {
+		if bytes.HasPrefix(buf, []byte{0xff, 0xfe}) || bytes.HasPrefix(buf, []byte{0xfe, 0xff}) {
+			return "file is UTF-16 encoded text (BOM detected); read_file only handles UTF-8/ASCII. " +
+				"Convert it via the terminal tool first (e.g. iconv -f utf-16 -t utf-8, or PowerShell " +
+				"Get-Content <file> | Set-Content -Encoding utf8 <out>)", nil
+		}
+		return "file content looks binary (NUL byte in the first 512 bytes); read_file only handles text. " +
+			"Use the terminal tool to inspect binary files (e.g. file, strings, xxd, or a script)", nil
+	}
+
+	if _, serr := f.Seek(0, io.SeekStart); serr != nil {
+		return "", fmt.Errorf("sniff rewind: %w", serr)
+	}
+	return "", nil
 }
 
 // blockedDevicePaths are paths whose read would block the agent forever

--- a/internal/tools/read_file_sniff_test.go
+++ b/internal/tools/read_file_sniff_test.go
@@ -46,6 +46,27 @@ func TestReadFile_RefusesUTF16WithConversionHint(t *testing.T) {
 	}
 }
 
+// TestReadFile_RefusesUTF16BENoNUL: a big-endian BOM must be recognized even
+// when the first 512 bytes contain no NUL at all (pure non-ASCII text, where
+// UTF-16BE code units have no zero byte) — the BOM check must not be gated
+// behind the NUL check.
+func TestReadFile_RefusesUTF16BENoNUL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cjk16.txt")
+	// UTF-16BE BOM + "中文" (U+4E2D U+6587) — no zero bytes anywhere.
+	if err := os.WriteFile(path, []byte{0xfe, 0xff, 0x4e, 0x2d, 0x65, 0x87}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{"path": path})
+	if err == nil {
+		t.Fatal("expected refusal for UTF-16BE content")
+	}
+	if !strings.Contains(err.Error(), "UTF-16") {
+		t.Errorf("refusal should name UTF-16, got: %v", err)
+	}
+}
+
 // TestReadFile_SniffAllowsUTF8AndRewinds: multi-byte UTF-8 (and a NUL past
 // the 512-byte sniff window) must not trip the sniff, and the rewind must
 // leave the scanner reading from line 1.

--- a/internal/tools/read_file_sniff_test.go
+++ b/internal/tools/read_file_sniff_test.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestReadFile_RefusesBinaryContent: the extension check misses binaries
+// with an unknown or missing extension — the content sniff must catch the
+// NUL bytes every real binary format carries in its header.
+func TestReadFile_RefusesBinaryContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.out")
+	if err := os.WriteFile(path, []byte("\x7fELF\x02\x01\x01\x00\x00\x00some machine code"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{"path": path})
+	if err == nil {
+		t.Fatal("expected refusal for binary content")
+	}
+	if !strings.Contains(err.Error(), "looks binary") || !strings.Contains(err.Error(), "terminal") {
+		t.Errorf("refusal should name the binary sniff and point at the terminal tool, got: %v", err)
+	}
+}
+
+// TestReadFile_RefusesUTF16WithConversionHint: UTF-16 text is NUL-laced by
+// encoding, not by nature — it gets a conversion hint, not the binary lump.
+func TestReadFile_RefusesUTF16WithConversionHint(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+	// "hi\n" as UTF-16LE with BOM — what Windows PowerShell 5 redirection writes.
+	if err := os.WriteFile(path, []byte{0xff, 0xfe, 'h', 0x00, 'i', 0x00, '\n', 0x00}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{"path": path})
+	if err == nil {
+		t.Fatal("expected refusal for UTF-16 content")
+	}
+	if !strings.Contains(err.Error(), "UTF-16") || !strings.Contains(err.Error(), "Convert") {
+		t.Errorf("refusal should name UTF-16 and suggest conversion, got: %v", err)
+	}
+}
+
+// TestReadFile_SniffAllowsUTF8AndRewinds: multi-byte UTF-8 (and a NUL past
+// the 512-byte sniff window) must not trip the sniff, and the rewind must
+// leave the scanner reading from line 1.
+func TestReadFile_SniffAllowsUTF8AndRewinds(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cjk.txt")
+	content := "第一行 中文\n" + strings.Repeat("padding line\n", 100) + "tail\n"
+	writeTestFile(t, path, content)
+
+	out, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{"path": path})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, "     1\t第一行 中文") {
+		t.Errorf("first line missing after sniff rewind:\n%s", out.Text[:min(len(out.Text), 200)])
+	}
+	if !strings.Contains(out.Text, "tail") {
+		t.Errorf("last line missing after sniff rewind")
+	}
+}


### PR DESCRIPTION
## Problem

`read_file` already refuses non-image binaries **by extension** (`binaryExtensions`), handles images through the vision gate, and blocks device files — but a binary with an unknown or missing extension (`./a.out`, a PNG saved as `.txt`) slips through and fills the model's context with NUL-laced garbage lines.

## Fix

After open, sniff the first 512 bytes (the same window `net/http.DetectContentType` uses):

- A NUL byte marks a binary — every common binary format carries one in its header, while UTF-8/ASCII text never does. The refusal names the sniff and points at the terminal tool (`file`/`strings`/`xxd`) instead.
- UTF-16 text is NUL-laced by encoding, not by nature (Windows PowerShell 5 redirection writes UTF-16LE with BOM), so a BOM-detected file gets its own message with a concrete conversion hint rather than being lumped in with executables.
- The reader is rewound on success, so the scanner still reads from line 1; clean files pay one 512-byte read.

Known interaction: a terminal-output spill file (`~/.octo/tmp/term-*.log`) that captured binary garbage will now also be refused with the same terminal-tool guidance — which is the correct outcome, since reading NUL garbage back into context is exactly what this guards against.

## Testing

New tests: extension-less ELF refused with the binary message; UTF-16LE+BOM refused with the conversion hint; multi-byte UTF-8 text (with content past the sniff window) reads intact from line 1 after the rewind. Full `go test -race ./internal/tools/` passes; `gofmt`/`go vet` clean.

Follow-up to #2118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)