### PR TITLE
chore: bump version to 1.15.16

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.15"
+var Version = "1.15.16"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
小版本发布：`internal/version/version.go` 1.15.15 → 1.15.16。

包含自 1.15.15 以来的修复：
- #2135 internal/skills: embed underscore-prefixed default-skill files（`//go:embed all:defaults`，修复 ppt-master 等 skill 的 `_`/`.` 前缀文件未进二进制的问题）

合并后打 tag `v1.15.16` 即触发 release 工作流。