### PR TITLE
chore: bump version to 1.15.15

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.14"
+var Version = "1.15.15"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Release 1.15.15. Highlights since 1.15.14 (follow-ups to #2118):

- #2124 — recognize CN-provider context-overflow error strings so overflow recovery runs on Zhipu/Kimi endpoints
- #2126 — sanitize control bytes, ANSI escapes, and invalid UTF-8 in tool results
- #2128 — persist the streamed partial reply when a turn dies on an error
- #2130 — read_file refuses binary content via NUL sniff

🤖 Generated with [Claude Code](https://claude.com/claude-code)