### PR TITLE
feat: show prompt-cache utilization in the per-turn summary line

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -2266,8 +2266,9 @@ func turnSummaryLine(v verbosity, stats TurnStats) string {
 	if v.quiet() {
 		return ""
 	}
-	return noticeStyle.Render(fmt.Sprintf("  ⏱ %s, %s tokens",
-		agent.FormatElapsedSeconds(int64(stats.Elapsed.Seconds())), agent.FormatGoalTokens(int64(stats.Tokens))))
+	return noticeStyle.Render(fmt.Sprintf("  ⏱ %s, %s tokens%s",
+		agent.FormatElapsedSeconds(int64(stats.Elapsed.Seconds())), agent.FormatGoalTokens(int64(stats.Tokens)),
+		stats.cacheSuffix()))
 }
 
 // thinkingPhrases rotate (slowly) on the initial-wait placeholder so the

--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -53,6 +53,24 @@ type ViewSink interface {
 type TurnStats struct {
 	Elapsed time.Duration
 	Tokens  int // input + output tokens billed during this turn
+	// Prompt-side cache accounting for the turn, from Agent.SessionCacheTokens()
+	// deltas. InputTokens is the uncached remainder (non-overlapping with the
+	// cache buckets), so views can derive utilization via
+	// agent.CacheUtilizationPct. All zero when the backend reports no cache info.
+	InputTokens      int
+	CacheReadTokens  int
+	CacheWriteTokens int
+}
+
+// cacheSuffix renders the summary line's ", cache NN%" tail — the share of
+// this turn's prompt served from the provider cache — or "" when the backend
+// reported no cache activity, so cache-less providers keep the old line.
+func (s TurnStats) cacheSuffix() string {
+	pct, ok := agent.CacheUtilizationPct(s.InputTokens, s.CacheReadTokens, s.CacheWriteTokens)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf(", cache %d%%", pct)
 }
 
 // runTurn executes one user turn: it applies the memory nudge and the pre-turn
@@ -102,6 +120,7 @@ func runTurn(ctx context.Context, a *agent.Agent, cfg replConfig, sink ViewSink,
 
 	turnStart := time.Now()
 	inBefore, outBefore := a.SessionTokens()
+	crBefore, cwBefore := a.SessionCacheTokens()
 
 	// RunStream owns the streaming + agentic tool loop. With no tools it falls
 	// back internally to TurnStream, adapting text deltas into EventTextDelta
@@ -111,9 +130,13 @@ func runTurn(ctx context.Context, a *agent.Agent, cfg replConfig, sink ViewSink,
 	reply, err := a.RunStream(ctx, turnInput, cfg.tools, cfg.executor, sink.Emit)
 
 	inAfter, outAfter := a.SessionTokens()
+	crAfter, cwAfter := a.SessionCacheTokens()
 	stats := TurnStats{
-		Elapsed: time.Since(turnStart),
-		Tokens:  (inAfter - inBefore) + (outAfter - outBefore),
+		Elapsed:          time.Since(turnStart),
+		Tokens:           (inAfter - inBefore) + (outAfter - outBefore),
+		InputTokens:      inAfter - inBefore,
+		CacheReadTokens:  crAfter - crBefore,
+		CacheWriteTokens: cwAfter - cwBefore,
 	}
 
 	sink.TurnEnded(reply, stats, err)
@@ -188,8 +211,9 @@ func (v *plainView) TurnEnded(reply agent.Reply, stats TurnStats, err error) {
 			// one-shot run (`octo "…" | program`) leaves stdout carrying only the
 			// reply text. Interactive plain-REPL users still see it (their stderr
 			// is the terminal). Mirrors printUsageLine's stderr routing.
-			fmt.Fprintf(v.errOut, "  ⏱ %s, %s tokens\n",
-				agent.FormatElapsedSeconds(int64(stats.Elapsed.Seconds())), agent.FormatGoalTokens(int64(stats.Tokens)))
+			fmt.Fprintf(v.errOut, "  ⏱ %s, %s tokens%s\n",
+				agent.FormatElapsedSeconds(int64(stats.Elapsed.Seconds())), agent.FormatGoalTokens(int64(stats.Tokens)),
+				stats.cacheSuffix())
 		}
 	}
 }

--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -57,6 +57,11 @@ type TurnStats struct {
 	// deltas. InputTokens is the uncached remainder (non-overlapping with the
 	// cache buckets), so views can derive utilization via
 	// agent.CacheUtilizationPct. All zero when the backend reports no cache info.
+	//
+	// Scope caveat: AccrueChildUsage folds sub-agent and mid-turn compaction /
+	// consolidation tokens into the input total but never their cache hits
+	// (internal/agent/agent.go), so for turns that spawned sub-agents or
+	// compacted, the percentage is a lower bound rather than the true figure.
 	InputTokens      int
 	CacheReadTokens  int
 	CacheWriteTokens int

--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -57,11 +57,9 @@ type TurnStats struct {
 	// deltas. InputTokens is the uncached remainder (non-overlapping with the
 	// cache buckets), so views can derive utilization via
 	// agent.CacheUtilizationPct. All zero when the backend reports no cache info.
-	//
-	// Scope caveat: AccrueChildUsage folds sub-agent and mid-turn compaction /
-	// consolidation tokens into the input total but never their cache hits
-	// (internal/agent/agent.go), so for turns that spawned sub-agents or
-	// compacted, the percentage is a lower bound rather than the true figure.
+	// Sub-agent and mid-turn compaction/consolidation usage folds into these
+	// counters too (AccrueChildUsage/addUsage carry cache deltas), so the
+	// percentage is the true share, not a lower bound.
 	InputTokens      int
 	CacheReadTokens  int
 	CacheWriteTokens int

--- a/cmd/octo/turncore_cache_test.go
+++ b/cmd/octo/turncore_cache_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+// TestTurnStatsCacheSuffix locks the summary line's cache tail: the exact
+// ", cache NN%" format when the backend reported cache activity, and the
+// empty string (cache-less providers keep the old two-part line) when it
+// did not.
+func TestTurnStatsCacheSuffix(t *testing.T) {
+	cases := []struct {
+		name  string
+		stats TurnStats
+		want  string
+	}{
+		{"no cache info", TurnStats{InputTokens: 1000}, ""},
+		{"zero everything", TurnStats{}, ""},
+		{"warming turn reports 0%", TurnStats{InputTokens: 100, CacheWriteTokens: 2000}, ", cache 0%"},
+		{"typical hit", TurnStats{InputTokens: 114, CacheReadTokens: 2304}, ", cache 95%"},
+		{"fully cached", TurnStats{CacheReadTokens: 500}, ", cache 100%"},
+	}
+	for _, c := range cases {
+		if got := c.stats.cacheSuffix(); got != c.want {
+			t.Errorf("%s: cacheSuffix() = %q, want %q", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2255,23 +2255,29 @@ func (a *Agent) SessionTokens() (inputTokens, outputTokens int) {
 }
 
 // AccrueChildUsage folds tokens spent by a spawned sub-agent into this
-// agent's session totals, so SessionTokens still reports one
-// consolidated number even when the LLM used sub_agent. cache totals are
-// left untouched — the child runs against the same provider but reports its
-// own cache hits internally; the parent only sees the bottom-line counts here.
-func (a *Agent) AccrueChildUsage(inputTokens, outputTokens int) {
-	a.addUsage(inputTokens, outputTokens)
+// agent's session totals, so SessionTokens and SessionCacheTokens still
+// report one consolidated number even when the LLM used sub_agent. The
+// child's cache read/write deltas ride along so the per-turn cache
+// utilization readout (CacheUtilizationPct) stays a true value rather
+// than a lower bound on turns that spawned sub-agents.
+func (a *Agent) AccrueChildUsage(inputTokens, outputTokens, cacheRead, cacheWrite int) {
+	a.addUsage(inputTokens, outputTokens, cacheRead, cacheWrite)
 }
 
-// addUsage folds input/output token counts into the session totals under the
-// usage lock. Shared by AccrueChildUsage (concurrent sub-agent goroutines) and
-// the internal sub-operation accruals (compaction / consolidation / planning),
-// all of which can run while a sub-agent goroutine is still accruing.
-func (a *Agent) addUsage(inputTokens, outputTokens int) {
+// addUsage folds input/output/cache token counts into the session totals
+// under the usage lock. Shared by AccrueChildUsage (concurrent sub-agent
+// goroutines) and the internal sub-operation accruals (compaction /
+// consolidation / planning), all of which can run while a sub-agent
+// goroutine is still accruing. Unlike accrueUsage it does NOT touch
+// lastInputTokens — a summary call's prompt size must not corrupt the
+// main conversation's context-usage gauge.
+func (a *Agent) addUsage(inputTokens, outputTokens, cacheRead, cacheWrite int) {
 	a.usageMu.Lock()
 	defer a.usageMu.Unlock()
 	a.sessionInputTokens += inputTokens
 	a.sessionOutputTokens += outputTokens
+	a.sessionCacheReadTokens += cacheRead
+	a.sessionCacheWriteTokens += cacheWrite
 }
 
 // ClearHistory drops the entire conversation history, returning the agent to a

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1369,11 +1369,15 @@ func TestAgent_RunStream_GateDenies_EmitsErrorEvent(t *testing.T) {
 
 func TestAccrueChildUsage_FoldsIntoSessionTotals(t *testing.T) {
 	a := New(nil, "m")
-	a.AccrueChildUsage(100, 50)
-	a.AccrueChildUsage(200, 75)
+	a.AccrueChildUsage(100, 50, 800, 40)
+	a.AccrueChildUsage(200, 75, 1600, 60)
 	in, out := a.SessionTokens()
 	if in != 300 || out != 125 {
 		t.Errorf("SessionTokens after two AccrueChildUsage = (%d,%d), want (300,125)", in, out)
+	}
+	cr, cw := a.SessionCacheTokens()
+	if cr != 2400 || cw != 100 {
+		t.Errorf("SessionCacheTokens after two AccrueChildUsage = (%d,%d), want (2400,100)", cr, cw)
 	}
 }
 

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -608,8 +608,9 @@ func (a *Agent) summarizeOn(ctx context.Context, sender Sender, model string, ms
 		return "", fmt.Errorf("agent: compact: LLM returned tool_calls instead of summary")
 	}
 
-	// Summary tokens count toward the session budget like any other call.
-	a.addUsage(reply.InputTokens, reply.OutputTokens)
+	// Summary tokens count toward the session budget like any other call,
+	// cache hits included so the turn's cache utilization stays accurate.
+	a.addUsage(reply.InputTokens, reply.OutputTokens, reply.CacheReadTokens, reply.CacheWriteTokens)
 	return reply.Content, nil
 }
 

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -14,12 +14,16 @@ type summarizeFake struct {
 	summary string
 	calls   int
 	gotMsgs []Message
+	// cacheRead/cacheWrite ride the fake Reply so tests can verify the
+	// summary call's cache tokens fold into the session totals.
+	cacheRead  int
+	cacheWrite int
 }
 
 func (f *summarizeFake) SendMessages(_ context.Context, _, _ string, msgs []Message, _ int) (Reply, error) {
 	f.calls++
 	f.gotMsgs = msgs
-	return Reply{Content: f.summary, InputTokens: 5, OutputTokens: 3}, nil
+	return Reply{Content: f.summary, InputTokens: 5, OutputTokens: 3, CacheReadTokens: f.cacheRead, CacheWriteTokens: f.cacheWrite}, nil
 }
 
 func TestSafeSplitIndexByBudget(t *testing.T) {
@@ -385,6 +389,34 @@ func TestForceCompact_FoldsBelowAutoThreshold(t *testing.T) {
 	}
 	if a.lastInputTokens != 0 {
 		t.Errorf("trigger should reset to 0 after compaction, got %d", a.lastInputTokens)
+	}
+}
+
+// TestForceCompact_AccruesCacheTokens: the summary call's cache read/write
+// tokens fold into the session cache totals (via addUsage), so a turn that
+// compacted mid-flight reports true cache utilization instead of a lower
+// bound — while lastInputTokens (the ctx-usage gauge) stays unpolluted.
+func TestForceCompact_AccruesCacheTokens(t *testing.T) {
+	f := &summarizeFake{summary: "GOAL: build X.", cacheRead: 40, cacheWrite: 6}
+	a := New(f, "m")
+	a.CompactThreshold = 4000
+
+	longMsg := strings.Repeat("x ", 500)
+	for i := 0; i < 6; i++ {
+		a.History.Append(NewUserMessage(longMsg))
+		a.History.Append(NewAssistantMessage(longMsg))
+	}
+
+	if _, err := a.ForceCompact(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	in, out := a.SessionTokens()
+	if in != 5 || out != 3 {
+		t.Errorf("SessionTokens = (%d,%d), want (5,3) from the summary call", in, out)
+	}
+	cr, cw := a.SessionCacheTokens()
+	if cr != 40 || cw != 6 {
+		t.Errorf("SessionCacheTokens = (%d,%d), want (40,6) from the summary call", cr, cw)
 	}
 }
 

--- a/internal/agent/consolidate.go
+++ b/internal/agent/consolidate.go
@@ -54,6 +54,6 @@ func (a *Agent) ConsolidateMemory(ctx context.Context, priorSummary, newNotes st
 	if err != nil {
 		return "", err
 	}
-	a.addUsage(reply.InputTokens, reply.OutputTokens)
+	a.addUsage(reply.InputTokens, reply.OutputTokens, reply.CacheReadTokens, reply.CacheWriteTokens)
 	return strings.TrimSpace(reply.Content), nil
 }

--- a/internal/agent/goal_command.go
+++ b/internal/agent/goal_command.go
@@ -193,6 +193,22 @@ func FormatElapsedSeconds(seconds int64) string {
 	return fmt.Sprintf("%dm%ds", seconds/60, seconds%60)
 }
 
+// CacheUtilizationPct returns the share of a turn's prompt tokens that were
+// served from the provider's prompt cache: read / (input + read + write).
+// InputTokens and CacheRead/WriteTokens are non-overlapping buckets (see
+// accrueUsage), so the denominator is the whole prompt sent. ok is false when
+// the backend reported no cache activity at all — callers omit the readout
+// then instead of rendering a misleading "cache 0%". A warming turn (write
+// only, read 0) does report 0%, which is honest: the cache exists but nothing
+// was served from it yet.
+func CacheUtilizationPct(inputTokens, cacheRead, cacheWrite int) (pct int, ok bool) {
+	total := inputTokens + cacheRead + cacheWrite
+	if cacheRead+cacheWrite <= 0 || total <= 0 {
+		return 0, false
+	}
+	return cacheRead * 100 / total, true
+}
+
 // GoalUsageLine summarizes a goal's spend: "12m, 63.9K/50K tokens".
 func GoalUsageLine(g Goal) string {
 	var parts []string

--- a/internal/agent/goal_command_test.go
+++ b/internal/agent/goal_command_test.go
@@ -107,3 +107,25 @@ func TestFormatGoalHelpers(t *testing.T) {
 		t.Errorf("GoalUsageLine = %q", got)
 	}
 }
+
+func TestCacheUtilizationPct(t *testing.T) {
+	cases := []struct {
+		name                    string
+		input, read, write, pct int
+		ok                      bool
+	}{
+		{"no cache info at all", 1000, 0, 0, 0, false},
+		{"zero everything", 0, 0, 0, 0, false},
+		{"warming turn (write only)", 100, 0, 2000, 0, true},
+		{"typical hit", 114, 2304, 0, 95, true},
+		{"hit plus write", 100, 800, 100, 80, true},
+		{"fully cached", 0, 500, 0, 100, true},
+	}
+	for _, c := range cases {
+		pct, ok := CacheUtilizationPct(c.input, c.read, c.write)
+		if pct != c.pct || ok != c.ok {
+			t.Errorf("%s: CacheUtilizationPct(%d, %d, %d) = (%d, %v), want (%d, %v)",
+				c.name, c.input, c.read, c.write, pct, ok, c.pct, c.ok)
+		}
+	}
+}

--- a/internal/agent/usage_race_test.go
+++ b/internal/agent/usage_race_test.go
@@ -18,7 +18,7 @@ func TestAccrueChildUsageConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			a.AccrueChildUsage(1, 2)
+			a.AccrueChildUsage(1, 2, 3, 4)
 		}()
 	}
 	wg.Wait()
@@ -26,5 +26,9 @@ func TestAccrueChildUsageConcurrent(t *testing.T) {
 	in, out := a.SessionTokens()
 	if in != n || out != 2*n {
 		t.Errorf("SessionTokens = (%d, %d), want (%d, %d)", in, out, n, 2*n)
+	}
+	cr, cw := a.SessionCacheTokens()
+	if cr != 3*n || cw != 4*n {
+		t.Errorf("SessionCacheTokens = (%d, %d), want (%d, %d)", cr, cw, 3*n, 4*n)
 	}
 }

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -313,11 +313,14 @@ func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (r
 	}
 
 	// Accrue the round's token delta even on a max-turns checkpoint — the
-	// partial work cost real tokens.
+	// partial work cost real tokens. Cache deltas ride along so the parent's
+	// per-turn cache utilization readout stays a true value.
 	totIn, totOut := lc.agent.SessionTokens()
+	totCR, totCW := lc.agent.SessionCacheTokens()
 	in, out = totIn-lc.accruedIn, totOut-lc.accruedOut
 	lc.accruedIn, lc.accruedOut = totIn, totOut
-	s.parent.AccrueChildUsage(in, out)
+	s.parent.AccrueChildUsage(in, out, totCR-lc.accruedCacheRead, totCW-lc.accruedCacheWrite)
+	lc.accruedCacheRead, lc.accruedCacheWrite = totCR, totCW
 
 	lc.syncSession()
 	s.fireSubagentStop(r.Content)
@@ -417,11 +420,13 @@ type liveChild struct {
 
 	mu sync.Mutex // serializes runChild on this child
 
-	// accruedIn/accruedOut track how much of the child's cumulative
-	// SessionTokens has already been folded into the parent, so each round
-	// accrues only its delta.
-	accruedIn  int
-	accruedOut int
+	// accruedIn/accruedOut/accruedCacheRead/accruedCacheWrite track how much
+	// of the child's cumulative SessionTokens/SessionCacheTokens has already
+	// been folded into the parent, so each round accrues only its delta.
+	accruedIn         int
+	accruedOut        int
+	accruedCacheRead  int
+	accruedCacheWrite int
 
 	lastUsed time.Time // for TTL eviction
 	seq      uint64    // monotonic touch order, for LRU eviction (clock-independent)

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -281,8 +281,9 @@ func (s *Spawner) Continue(ctx context.Context, agentID, message string) (tools.
 //
 // A max-turns checkpoint is NOT an error: the partial reply and StopReason
 // ("max_turns") are returned so the caller can checkpoint and Continue.
-// Tokens spent on the partial round are still accrued. Callers that
-// drive a continuation can inspect the child StopReason themselves.
+// Tokens spent on partial rounds — checkpoint OR error — are still accrued
+// into the parent before the error is returned. Callers that drive a
+// continuation can inspect the child StopReason themselves.
 func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (reply string, in, out int, stopReason string, turns int, err error) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
@@ -308,19 +309,22 @@ func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (r
 	}
 	r, err := lc.agent.RunStream(childCtx, prompt, lc.tools, lc.executor, handler)
 	turns = lc.agent.TurnIterations()
-	if err != nil {
-		return "", 0, 0, "", turns, err
-	}
 
-	// Accrue the round's token delta even on a max-turns checkpoint — the
-	// partial work cost real tokens. Cache deltas ride along so the parent's
-	// per-turn cache utilization readout stays a true value.
+	// Accrue the round's token delta BEFORE the error check: a failed or
+	// max-turns-checkpoint round still burned real tokens on its partial
+	// work (a streamed partial reply is kept in history on error), so the
+	// parent's session totals and per-turn cache utilization must see it.
+	// Cache deltas ride along so the readout stays a true value.
 	totIn, totOut := lc.agent.SessionTokens()
 	totCR, totCW := lc.agent.SessionCacheTokens()
 	in, out = totIn-lc.accruedIn, totOut-lc.accruedOut
 	lc.accruedIn, lc.accruedOut = totIn, totOut
 	s.parent.AccrueChildUsage(in, out, totCR-lc.accruedCacheRead, totCW-lc.accruedCacheWrite)
 	lc.accruedCacheRead, lc.accruedCacheWrite = totCR, totCW
+
+	if err != nil {
+		return "", in, out, "", turns, err
+	}
 
 	lc.syncSession()
 	s.fireSubagentStop(r.Content)

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -264,6 +265,64 @@ func TestAgentSpawner_ContinueAccruesOnlyDeltaTokens(t *testing.T) {
 	in, out := parent.SessionTokens()
 	if in != 400 || out != 160 {
 		t.Errorf("parent session tokens = (%d,%d), want (400,160) — double-counting bug if 600/240", in, out)
+	}
+}
+
+// erroringChildSender succeeds once with a tool_use reply (accruing tokens
+// and cache activity), then fails — a partial round that burned real tokens
+// before dying.
+type erroringChildSender struct {
+	calls int32
+}
+
+func (s *erroringChildSender) scripted() (agent.Reply, error) {
+	if atomic.AddInt32(&s.calls, 1) == 1 {
+		return agent.Reply{
+			StopReason:       "tool_use",
+			Blocks:           []agent.ContentBlock{agent.NewToolUseBlock("c1", "read_file", map[string]any{"path": "x"})},
+			InputTokens:      120,
+			OutputTokens:     30,
+			CacheReadTokens:  40,
+			CacheWriteTokens: 6,
+		}, nil
+	}
+	return agent.Reply{}, errors.New("boom")
+}
+
+func (s *erroringChildSender) SendMessages(_ context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	return s.scripted()
+}
+
+// SendMessagesWithTools makes the sender a ToolSender so the child stays on
+// the runLoop path (a plain Sender falls back to single-shot TurnStream and
+// round 2 would never run).
+func (s *erroringChildSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition) (agent.Reply, error) {
+	return s.scripted()
+}
+
+// TestAgentSpawner_ErrorRoundStillAccruesTokens: when a child round dies on
+// an error after burning tokens, the delta (cache included) still folds into
+// the parent before the error propagates — otherwise a failed Spawn leaves
+// the parent's session totals and per-turn cache utilization under-counted.
+func TestAgentSpawner_ErrorRoundStillAccruesTokens(t *testing.T) {
+	send := &erroringChildSender{}
+	parent := agent.New(send, "parent-model")
+	// A non-empty toolbelt keeps the child on the tool-loop path — with no
+	// tools RunStream takes the single-shot fast path and round 2 never runs.
+	childTools := []agent.ToolDefinition{{Name: "read_file"}}
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return childTools })
+
+	_, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "go"})
+	if err == nil {
+		t.Fatal("expected the child's round-2 failure to propagate")
+	}
+	in, out := parent.SessionTokens()
+	if in != 120 || out != 30 {
+		t.Errorf("parent session tokens = (%d,%d), want (120,30) from the partial round", in, out)
+	}
+	cr, cw := parent.SessionCacheTokens()
+	if cr != 40 || cw != 6 {
+		t.Errorf("parent session cache tokens = (%d,%d), want (40,6) from the partial round", cr, cw)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3591,6 +3591,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// after, the same technique the goal accountant uses for its own totals.
 	turnStart := time.Now()
 	inBefore, outBefore := sess.Agent.SessionTokens()
+	crBefore, cwBefore := sess.Agent.SessionCacheTokens()
 
 	_, runErr := channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, content)
 	persist()
@@ -3667,9 +3668,14 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// goal-terminal turn skips it in favor of the terminal notice below.
 	if runErr == nil && goalTerminalNotice == "" {
 		inAfter, outAfter := sess.Agent.SessionTokens()
+		crAfter, cwAfter := sess.Agent.SessionCacheTokens()
 		tokens := (inAfter - inBefore) + (outAfter - outBefore)
 		elapsed := agent.FormatElapsedSeconds(int64(time.Since(turnStart).Seconds()))
-		ad.SendText(ev.ChatID, "⏱ "+elapsed+", "+agent.FormatGoalTokens(int64(tokens))+" tokens", ev.MessageID)
+		line := "⏱ " + elapsed + ", " + agent.FormatGoalTokens(int64(tokens)) + " tokens"
+		if pct, ok := agent.CacheUtilizationPct(inAfter-inBefore, crAfter-crBefore, cwAfter-cwBefore); ok {
+			line += fmt.Sprintf(", cache %d%%", pct)
+		}
+		ad.SendText(ev.ChatID, line, ev.MessageID)
 	}
 
 	if goalTerminalNotice != "" {

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -406,6 +406,12 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (sessionID st
 		inTok, outTok := a.SessionTokens()
 		completeEvent["duration_ms"] = time.Since(turnCallStart).Milliseconds()
 		completeEvent["tokens"] = inTok + outTok
+		// Cache utilization for the turn's prompt side; omitted (not 0) when
+		// the backend reported no cache activity, so the UI hides the readout.
+		cr, cw := a.SessionCacheTokens()
+		if pct, ok := agent.CacheUtilizationPct(inTok, cr, cw); ok {
+			completeEvent["cache_pct"] = pct
+		}
 	}
 	s.wsHub.broadcast(sessionID, completeEvent)
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1755,6 +1755,12 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		inTok, outTok := a.SessionTokens()
 		completeEvent["duration_ms"] = time.Since(turnCallStart).Milliseconds()
 		completeEvent["tokens"] = inTok + outTok
+		// Cache utilization for the turn's prompt side; omitted (not 0) when
+		// the backend reported no cache activity, so the UI hides the readout.
+		cr, cw := a.SessionCacheTokens()
+		if pct, ok := agent.CacheUtilizationPct(inTok, cr, cw); ok {
+			completeEvent["cache_pct"] = pct
+		}
 	}
 	s.wsHub.broadcast(sess.ID, completeEvent)
 	// completeEvent above only reaches tabs subscribed to this session; a tab

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1057,13 +1057,16 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       clearDoneSubAgents(sid)
       // Per-turn summary: elapsed time + tokens spent. The backend omits both
       // fields on error/interrupt, so this only fires on a clean completion.
+      // cache_pct is omitted (not 0) when the backend reported no cache
+      // activity, so cache-less providers keep the two-part line.
       const durationMs = (ev as any).duration_ms
       const tokens = (ev as any).tokens
+      const cachePct = (ev as any).cache_pct
       if (typeof durationMs === 'number' && typeof tokens === 'number') {
         addChatMsg(sid, {
           id: uid('sum'),
           type: 'notice',
-          content: `⏱ ${fmtDur(Math.round(durationMs / 1000))}, ${fmtTokens(tokens)} tokens`,
+          content: `⏱ ${fmtDur(Math.round(durationMs / 1000))}, ${fmtTokens(tokens)} tokens${typeof cachePct === 'number' ? `, cache ${cachePct}%` : ''}`,
           level: 'info',
           createdAt: Date.now(),
           streaming: false,


### PR DESCRIPTION
## What

The per-turn summary line ("⏱ 3s, 5.2K tokens") now appends the share of the turn's prompt served from the provider prompt cache: "⏱ 3s, 5.2K tokens, cache 95%".

All four surfaces:

- **TUI** (`turnSummaryLine`) and **plain REPL** (`plainView.TurnEnded`) — via `TurnStats.cacheSuffix()`
- **IM channel turns** (`runChannelTurns`) — same line construction
- **Web** — `cache_pct` field on the turn-complete ws event (omitted, not 0, when the backend reported no cache activity), rendered by `ChatView.svelte`

Core math is one pure function `agent.CacheUtilizationPct(input, cacheRead, cacheWrite)`; `ok=false` when the backend reported no cache activity at all, so cache-less providers keep the old two-part line instead of a misleading "cache 0%". A warming turn (write only) honestly reports 0%.

## Accounting fixes riding along

The readout exposed two gaps in usage accounting, both fixed here so the percentage is a true value:

- **Sub-agent / compaction / consolidation cache tokens now fold into session totals.** `AccrueChildUsage`/`addUsage` took only input/output; the cache read/write those calls earned were discarded, shrinking the numerator while the denominator grew. The spawner's per-round delta accounting gains a matching `accruedCacheRead/Write` pair. `addUsage` still deliberately skips `lastInputTokens` so a summary call never pollutes the main conversation's context-usage gauge.
- **Failed sub-agent rounds now accrue their delta.** `runChild` previously accrued only on success; a partial round that burned tokens then errored was lost whenever the child was never resumed.

## Tests

- `TestCacheUtilizationPct` — 6 cases incl. no-cache-info, warming turn, fully cached
- `TestTurnStatsCacheSuffix` — locks the `", cache NN%"` format and the empty suffix
- `TestForceCompact_AccruesCacheTokens` — summary-call cache folds into session totals
- `TestAccrueChildUsageConcurrent` / `TestAccrueChildUsage_FoldsIntoSessionTotals` — extended to cache totals
- `TestAgentSpawner_ErrorRoundStillAccruesTokens` — error-path delta accrual, cache included

`go test -race`, `go vet`, `gofmt` green on all touched packages.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
