### PR TITLE
fix(web): highlight only the bound endpoint's model in the composer picker

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -123,6 +123,7 @@ func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) 
 		CreatedAt:           s.CreatedAt,
 		UpdatedAt:           updated,
 		Model:               s.Model,
+		ModelID:             s.ModelConfig,
 		Status:              srv.sessionStatus(s.ID),
 		Source:              source,
 		AgentProfile:        agentProfile,

--- a/internal/server/model_binding_endpoint_test.go
+++ b/internal/server/model_binding_endpoint_test.go
@@ -99,3 +99,40 @@ func TestHandleCreateSession_CompositeIDKeepsEndpoint(t *testing.T) {
 		t.Fatalf("re-resolved entry = (%+v, %v), want the ep-proxy endpoint", entry, ok)
 	}
 }
+
+// The session list must surface the binding as model_id: the composer's model
+// menu highlights the current row by composite id, and two endpoints exposing
+// the same model name are indistinguishable by the bare name alone.
+func TestHandleListSessions_SurfacesModelID(t *testing.T) {
+	sameModelTwoEndpointsConfig(t)
+
+	sess := agent.NewSession("kimi-k2.6", "")
+	sess.ModelConfig = "ep-proxy::kimi-k2.6"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := doJSON(t, srv, http.MethodGet, "/api/sessions", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/sessions = %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Sessions []struct {
+			ID      string `json:"id"`
+			ModelID string `json:"model_id"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range resp.Sessions {
+		if s.ID == sess.ID {
+			if s.ModelID != "ep-proxy::kimi-k2.6" {
+				t.Fatalf("model_id = %q, want the composite id ep-proxy::kimi-k2.6", s.ModelID)
+			}
+			return
+		}
+	}
+	t.Fatalf("session %s not in list", sess.ID)
+}

--- a/internal/server/model_binding_endpoint_test.go
+++ b/internal/server/model_binding_endpoint_test.go
@@ -136,3 +136,26 @@ func TestHandleListSessions_SurfacesModelID(t *testing.T) {
 	}
 	t.Fatalf("session %s not in list", sess.ID)
 }
+
+// The WS brief list feeds the sidebar's first hydration (session_list on
+// connect) and must carry the same binding identity as the HTTP list.
+func TestListSessionsBrief_SurfacesModelID(t *testing.T) {
+	sameModelTwoEndpointsConfig(t)
+
+	sess := agent.NewSession("kimi-k2.6", "")
+	sess.ModelConfig = "ep-proxy::kimi-k2.6"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	for _, info := range srv.listSessionsBrief() {
+		if info.ID == sess.ID {
+			if info.ModelID != "ep-proxy::kimi-k2.6" {
+				t.Fatalf("brief model_id = %q, want the composite id ep-proxy::kimi-k2.6", info.ModelID)
+			}
+			return
+		}
+	}
+	t.Fatalf("session %s not in brief list", sess.ID)
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -122,6 +122,7 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 			Source:              source,
 			AgentProfile:        sess.EffectiveAgentID(),
 			Model:               sess.Model,
+			ModelID:             sess.ModelConfig,
 			TotalTurns:          sess.TurnCount(),
 			WorkingDir:          s.sessionCwd(sess),
 			PermissionMode:      pm,

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -116,6 +116,7 @@ type wsSessionInfo struct {
 	Source              string `json:"source,omitempty"` // "manual" | "cron" | "channel" | "setup"
 	AgentProfile        string `json:"agent_profile,omitempty"`
 	Model               string `json:"model,omitempty"`
+	ModelID             string `json:"model_id,omitempty"`
 	TotalTurns          int    `json:"total_turns,omitempty"`
 	WorkingDir          string `json:"working_dir,omitempty"`
 	PermissionMode      string `json:"permission_mode,omitempty"`

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -773,7 +773,10 @@
         }
       }
       models = flat
-      defaultModelId = ep.default ?? ''
+      // Default is echoed verbatim from config — a hand-written file may
+      // carry a bare model name, which no menu row's composite id can ever
+      // equal. Treat that as identity-unknown so name matching still applies.
+      defaultModelId = ep.default?.includes('::') ? ep.default : ''
     } catch { /* keep the previous list */ }
   }
 

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -672,6 +672,9 @@
   // updateSessionModel, which resolves it via cfg.EntryByModel (composite-id
   // aware since PR2).
   let models = $state<{ id: string; model: string; endpoint: string }[]>([])
+  // Composite id of the configured default entry (EndpointsResponse.default),
+  // refreshed together with the model list.
+  let defaultModelId = $state('')
   let modelMenu = $state(false)
   let reasonMenu = $state(false)
   let dirMenu = $state(false)
@@ -687,6 +690,23 @@
       g.items.push({ id: m.id, model: m.model })
     }
     return out
+  })
+
+  // Composite id of the row the menu should highlight as current. Rows are
+  // unique by composite id but NOT by model name (two endpoints may expose
+  // the same model, #2141), so matching by name alone lights up both — prefer
+  // the composite id whenever one is known: the session's own binding
+  // (model_id), the pending pick for a yet-to-be-created session, or the
+  // configured default for an unbound session. Empty means identity unknown
+  // (legacy bare-model binding) and the menu falls back to name matching.
+  let activeModelId = $derived.by(() => {
+    const bound = currentSession?.model_id ?? ''
+    if (bound.includes('::')) return bound
+    if (bound) return ''
+    if (!sid) return $pendingModel || defaultModelId
+    // Unbound session: it runs on the default entry — trust that only while
+    // the default still points at the model the session displays.
+    return defaultModelId.split('::').pop() === modelName ? defaultModelId : ''
   })
 
   // ── agent assignment ───────────────────────────────────────────────────────
@@ -753,6 +773,7 @@
         }
       }
       models = flat
+      defaultModelId = ep.default ?? ''
     } catch { /* keep the previous list */ }
   }
 
@@ -1222,7 +1243,7 @@
                 {#each modelGroups as g (g.endpoint)}
                   <div class="menu-label mono">{g.endpoint}</div>
                   {#each g.items as m (m.id)}
-                    <button class="menu-item" class:active={m.model === modelName} onclick={() => pickModel({ id: m.id, model: m.model, endpoint: g.endpoint })}>
+                    <button class="menu-item" class:active={activeModelId ? m.id === activeModelId : m.model === modelName} onclick={() => pickModel({ id: m.id, model: m.model, endpoint: g.endpoint })}>
                       <span class="mi-name mono">{m.model}</span>
                     </button>
                   {/each}


### PR DESCRIPTION
## Problem

The composer's model menu marks the current row with `m.model === modelName` — a bare model-name comparison. With two endpoints exposing the same model name (e.g. `deepseek::deepseek-v4-flash` and `opencode::deepseek-v4-flash`), both rows are highlighted.

## Root cause

The frontend can't do better: `sessionItem.ModelID` (json `model_id`) existed but was never populated in `GET /api/sessions`, and the WS brief list (`wsSessionInfo`) had no such field at all. The only place the composite id reached the client was the `PATCH /model` response, which does not survive a reload or a WS `session_list` refresh.

## Fix

- **Server**: populate `model_id` from `Session.ModelConfig` in `toSessionItem` and in the WS brief list (`wsSessionInfo` gains `model_id`).
- **Composer**: highlight by composite id when one is known — the session's own binding, then the pending pick for a yet-to-be-created session, then the configured default (`EndpointsResponse.default`) for an unbound session. Bare-name matching stays as the fallback for legacy bare-model bindings.

The mobile `NewTask` picker binds a `<select>` to the composite id directly and was not affected.

## Testing

- New `TestHandleListSessions_SurfacesModelID` (two endpoints, same model name → list returns the composite id).
- `go test ./internal/server/`, `go vet`, `gofmt -l` clean.
- `svelte-check` 0 errors; web `vitest` 230/230 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)