### PR TITLE
feat: sub-agent "lite" model keyword + endpoint model list in schema

### DIFF
--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -67,10 +67,18 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 	childTools := filterChildTools(s.toolsFn(ctx), req.Tools, req.DisallowedTools, req.ReadOnly)
 
 	// The child runs on the parent's sender + model unless the request
-	// overrides the model explicitly. No preset downgrades to the lite model:
-	// a sub-agent's output gates the parent's next step, so cost is trimmed
-	// via the lean system prompt (below), never via model quality.
+	// overrides the model explicitly. No preset downgrades to the lite model
+	// SILENTLY — a sub-agent's output gates the parent's next step, so cost
+	// is trimmed via the lean system prompt (below) by default — but an
+	// explicit "lite" override (call parameter or frontmatter `model: lite`)
+	// opts the child onto the parent's lite sender/model.
 	sender, model := s.parent.GetSender(), req.Model
+	if strings.EqualFold(model, "lite") {
+		model = "" // no lite configured: inherit the parent's model
+		if s.parent.LiteSender != nil && s.parent.LiteModel != "" {
+			sender, model = s.parent.LiteSender, s.parent.LiteModel
+		}
+	}
 	if model == "" {
 		model = s.parent.Model
 	}

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -152,6 +152,51 @@ func TestAgentSpawner_ModelOverride(t *testing.T) {
 	}
 }
 
+func TestAgentSpawner_LiteModelOverrideUsesLiteSender(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	lite := &subAgentSender{reply: "lite ok"}
+	parent := agent.New(send, "parent-model")
+	parent.LiteSender = lite
+	parent.LiteModel = "lite-model"
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
+
+	_, err := sp.Spawn(context.Background(), tools.SpawnRequest{
+		Description: "x",
+		Prompt:      "y",
+		Model:       "lite",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lite.calls != 1 {
+		t.Fatalf("lite sender calls = %d, want 1", lite.calls)
+	}
+	if lite.lastModel != "lite-model" {
+		t.Errorf("child ran with %q, want lite-model", lite.lastModel)
+	}
+	if send.calls != 0 {
+		t.Errorf("primary sender called %d times, want 0", send.calls)
+	}
+}
+
+func TestAgentSpawner_LiteModelFallsBackToParentWhenUnconfigured(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
+
+	_, err := sp.Spawn(context.Background(), tools.SpawnRequest{
+		Description: "x",
+		Prompt:      "y",
+		Model:       "lite",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if send.lastModel != "parent-model" {
+		t.Errorf("child ran with %q, want fallback to parent-model", send.lastModel)
+	}
+}
+
 func TestAgentSpawner_SpawnReturnsIDAndContinueResumesSameChild(t *testing.T) {
 	send := &subAgentSender{reply: "round one", inputTokens: 200, outputTokens: 80}
 	parent := agent.New(send, "parent-model")

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/agentprofile"
+	"github.com/open-octo/octo-agent/internal/config"
 )
 
 // ctxKeyProfileStore is the context key for the per-turn agentprofile.Store.
@@ -54,13 +55,20 @@ func profileNames(store *agentprofile.Store) string {
 //     user-defined agent from ~/.octo/agents). Required.
 //   - run_in_background: when true the agent runs async and you are notified
 //     on completion. When false (default) it blocks and returns the result.
-//   - model: optional model override
+//   - model: optional model override ("lite" resolves to the endpoint's lite
+//     model, falling back to the parent's model when none is configured)
 //   - tools: optional tool-name allowlist for the child
 //
 // The tool is advertised only when a SubAgentManager is registered.
 type AgentTool struct{}
 
-func (AgentTool) Definition() agent.ToolDefinition {
+func (t AgentTool) Definition() agent.ToolDefinition { return t.DefinitionFor("") }
+
+// DefinitionFor is Definition with session-model context: when the registry
+// knows which model this turn runs on, the model-override parameter lists the
+// sibling models reachable on that model's endpoint (the child reuses the
+// parent's endpoint connection, so only those are valid overrides).
+func (AgentTool) DefinitionFor(sessionModel string) agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "sub_agent",
 		Description: "Launch an autonomous sub-agent to handle a focused sub-task. " +
@@ -102,7 +110,7 @@ func (AgentTool) Definition() agent.ToolDefinition {
 				},
 				"model": map[string]any{
 					"type":        "string",
-					"description": "Optional model override. Defaults to the parent's model.",
+					"description": subAgentModelParamDesc(sessionModel),
 				},
 				"tools": map[string]any{
 					"type":        "array",
@@ -113,6 +121,53 @@ func (AgentTool) Definition() agent.ToolDefinition {
 			"required": []string{"description", "prompt", "subagent_type"},
 		},
 	}
+}
+
+// subAgentModelParamBase documents the model-override parameter without any
+// endpoint context: the plain default plus the "lite" keyword.
+const subAgentModelParamBase = "Optional model override. Defaults to the parent's model. " +
+	"Pass \"lite\" to run the sub-agent on the endpoint's configured lite model — right for " +
+	"mechanical subtasks where speed/cost beats quality; it falls back to the parent's model " +
+	"when no lite model is configured."
+
+// subAgentModelParamDesc returns the model-override parameter description,
+// appending the sibling models of the session model's endpoint when the
+// config resolves them. Only same-endpoint models are listed because the
+// child reuses the parent's endpoint connection — a model served elsewhere
+// would be rejected by the endpoint.
+func subAgentModelParamDesc(sessionModel string) string {
+	if sessionModel == "" {
+		return subAgentModelParamBase
+	}
+	cfg, err := config.LoadCached()
+	if err != nil {
+		return subAgentModelParamBase
+	}
+	return subAgentModelParamDescFor(cfg, sessionModel)
+}
+
+// subAgentModelParamDescFor is subAgentModelParamDesc over an explicit config,
+// split out so tests don't touch the on-disk config cache.
+func subAgentModelParamDescFor(cfg config.Config, sessionModel string) string {
+	for _, ep := range cfg.Endpoints {
+		for _, m := range ep.Models {
+			if m.Model != sessionModel {
+				continue
+			}
+			names := make([]string, 0, len(ep.Models))
+			for _, mm := range ep.Models {
+				name := mm.Model
+				if name == ep.LiteModel {
+					name += " (lite)"
+				}
+				names = append(names, name)
+			}
+			return subAgentModelParamBase +
+				" Models available on the current endpoint: " + strings.Join(names, ", ") + "."
+		}
+	}
+	// Session model not in the config (e.g. an ad-hoc --model value): no list.
+	return subAgentModelParamBase
 }
 
 func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -51,7 +51,7 @@ func profileNames(store *agentprofile.Store) string {
 //   - description: short label for UI/logging
 //   - prompt:      the task. Self-contained — the child starts with zero
 //     conversation context and can't see this conversation.
-//   - subagent_type: agent type (explore, plan, general, code-review, or a
+//   - subagent_type: agent type (explore, general, code-review, or a
 //     user-defined agent from ~/.octo/agents). Required.
 //   - run_in_background: when true the agent runs async and you are notified
 //     on completion. When false (default) it blocks and returns the result.
@@ -78,7 +78,7 @@ func (AgentTool) DefinitionFor(sessionModel string) agent.ToolDefinition {
 			"The child always starts with zero conversation context and the persona named by " +
 			"subagent_type — it can never see this conversation, so make the prompt a complete, " +
 			"self-contained task description (file paths, constraints, deliverable). " +
-			"'explore' for read-only investigation/research, 'plan' for read-only planning, " +
+			"'explore' for read-only investigation/research and planning, " +
 			"'general' for delegated work that modifies files, 'code-review' for an independent " +
 			"read of changes. To branch the conversation itself, use the session branch feature " +
 			"instead — a sub-agent is not a conversation fork.\n\n" +

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -126,9 +126,9 @@ func (AgentTool) DefinitionFor(sessionModel string) agent.ToolDefinition {
 // subAgentModelParamBase documents the model-override parameter without any
 // endpoint context: the plain default plus the "lite" keyword.
 const subAgentModelParamBase = "Optional model override. Defaults to the parent's model. " +
-	"Pass \"lite\" to run the sub-agent on the endpoint's configured lite model — right for " +
-	"mechanical subtasks where speed/cost beats quality; it falls back to the parent's model " +
-	"when no lite model is configured."
+	"Pass \"lite\" to run the sub-agent on the session's lite model (the endpoint's configured " +
+	"or vendor-inferred lite model) — right for mechanical subtasks where speed/cost beats " +
+	"quality; it falls back to the parent's model when the session has no lite model."
 
 // subAgentModelParamDesc returns the model-override parameter description,
 // appending the sibling models of the session model's endpoint when the
@@ -148,6 +148,13 @@ func subAgentModelParamDesc(sessionModel string) string {
 
 // subAgentModelParamDescFor is subAgentModelParamDesc over an explicit config,
 // split out so tests don't touch the on-disk config cache.
+//
+// Known ambiguity: the flat session-model string is the only endpoint handle
+// this seam has, so when two endpoints serve the same model id the first match
+// wins and may list the wrong endpoint's siblings — cosmetic only, since an
+// unreachable override fails loudly at the provider. The "(lite)" marker covers
+// only an explicit endpoint lite_model; a vendor-inferred lite (see
+// app.ImplicitLiteModelForEndpoint) may not appear in Models at all.
 func subAgentModelParamDescFor(cfg config.Config, sessionModel string) string {
 	for _, ep := range cfg.Endpoints {
 		for _, m := range ep.Models {

--- a/internal/tools/agent_model_desc_test.go
+++ b/internal/tools/agent_model_desc_test.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/config"
+)
+
+// The model-override description must list only the sibling models of the
+// endpoint serving the session model, marking the endpoint's lite model.
+func TestSubAgentModelParamDescFor_ListsSiblingModels(t *testing.T) {
+	cfg := config.Config{
+		Endpoints: []config.Endpoint{
+			{
+				ID:        "main",
+				LiteModel: "cheap-model",
+				Models: []config.EndpointModel{
+					{Model: "big-model"},
+					{Model: "cheap-model"},
+				},
+			},
+			{
+				ID:     "other",
+				Models: []config.EndpointModel{{Model: "elsewhere-model"}},
+			},
+		},
+	}
+
+	desc := subAgentModelParamDescFor(cfg, "big-model")
+	if !strings.Contains(desc, "big-model") || !strings.Contains(desc, "cheap-model (lite)") {
+		t.Errorf("description missing sibling models: %q", desc)
+	}
+	if strings.Contains(desc, "elsewhere-model") {
+		t.Errorf("description leaked another endpoint's model: %q", desc)
+	}
+}
+
+func TestSubAgentModelParamDescFor_UnknownModelOmitsList(t *testing.T) {
+	cfg := config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "main", Models: []config.EndpointModel{{Model: "big-model"}}},
+		},
+	}
+	if got := subAgentModelParamDescFor(cfg, "adhoc-model"); got != subAgentModelParamBase {
+		t.Errorf("unknown session model should fall back to the base description, got %q", got)
+	}
+}
+
+// Definition (no session model) must still document the "lite" keyword.
+func TestAgentToolDefinition_DocumentsLiteKeyword(t *testing.T) {
+	def := AgentTool{}.Definition()
+	props := def.Parameters["properties"].(map[string]any)
+	modelDesc := props["model"].(map[string]any)["description"].(string)
+	if !strings.Contains(modelDesc, "lite") {
+		t.Errorf("model parameter description does not mention lite: %q", modelDesc)
+	}
+}

--- a/internal/tools/agent_presets.go
+++ b/internal/tools/agent_presets.go
@@ -12,15 +12,18 @@ type agentPreset struct {
 	// tools, when non-empty, is the agent's tool allowlist (frontmatter
 	// `tools`). disallowedTools (frontmatter `disallowed_tools`) is subtracted
 	// from the inherited set. model (frontmatter `model`, default "inherit")
-	// pins the child's model; empty means inherit the parent's.
+	// pins the child's model; empty means inherit the parent's, and "lite"
+	// resolves to the parent's lite model at spawn time (parent's model when
+	// none is configured).
 	tools           []string
 	disallowedTools []string
 	model           string
 	// leanSystem seeds the agent with the parent's lean system prompt (skills
-	// manifest + memory dropped) to keep its context small. Presets always
-	// run on the parent's model (or an explicit model override) — a research
-	// agent's findings gate the parent's next step, so model quality is never
-	// traded for cost; only context is trimmed.
+	// manifest + memory dropped) to keep its context small. Presets run on
+	// the parent's model unless the frontmatter or the call opts into an
+	// explicit override — a research agent's findings gate the parent's next
+	// step, so model quality is never traded for cost implicitly; only
+	// context is trimmed.
 	leanSystem bool
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -671,7 +671,13 @@ func defaultToolsFor(ctx context.Context, model string) []agent.ToolDefinition {
 		if _, isEnableOwn := t.(EnableOwnSkillTool); isEnableOwn && !enableOwnSkillOn(ctx) {
 			continue
 		}
-		if _, isAgent := t.(AgentTool); isAgent && !mgrOn {
+		if at, isAgent := t.(AgentTool); isAgent {
+			if !mgrOn {
+				continue
+			}
+			// Model-aware schema: the model-override parameter lists the
+			// sibling models reachable on the session model's endpoint.
+			defs = append(defs, at.DefinitionFor(model))
 			continue
 		}
 		if _, isSend := t.(AgentSendTool); isSend && !mgrOn {

--- a/internal/tools/spawner.go
+++ b/internal/tools/spawner.go
@@ -49,7 +49,7 @@ type SpawnRequest struct {
 	// Model, when non-empty, overrides the parent's model for this child.
 	// The special value "lite" (case-insensitive) resolves to the parent's
 	// lite sender/model at spawn time, falling back to the parent's model
-	// when no lite model is configured.
+	// when the parent has no lite sender/model.
 	Model string
 
 	// SystemSuffix, when non-empty, is appended to the child's system prompt

--- a/internal/tools/spawner.go
+++ b/internal/tools/spawner.go
@@ -47,6 +47,9 @@ type SpawnRequest struct {
 	DisallowedTools []string
 
 	// Model, when non-empty, overrides the parent's model for this child.
+	// The special value "lite" (case-insensitive) resolves to the parent's
+	// lite sender/model at spawn time, falling back to the parent's model
+	// when no lite model is configured.
 	Model string
 
 	// SystemSuffix, when non-empty, is appended to the child's system prompt

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -98,8 +98,9 @@ func (WorkflowTool) Definition() agent.ToolDefinition {
 			"Primitives:\n" +
 			"- `agent(prompt, opts = {}) -> String`: run one sub-agent to completion, return " +
 			"its reply. Inside parallel/pipeline it runs concurrently with siblings. " +
-			"Optional opts: `model:` (override the model for this call, e.g. a cheaper model " +
-			"for mechanical stages), `tools:` (Array restricting the child's tools), " +
+			"Optional opts: `model:` (override the model for this call — pass \"lite\" for the " +
+			"endpoint's lite model on mechanical stages; falls back to the parent's model when " +
+			"no lite model is configured), `tools:` (Array restricting the child's tools), " +
 			"`read_only: true` (strip write_file/edit_file), `schema:` (a JSON Schema as a " +
 			"JSON **string** — the call then returns the sub-agent's reply as JSON text matching it), " +
 			"`isolation: \"worktree\"` (run the sub-agent in a fresh git worktree so its file changes " +

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -99,8 +99,8 @@ func (WorkflowTool) Definition() agent.ToolDefinition {
 			"- `agent(prompt, opts = {}) -> String`: run one sub-agent to completion, return " +
 			"its reply. Inside parallel/pipeline it runs concurrently with siblings. " +
 			"Optional opts: `model:` (override the model for this call — pass \"lite\" for the " +
-			"endpoint's lite model on mechanical stages; falls back to the parent's model when " +
-			"no lite model is configured), `tools:` (Array restricting the child's tools), " +
+			"session's lite model on mechanical stages; falls back to the parent's model when " +
+			"the session has none), `tools:` (Array restricting the child's tools), " +
 			"`read_only: true` (strip write_file/edit_file), `schema:` (a JSON Schema as a " +
 			"JSON **string** — the call then returns the sub-agent's reply as JSON text matching it), " +
 			"`isolation: \"worktree\"` (run the sub-agent in a fresh git worktree so its file changes " +


### PR DESCRIPTION
## What

Two additions to sub-agent model selection:

**1. `"lite"` as a model-override value.** The sub_agent tool's `model` parameter, the workflow `agent(model:)` opt, and agent-profile frontmatter `model:` now accept the special value `lite` (case-insensitive). At spawn time it resolves to the parent's lite sender/model (the endpoint's `lite_model`); when no lite model is configured it falls back to the parent's model. Resolution lives in one place — `app.Spawner.Spawn` — which every spawn path (sub_agent tool, workflow agents) already converges on.

This does not change the settled "no silent downgrade" policy: built-in presets still always inherit the parent's model. `lite` is an explicit per-preset or per-call opt-in for mechanical subtasks.

**2. Endpoint model list in the tool schema.** Previously the `model` parameter description was just "Optional model override" — the model had no way to know which override names are valid, so the parameter was effectively unusable unless the user dictated a name. `DefaultToolsFor(model)` already carries the session model, so the sub_agent definition is now built per-session: the description lists the sibling models of the session model's endpoint (from the cached config, lite model marked `(lite)`). Only same-endpoint models are listed because the child reuses the parent's endpoint connection — a model served elsewhere would be rejected.

## Notes

- Frontmatter parsers already pass `lite` through untouched (only `inherit` is normalized to empty), so no parser change was needed.
- When the session model isn't found in the config (ad-hoc `--model` value), the description falls back to the base text without a list.

## Tests

- `TestAgentSpawner_LiteModelOverrideUsesLiteSender` / `_LiteModelFallsBackToParentWhenUnconfigured`
- `TestSubAgentModelParamDescFor_ListsSiblingModels` / `_UnknownModelOmitsList`, `TestAgentToolDefinition_DocumentsLiteKeyword`
- Full `make test` (race) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)