### PR TITLE
internal/skills: embed underscore-prefixed default-skill files

### DIFF
--- a/internal/skills/defaults.go
+++ b/internal/skills/defaults.go
@@ -14,7 +14,13 @@ import (
 // skill. Embedding (rather than downloading) keeps a fresh install offline-
 // capable and version-locked to the binary — no network, no supply chain.
 //
-//go:embed defaults
+// The `all:` prefix is deliberate: plain directory embedding skips files
+// whose names start with "." or "_", which silently drops skill files that
+// need to ship — e.g. ppt-master's Python package markers (`__init__.py`),
+// its underscore-prefixed modules (`_dispatcher.py`, `_batch.py`, …), and
+// the `_index.md` catalogs that several skills' instructions read.
+//
+//go:embed all:defaults
 var defaultsFS embed.FS
 
 // defaultStampFile records which binary version last materialized the default

--- a/internal/skills/defaults_test.go
+++ b/internal/skills/defaults_test.go
@@ -104,6 +104,36 @@ func TestMaterializeDefaults_NoOpWhenCurrent(t *testing.T) {
 	}
 }
 
+func TestMaterializeDefaults_UnderscorePrefixedFilesShip(t *testing.T) {
+	// Regression: a plain //go:embed defaults silently skips files whose
+	// names start with "." or "_", which used to drop Python package markers
+	// (__init__.py), underscore-prefixed modules (_dispatcher.py, _batch.py,
+	// _conversion_profile.py), and the _index.md catalogs several skills'
+	// instructions read — all absent from the binary even though they exist
+	// in the repo tree. The all: prefix must include them.
+	root := filepath.Join(t.TempDir(), "skills-default")
+	useDefaultRoot(t, root)
+	if err := MaterializeDefaults("v1"); err != nil {
+		t.Fatalf("MaterializeDefaults: %v", err)
+	}
+
+	want := []string{
+		filepath.Join("ppt-master", "scripts", "source_to_md", "_dispatcher.py"),
+		filepath.Join("ppt-master", "scripts", "source_to_md", "_conversion_profile.py"),
+		filepath.Join("ppt-master", "scripts", "source_to_md", "_batch.py"),
+		filepath.Join("ppt-master", "scripts", "svg_to_pptx", "native_objects", "__init__.py"),
+		filepath.Join("ppt-master", "references", "modes", "_index.md"),
+		filepath.Join("ppt-master", "references", "visual-styles", "_index.md"),
+		filepath.Join("image-gen", "references", "image-palettes", "_index.md"),
+		filepath.Join("image-gen", "scripts", "image_backends", "__init__.py"),
+	}
+	for _, f := range want {
+		if _, err := os.Stat(filepath.Join(root, f)); err != nil {
+			t.Errorf("expected %s materialized (was it embedded?): %v", f, err)
+		}
+	}
+}
+
 func TestDiscover_DefaultSkillSurfacesAndIsOverridable(t *testing.T) {
 	defaultRoot := filepath.Join(t.TempDir(), "skills-default")
 	useDefaultRoot(t, defaultRoot)


### PR DESCRIPTION
## 问题

`internal/skills/defaults.go` 用 `//go:embed defaults` 嵌入默认 skill 目录，但 Go 的目录嵌入会**静默跳过文件名以 `.` 或 `_` 开头的文件**，导致一批仓库里存在、但从未进过二进制的 skill 文件：

- `ppt-master/scripts/source_to_md/_dispatcher.py` / `_conversion_profile.py` / `_batch.py` —— `project_manager.py` / `source_to_md.py` 运行时直接 import，缺失时整个 ppt-master 流程从初始化就 `ModuleNotFoundError`
- 所有 Python 包标记 `__init__.py`（ppt-master 9 个、image-gen 2 个）
- `ppt-master/references/{modes,visual-styles}/_index.md`、`image-gen/references/image-*/_index.md` —— skill 文档明确要求先读的目录索引
- `image-gen/.env.example`（配置模板）

实测：`go list` 显示修复前二进制里 ppt-master 嵌入 406 个文件、`_` 前缀文件为 0。

## 修复

`//go:embed defaults` → `//go:embed all:defaults`（`all:` 前缀会包含 `.`/`_` 开头文件）。已核对 `defaults/` 下全部 25 个受影响文件均为应发布的正常内容，无 `__pycache__` / `.DS_Store` / 符号链接等垃圾。

## 验证

- 新增回归测试 `TestMaterializeDefaults_UnderscorePrefixedFilesShip`，断言关键 `_` 文件物化到 `~/.octo/skills-default`
- 已实测：旧 embed 下该测试失败（文件缺失），新 embed 下通过
- `go build ./cmd/octo`、`go test ./internal/skills/...`、`go vet ./internal/skills/...` 全部通过

## 附带说明

`templates/icons/`（11,600+ 图标）缺失不是本问题 —— 那是 `PROVENANCE.md` 记录的有意裁剪（约 10 MB），仓库源码树里本就为空。