### PR TITLE
fix(web): Fix the style of the upgrade prompt box being positioned too far to the left

### DIFF
--- a/web/src/components/layout/VersionBadge.svelte
+++ b/web/src/components/layout/VersionBadge.svelte
@@ -253,7 +253,7 @@
 .vb-scrim { position: fixed; inset: 0; z-index: 60; background: none; border: none; cursor: default; }
 .vb-pop {
   position: absolute; bottom: calc(100% + 8px); right: 0; z-index: 61;
-  width: 260px; padding: 14px;
+  width: 232px; padding: 14px;
   background: var(--bg-container); border: 1px solid var(--border);
   border-radius: 10px; box-shadow: 0 12px 32px rgba(0,0,0,0.16);
   animation: octo-fadein 0.14s ease;


### PR DESCRIPTION
# Problem

The maximum width of the leftmost border is `256px`, but the width of the upgrade pop-up box is set to `260px`, and `padding` and `border` are also set, resulting in the overall content being shifted to the left and not centered

like this:
<img width="294" height="219" alt="before" src="https://github.com/user-attachments/assets/f5873e0b-67a3-4d20-80a2-3ad096d02d2d" />

# Fix

Set the width of the pop-up box to `232px`, so that it is centered overall

like this:
<img width="283" height="230" alt="after" src="https://github.com/user-attachments/assets/990ca477-6ef4-4147-9818-532d0919a188" />

# Testing

Only the style of a single page was changed, without modifying any critical code. It was only previewed after local compilation