### PR TITLE
fix(web): dedupe session prepends to stop each_key_duplicate crash

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -128,7 +128,12 @@
     const folded = $collapsedSessions.map(id => byId.get(id)).filter(Boolean).filter(s => !claimed.has((s as any).id)) as typeof $sessions
     folded.forEach(s => claimed.add(s.id))
     const groups = $sessionGroups.map(g => {
-      const items = g.session_ids.map(id => byId.get(id)).filter(Boolean).filter(s => !claimed.has((s as any).id)) as typeof $sessions
+      // A duplicate id in session_ids (e.g. an optimistic prepend racing the
+      // 'session_created' broadcast's own full sessionGroups refresh) would
+      // otherwise map to the same session object twice and throw Svelte's
+      // each_key_duplicate on the keyed {#each} below.
+      const ids = [...new Set(g.session_ids)]
+      const items = ids.map(id => byId.get(id)).filter(Boolean).filter(s => !claimed.has((s as any).id)) as typeof $sessions
       items.forEach(s => claimed.add(s.id))
       return { group: g, items }
     })

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -137,7 +137,10 @@
       items.forEach(s => claimed.add(s.id))
       return { group: g, items }
     })
-    const ungrouped = $sessions.filter(s => !claimed.has(s.id))
+    // Route through byId (already deduped by id) rather than $sessions
+    // directly, for the same reason as the groups' session_ids above — a
+    // duplicate session id would otherwise reach this keyed {#each} twice.
+    const ungrouped = [...byId.values()].filter(s => !claimed.has((s as any).id))
     return { folded, pinned, groups, ungrouped }
   })
 

--- a/web/src/lib/prependSession.test.ts
+++ b/web/src/lib/prependSession.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { get } from 'svelte/store'
+import { sessions, prependSession } from './stores'
+import type { Session } from './types'
+
+const sess = (id: string, extra: Partial<Session> = {}): Session => ({ id, title: id, ...extra } as Session)
+
+describe('prependSession', () => {
+  it('puts a brand new session at the front', () => {
+    sessions.set([sess('a'), sess('b')])
+    prependSession(sess('new'))
+    expect(get(sessions).map(s => s.id)).toEqual(['new', 'a', 'b'])
+  })
+
+  // The 'session_created' broadcast's own full sessions.set() refresh can
+  // land before this call and already include the new session — without
+  // dedup, prepending again would leave the id twice in the list and crash
+  // Sidebar's keyed {#each ... (s.id)} with each_key_duplicate.
+  it('replaces an existing entry instead of duplicating the id', () => {
+    sessions.set([sess('a'), sess('new', { title: 'stale' }), sess('b')])
+    prependSession(sess('new', { title: 'fresh' }))
+    const list = get(sessions)
+    expect(list.map(s => s.id)).toEqual(['new', 'a', 'b'])
+    expect(list.filter(s => s.id === 'new')).toHaveLength(1)
+    expect(list[0].title).toBe('fresh')
+  })
+})

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -237,6 +237,17 @@ export function setActiveSession(id: string) {
   chatMessages.update(m => ({ ...m, [id]: m[id] || [] }))
 }
 
+// Prepend a freshly created session, replacing any entry the same id already
+// has. Without the dedup, a session-creation call racing the 'session_created'
+// broadcast's own sessions.set() refresh (App.svelte) can leave the id twice
+// in the list — which throws Svelte's each_key_duplicate in the sidebar's
+// keyed {#each} and aborts that render flush before ChatView's own
+// activeSessionId effect gets to run, freezing the chat pane on the old
+// session even though the URL/active id already moved on.
+function prependSession(sess: Session) {
+  sessions.update(ss => [sess, ...ss.filter(s => s.id !== sess.id)])
+}
+
 // Sessions opened by openAgentSession — single-purpose, panel-launched (Browser
 // Replay/Record/Edit, Skills, Tasks, …). The after-turn follow-up suggestion is
 // noise here, so ChatView skips it for these ids.
@@ -256,7 +267,7 @@ export async function createNewSession(agentProfile?: string): Promise<void> {
   if (pending) opts.model = pending
   const sess = await api.createSession(opts)
   if (pending) pendingModel.set('')
-  sessions.update(ss => [sess, ...ss])
+  prependSession(sess)
   activeSessionId.set(sess.id)
   view.set('chat')
 }
@@ -268,9 +279,9 @@ export async function createNewSession(agentProfile?: string): Promise<void> {
 // its group without a refetch.
 export async function createSessionInGroup(groupId: string): Promise<void> {
   const sess = await api.createSession({ source: 'manual', group_id: groupId })
-  sessions.update(ss => [sess, ...ss])
+  prependSession(sess)
   sessionGroups.update(gs =>
-    gs.map(g => (g.id === groupId ? { ...g, session_ids: [sess.id, ...g.session_ids] } : g)),
+    gs.map(g => (g.id === groupId ? { ...g, session_ids: [sess.id, ...g.session_ids.filter(id => id !== sess.id)] } : g)),
   )
   activeSessionId.set(sess.id)
   view.set('chat')
@@ -283,7 +294,7 @@ export async function createSessionInGroup(groupId: string): Promise<void> {
 export async function openAgentSession(content: string, name?: string): Promise<void> {
   const sess = await api.createSession({ source: 'manual', ...(name ? { name } : {}) })
   agenticSessions.add(sess.id)
-  sessions.update(s => [sess, ...s])
+  prependSession(sess)
   pendingPrompt.set({ sessionId: sess.id, content })
   activeSessionId.set(sess.id)
   view.set('chat')
@@ -297,7 +308,7 @@ export async function openAgentSession(content: string, name?: string): Promise<
 // deliberately NOT added to agenticSessions.
 export async function summonAgent(agentId: string, agentName: string, examplePrompt?: string): Promise<void> {
   const sess = await api.createSession({ source: 'manual', agent_profile: agentId, name: agentName })
-  sessions.update(ss => [sess, ...ss])
+  prependSession(sess)
   if (examplePrompt) pendingPrompt.set({ sessionId: sess.id, content: examplePrompt })
   activeSessionId.set(sess.id)
   view.set('chat')

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -244,7 +244,7 @@ export function setActiveSession(id: string) {
 // keyed {#each} and aborts that render flush before ChatView's own
 // activeSessionId effect gets to run, freezing the chat pane on the old
 // session even though the URL/active id already moved on.
-function prependSession(sess: Session) {
+export function prependSession(sess: Session) {
   sessions.update(ss => [sess, ...ss.filter(s => s.id !== sess.id)])
 }
 


### PR DESCRIPTION
## Summary
- Group "+" (and the other three session-creation entry points) optimistically prepend the new session into `sessions`/`group.session_ids` without deduping. That races the server's `session_created` broadcast, which triggers its own full refetch of the same stores — if the refetch lands first, the local prepend then duplicates the id.
- Sidebar's keyed `{#each gv.items as s (s.id)}` throws Svelte's `each_key_duplicate` on that duplicate, aborting the render flush before ChatView's `activeSessionId` effect runs — so the chat pane freezes on the old session even though the URL hash and sidebar selection already moved to the new one. Confirmed against a live repro (console showed the exact `each_key_duplicate` error).
- Added a `prependSession()` helper (dedupes by id) used by all four session-creation entry points, deduped the `session_ids` prepend too, and added a defensive dedupe in `groupedView` (both the per-group `items` and the `ungrouped` list, per review) so any other source of a duplicate id can't crash the keyed each again.
- Added a regression test (`prependSession.test.ts`) pinning the dedup behavior.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run` — 232/232 passing
- [ ] Rebuild (`make build`) and manually repro: rapid-fire group-header "+" clicks under load, confirm no console error and the chat pane switches every time

🤖 Generated with [Claude Code](https://claude.com/claude-code)