### PR TITLE
chore: bump version to 1.15.19

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.18"
+var Version = "1.15.19"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release: desktop webview background black/blank screen fix (#2150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)