### PR TITLE
chore: bump version to 1.15.20

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.19"
+var Version = "1.15.20"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release: DeepSeek V4 thinking-mode reasoning_content empty echo (#2152).

🤖 Generated with [Claude Code](https://claude.com/claude-code)