### PR TITLE
fix(openai): empty reasoning_content echo after thinking tool calls

### DIFF
--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -476,6 +476,12 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 	// with HTTP 400. Gating on an actually-seen trace keeps the field
 	// completely off sessions with non-thinking models and R1 (which rejects
 	// it on plain text turns); before the first trace nothing changes either.
+	// Known gap, accepted deliberately: a session whose every tool round
+	// skipped thinking never flips the gate, so a backend that demands the
+	// field even then still 400s. Closing it would need tracking field
+	// PRESENCE (not content) from responses through history — an agent-layer
+	// marker the streaming deltas can't reliably supply — for a case no
+	// real-world report has exhibited yet.
 	thinkingSeen := false
 	emptyReasoning := ""
 	for _, m := range in {

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -362,7 +362,9 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 	}
 	// Stash the reasoning trace on the tool_use block so it round-trips back to
 	// the API on the follow-up request (required by thinking models).
-	attachReasoning(blocks, first.Message.ReasoningContent)
+	if first.Message.ReasoningContent != nil {
+		attachReasoning(blocks, *first.Message.ReasoningContent)
+	}
 
 	return provider.Response{
 		Content:      first.Message.Content,
@@ -467,6 +469,15 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 	if strings.TrimSpace(systemPrompt) != "" {
 		out = append(out, apiMessage{Role: "system", Content: systemPrompt})
 	}
+	// DeepSeek V4 thinking mode: once a tool call carried a reasoning trace,
+	// every LATER assistant message must include reasoning_content — an empty
+	// string when that turn has none (a tool round where the model skipped
+	// thinking, a plain text answer) — or strict backends reject the request
+	// with HTTP 400. Gating on an actually-seen trace keeps the field
+	// completely off sessions with non-thinking models and R1 (which rejects
+	// it on plain text turns); before the first trace nothing changes either.
+	thinkingSeen := false
+	emptyReasoning := ""
 	for _, m := range in {
 		if m.Role == agent.RoleSystem {
 			continue
@@ -481,7 +492,8 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 					msg.Content = b.Text
 				case "tool_use":
 					if b.Reasoning != "" {
-						msg.ReasoningContent = b.Reasoning
+						r := b.Reasoning
+						msg.ReasoningContent = &r
 					}
 					msg.ToolCalls = append(msg.ToolCalls, apiToolCall{
 						ID:   b.ID,
@@ -492,6 +504,12 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 						},
 					})
 				}
+			}
+			if thinkingSeen && msg.ReasoningContent == nil {
+				msg.ReasoningContent = &emptyReasoning
+			}
+			if msg.ReasoningContent != nil && *msg.ReasoningContent != "" {
+				thinkingSeen = true
 			}
 			out = append(out, msg)
 			continue
@@ -566,7 +584,11 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 		}
 
 		// Plain text message.
-		out = append(out, apiMessage{Role: string(m.Role), Content: m.Content})
+		msg := apiMessage{Role: string(m.Role), Content: m.Content}
+		if m.Role == agent.RoleAssistant && thinkingSeen {
+			msg.ReasoningContent = &emptyReasoning
+		}
+		out = append(out, msg)
 	}
 	return out, nil
 }
@@ -574,8 +596,10 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 // attachReasoning records a thinking model's reasoning trace on the first
 // tool_use block so it survives in history and is re-sent on the follow-up
 // request. No-op when reasoning is empty or there is no tool_use block — which
-// keeps reasoning_content off plain text turns (some reasoning models reject it
-// there).
+// keeps stored reasoning off plain text turns (some reasoning models reject a
+// non-empty echo there). toAPIMessages may still emit an EMPTY
+// reasoning_content on later assistant turns once a trace has been seen; see
+// the thinkingSeen note there.
 func attachReasoning(blocks []agent.ContentBlock, reasoning string) {
 	if reasoning == "" {
 		return

--- a/internal/provider/openai/tools_test.go
+++ b/internal/provider/openai/tools_test.go
@@ -213,6 +213,88 @@ func TestReasoningContent_RoundTrips(t *testing.T) {
 	}
 }
 
+// TestReasoningContent_EmptyEchoAfterThinking verifies the DeepSeek V4
+// thinking-mode contract: once an assistant message carried a reasoning
+// trace, every LATER assistant message must include reasoning_content —
+// empty string when that turn has none. Assistant messages BEFORE the first
+// trace, and whole sessions without one, must keep the field omitted (R1
+// rejects it on plain text turns).
+func TestReasoningContent_EmptyEchoAfterThinking(t *testing.T) {
+	withReasoning := agent.NewToolUseBlock("call-1", "read_file", map[string]any{"path": "go.mod"})
+	withReasoning.Reasoning = "I should read the file."
+	withoutReasoning := agent.NewToolUseBlock("call-2", "read_file", map[string]any{"path": "go.sum"})
+
+	msgs, err := toAPIMessages("", []agent.Message{
+		agent.NewUserMessage("read go.mod"),
+		agent.NewAssistantMessage("a plain reply before any thinking"),
+		agent.NewToolUseMessage([]agent.ContentBlock{withReasoning}),
+		agent.NewToolResultMessage([]agent.ContentBlock{agent.NewToolResultBlock("call-1", "module x", false)}),
+		agent.NewAssistantMessage("final answer of that turn"),
+		agent.NewUserMessage("now read go.sum"),
+		agent.NewToolUseMessage([]agent.ContentBlock{withoutReasoning}),
+	})
+	if err != nil {
+		t.Fatalf("toAPIMessages: %v", err)
+	}
+
+	reasoningByIndex := map[int]*string{}
+	var assistants []int
+	for i, m := range msgs {
+		if m.Role == "assistant" {
+			assistants = append(assistants, i)
+			reasoningByIndex[i] = m.ReasoningContent
+		}
+	}
+	if len(assistants) != 4 {
+		t.Fatalf("assistant messages = %d, want 4", len(assistants))
+	}
+	if rc := reasoningByIndex[assistants[0]]; rc != nil {
+		t.Errorf("assistant before first trace: reasoning_content = %q, want omitted", *rc)
+	}
+	if rc := reasoningByIndex[assistants[1]]; rc == nil || *rc != "I should read the file." {
+		t.Errorf("tool-call assistant with trace: reasoning_content = %v, want the trace", rc)
+	}
+	if rc := reasoningByIndex[assistants[2]]; rc == nil || *rc != "" {
+		t.Errorf("plain text assistant after thinking: reasoning_content = %v, want empty string", rc)
+	}
+	if rc := reasoningByIndex[assistants[3]]; rc == nil || *rc != "" {
+		t.Errorf("tool-call assistant without trace after thinking: reasoning_content = %v, want empty string", rc)
+	}
+
+	// The empty echo must serialize as "reasoning_content":"" — omitempty on a
+	// nil pointer omits, but a pointer to "" must survive marshalling.
+	wire, err := json.Marshal(msgs[assistants[2]])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(wire), `"reasoning_content":""`) {
+		t.Errorf("empty echo not on the wire: %s", wire)
+	}
+	wire, err = json.Marshal(msgs[assistants[0]])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(wire), "reasoning_content") {
+		t.Errorf("pre-thinking assistant must omit the field: %s", wire)
+	}
+
+	// A session with no trace anywhere keeps the field off every message.
+	msgs, err = toAPIMessages("", []agent.Message{
+		agent.NewUserMessage("read go.sum"),
+		agent.NewToolUseMessage([]agent.ContentBlock{withoutReasoning}),
+		agent.NewToolResultMessage([]agent.ContentBlock{agent.NewToolResultBlock("call-2", "hash y", false)}),
+		agent.NewAssistantMessage("done"),
+	})
+	if err != nil {
+		t.Fatalf("toAPIMessages: %v", err)
+	}
+	for _, m := range msgs {
+		if m.ReasoningContent != nil {
+			t.Errorf("non-thinking session: role=%s carries reasoning_content %q, want omitted", m.Role, *m.ReasoningContent)
+		}
+	}
+}
+
 // TestSend_ToolResultMessages_WireFormat verifies that tool_result blocks are
 // serialized as individual role="tool" messages (OpenAI format).
 func TestSend_ToolResultMessages_WireFormat(t *testing.T) {

--- a/internal/provider/openai/tools_test.go
+++ b/internal/provider/openai/tools_test.go
@@ -295,6 +295,50 @@ func TestReasoningContent_EmptyEchoAfterThinking(t *testing.T) {
 	}
 }
 
+// TestReasoningContent_GateFlipsMidConversation pins the deliberate semantics
+// of the thinkingSeen gate when the FIRST tool round skipped thinking: that
+// round's assistant message stays without the field (nothing was seen yet),
+// and only messages after the first actual trace get the empty echo. This is
+// a known, accepted gap versus the literal V4 contract — do not "fix" the
+// pre-trace omission without solving field-presence tracking end to end (see
+// the thinkingSeen note in toAPIMessages).
+func TestReasoningContent_GateFlipsMidConversation(t *testing.T) {
+	round1 := agent.NewToolUseBlock("call-1", "read_file", map[string]any{"path": "go.mod"})
+	round2 := agent.NewToolUseBlock("call-2", "read_file", map[string]any{"path": "go.sum"})
+	round2.Reasoning = "now I should check the lockfile"
+
+	msgs, err := toAPIMessages("", []agent.Message{
+		agent.NewUserMessage("read both files"),
+		agent.NewToolUseMessage([]agent.ContentBlock{round1}),
+		agent.NewToolResultMessage([]agent.ContentBlock{agent.NewToolResultBlock("call-1", "module x", false)}),
+		agent.NewToolUseMessage([]agent.ContentBlock{round2}),
+		agent.NewToolResultMessage([]agent.ContentBlock{agent.NewToolResultBlock("call-2", "hash y", false)}),
+		agent.NewAssistantMessage("both read"),
+	})
+	if err != nil {
+		t.Fatalf("toAPIMessages: %v", err)
+	}
+
+	var assistants []*string
+	for _, m := range msgs {
+		if m.Role == "assistant" {
+			assistants = append(assistants, m.ReasoningContent)
+		}
+	}
+	if len(assistants) != 3 {
+		t.Fatalf("assistant messages = %d, want 3", len(assistants))
+	}
+	if assistants[0] != nil {
+		t.Errorf("traceless round before the first trace: reasoning_content = %q, want omitted", *assistants[0])
+	}
+	if assistants[1] == nil || *assistants[1] != "now I should check the lockfile" {
+		t.Errorf("first traced round: reasoning_content = %v, want the trace", assistants[1])
+	}
+	if assistants[2] == nil || *assistants[2] != "" {
+		t.Errorf("text turn after the trace: reasoning_content = %v, want empty string", assistants[2])
+	}
+}
+
 // TestSend_ToolResultMessages_WireFormat verifies that tool_result blocks are
 // serialized as individual role="tool" messages (OpenAI format).
 func TestSend_ToolResultMessages_WireFormat(t *testing.T) {

--- a/internal/provider/openai/types.go
+++ b/internal/provider/openai/types.go
@@ -100,8 +100,13 @@ type apiMessage struct {
 	ToolCallID string        `json:"tool_call_id,omitempty"`
 	// ReasoningContent is the thinking trace returned by reasoning models
 	// (deepseek-v4 etc.). It must be echoed back on the assistant message that
-	// carries tool_calls, or the next request is rejected; omitted otherwise.
-	ReasoningContent string `json:"reasoning_content,omitempty"`
+	// carries tool_calls, or the next request is rejected. DeepSeek V4 goes
+	// further: once a tool call happened in thinking mode, EVERY later
+	// assistant message must carry the field — empty string when that turn has
+	// no trace. A pointer distinguishes "send empty" (non-nil "") from "omit
+	// entirely" (nil), which matters for models that reject the field outright
+	// on plain text turns (R1) — see toAPIMessages.
+	ReasoningContent *string `json:"reasoning_content,omitempty"`
 	// ContentParts is the array form of content used for vision/multimodal
 	// messages. When non-empty it overrides Content in JSON serialization.
 	ContentParts []apiContentPart `json:"-"`


### PR DESCRIPTION
## Problem

A user on a DeepSeek V4 relay reported intermittent HTTP 400s in chat: `The reasoning_content in the thinking mode must be passed back to the API` — retry sometimes succeeds.

DeepSeek V4's thinking-mode contract is stricter than what #73 implemented: once a tool call has happened, **every subsequent assistant message** must carry `reasoning_content`, with an **empty string** when that turn has no trace (same rule other clients are hitting: [opencode#24130](https://github.com/anomalyco/opencode/issues/24130), [openclaude#878](https://github.com/Gitlawb/openclaude/issues/878)).

Our adapter only echoed the field on tool-call messages that actually carried a trace (`omitempty` string), so two shapes violated the rule on strict deployments:
- a tool round where the model skipped thinking (nondeterministic → the intermittent part),
- plain-text assistant turns replayed in later requests of a thinking session.

## Fix

- `apiMessage.ReasoningContent` becomes `*string`: `nil` omits the field, `&""` sends an empty echo.
- `toAPIMessages` tracks `thinkingSeen`: after the first non-empty trace in history, every later assistant message gets the field (stored trace or `""`).
- **Compatibility unchanged where it matters**: before the first trace, and in sessions with no trace at all, the field is never sent — R1 (rejects the field on plain text turns) and non-thinking backends see identical wire output. The existing `TestReasoningContent_RoundTrips` R1 guard still passes untouched.

## Testing

- New `TestReasoningContent_EmptyEchoAfterThinking`: pre-thinking text turn omits, traced tool round echoes verbatim, post-thinking text turn and traceless tool round send `""`, wire-level JSON asserts `"reasoning_content":""` survives marshalling, and a no-trace session carries the field nowhere.
- `go test -race ./...` passes; vet/gofmt clean.
- Note: this fixes the shape octo sends. If the user's relay strips the field in transit, only switching endpoints helps — worth re-testing on their relay after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)