### PR TITLE
fix(desktop): recover webview from background black/blank screen

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -484,13 +484,19 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		// leaving a permanently blank window — nothing reloads it on its own.
 		// Navigate back to the hub root to revive the page (SetURL for the
 		// same reason as below: the page is octo-served, so the Wails runtime
-		// and ExecJS are unavailable). The event only fires on macOS; the
-		// registration is inert elsewhere. Windows' equivalent (WebView2
+		// and ExecJS are unavailable). Windows' equivalent (WebView2
 		// ProcessFailed) isn't reachable through Wails — prevention lives in
-		// the browser flags set in main.go instead.
-		w.OnWindowEvent(events.Mac.WebViewWebContentProcessDidTerminate, func(*application.WindowEvent) {
-			w.SetURL(shellURL(b.url, ""))
-		})
+		// the browser flags set in main.go instead. The b.window guard skips
+		// a terminate that races window close: Wails' SetURL has no
+		// isDestroyed check, so it could otherwise touch a freed NSWindow.
+		if runtime.GOOS == "darwin" {
+			w.OnWindowEvent(events.Mac.WebViewWebContentProcessDidTerminate, func(*application.WindowEvent) {
+				if b.window != w {
+					return
+				}
+				w.SetURL(shellURL(b.url, ""))
+			})
+		}
 		b.window = w
 	} else if hash != "" {
 		// Already open — navigate to the route. ExecJS can't be used here: the

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -480,6 +480,17 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		w.OnWindowEvent(events.Common.WindowDidResize, func(*application.WindowEvent) {
 			b.rememberWindowGeometry(w)
 		})
+		// macOS kills WKWebView's WebContent process under memory pressure,
+		// leaving a permanently blank window — nothing reloads it on its own.
+		// Navigate back to the hub root to revive the page (SetURL for the
+		// same reason as below: the page is octo-served, so the Wails runtime
+		// and ExecJS are unavailable). The event only fires on macOS; the
+		// registration is inert elsewhere. Windows' equivalent (WebView2
+		// ProcessFailed) isn't reachable through Wails — prevention lives in
+		// the browser flags set in main.go instead.
+		w.OnWindowEvent(events.Mac.WebViewWebContentProcessDidTerminate, func(*application.WindowEvent) {
+			w.SetURL(shellURL(b.url, ""))
+		})
 		b.window = w
 	} else if hash != "" {
 		// Already open — navigate to the route. ExecJS can't be used here: the

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -243,6 +243,17 @@ func main() {
 			// reachable. When they opt out, last-window-close quits as usual.
 			ApplicationShouldTerminateAfterLastWindowClosed: !settings.KeepRunningInBackground,
 		},
+		Windows: application.WindowsOptions{
+			// Chromium's native-window occlusion tracker stops rendering a
+			// WebView2 whose window is minimised or fully covered; on some
+			// machines the compositor never paints again after restore,
+			// leaving a permanently black window (WebView2Feedback#5171).
+			// Disable the tracker so a backgrounded window keeps its render
+			// pipeline alive. Wails appends this to its own disabled-feature
+			// defaults. The cost is a still-rendering hidden webview, which
+			// is acceptable for a tray-resident hub.
+			DisabledFeatures: []string{"CalculateNativeWinOcclusion"},
+		},
 	})
 	bridge.app = app
 


### PR DESCRIPTION
## Problem

On Windows, putting the desktop app in the background for a while and reopening it can leave the window **permanently black** (reported with a screenshot: full-black window, tray still shows the backend alive).

Root cause chain:
- Chromium's native-window occlusion tracker stops rendering a WebView2 whose window is minimised or fully covered; on some machines the compositor never paints again after restore — exactly [WebView2Feedback#5171](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5171).
- Wails v3 registers no `ProcessFailed` handler and its efficiency-mode mitigation is a commented-out TODO (`webview_window_windows.go:2493`, byte-identical through beta.9), so nothing ever recovers the webview.
- Our shell's `showWindowAt` only does `Show()+Focus()` on an existing window, so tray → "Show Octo" just foregrounds the dead surface.

macOS has an equivalent (rarer) failure: WKWebView's WebContent process killed under memory pressure → permanently blank window.

## Fix

- **Windows (prevention):** disable `CalculateNativeWinOcclusion` via `WindowsOptions.DisabledFeatures` so a backgrounded window keeps its render pipeline alive. Wails appends this to its own disabled-feature defaults. Cost: a hidden webview keeps rendering, acceptable for a tray-resident hub.
- **macOS (recovery):** Wails does surface the WKWebView termination as `events.Mac.WebViewWebContentProcessDidTerminate` — subscribe and revive by navigating back to the hub root. `SetURL` rather than `ExecJS` for the usual reason (page is octo-served; the Wails runtime never loads). The registration is inert on other platforms.

## Testing

- `go build` for host, `GOOS=windows`, `GOOS=darwin`; `go vet`; `gofmt -l` clean; `go test -race ./...` in `cmd/octo-desktop` passes.
- Needs a few days of real-world validation on a Windows machine (background the app, sleep/wake, reopen). If black screens persist after this (e.g. GPU-process crash on sleep/wake, [WebView2Feedback#3817](https://github.com/MicrosoftEdge/WebView2Feedback/issues/3817)), the follow-up is a native-shell heartbeat + window re-create on stale beat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)