### PR TITLE
fix(server): broadcast live context usage on each tool round

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -245,6 +245,11 @@ type Agent struct {
 	// lastInputTokens is the size of the most recently sent context, used as
 	// the compaction trigger.
 	lastInputTokens int
+	// toolDefTokens is the estimated size of the tool schemas sent with each
+	// request, stashed at Run/RunStream entry from the actual definitions.
+	// Folded into ContextUsage's estimate fallback only — the transcript
+	// alone badly undercounts what a request actually sends.
+	toolDefTokens int
 
 	// Inbox holds user messages that arrived while a turn was running.
 	// The run loop drains it at the start of each iteration, before the LLM
@@ -824,6 +829,7 @@ func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinitio
 	if userInput == "" && len(a.pendingUserBlocks) == 0 {
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
+	a.setToolDefOverhead(tools)
 
 	// Fire Stop once the turn concludes — success or failure. Registered after
 	// validation so config errors (no turn ran) don't emit a spurious Stop. The
@@ -874,6 +880,7 @@ func (a *Agent) RunStream(
 	if userInput == "" && len(a.pendingUserBlocks) == 0 {
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
+	a.setToolDefOverhead(tools)
 
 	// Fire Stop once the turn concludes — success or failure. See Run.
 	defer func() { a.fireStop(userInput, reply, err) }()
@@ -2312,14 +2319,33 @@ func (a *Agent) resetContextTrigger() {
 func (a *Agent) ContextUsage() (used, window int) {
 	a.usageMu.Lock()
 	real := a.lastInputTokens
+	overhead := a.toolDefTokens
 	a.usageMu.Unlock()
 	if real > 0 {
 		return real, contextWindow(a.Model)
 	}
 	// Only pay for the History snapshot + heuristic estimate when there's no
 	// real count yet (cold start) — this is called at TUI render-tick rate,
-	// where a real count is the common case.
-	return estimateMessages(a.History.Snapshot()), contextWindow(a.Model)
+	// where a real count is the common case. The transcript alone badly
+	// undercounts what a request actually sends: the system prompt and tool
+	// schemas ride every call and routinely add 10k+ tokens, so include both
+	// (tool schemas once Run/RunStream has stashed their size).
+	est := estimateMessages(a.History.Snapshot()) + estimateText(a.System) + overhead
+	return est, contextWindow(a.Model)
+}
+
+// setToolDefOverhead stashes the estimated wire size of the tool schemas sent
+// with each request, so ContextUsage's estimate fallback accounts for them.
+// Called at Run/RunStream entry with the actual definitions (nil clears it —
+// a no-tools turn sends none).
+func (a *Agent) setToolDefOverhead(tools []ToolDefinition) {
+	total := 0
+	for _, d := range tools {
+		total += estimateText(d.Name) + estimateText(d.Description) + estimateMap(d.Parameters)
+	}
+	a.usageMu.Lock()
+	a.toolDefTokens = total
+	a.usageMu.Unlock()
 }
 
 // RealContextTokens returns the provider-reported size of the most recently

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2322,6 +2322,17 @@ func (a *Agent) ContextUsage() (used, window int) {
 	return estimateMessages(a.History.Snapshot()), contextWindow(a.Model)
 }
 
+// RealContextTokens returns the provider-reported size of the most recently
+// sent context, or 0 when no round-trip has reported usage yet (a fresh Agent
+// before its first reply lands). Unlike ContextUsage it never falls back to
+// the transcript estimate — for callers that have a better zero fallback
+// (e.g. the persisted Session.LastContextTokens).
+func (a *Agent) RealContextTokens() int {
+	a.usageMu.Lock()
+	defer a.usageMu.Unlock()
+	return a.lastInputTokens
+}
+
 // PersistContextUsage records this agent's current context-window token count on
 // the session (Session.LastContextTokens) so an idle or resumed session — one
 // with no live Agent in memory — reports its true context usage instead of a

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2330,7 +2330,15 @@ func (a *Agent) ContextUsage() (used, window int) {
 	// undercounts what a request actually sends: the system prompt and tool
 	// schemas ride every call and routinely add 10k+ tokens, so include both
 	// (tool schemas once Run/RunStream has stashed their size).
-	est := estimateMessages(a.History.Snapshot()) + estimateText(a.System) + overhead
+	msgs := a.History.Snapshot()
+	if len(msgs) == 0 {
+		// A conversation that hasn't started (or was just /clear-ed) shows no
+		// gauge at all — the system/tools overhead is real but reporting it
+		// here would put a misleading "ctx N%" on an empty transcript (the
+		// TUI status bar keys on used > 0).
+		return 0, contextWindow(a.Model)
+	}
+	est := estimateMessages(msgs) + estimateText(a.System) + overhead
 	return est, contextWindow(a.Model)
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1473,9 +1473,13 @@ func TestContextUsage_EstimateIncludesSystemAndToolSchemas(t *testing.T) {
 
 // A brand new session with no history yet must report used == 0, not a
 // nonzero estimate, or the TUI status bar's used > 0 guard would show a
-// misleading "ctx N%" for a conversation that hasn't started.
+// misleading "ctx N%" for a conversation that hasn't started. The real TUI
+// always has a composed System (and, once a turn ran, stashed tool schemas)
+// before the first message — the empty-transcript gate must beat both.
 func TestContextUsage_ZeroForEmptyHistory(t *testing.T) {
 	a := New(nil, "m")
+	a.System = strings.Repeat("rule ", 400)
+	a.setToolDefOverhead([]ToolDefinition{{Name: "terminal", Description: "runs a command"}})
 
 	if used, _ := a.ContextUsage(); used != 0 {
 		t.Errorf("ContextUsage used = %d, want 0 for empty history", used)
@@ -1487,6 +1491,10 @@ func TestContextUsage_ZeroForEmptyHistory(t *testing.T) {
 func TestContextUsage_ZeroAfterClearHistory(t *testing.T) {
 	send := &fakeSender{reply: Reply{Content: "ok", InputTokens: 500}}
 	a := New(send, "m")
+	// ClearHistory keeps System and the stashed tool overhead — only the
+	// transcript is wiped, so the empty-transcript gate must carry the reset.
+	a.System = strings.Repeat("rule ", 400)
+	a.setToolDefOverhead([]ToolDefinition{{Name: "terminal", Description: "runs a command"}})
 	if _, err := a.Turn(context.Background(), "hi"); err != nil {
 		t.Fatalf("Turn: %v", err)
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1429,6 +1429,48 @@ func TestContextUsage_EstimatesFromHistoryBeforeFirstTurn(t *testing.T) {
 	}
 }
 
+// The estimate fallback must count the whole request, not just the transcript:
+// the system prompt and tool schemas ride every call and routinely add 10k+
+// tokens, so a transcript-only estimate read far below the real count the
+// provider reports one round-trip later (the gauge visibly jumped up).
+func TestContextUsage_EstimateIncludesSystemAndToolSchemas(t *testing.T) {
+	a := New(nil, "m")
+	a.History.Append(Message{Role: "user", Content: strings.Repeat("word ", 200)})
+	base, _ := a.ContextUsage()
+
+	a.System = strings.Repeat("rule ", 400)
+	withSystem, _ := a.ContextUsage()
+	if want := base + estimateText(a.System); withSystem != want {
+		t.Errorf("ContextUsage with system = %d, want %d (transcript + system prompt)", withSystem, want)
+	}
+
+	defs := []ToolDefinition{{
+		Name:        "terminal",
+		Description: strings.Repeat("runs a shell command ", 20),
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"command": map[string]any{"type": "string"}},
+		},
+	}}
+	a.setToolDefOverhead(defs)
+	withTools, _ := a.ContextUsage()
+	if withTools <= withSystem {
+		t.Errorf("ContextUsage with tool schemas = %d, want > %d", withTools, withSystem)
+	}
+
+	// A no-tools turn sends no schemas — nil must clear the stash.
+	a.setToolDefOverhead(nil)
+	if cleared, _ := a.ContextUsage(); cleared != withSystem {
+		t.Errorf("ContextUsage after clearing tool overhead = %d, want %d", cleared, withSystem)
+	}
+
+	// A real provider-reported count always wins over the estimate.
+	a.accrueUsage(Reply{InputTokens: 12345})
+	if real, _ := a.ContextUsage(); real != 12345 {
+		t.Errorf("ContextUsage with real count = %d, want 12345", real)
+	}
+}
+
 // A brand new session with no history yet must report used == 0, not a
 // nonzero estimate, or the TUI status bar's used > 0 guard would show a
 // misleading "ctx N%" for a conversation that hasn't started.

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -41,6 +41,11 @@ func ContextWindow(model string) int { return contextWindow(model) }
 // ContextUsage instead of maintaining a second implementation.
 func EstimateTokens(msgs []Message) int { return estimateMessages(msgs) }
 
+// EstimateTextTokens exposes estimateText for the same reason — the web
+// server folds a resumed session's frozen system prompt into its cold-start
+// context-percent estimate, which the transcript-only count omits.
+func EstimateTextTokens(s string) int { return estimateText(s) }
+
 // contextWindow returns the approximate context-window size (in tokens) for a
 // model. Values are deliberately conservative; matched case-insensitively by
 // substring so dated/aliased names ("claude-haiku-4-5-2025…") still resolve.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2631,6 +2631,102 @@ func TestWSStreamWriter_TurnError_DistinctType(t *testing.T) {
 	}
 }
 
+// TestWSStreamWriter_BroadcastsContextUsageMidTurn guards the live refresh of
+// the composer's Context bar: the only other context_usage broadcasts happen
+// at subscribe time and at turn end, so each tool round must push the Agent's
+// fresh count — and parallel tool calls in one round (same count) must push
+// it once, not per tool.
+func TestWSStreamWriter_BroadcastsContextUsageMidTurn(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "sess-ctx-usage"
+	a := agent.New(&stubSender{}, "stub-model")
+	// A resumed-history estimate is the only usage source reachable from a
+	// test (real counts come from provider replies); any positive count
+	// exercises the same broadcast path.
+	a.History.Append(agent.NewUserMessage(strings.Repeat("x", 8000)))
+	srv.sessionAgentsMu.Lock()
+	srv.sessionAgents[sid] = a
+	srv.sessionAgentsMu.Unlock()
+
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+	srv.wsHub.subscribe(conn, sid)
+
+	sw := srv.newWSStreamWriter(sid)
+
+	// drainUntil reads broadcasts until an event of type typ (or deadline),
+	// returning it plus every session_update seen on the way.
+	drainUntil := func(typ string) (map[string]any, []map[string]any) {
+		deadline := time.After(2 * time.Second)
+		var updates []map[string]any
+		for {
+			select {
+			case b := <-conn.send:
+				var ev map[string]any
+				if err := json.Unmarshal(b, &ev); err != nil {
+					continue
+				}
+				if got, _ := ev["type"].(string); got == "session_update" {
+					updates = append(updates, ev)
+				} else if got == typ {
+					return ev, updates
+				}
+			case <-deadline:
+				return nil, updates
+			}
+		}
+	}
+
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolName: "terminal", ToolID: "t1"})
+	// Sentinel: hub delivery is FIFO per conn, so once the delta arrives every
+	// broadcast from the tool start has been delivered.
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "sentinel"})
+	if ev, updates := drainUntil("text_delta"); ev == nil {
+		t.Fatal("sentinel text_delta never arrived")
+	} else if len(updates) != 1 {
+		t.Fatalf("got %d session_update broadcasts after first tool start, want 1: %v", len(updates), updates)
+	} else {
+		if tok, _ := updates[0]["context_tokens"].(float64); tok <= 0 {
+			t.Errorf("context_tokens = %v, want > 0", updates[0]["context_tokens"])
+		}
+		if _, ok := updates[0]["context_usage"].(float64); !ok {
+			t.Errorf("context_usage missing from mid-turn session_update: %v", updates[0])
+		}
+		if _, ok := updates[0]["status"]; ok {
+			t.Errorf("mid-turn session_update must not carry status (it would clobber \"running\"): %v", updates[0])
+		}
+	}
+
+	// Same count again (a second tool in the same round) — deduped.
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolName: "terminal", ToolID: "t2"})
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "sentinel"})
+	if ev, updates := drainUntil("text_delta"); ev == nil {
+		t.Fatal("sentinel text_delta never arrived")
+	} else if len(updates) != 0 {
+		t.Fatalf("got %d session_update broadcasts for an unchanged count, want 0: %v", len(updates), updates)
+	}
+
+	// The count grows (next provider round-trip landed) — broadcast resumes.
+	a.History.Append(agent.NewUserMessage(strings.Repeat("y", 8000)))
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolName: "terminal", ToolID: "t3"})
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "sentinel"})
+	if ev, updates := drainUntil("text_delta"); ev == nil {
+		t.Fatal("sentinel text_delta never arrived")
+	} else if len(updates) != 1 {
+		t.Fatalf("got %d session_update broadcasts after the count grew, want 1: %v", len(updates), updates)
+	}
+}
+
 // PATCH /api/sessions/{id} is the sidebar rename action — the title must
 // persist through a session reload, and bad input must not slip through.
 func TestHandleUpdateSession_Rename(t *testing.T) {

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -234,14 +234,23 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 
 // estimateContextPct approximates how full the model's context window a
 // persisted transcript occupies, using the same heuristic Agent.ContextUsage
-// falls back to (agent.EstimateTokens). Used only when no live token count is
-// available (no Agent has run in this process for the session yet).
+// falls back to (agent.EstimateTokens). Used only when no real token count is
+// available anywhere (neither a live Agent nor a persisted LastContextTokens).
+// The frozen system prompt rides every request, so it counts too — the
+// transcript alone reads far lower than what a turn actually sends. Tool
+// schemas also ride along but the session doesn't record them; this stays a
+// (closer) lower bound.
 func estimateContextPct(sess *agent.Session) int {
 	window := agent.ContextWindow(sess.Model)
 	if window <= 0 {
 		return 0
 	}
-	return agent.EstimateTokens(sess.Messages) * 100 / window
+	sys := sess.ComposedSystem
+	if sys == "" {
+		sys = sess.System
+	}
+	est := agent.EstimateTokens(sess.Messages) + agent.EstimateTextTokens(sys)
+	return est * 100 / window
 }
 
 // replayLiveState replays in-progress agent state (progress + stdout) to a

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1946,6 +1946,11 @@ type wsStreamWriter struct {
 	hub       *wsHub
 	server    *Server // for live state tracking
 	mu        sync.Mutex
+
+	// lastCtxTokens is the context-token count most recently broadcast by
+	// broadcastContextUsage, so parallel tool calls in one round (same count)
+	// broadcast once. Guarded by mu (handleEvent holds it).
+	lastCtxTokens int
 }
 
 func (s *Server) newWSStreamWriter(sessionID string) *wsStreamWriter {
@@ -2042,6 +2047,37 @@ func (w *wsStreamWriter) reseedThinkingProgress() {
 	})
 }
 
+// broadcastContextUsage pushes the live context-window fill to subscribed
+// tabs mid-turn. The Agent updates its count after every provider round-trip,
+// but the only other context_usage broadcasts happen at subscribe time and at
+// turn end — without this, a long multi-tool turn leaves the composer's
+// Context bar frozen at its turn-start value until the turn finishes. Called
+// on EventToolStarted (the first event after each round-trip's usage lands)
+// and deduped by token count. Caller must hold w.mu.
+func (w *wsStreamWriter) broadcastContextUsage() {
+	w.server.sessionAgentsMu.Lock()
+	a := w.server.sessionAgents[w.sessionID]
+	w.server.sessionAgentsMu.Unlock()
+	if a == nil {
+		return
+	}
+	used, window := a.ContextUsage()
+	if used <= 0 || window <= 0 || used == w.lastCtxTokens {
+		return
+	}
+	w.lastCtxTokens = used
+	pct := used * 100 / window
+	if pct > 100 {
+		pct = 100
+	}
+	w.hub.broadcast(w.sessionID, map[string]any{
+		"type":           "session_update",
+		"session_id":     w.sessionID,
+		"context_usage":  pct,
+		"context_tokens": used,
+	})
+}
+
 // handleEvent converts agent.AgentEvent to WS JSON events and broadcasts them.
 // It also updates the server's live state for late-subscriber replay.
 func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
@@ -2091,6 +2127,11 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 			ls.stdoutToolID = ""
 		}
 		w.server.liveStateMu.Unlock()
+
+		// The provider round-trip that produced this tool call already folded
+		// its usage into the live Agent (accrueUsage), so this is the earliest
+		// point each round where the fresh count is available.
+		w.broadcastContextUsage()
 
 	case agent.EventToolProgress:
 		// Live output for a running terminal command (issue #1094). Only

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -193,25 +193,27 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 			}
 		}
 	}
-	if pct == 0 && sess != nil && sess.LastContextTokens > 0 {
+	if usedTokens == 0 && sess != nil && sess.LastContextTokens > 0 {
 		// Idle/resumed session — or a turn whose first provider call hasn't
 		// reported usage yet (RealContextTokens returns 0). Report the real
 		// count persisted from its last turn (matches what the turn-end
-		// broadcast sent).
+		// broadcast sent). Keyed on usedTokens, not pct: a live count too
+		// small to reach 1% of the window (a huge-window model, or right
+		// after a mid-turn compaction) is still authoritative and must not
+		// be displaced by a larger stale persisted count.
 		if window := agent.ContextWindow(sess.Model); window > 0 {
 			pct = sess.LastContextTokens * 100 / window
 			usedTokens = sess.LastContextTokens
 		}
 	}
-	if pct == 0 && sess != nil {
-		// No real count anywhere (a session predating the field, one that never
-		// completed a turn with a real count, or a count too small to reach 1% of
-		// the window): fall back to a transcript estimate. It carries no exact
-		// token count, so clear usedTokens — the UI shows a bare arrow.
+	if usedTokens == 0 && sess != nil {
+		// No real count anywhere (a session predating the field, or one that
+		// never completed a turn with a real count): fall back to a transcript
+		// estimate. It carries no exact token count, so usedTokens stays 0 —
+		// the UI shows a bare arrow.
 		pct = estimateContextPct(sess)
-		usedTokens = 0
 	}
-	if pct <= 0 {
+	if pct <= 0 && usedTokens <= 0 {
 		return
 	}
 	if pct > 100 {
@@ -243,6 +245,12 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 func estimateContextPct(sess *agent.Session) int {
 	window := agent.ContextWindow(sess.Model)
 	if window <= 0 {
+		return 0
+	}
+	if len(sess.Messages) == 0 {
+		// Same gate as Agent.ContextUsage: an empty transcript (new session,
+		// or just /clear-ed) shows no gauge — the system prompt overhead is
+		// real but a "ctx N%" on a conversation that hasn't started misleads.
 		return 0
 	}
 	sys := sess.ComposedSystem
@@ -683,6 +691,10 @@ func (s *Server) wsClearSession(sid string) {
 		return
 	}
 	sess.Messages = nil
+	// The persisted count describes the wiped conversation — left in place, a
+	// resubscribe after /clear would report the pre-clear context usage (the
+	// broadcast below says 0, but sendContextUsage reads this field).
+	sess.LastContextTokens = 0
 	if err := sess.Save(); err != nil {
 		s.wsToast(sid, "Clear failed: "+err.Error(), "error")
 		return

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -179,16 +179,25 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 	s.sessionAgentsMu.Unlock()
 	sess, _ := agent.LoadSession(sessionID)
 	if a != nil {
-		// Turn in flight: the live Agent has the exact current count.
-		if used, window := a.ContextUsage(); window > 0 && used > 0 {
-			pct = used * 100 / window
-			usedTokens = used
+		// Turn in flight: the live Agent has the exact current count. Only the
+		// provider-reported count qualifies — before the turn's first
+		// round-trip lands, ContextUsage() would fall back to a chars/4
+		// transcript estimate that undercounts (no system-prompt/tools
+		// overhead), making the bar visibly SHRINK on a mid-turn resubscribe.
+		// The persisted last-turn count below is far closer; the next round's
+		// usage broadcast corrects it.
+		if used := a.RealContextTokens(); used > 0 {
+			if window := agent.ContextWindow(a.Model); window > 0 {
+				pct = used * 100 / window
+				usedTokens = used
+			}
 		}
 	}
 	if pct == 0 && sess != nil && sess.LastContextTokens > 0 {
 		// Idle/resumed session — or a turn whose first provider call hasn't
-		// reported usage yet (live agent returns 0). Report the real count
-		// persisted from its last turn (matches what the turn-end broadcast sent).
+		// reported usage yet (RealContextTokens returns 0). Report the real
+		// count persisted from its last turn (matches what the turn-end
+		// broadcast sent).
 		if window := agent.ContextWindow(sess.Model); window > 0 {
 			pct = sess.LastContextTokens * 100 / window
 			usedTokens = sess.LastContextTokens

--- a/internal/server/ws_handlers_test.go
+++ b/internal/server/ws_handlers_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -103,6 +104,54 @@ func TestSendContextUsage_UsesPersistedTokens(t *testing.T) {
 	}
 	if reloaded.LastContextTokens != 6400 {
 		t.Fatalf("reloaded LastContextTokens = %d, want 6400", reloaded.LastContextTokens)
+	}
+}
+
+// A mid-turn resubscribe before the turn's first provider round-trip reports
+// usage must fall back to the persisted last-turn count, NOT the live Agent's
+// transcript estimate. serve registers a fresh Agent (restored history, no
+// real count yet) at turn start; the estimate omits the system-prompt/tools
+// overhead, so trusting it made the Context bar visibly shrink on a page
+// refresh during a turn, then jump back once usage landed.
+func TestSendContextUsage_PrefersPersistedOverLiveEstimate(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	sess := agent.NewSession("stub-model", "")
+	sess.LastContextTokens = 6400
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A turn-in-flight Agent whose first round-trip hasn't reported usage:
+	// restored history yields a chars/4 estimate (~2000 tokens here) that
+	// undercuts the persisted 6400.
+	a := agent.New(&stubSender{}, "stub-model")
+	a.History.Append(agent.NewUserMessage(strings.Repeat("x", 8000)))
+	srv.sessionAgentsMu.Lock()
+	srv.sessionAgents[sess.ID] = a
+	srv.sessionAgentsMu.Unlock()
+
+	conn := &wsConn{send: make(chan []byte, 4), subscribed: map[string]struct{}{}}
+	srv.sendContextUsage(sess.ID, conn)
+
+	select {
+	case b := <-conn.send:
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if ct, _ := m["context_tokens"].(float64); ct != 6400 {
+			t.Fatalf("context_tokens = %v, want the persisted 6400 (a smaller value means the live estimate won)", m["context_tokens"])
+		}
+		if cu, _ := m["context_usage"].(float64); cu != 5 {
+			t.Fatalf("context_usage = %v, want 5 (6400/128000)", cu)
+		}
+	default:
+		t.Fatal("sendContextUsage sent no frame")
 	}
 }
 

--- a/internal/server/ws_handlers_test.go
+++ b/internal/server/ws_handlers_test.go
@@ -155,6 +155,27 @@ func TestSendContextUsage_PrefersPersistedOverLiveEstimate(t *testing.T) {
 	}
 }
 
+// The cold-start estimate must count the frozen system prompt riding every
+// request (transcript alone reads far too low) — but never on an empty
+// transcript, where any nonzero gauge misleads (new session, or just
+// /clear-ed with the persisted count reset).
+func TestEstimateContextPct_ComposedSystemAndEmptyGate(t *testing.T) {
+	sess := agent.NewSession("stub-model", "")
+	sess.ComposedSystem = strings.Repeat("rule ", 8000) // ~10k tokens of a 128k window
+
+	if got := estimateContextPct(sess); got != 0 {
+		t.Errorf("estimateContextPct on empty transcript = %d, want 0", got)
+	}
+
+	sess.Messages = []agent.Message{agent.NewUserMessage(strings.Repeat("word ", 800))}
+	withComposed := estimateContextPct(sess)
+	sess.ComposedSystem = ""
+	transcriptOnly := estimateContextPct(sess)
+	if withComposed <= transcriptOnly {
+		t.Errorf("estimateContextPct with composed system = %d, want > transcript-only %d", withComposed, transcriptOnly)
+	}
+}
+
 // lastVisibleUserIdx must land on the typed prompt, not the tool_result
 // carrier an agentic turn leaves as its most recent user-role message.
 func TestLastVisibleUserIdx_SkipsToolResultCarriers(t *testing.T) {


### PR DESCRIPTION
Three fixes to the same web-UI Context bar (the third also improves the TUI's cold-start gauge). No frontend change — `App.svelte`/`ChatView.svelte` already merge `session_update` per-field.

## 1. Frozen bar during multi-tool turns

During a multi-tool turn, the composer's Context bar stayed frozen at its turn-start value and only jumped to the real count when the turn finished.

The data source is live the whole time — the Agent folds usage in after every provider round-trip (`accrueUsage`), and the TUI reads `Agent.ContextUsage()` at render time so it already refreshes live. The gap was server-side: the only `context_usage` broadcasts were the subscribe-time `sendContextUsage` and the turn-end `session_update`.

**Fix:** broadcast a partial `session_update` (`context_usage` + `context_tokens` only) from the `EventToolStarted` handler — the first event after each round-trip's usage lands. Deduped by token count so parallel tool calls in one round broadcast once.

## 2. Bar shrinks on mid-turn resubscribe

`sendContextUsage` trusted any positive count from the live Agent, but a turn-in-flight Agent whose first round-trip hasn't reported usage falls back to a transcript estimate that undercounts badly. A page refresh early in a turn made the bar visibly shrink, then jump back once real usage landed. The persisted-count fallback never triggered: the estimate is non-zero whenever history is non-empty.

**Fix:** add `Agent.RealContextTokens()` (provider-reported count only, 0 when none), making the subscribe-time priority: live real count > persisted `Session.LastContextTokens` > transcript estimate.

## 3. Estimate fallback badly undercounts

Where the estimate IS the only source (cold resume before the first turn, providers that omit usage, sessions predating the persisted count), it only measured the transcript. The system prompt and tool schemas ride every request and routinely add 10k+ tokens, so the estimated gauge read far below the real count and visibly jumped up one round-trip later.

**Fix:** `Agent.ContextUsage`'s fallback now adds `estimateText(a.System)` plus the tool-schema size stashed at Run/RunStream entry from the actual definitions (nil clears it for no-tools turns). The server's `estimateContextPct` adds the session's frozen composed system prompt. Compaction is untouched — `historyTokens`/`estimateMessages` keep their transcript-only semantics and use the real count whenever one exists.

## Testing

- `TestWSStreamWriter_BroadcastsContextUsageMidTurn`: one broadcast per round, dedupe on an unchanged count, resume when the count grows, no `status` field on the mid-turn event.
- `TestSendContextUsage_PrefersPersistedOverLiveEstimate`: a live Agent with restored history but no real count must yield the persisted 6400, not the ~2000-token estimate.
- `TestContextUsage_EstimateIncludesSystemAndToolSchemas`: estimate = transcript + system + tool schemas; nil clears the schema stash; a real count always wins.
- `go test -race ./...` full suite green; `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)