### PR TITLE
fix(mobile): key the queued first prompt to its own session

### DIFF
--- a/web/src/mobile/ChatDetail.svelte
+++ b/web/src/mobile/ChatDetail.svelte
@@ -13,13 +13,17 @@
   import ArtifactViewer from './ArtifactViewer.svelte'
   import { t } from '../lib/i18n'
 
-  let { onBack, onViewApproval, initialPrompt = '', onInitialSent }: {
+  let { onBack, onViewApproval, initial = null, onInitialSent }: {
     onBack: () => void
     onViewApproval: () => void
     // Queued first message from the new-task sheet, sent once the WS
-    // subscription is live (so the reply stream isn't missed). onInitialSent
-    // lets the owner clear it so a remount doesn't re-send.
-    initialPrompt?: string
+    // subscription is live (so the reply stream isn't missed). Carries the id
+    // of the session it was queued for: activeSessionId can flip to another
+    // session while the history fetch is in flight (the question-toast "View"
+    // button sets it without going through openSession), and the prompt must
+    // only ever be sent to its own session (#2093). onInitialSent lets the
+    // owner clear it so a remount doesn't re-send.
+    initial?: { id: string; prompt: string } | null
     onInitialSent?: () => void
   } = $props()
 
@@ -57,8 +61,8 @@
     loadMobileHistory(s).then(() => {
       if (cancelled) return
       ws.subscribe(s)
-      if (initialPrompt) {
-        sendMobile(s, initialPrompt, [])
+      if (initial?.prompt && initial.id === s) {
+        sendMobile(s, initial.prompt, [])
         onInitialSent?.()
       }
     })

--- a/web/src/mobile/MobileApp.svelte
+++ b/web/src/mobile/MobileApp.svelte
@@ -57,7 +57,7 @@
           <ChatDetail
             onBack={closeDetail}
             onViewApproval={() => (openKind = 'approval')}
-            initialPrompt={initial?.id === openId ? initial.prompt : ''}
+            {initial}
             onInitialSent={() => (initial = null)}
           />
         {/if}


### PR DESCRIPTION
## Problem

Fixes #2093.

The new-task sheet's queued first prompt was resolved against `openId` in MobileApp (`initialPrompt={initial?.id === openId ? initial.prompt : ''}`) but sent to `sid = $activeSessionId` in ChatDetail — and the two can diverge: the QuestionOverlay toast's "View" button calls `setActiveSession(sid)` without going through `openSession`, so `activeSessionId` flips while `openId` stays put. If that happened while session A's history fetch was in flight, ChatDetail's effect re-ran for session B, `initialPrompt` still evaluated to A's prompt, and it was sent to B then cleared — silently misdirected and never delivered to A.

## Fix

Pass the whole `{id, prompt}` pair down to ChatDetail and check `initial.id === s` at the send site — the prompt is now keyed to the session it is actually sent to, so it can only ever be delivered to the session it was queued for, no matter how `activeSessionId` moves. The prop is read inside the fetch's `.then` (async), so the parent clearing it does not re-trigger the wiring effect — same tracking behavior as the previous `initialPrompt` read.

The issue's alternative (routing the toast through `openSession`-equivalent logic) would change the toast's navigation behavior; not taken here to keep the fix scoped to the misdirection bug.

## Testing

- `svelte-check`: 0 errors (2 pre-existing CSS warnings in unrelated views)
- `vitest run` in `web/`: 230 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)