### PR TITLE
fix(server): rebuild default sender on endpoint update/delete

### DIFF
--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -951,6 +951,14 @@ func (s *Server) handleUpdateEndpoint(w http.ResponseWriter, r *http.Request) {
 		invalidID = id
 	}
 	s.invalidateEndpointSenders(invalidID)
+	// Connection params (base_url, api_key, headers, ...) of the endpoint
+	// backing the default entry may have changed; unbound sessions ride the
+	// default sender, so rebuild it too — otherwise the update only reaches
+	// bound sessions and the default sender keeps the stale connection until
+	// restart.
+	if err := s.reloadDefaultSender(); err != nil {
+		log.Printf("[server] reload default sender after endpoint update: %v", err)
+	}
 	writeJSON(w, http.StatusOK, endpointToJSON(updated))
 }
 
@@ -994,6 +1002,12 @@ func (s *Server) handleDeleteEndpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.invalidateEndpointSenders(id)
+	// Deleting the endpoint may have cleared Default (when it pointed at this
+	// endpoint) — rebuild the default sender so unbound sessions stop riding
+	// a sender built against the deleted endpoint.
+	if err := s.reloadDefaultSender(); err != nil {
+		log.Printf("[server] reload default sender after endpoint delete: %v", err)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
@@ -1081,6 +1095,12 @@ func (s *Server) handleDeleteEndpointModel(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	s.invalidateEndpointSenders(id)
+	// Deleting the model may have cleared Default (when it pointed exactly at
+	// "<id>::<model>") — rebuild the default sender so unbound sessions pick
+	// up the new default (or fall out of the stale one) on their next turn.
+	if err := s.reloadDefaultSender(); err != nil {
+		log.Printf("[server] reload default sender after endpoint model delete: %v", err)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -929,6 +929,113 @@ func TestUpdateEndpoint_HeadersExplicitEmpty_ClearsAll(t *testing.T) {
 	}
 }
 
+// TestUpdateEndpoint_ReloadsDefaultSender is the regression test for the
+// missing reloadDefaultSender call in handleUpdateEndpoint: editing an
+// endpoint's connection params (base_url, api_key, headers, …) used to reach
+// only bound sessions via invalidateEndpointSenders, while unbound sessions
+// kept riding the server's stale default sender until restart — e.g. a newly
+// added custom User-Agent header never hit the wire for them.
+func TestUpdateEndpoint_ReloadsDefaultSender(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "custom", BaseURL: "https://api.example.com", Protocol: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "m1"}}},
+		},
+		Default: "ep-a::m1",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	before := srv.getSender()
+	if before == nil {
+		t.Fatal("server should have a default sender after startup")
+	}
+
+	w := doJSON(t, srv, http.MethodPatch, "/api/config/endpoints/ep-a", `{"headers": {"user-agent": "cc-test"}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH /api/config/endpoints/ep-a = %d: %s", w.Code, w.Body.String())
+	}
+
+	after := srv.getSender()
+	if after == nil {
+		t.Fatal("server default sender missing after endpoint update")
+	}
+	if after == before {
+		t.Error("default sender pointer did not change after endpoint update — unbound sessions would keep the stale connection params")
+	}
+
+	// An unbound session must resolve to the rebuilt default sender.
+	sess := agent.NewSession("m1", "")
+	sender, _ := srv.senderForSession(sess)
+	if sender != after {
+		t.Error("unbound session did not pick up the rebuilt default sender")
+	}
+}
+
+// TestDeleteEndpoint_ReloadsDefaultSender covers the same wiring gap in
+// handleDeleteEndpoint: removing an endpoint can clear Default, and even when
+// it doesn't, the default sender must be rebuilt from the post-delete config.
+func TestDeleteEndpoint_ReloadsDefaultSender(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "custom", BaseURL: "https://api.example.com", Protocol: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "m1"}}},
+			{ID: "ep-b", Provider: "custom", BaseURL: "https://api2.example.com", Protocol: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "m2"}}},
+		},
+		Default: "ep-a::m1",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	before := srv.getSender()
+	if before == nil {
+		t.Fatal("server should have a default sender after startup")
+	}
+
+	w := doJSON(t, srv, http.MethodDelete, "/api/config/endpoints/ep-b", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("DELETE /api/config/endpoints/ep-b = %d: %s", w.Code, w.Body.String())
+	}
+
+	after := srv.getSender()
+	if after == nil {
+		t.Fatal("server default sender missing after endpoint delete")
+	}
+	if after == before {
+		t.Error("default sender pointer did not change after endpoint delete")
+	}
+}
+
+// TestDeleteEndpointModel_ReloadsDefaultSender covers the same wiring gap in
+// handleDeleteEndpointModel: deleting a model can clear Default (when it
+// pointed at "<id>::<model>"), so the default sender must be rebuilt.
+func TestDeleteEndpointModel_ReloadsDefaultSender(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Endpoints: []config.Endpoint{
+			{ID: "ep-a", Provider: "custom", BaseURL: "https://api.example.com", Protocol: "anthropic", APIKey: "sk-test", Models: []config.EndpointModel{{Model: "m1"}, {Model: "m2"}}},
+		},
+		Default: "ep-a::m1",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	before := srv.getSender()
+	if before == nil {
+		t.Fatal("server should have a default sender after startup")
+	}
+
+	w := doJSON(t, srv, http.MethodDelete, "/api/config/endpoints/ep-a/models/m2", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("DELETE /api/config/endpoints/ep-a/models/m2 = %d: %s", w.Code, w.Body.String())
+	}
+
+	after := srv.getSender()
+	if after == nil {
+		t.Fatal("server default sender missing after endpoint model delete")
+	}
+	if after == before {
+		t.Error("default sender pointer did not change after endpoint model delete")
+	}
+}
+
 func TestSetEndpointDefault_WithModelQuery_SetsSpecificModel(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{


### PR DESCRIPTION
## 问题

在设置里编辑端点的连接参数（Base URL、API Key、**自定义请求头**等）后，已保存但未绑定模型的会话不生效——请求仍然带着旧的连接参数发出，直到重启服务器。

## 根因

服务端有两类 sender：

- **按端点缓存的 sender**（`senderCache`，key 如 `Kimi::k3-256k`）——绑定了模型的会话使用
- **默认 sender**（`s.sender`）——未绑定会话使用，只能由 `reloadDefaultSender()` 重建

`handleUpdateEndpoint` / `handleDeleteEndpoint` / `handleDeleteEndpointModel` 保存配置后只调用了 `invalidateEndpointSenders()` 清第一类缓存，漏掉了 `reloadDefaultSender()`（对比：改默认模型、reasoning_effort、show_reasoning 的接口都调了）。删除端点/模型时还可能清空 `cfg.Default`，默认 sender 同样需要重建。

## 修复

三个 handler 在 `invalidateEndpointSenders()` 之后补 `reloadDefaultSender()`（出错只记日志、不失败请求，与现有模式一致）。

## 测试

新增 3 个回归测试（未修复时全部变红，修复后全绿）：

- `TestUpdateEndpoint_ReloadsDefaultSender` — PATCH 端点 headers 后默认 sender 重建，未绑定会话拿到新 sender
- `TestDeleteEndpoint_ReloadsDefaultSender`
- `TestDeleteEndpointModel_ReloadsDefaultSender`

`go test ./internal/server/ ./internal/config/ ./internal/app/` 全绿。

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
