### PR TITLE
feat(web): use folder icons for sidebar session groups

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -485,8 +485,10 @@
         {@const g = gv.group}
         {@const editingG = $editGroupId === g.id}
         <div class="grp-header">
+          <!-- Folder icon doubles as the collapse toggle: open when expanded,
+               closed when collapsed, so it carries both identity and state. -->
           <span class="grp-caret" onclick={() => toggleCollapse(g.id, !g.collapsed)}>
-            <iconify-icon icon={g.collapsed ? 'ant-design:right-outlined' : 'ant-design:down-outlined'} width="10"></iconify-icon>
+            <iconify-icon icon={g.collapsed ? 'ant-design:folder-outlined' : 'ant-design:folder-open-outlined'} width="13"></iconify-icon>
           </span>
           {#if editingG}
           <input


### PR DESCRIPTION
## What

Replace the chevron (`down-outlined` / `right-outlined`) in front of each session group name in the web sidebar with a folder icon:

- **Expanded** → `ant-design:folder-open-outlined`
- **Collapsed** → `ant-design:folder-outlined`

The icon remains the collapse toggle (same click handler), so the folder carries both the group's identity as a project container and its collapse state. It also matches the `folder-add-outlined` icon already used by the "新建分组" button.

Scope: only real session groups. The pinned section (pushpin) and the collapsed-sessions folded panel keep their existing icons.

## Verification

- `npm run build` — vite build green
- `npm run test` — 230/230 vitest tests pass

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
