### PR TITLE
fix(desktop): revive a dead or black webview instead of showing it

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -44,6 +44,31 @@ type nativeBridge struct {
 	// option; ShouldQuit there always allows the quit).
 	allowQuit atomic.Bool
 
+	// Webview liveness, fed by POST /api/native/heartbeat from the page in
+	// nativeShell mode (see startNativeHeartbeat in the frontend). lastBeat is
+	// when the last beat arrived (JS provably alive then); lastFrame is when
+	// the page's requestAnimationFrame last fired (beat time minus the
+	// reported frame age — the frame pipeline provably alive then). All unix
+	// nanos, atomic: HTTP-handler goroutines write, show/probe paths read.
+	// windowShownAt is when the current window was created, the grace anchor
+	// so a still-loading fresh window isn't declared dead before its first
+	// beat. probeInFlight collapses concurrent post-show probes; lastRevive
+	// rate-limits automatic re-creation so a persistently broken page can't
+	// enter a destroy/create loop.
+	lastBeat      atomic.Int64
+	lastFrame     atomic.Int64
+	windowShownAt atomic.Int64
+	probeInFlight atomic.Bool
+	lastRevive    atomic.Int64
+
+	// windowMu serialises the paths that REPLACE b.window: a show that finds
+	// the webview dead, the frame probe's background goroutine, and the
+	// WindowClosing handler that clears it. Held only around the pointer
+	// swap, never across a window method — those marshal to the UI thread and
+	// would deadlock under a lock. The read-only accessors (Minimise, Close,
+	// WindowState…) stay lock-free as they were.
+	windowMu sync.Mutex
+
 	// notifySeq makes each Notify call's notification identifier unique. macOS
 	// rejects an addNotificationRequest with an empty identifier (its completion
 	// handler errors and nothing is delivered), and a shared constant id would
@@ -425,7 +450,15 @@ func (b *nativeBridge) showWindowAt(hash string) {
 	// The marker rides on every navigation the shell performs (fresh window and
 	// SetURL alike) so nativeShell stays true across reloads and route changes.
 	target := shellURL(b.url, hash)
+	// A webview whose page stopped beating is a dead surface (renderer or
+	// browser process gone) — foregrounding it shows a black window forever.
+	// Destroy it and fall through to the fresh-window path instead.
+	if old := b.detachIfDead(time.Now()); old != nil {
+		old.Close()
+	}
+	created := false
 	if b.window == nil {
+		created = true
 		if b.app == nil || b.url == "" {
 			return // not bound yet
 		}
@@ -474,7 +507,13 @@ func (b *nativeBridge) showWindowAt(hash string) {
 			}
 			b.settingsMu.Unlock()
 			b.persistSettings()
-			b.window = nil
+			// Guarded: when a revive replaced this window, b.window already
+			// points at the successor and must survive the old one's close.
+			b.windowMu.Lock()
+			if b.window == w {
+				b.window = nil
+			}
+			b.windowMu.Unlock()
 		})
 		// Capture size/maximised changes as the user drags or zooms the window.
 		w.OnWindowEvent(events.Common.WindowDidResize, func(*application.WindowEvent) {
@@ -497,7 +536,10 @@ func (b *nativeBridge) showWindowAt(hash string) {
 				w.SetURL(shellURL(b.url, ""))
 			})
 		}
+		b.windowMu.Lock()
 		b.window = w
+		b.windowMu.Unlock()
+		b.windowShownAt.Store(time.Now().UnixNano())
 	} else if hash != "" {
 		// Already open — navigate to the route. ExecJS can't be used here: the
 		// page is served by octo's own server, not Wails' asset server, so the
@@ -515,6 +557,136 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		b.window.Restore()
 	}
 	b.window.Focus()
+	// Probe only a window that already existed: a black-but-alive webview is
+	// something that happens TO a window over time, and a freshly created one
+	// that never comes up is webviewDead's business on the next show — probing
+	// it here would race a slow first load into a pointless reload.
+	if !created {
+		b.probeFramesAfterShow()
+	}
+}
+
+// Webview liveness thresholds. The frontend beats every heartbeatInterval
+// while alive (plus immediately on focus/visibility, which Show/Focus above
+// trigger), so a beat gap several intervals wide means the page is gone, not
+// slow. beatGrace also covers a fresh window's load time before its first
+// beat. The probe delay exceeds the beat interval so a healthy shown page is
+// guaranteed at least one scheduled beat — with a running requestAnimationFrame
+// — inside the probe window even if no focus/visibility event fired.
+const (
+	heartbeatInterval = 5 * time.Second  // matches web/src/lib/nativeHeartbeat.ts
+	beatGrace         = 45 * time.Second // webviewDead threshold and fresh-window grace
+	frameProbeDelay   = 12 * time.Second
+	reviveCooldown    = 90 * time.Second
+)
+
+// webviewDead reports whether the page inside the current window has provably
+// stopped running: the window has been up longer than the grace period yet no
+// beat arrived within it. Never true before the first beat of a young window
+// (still loading) and never true while beats keep flowing — a black-but-alive
+// compositor is probeFramesAfterShow's job, not this one's.
+func (b *nativeBridge) webviewDead(now time.Time) bool {
+	shownAt := b.windowShownAt.Load()
+	if shownAt == 0 || now.Sub(time.Unix(0, shownAt)) < beatGrace {
+		return false
+	}
+	lastBeat := b.lastBeat.Load()
+	if lastBeat > shownAt {
+		return now.Sub(time.Unix(0, lastBeat)) > beatGrace
+	}
+	// No beat since this window appeared and the grace is over: the page
+	// never came up (or died before beating).
+	return true
+}
+
+// reviveAllowed rate-limits automatic window re-creation so a page that is
+// broken for a persistent reason (server wedged, port hijacked) can't put the
+// shell into a destroy/create loop.
+func (b *nativeBridge) reviveAllowed(now time.Time) bool {
+	last := b.lastRevive.Load()
+	return last == 0 || now.Sub(time.Unix(0, last)) > reviveCooldown
+}
+
+// detachIfDead detaches the current window when its page has stopped beating
+// and a revive is off cooldown, returning it for the caller to Close OUTSIDE
+// the lock (Close marshals to the UI thread). Returns nil when there is
+// nothing to revive. Detaching before the close is what lets the replacement
+// window survive the old one's WindowClosing handler.
+func (b *nativeBridge) detachIfDead(now time.Time) *application.WebviewWindow {
+	b.windowMu.Lock()
+	defer b.windowMu.Unlock()
+	if b.window == nil || !b.webviewDead(now) || !b.reviveAllowed(now) {
+		return nil
+	}
+	b.lastRevive.Store(now.UnixNano())
+	old := b.window
+	b.window = nil
+	return old
+}
+
+// detachStalled detaches w when it is still the current window and a revive is
+// off cooldown — the frame-probe counterpart of detachIfDead, keyed on window
+// identity because the probe already decided (from frame timestamps) that this
+// particular surface is black. Same Close-outside-the-lock contract.
+func (b *nativeBridge) detachStalled(w *application.WebviewWindow, now time.Time) *application.WebviewWindow {
+	b.windowMu.Lock()
+	defer b.windowMu.Unlock()
+	if b.window != w || !b.reviveAllowed(now) {
+		return nil
+	}
+	b.lastRevive.Store(now.UnixNano())
+	b.window = nil
+	return w
+}
+
+// probeFramesAfterShow schedules the black-window check for a webview that is
+// alive but no longer rendering — the WebView2 failure mode where the GPU
+// process died (e.g. across sleep/wake) and the compositor never recovers:
+// JS keeps running, beats keep arriving, the window stays black. Frames are
+// the tell: a healthy page's requestAnimationFrame resumes within a frame of
+// the window becoming visible, so if no beat with a fresh frame timestamp
+// lands within frameProbeDelay of this Show, the surface is gone — destroy
+// the window and bring up a replacement. Runs off the UI thread; the window
+// methods it calls marshal themselves.
+func (b *nativeBridge) probeFramesAfterShow() {
+	if !b.probeInFlight.CompareAndSwap(false, true) {
+		return
+	}
+	shownAt := time.Now()
+	b.windowMu.Lock()
+	shown := b.window
+	b.windowMu.Unlock()
+	if shown == nil {
+		b.probeInFlight.Store(false)
+		return
+	}
+	go func() {
+		defer b.probeInFlight.Store(false)
+		time.Sleep(frameProbeDelay)
+		if lastFrame := b.lastFrame.Load(); lastFrame != 0 && time.Unix(0, lastFrame).After(shownAt) {
+			return // frames flowed after this Show — healthy
+		}
+		// Identity-keyed: skips the case where the user closed this window (or
+		// a revive already replaced it) while the probe was sleeping.
+		old := b.detachStalled(shown, time.Now())
+		if old == nil {
+			return
+		}
+		old.Close()
+		b.showWindowAt("")
+	}()
+}
+
+// Heartbeat implements server.NativeBridge: the page beats every
+// heartbeatInterval (and on focus/visibilitychange) with the age of its last
+// requestAnimationFrame tick. The beat itself proves JS alive; the derived
+// frame timestamp proves the render pipeline alive.
+func (b *nativeBridge) Heartbeat(frameAgeMS int64) {
+	now := time.Now()
+	b.lastBeat.Store(now.UnixNano())
+	if frameAgeMS >= 0 {
+		b.lastFrame.Store(now.Add(-time.Duration(frameAgeMS) * time.Millisecond).UnixNano())
+	}
 }
 
 // confirm shows a modal question dialog and reports whether the user chose the

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -76,10 +76,11 @@ type nativeBridge struct {
 
 	// windowMu guards every read and write of b.window that could race the
 	// pointer being REPLACED: showWindowAt's snapshot, the liveness probe's
-	// background goroutine, and the WindowClosing handler that clears it. Held
+	// background goroutine, the WindowClosing handler that clears it, and the
+	// read-only accessors (Minimise, Close, WindowState…), which load through
+	// currentWindow now that the probe can swap the pointer autonomously. Held
 	// only around the pointer access, never across a window method — those
-	// marshal to the UI thread and would deadlock under a lock. The read-only
-	// accessors (Minimise, Close, WindowState…) stay lock-free as they were.
+	// marshal to the UI thread and would deadlock under a lock.
 	windowMu sync.Mutex
 
 	// notifySeq makes each Notify call's notification identifier unique. macOS
@@ -198,6 +199,17 @@ func (b *nativeBridge) persistSettings() {
 	_ = saveDesktopSettings(snapshot)
 }
 
+// currentWindow loads the window pointer under windowMu. Callers must not
+// hold windowMu across any method on the returned window — those marshal to
+// the UI thread and would deadlock under the lock. A liveness probe can still
+// detach and close the window between the load and the call; that sliver is
+// unavoidable without locking across UI-thread marshalling.
+func (b *nativeBridge) currentWindow() *application.WebviewWindow {
+	b.windowMu.Lock()
+	defer b.windowMu.Unlock()
+	return b.window
+}
+
 // PickFolder opens the OS directory-choose dialog and returns the chosen path.
 // PromptForSingleSelection returns "" when the user cancels, which we surface
 // as cancelled=true so the caller leaves the working dir untouched.
@@ -209,8 +221,8 @@ func (b *nativeBridge) PickFolder(_ context.Context, startDir string) (string, b
 	// Attach to the window so it opens as a sheet. A detached panel (Wails'
 	// beginWithCompletionHandler path when no window is set) stops responding
 	// to its buttons after the user switches away from the app and back.
-	if b.window != nil {
-		dlg.AttachToWindow(b.window)
+	if win := b.currentWindow(); win != nil {
+		dlg.AttachToWindow(win)
 	}
 	if startDir != "" {
 		dlg.SetDirectory(startDir)
@@ -231,8 +243,8 @@ func (b *nativeBridge) PickFile(_ context.Context, startDir string) (string, boo
 	dlg := b.app.Dialog.OpenFile().
 		CanChooseFiles(true).
 		CanChooseDirectories(false)
-	if b.window != nil { // sheet, not a detached panel — see PickFolder.
-		dlg.AttachToWindow(b.window)
+	if win := b.currentWindow(); win != nil { // sheet, not a detached panel — see PickFolder.
+		dlg.AttachToWindow(win)
 	}
 	if startDir != "" {
 		dlg.SetDirectory(startDir)
@@ -254,8 +266,8 @@ func (b *nativeBridge) PickFile(_ context.Context, startDir string) (string, boo
 // download does nothing.
 func (b *nativeBridge) SaveFile(_ context.Context, defaultName, content string) (string, bool, error) {
 	dlg := b.app.Dialog.SaveFile().CanCreateDirectories(true)
-	if b.window != nil { // sheet, not a detached panel — see PickFolder.
-		dlg.AttachToWindow(b.window)
+	if win := b.currentWindow(); win != nil { // sheet, not a detached panel — see PickFolder.
+		dlg.AttachToWindow(win)
 	}
 	if defaultName != "" {
 		dlg.SetFilename(defaultName)
@@ -282,10 +294,11 @@ func (b *nativeBridge) SaveFile(_ context.Context, defaultName, content string) 
 // returns while it is still open and the page must keep its print layout up.
 // No-op before the window exists.
 func (b *nativeBridge) Print() error {
-	if b.window == nil {
+	win := b.currentWindow()
+	if win == nil {
 		return nil
 	}
-	return b.window.Print()
+	return win.Print()
 }
 
 // Notify raises an OS-native notification. No-op when the notifications service
@@ -411,15 +424,15 @@ func (b *nativeBridge) SetAutostart(enable bool) error {
 // ToggleMaximise maximises or restores the window (the double-click-titlebar
 // zoom the frontend can't trigger itself). No-op before the window exists.
 func (b *nativeBridge) ToggleMaximise() {
-	if b.window != nil {
-		b.window.ToggleMaximise()
+	if win := b.currentWindow(); win != nil {
+		win.ToggleMaximise()
 	}
 }
 
 // Minimise minimises the window to the taskbar/dock. No-op before the window exists.
 func (b *nativeBridge) Minimise() {
-	if b.window != nil {
-		b.window.Minimise()
+	if win := b.currentWindow(); win != nil {
+		win.Minimise()
 	}
 }
 
@@ -427,18 +440,19 @@ func (b *nativeBridge) Minimise() {
 // decides whether the hub actually terminates or keeps running in the tray).
 // No-op before the window exists.
 func (b *nativeBridge) Close() {
-	if b.window != nil {
-		b.window.Close()
+	if win := b.currentWindow(); win != nil {
+		win.Close()
 	}
 }
 
 // WindowState reports whether the window is currently maximised. Returns false
 // before the window exists.
 func (b *nativeBridge) WindowState() bool {
-	if b.window == nil {
+	win := b.currentWindow()
+	if win == nil {
 		return false
 	}
-	return b.window.IsMaximised()
+	return win.IsMaximised()
 }
 
 // showWindow brings the hub window to the foreground on the current view.
@@ -466,9 +480,7 @@ func (b *nativeBridge) showWindowAt(hash string) {
 	// Snapshot the pointer once: the frame probe's goroutine can clear it
 	// concurrently, and a lock-free re-read mid-function could see that nil and
 	// panic. Everything below works off win, then publishes it back.
-	b.windowMu.Lock()
-	win := b.window
-	b.windowMu.Unlock()
+	win := b.currentWindow()
 	created := false
 	if win == nil {
 		if b.app == nil || b.url == "" {
@@ -478,9 +490,7 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		// if the winner has already published one it just shows that, otherwise
 		// it leaves the work to the winner, which shows the window itself.
 		if !b.creating.CompareAndSwap(false, true) {
-			b.windowMu.Lock()
-			win = b.window
-			b.windowMu.Unlock()
+			win = b.currentWindow()
 			if win == nil {
 				return
 			}
@@ -567,10 +577,7 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		// isDestroyed check, so it could otherwise touch a freed NSWindow.
 		if runtime.GOOS == "darwin" {
 			w.OnWindowEvent(events.Mac.WebViewWebContentProcessDidTerminate, func(*application.WindowEvent) {
-				b.windowMu.Lock()
-				current := b.window
-				b.windowMu.Unlock()
-				if current != w {
+				if b.currentWindow() != w {
 					return
 				}
 				w.SetURL(shellURL(b.url, ""))
@@ -580,12 +587,26 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		b.windowMu.Lock()
 		b.window = w
 		b.windowMu.Unlock()
-	} else if hash != "" {
-		// Already open — navigate to the route. ExecJS can't be used here: the
-		// page is served by octo's own server, not Wails' asset server, so the
-		// Wails runtime never loads and ExecJS stays queued forever. SetURL is a
-		// native navigation that doesn't depend on it.
-		win.SetURL(target)
+	} else {
+		// Re-validate the snapshot before touching the window: a liveness
+		// probe may have detached and closed it meanwhile (its revive path
+		// brings up the replacement itself, so there is nothing to do here).
+		// SetURL on a destroyed window touches a freed NSWindow on macOS — the
+		// hazard the terminate handler in the create path guards against. The
+		// check cannot close the race entirely — the corpse is closed outside
+		// windowMu, and holding the lock across a window method would deadlock
+		// on the UI thread — but it shrinks it to the sliver between this
+		// check and the first method call.
+		if b.currentWindow() != win {
+			return
+		}
+		if hash != "" {
+			// Already open — navigate to the route. ExecJS can't be used here:
+			// the page is served by octo's own server, not Wails' asset server,
+			// so the Wails runtime never loads and ExecJS stays queued forever.
+			// SetURL is a native navigation that doesn't depend on it.
+			win.SetURL(target)
+		}
 	}
 	win.Show()
 	// Only un-minimise here. Wails' Restore() also un-maximises (and exits

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -45,28 +45,32 @@ type nativeBridge struct {
 	allowQuit atomic.Bool
 
 	// Webview liveness, fed by POST /api/native/heartbeat from the page in
-	// nativeShell mode (see startNativeHeartbeat in the frontend). lastBeat is
-	// when the last beat arrived (JS provably alive then); lastFrame is when
-	// the page's requestAnimationFrame last fired (beat time minus the
-	// reported frame age — the frame pipeline provably alive then). All unix
-	// nanos, atomic: HTTP-handler goroutines write, show/probe paths read.
-	// windowShownAt is when the current window was created, the grace anchor
-	// so a still-loading fresh window isn't declared dead before its first
-	// beat. probeInFlight collapses concurrent post-show probes; lastRevive
-	// rate-limits automatic re-creation so a persistently broken page can't
-	// enter a destroy/create loop.
-	lastBeat      atomic.Int64
-	lastFrame     atomic.Int64
-	windowShownAt atomic.Int64
-	probeInFlight atomic.Bool
-	lastRevive    atomic.Int64
+	// nativeShell mode (see startNativeHeartbeat in the frontend). All unix
+	// nanos, atomic: HTTP-handler goroutines write, the show/probe paths read.
+	// lastBeat is when a beat last arrived (JS provably alive then).
+	// lastFrame is when the page last observed a requestAnimationFrame tick
+	// (the render pipeline provably alive then). lastHiddenBeat is when the
+	// page last reported itself hidden — it owes no frames then, so a missing
+	// frame must not read as a black window. windowShownAt anchors every
+	// verdict to the last show, probeInFlight collapses concurrent probes, and
+	// lastRevive rate-limits re-creation.
+	lastBeat       atomic.Int64
+	lastFrame      atomic.Int64
+	lastHiddenBeat atomic.Int64
+	windowShownAt  atomic.Int64
+	probeInFlight  atomic.Bool
+	lastRevive     atomic.Int64
 
-	// windowMu serialises the paths that REPLACE b.window: a show that finds
-	// the webview dead, the frame probe's background goroutine, and the
-	// WindowClosing handler that clears it. Held only around the pointer
-	// swap, never across a window method — those marshal to the UI thread and
-	// would deadlock under a lock. The read-only accessors (Minimise, Close,
-	// WindowState…) stay lock-free as they were.
+	// testProbeDelay shortens probeAfterShow's sleep in tests; zero means the
+	// production frameProbeDelay.
+	testProbeDelay time.Duration
+
+	// windowMu guards every read and write of b.window that could race the
+	// pointer being REPLACED: showWindowAt's snapshot, the liveness probe's
+	// background goroutine, and the WindowClosing handler that clears it. Held
+	// only around the pointer access, never across a window method — those
+	// marshal to the UI thread and would deadlock under a lock. The read-only
+	// accessors (Minimise, Close, WindowState…) stay lock-free as they were.
 	windowMu sync.Mutex
 
 	// notifySeq makes each Notify call's notification identifier unique. macOS
@@ -450,14 +454,14 @@ func (b *nativeBridge) showWindowAt(hash string) {
 	// The marker rides on every navigation the shell performs (fresh window and
 	// SetURL alike) so nativeShell stays true across reloads and route changes.
 	target := shellURL(b.url, hash)
-	// A webview whose page stopped beating is a dead surface (renderer or
-	// browser process gone) — foregrounding it shows a black window forever.
-	// Destroy it and fall through to the fresh-window path instead.
-	if old := b.detachIfDead(time.Now()); old != nil {
-		old.Close()
-	}
+	// Snapshot the pointer once: the frame probe's goroutine can clear it
+	// concurrently, and a lock-free re-read mid-function could see that nil and
+	// panic. Everything below works off win, then publishes it back.
+	b.windowMu.Lock()
+	win := b.window
+	b.windowMu.Unlock()
 	created := false
-	if b.window == nil {
+	if win == nil {
 		created = true
 		if b.app == nil || b.url == "" {
 			return // not bound yet
@@ -530,74 +534,59 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		// isDestroyed check, so it could otherwise touch a freed NSWindow.
 		if runtime.GOOS == "darwin" {
 			w.OnWindowEvent(events.Mac.WebViewWebContentProcessDidTerminate, func(*application.WindowEvent) {
-				if b.window != w {
+				b.windowMu.Lock()
+				current := b.window
+				b.windowMu.Unlock()
+				if current != w {
 					return
 				}
 				w.SetURL(shellURL(b.url, ""))
 			})
 		}
+		win = w
 		b.windowMu.Lock()
 		b.window = w
 		b.windowMu.Unlock()
-		b.windowShownAt.Store(time.Now().UnixNano())
 	} else if hash != "" {
 		// Already open — navigate to the route. ExecJS can't be used here: the
 		// page is served by octo's own server, not Wails' asset server, so the
 		// Wails runtime never loads and ExecJS stays queued forever. SetURL is a
 		// native navigation that doesn't depend on it.
-		b.window.SetURL(target)
+		win.SetURL(target)
 	}
-	b.window.Show()
+	win.Show()
 	// Only un-minimise here. Wails' Restore() also un-maximises (and exits
 	// fullscreen), so calling it unconditionally on every show/reopen — e.g.
 	// clicking the dock icon to return to a maximised window — would shrink the
 	// window back to its launch size. Guard on IsMinimised so a visible
 	// maximised/fullscreen window keeps its size.
-	if b.window.IsMinimised() {
-		b.window.Restore()
+	if win.IsMinimised() {
+		win.Restore()
 	}
-	b.window.Focus()
-	// Probe only a window that already existed: a black-but-alive webview is
-	// something that happens TO a window over time, and a freshly created one
-	// that never comes up is webviewDead's business on the next show — probing
-	// it here would race a slow first load into a pointless reload.
+	win.Focus()
+	// Every show is the anchor for the liveness verdict: a page only owes
+	// evidence of life AFTER it was asked to come up. A freshly created window
+	// is exempt — its first load can outlast the probe window, and if it never
+	// comes up the next show judges it.
+	b.windowShownAt.Store(time.Now().UnixNano())
 	if !created {
-		b.probeFramesAfterShow()
+		b.probeAfterShow(win)
 	}
 }
 
-// Webview liveness thresholds. The frontend beats every heartbeatInterval
-// while alive (plus immediately on focus/visibility, which Show/Focus above
-// trigger), so a beat gap several intervals wide means the page is gone, not
-// slow. beatGrace also covers a fresh window's load time before its first
-// beat. The probe delay exceeds the beat interval so a healthy shown page is
-// guaranteed at least one scheduled beat — with a running requestAnimationFrame
-// — inside the probe window even if no focus/visibility event fired.
+// Webview liveness timings. Every verdict is reached from evidence produced
+// AFTER a show, never from how long the page was quiet before one: a page has
+// many legitimate reasons to go silent in the background (system sleep freezes
+// it wholesale, Chromium throttles a long-hidden page's timers to ~1/minute)
+// and destroying a healthy window is far worse than a few more seconds of
+// black. probeDelay therefore only has to outlast two scheduled beats, so a
+// page that came back has certainly reported in.
 const (
-	heartbeatInterval = 5 * time.Second  // matches web/src/lib/nativeHeartbeat.ts
-	beatGrace         = 45 * time.Second // webviewDead threshold and fresh-window grace
-	frameProbeDelay   = 12 * time.Second
-	reviveCooldown    = 90 * time.Second
+	heartbeatInterval   = 5 * time.Second // matches BEAT_MS in web/src/lib/nativeHeartbeat.ts
+	frameProbeDelay     = 3 * heartbeatInterval
+	reviveCooldown      = 90 * time.Second
+	maxReportedFrameAge = 10 * time.Minute // clamp: a bad/hostile beat must not move lastFrame far
 )
-
-// webviewDead reports whether the page inside the current window has provably
-// stopped running: the window has been up longer than the grace period yet no
-// beat arrived within it. Never true before the first beat of a young window
-// (still loading) and never true while beats keep flowing — a black-but-alive
-// compositor is probeFramesAfterShow's job, not this one's.
-func (b *nativeBridge) webviewDead(now time.Time) bool {
-	shownAt := b.windowShownAt.Load()
-	if shownAt == 0 || now.Sub(time.Unix(0, shownAt)) < beatGrace {
-		return false
-	}
-	lastBeat := b.lastBeat.Load()
-	if lastBeat > shownAt {
-		return now.Sub(time.Unix(0, lastBeat)) > beatGrace
-	}
-	// No beat since this window appeared and the grace is over: the page
-	// never came up (or died before beating).
-	return true
-}
 
 // reviveAllowed rate-limits automatic window re-creation so a page that is
 // broken for a persistent reason (server wedged, port hijacked) can't put the
@@ -607,27 +596,30 @@ func (b *nativeBridge) reviveAllowed(now time.Time) bool {
 	return last == 0 || now.Sub(time.Unix(0, last)) > reviveCooldown
 }
 
-// detachIfDead detaches the current window when its page has stopped beating
-// and a revive is off cooldown, returning it for the caller to Close OUTSIDE
-// the lock (Close marshals to the UI thread). Returns nil when there is
-// nothing to revive. Detaching before the close is what lets the replacement
-// window survive the old one's WindowClosing handler.
-func (b *nativeBridge) detachIfDead(now time.Time) *application.WebviewWindow {
-	b.windowMu.Lock()
-	defer b.windowMu.Unlock()
-	if b.window == nil || !b.webviewDead(now) || !b.reviveAllowed(now) {
-		return nil
+// webviewRevived reports whether the page proved itself after the given show.
+// Three kinds of evidence count, and any one of them clears the window:
+//
+//   - a frame later than the show: the compositor is producing pixels;
+//   - a beat that reported the page hidden: it is legitimately not rendering
+//     (minimised, fully occluded, another space) — frames are not owed;
+//   - nothing else. A page that beats while claiming to be visible yet never
+//     produces a frame is the black-window signature, and a page that does not
+//     beat at all is a dead renderer. Both need a new window.
+func (b *nativeBridge) needsRevive(shownAt time.Time) bool {
+	if lastFrame := b.lastFrame.Load(); lastFrame != 0 && time.Unix(0, lastFrame).After(shownAt) {
+		return false
 	}
-	b.lastRevive.Store(now.UnixNano())
-	old := b.window
-	b.window = nil
-	return old
+	if hidden := b.lastHiddenBeat.Load(); hidden != 0 && time.Unix(0, hidden).After(shownAt) {
+		return false
+	}
+	return true
 }
 
 // detachStalled detaches w when it is still the current window and a revive is
-// off cooldown — the frame-probe counterpart of detachIfDead, keyed on window
-// identity because the probe already decided (from frame timestamps) that this
-// particular surface is black. Same Close-outside-the-lock contract.
+// off cooldown. Identity-keyed so a probe that slept through the user closing
+// the window — or through another revive — leaves the successor alone. The
+// caller closes the returned window; detaching first is what lets the
+// replacement survive the old window's WindowClosing handler.
 func (b *nativeBridge) detachStalled(w *application.WebviewWindow, now time.Time) *application.WebviewWindow {
 	b.windowMu.Lock()
 	defer b.windowMu.Unlock()
@@ -639,53 +631,76 @@ func (b *nativeBridge) detachStalled(w *application.WebviewWindow, now time.Time
 	return w
 }
 
-// probeFramesAfterShow schedules the black-window check for a webview that is
-// alive but no longer rendering — the WebView2 failure mode where the GPU
-// process died (e.g. across sleep/wake) and the compositor never recovers:
-// JS keeps running, beats keep arriving, the window stays black. Frames are
-// the tell: a healthy page's requestAnimationFrame resumes within a frame of
-// the window becoming visible, so if no beat with a fresh frame timestamp
-// lands within frameProbeDelay of this Show, the surface is gone — destroy
-// the window and bring up a replacement. Runs off the UI thread; the window
-// methods it calls marshal themselves.
-func (b *nativeBridge) probeFramesAfterShow() {
+// probeAfterShow schedules the liveness verdict for a window that was already
+// open when it was shown — the two failure modes a Show can't fix by itself:
+// a renderer that died (no beats at all) and a compositor that died while JS
+// kept running (beats, no frames — WebView2 across sleep/wake). The window is
+// replaced rather than reloaded because a broken WebView2 surface survives
+// navigation. Runs off the UI thread; the window methods it calls marshal
+// themselves.
+func (b *nativeBridge) probeAfterShow(shown *application.WebviewWindow) {
+	if shown == nil {
+		return
+	}
 	if !b.probeInFlight.CompareAndSwap(false, true) {
 		return
 	}
 	shownAt := time.Now()
-	b.windowMu.Lock()
-	shown := b.window
-	b.windowMu.Unlock()
-	if shown == nil {
-		b.probeInFlight.Store(false)
-		return
-	}
 	go func() {
 		defer b.probeInFlight.Store(false)
-		time.Sleep(frameProbeDelay)
-		if lastFrame := b.lastFrame.Load(); lastFrame != 0 && time.Unix(0, lastFrame).After(shownAt) {
-			return // frames flowed after this Show — healthy
+		time.Sleep(b.probeDelay())
+		if !b.needsRevive(shownAt) {
+			return
 		}
-		// Identity-keyed: skips the case where the user closed this window (or
-		// a revive already replaced it) while the probe was sleeping.
 		old := b.detachStalled(shown, time.Now())
 		if old == nil {
 			return
 		}
-		old.Close()
+		// Create the replacement BEFORE closing the corpse. Wails' Windows
+		// backend posts a quit message when the window map empties
+		// (unregisterWindow, bypassing ShouldQuit), and macOS/Linux quit on
+		// last-window-close unless the user keeps the hub in the background —
+		// closing first would race the shell's own survival.
 		b.showWindowAt("")
+		old.Close()
 	}()
 }
 
+// probeDelay is frameProbeDelay unless a test shortened it.
+func (b *nativeBridge) probeDelay() time.Duration {
+	if d := b.testProbeDelay; d > 0 {
+		return d
+	}
+	return frameProbeDelay
+}
+
 // Heartbeat implements server.NativeBridge: the page beats every
-// heartbeatInterval (and on focus/visibilitychange) with the age of its last
-// requestAnimationFrame tick. The beat itself proves JS alive; the derived
-// frame timestamp proves the render pipeline alive.
+// heartbeatInterval (and on focus/visibilitychange) with the age of the last
+// requestAnimationFrame it observed, or -1 while it is hidden and owes no
+// frames. The beat proves JS alive; the frame timestamp proves the render
+// pipeline alive; the hidden flag says frames aren't expected.
 func (b *nativeBridge) Heartbeat(frameAgeMS int64) {
 	now := time.Now()
 	b.lastBeat.Store(now.UnixNano())
-	if frameAgeMS >= 0 {
-		b.lastFrame.Store(now.Add(-time.Duration(frameAgeMS) * time.Millisecond).UnixNano())
+	if frameAgeMS < 0 {
+		// Hidden page (or one that has not yet seen a frame): record the beat
+		// as an explicit "not rendering, by design" so the probe doesn't read
+		// the missing frame as a black window.
+		b.lastHiddenBeat.Store(now.UnixNano())
+		return
+	}
+	age := time.Duration(frameAgeMS) * time.Millisecond
+	if frameAgeMS > int64(maxReportedFrameAge/time.Millisecond) {
+		age = maxReportedFrameAge
+	}
+	frame := now.Add(-age).UnixNano()
+	// Monotonic: a stale report (a focus beat whose rAF has not ticked yet,
+	// clock skew, a hostile local caller) must never erase newer evidence.
+	for {
+		prev := b.lastFrame.Load()
+		if frame <= prev || b.lastFrame.CompareAndSwap(prev, frame) {
+			return
+		}
 	}
 }
 

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -51,19 +51,28 @@ type nativeBridge struct {
 	// lastFrame is when the page last observed a requestAnimationFrame tick
 	// (the render pipeline provably alive then). lastHiddenBeat is when the
 	// page last reported itself hidden — it owes no frames then, so a missing
-	// frame must not read as a black window. windowShownAt anchors every
-	// verdict to the last show, probeInFlight collapses concurrent probes, and
-	// lastRevive rate-limits re-creation.
+	// frame must not read as a black window. Together they separate the three
+	// states judgePage distinguishes: healthy, black, and silent.
+	// probeInFlight collapses concurrent probes; lastRevive rate-limits
+	// re-creation.
 	lastBeat       atomic.Int64
 	lastFrame      atomic.Int64
 	lastHiddenBeat atomic.Int64
-	windowShownAt  atomic.Int64
 	probeInFlight  atomic.Bool
 	lastRevive     atomic.Int64
 
-	// testProbeDelay shortens probeAfterShow's sleep in tests; zero means the
-	// production frameProbeDelay.
+	// creating guards window CREATION (not the pointer, which windowMu covers):
+	// two shows racing on a nil window would each build one, leaving an orphan
+	// that the frontend's close button can't reach on the frameless platforms.
+	// A CAS rather than a mutex on purpose — showWindowAt can run on the UI
+	// thread (a notification click), and a lock held across the InvokeSync in
+	// window creation would deadlock against it.
+	creating atomic.Bool
+
+	// Test seams: testProbeDelay shortens probeAfterShow's sleep, reviveFn
+	// substitutes the window swap. Both zero/nil in production.
 	testProbeDelay time.Duration
+	reviveFn       func(old *application.WebviewWindow)
 
 	// windowMu guards every read and write of b.window that could race the
 	// pointer being REPLACED: showWindowAt's snapshot, the liveness probe's
@@ -462,10 +471,25 @@ func (b *nativeBridge) showWindowAt(hash string) {
 	b.windowMu.Unlock()
 	created := false
 	if win == nil {
-		created = true
 		if b.app == nil || b.url == "" {
 			return // not bound yet
 		}
+		// Only one goroutine builds the window. A loser re-reads the pointer:
+		// if the winner has already published one it just shows that, otherwise
+		// it leaves the work to the winner, which shows the window itself.
+		if !b.creating.CompareAndSwap(false, true) {
+			b.windowMu.Lock()
+			win = b.window
+			b.windowMu.Unlock()
+			if win == nil {
+				return
+			}
+		} else {
+			defer b.creating.Store(false)
+			created = true
+		}
+	}
+	if created {
 		// Restore the size and maximised state saved from the last session.
 		b.settingsMu.Lock()
 		width, height, maximised := b.settings.WindowWidth, b.settings.WindowHeight, b.settings.WindowMaximised
@@ -573,11 +597,10 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		win.Restore()
 	}
 	win.Focus()
-	// Every show is the anchor for the liveness verdict: a page only owes
-	// evidence of life AFTER it was asked to come up. A freshly created window
-	// is exempt — its first load can outlast the probe window, and if it never
+	// The probe anchors its verdict to this moment: a page only owes evidence
+	// of life AFTER it was asked to come up. A freshly created window is
+	// exempt — its first load can outlast the probe window, and if it never
 	// comes up the next show judges it.
-	b.windowShownAt.Store(time.Now().UnixNano())
 	if !created {
 		b.probeAfterShow(win)
 	}
@@ -616,23 +639,38 @@ func (b *nativeBridge) reviveAllowed(now time.Time) bool {
 	return last == 0 || now.Sub(time.Unix(0, last)) > reviveCooldown
 }
 
-// webviewRevived reports whether the page proved itself after the given show.
-// Three kinds of evidence count, and any one of them clears the window:
-//
-//   - a frame later than the show: the compositor is producing pixels;
-//   - a beat that reported the page hidden: it is legitimately not rendering
-//     (minimised, fully occluded, another space) — frames are not owed;
-//   - nothing else. A page that beats while claiming to be visible yet never
-//     produces a frame is the black-window signature, and a page that does not
-//     beat at all is a dead renderer. Both need a new window.
-func (b *nativeBridge) needsRevive(shownAt time.Time) bool {
-	if lastFrame := b.lastFrame.Load(); lastFrame != 0 && time.Unix(0, lastFrame).After(shownAt) {
-		return false
+// pageVerdict is what the evidence collected after a show says about the page.
+type pageVerdict int
+
+const (
+	// pageHealthy: it painted, or it reported itself hidden and owes no frames.
+	pageHealthy pageVerdict = iota
+	// pageBlack: it beats while claiming to be visible but has never painted
+	// since the show — the black-window signature. Unambiguous, act at once.
+	pageBlack
+	// pageSilent: no beat at all. Usually a dead renderer, but a wedged hub or
+	// a main thread stuck on a huge render looks identical from here, and both
+	// of those recover on their own — so this verdict earns a second look
+	// before the window is destroyed.
+	pageSilent
+)
+
+// judgePage reads the post-show evidence. Nothing before shownAt counts: a page
+// has ordinary reasons to be silent in the background (system sleep freezes it,
+// Chromium throttles a long-hidden page's timers), and pre-show silence must
+// never cost a healthy window.
+func (b *nativeBridge) judgePage(shownAt time.Time) pageVerdict {
+	after := func(v *atomic.Int64) bool {
+		ns := v.Load()
+		return ns != 0 && time.Unix(0, ns).After(shownAt)
 	}
-	if hidden := b.lastHiddenBeat.Load(); hidden != 0 && time.Unix(0, hidden).After(shownAt) {
-		return false
+	if after(&b.lastFrame) || after(&b.lastHiddenBeat) {
+		return pageHealthy
 	}
-	return true
+	if after(&b.lastBeat) {
+		return pageBlack
+	}
+	return pageSilent
 }
 
 // detachStalled detaches w when it is still the current window and a revive is
@@ -669,21 +707,41 @@ func (b *nativeBridge) probeAfterShow(shown *application.WebviewWindow) {
 	go func() {
 		defer b.probeInFlight.Store(false)
 		time.Sleep(b.probeDelay())
-		if !b.needsRevive(shownAt) {
+		switch b.judgePage(shownAt) {
+		case pageHealthy:
 			return
+		case pageSilent:
+			// Silence is ambiguous — a wedged hub or a blocked main thread
+			// recovers by itself, and replacing the window would lose the
+			// user's page state for nothing. Give it one more cycle; only
+			// persistent silence (or a black verdict by then) is acted on.
+			time.Sleep(b.probeDelay())
+			if b.judgePage(shownAt) == pageHealthy {
+				return
+			}
 		}
 		old := b.detachStalled(shown, time.Now())
 		if old == nil {
 			return
 		}
-		// Create the replacement BEFORE closing the corpse. Wails' Windows
-		// backend posts a quit message when the window map empties
-		// (unregisterWindow, bypassing ShouldQuit), and macOS/Linux quit on
-		// last-window-close unless the user keeps the hub in the background —
-		// closing first would race the shell's own survival.
-		b.showWindowAt("")
-		old.Close()
+		b.revive(old)
 	}()
+}
+
+// revive brings up a replacement for a window whose page can't be saved. The
+// new window is created BEFORE the corpse is closed: Wails' Windows backend
+// posts a quit message when its window map empties (unregisterWindow, which
+// does not consult ShouldQuit), and macOS/Linux quit on last-window-close
+// unless the hub keeps running in the background — closing first would race
+// the shell's own survival. Indirected through a field so tests can observe
+// the decision without a live Wails app.
+func (b *nativeBridge) revive(old *application.WebviewWindow) {
+	if b.reviveFn != nil {
+		b.reviveFn(old)
+		return
+	}
+	b.showWindowAt("")
+	old.Close()
 }
 
 // probeDelay is frameProbeDelay unless a test shortened it.
@@ -699,14 +757,18 @@ func (b *nativeBridge) probeDelay() time.Duration {
 // requestAnimationFrame it observed, or -1 while it is hidden and owes no
 // frames. The beat proves JS alive; the frame timestamp proves the render
 // pipeline alive; the hidden flag says frames aren't expected.
-func (b *nativeBridge) Heartbeat(frameAgeMS int64) {
+func (b *nativeBridge) Heartbeat(frameAgeMS int64, hidden bool) {
 	now := time.Now()
 	b.lastBeat.Store(now.UnixNano())
-	if frameAgeMS < 0 {
-		// Hidden page (or one that has not yet seen a frame): record the beat
-		// as an explicit "not rendering, by design" so the probe doesn't read
-		// the missing frame as a black window.
+	if hidden {
+		// Not visible, so no frames are owed: record that explicitly, or the
+		// probe would read the missing frame as a black window.
 		b.lastHiddenBeat.Store(now.UnixNano())
+		return
+	}
+	if frameAgeMS < 0 {
+		// Visible but has never painted. Deliberately records NO frame
+		// evidence — this is the black-window signature, not an excuse.
 		return
 	}
 	age := time.Duration(frameAgeMS) * time.Millisecond

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -514,10 +514,19 @@ func (b *nativeBridge) showWindowAt(hash string) {
 			// Guarded: when a revive replaced this window, b.window already
 			// points at the successor and must survive the old one's close.
 			b.windowMu.Lock()
-			if b.window == w {
+			replaced := b.window != w
+			if !replaced {
 				b.window = nil
 			}
 			b.windowMu.Unlock()
+			// Windows only: the framework's own last-window-close quit is
+			// suppressed (see DisableQuitOnLastWindowClosed in main.go), so a
+			// user who opted out of background running needs the quit performed
+			// here. Never for a revive's discarded window — that close is the
+			// shell repairing itself, not the user leaving.
+			if !replaced && closeShouldQuit(runtime.GOOS, b.allowQuit.Load()) {
+				b.app.Quit()
+			}
 		})
 		// Capture size/maximised changes as the user drags or zooms the window.
 		w.OnWindowEvent(events.Common.WindowDidResize, func(*application.WindowEvent) {
@@ -587,6 +596,17 @@ const (
 	reviveCooldown      = 90 * time.Second
 	maxReportedFrameAge = 10 * time.Minute // clamp: a bad/hostile beat must not move lastFrame far
 )
+
+// closeShouldQuit reports whether closing the window must terminate the app.
+// Only Windows needs this: mac routes last-window-close through
+// ApplicationShouldTerminateAfterLastWindowClosed and Linux's
+// unregisterWindow consults ShouldQuit, but the Windows backend's own quit is
+// suppressed (DisableQuitOnLastWindowClosed) because it fired unconditionally
+// — killing a hub the user wanted kept alive. allowQuit is false exactly when
+// the user has KeepRunningInBackground on, so closing hides to the tray.
+func closeShouldQuit(goos string, allowQuit bool) bool {
+	return goos == "windows" && allowQuit
+}
 
 // reviveAllowed rate-limits automatic window re-creation so a page that is
 // broken for a persistent reason (server wedged, port hijacked) can't put the

--- a/cmd/octo-desktop/bridge_test.go
+++ b/cmd/octo-desktop/bridge_test.go
@@ -38,36 +38,58 @@ func TestShellURL(t *testing.T) {
 	}
 }
 
-// TestWebviewDead pins the shell's revive decision: a window is declared dead
-// only when it is old enough to have beaten AND the beats stopped (or never
-// started). Young windows and actively-beating pages must never be revived —
-// a false positive here destroys a healthy window.
-func TestWebviewDead(t *testing.T) {
-	now := time.Now()
+// TestNeedsRevive is the false-positive guard for the whole feature: destroying
+// a healthy window (losing the user's draft and stealing focus) is far worse
+// than a few more seconds of black, so every legitimate reason a page has to be
+// quiet must read as healthy. Only post-show evidence counts — how long the
+// page was silent BEFORE the show is deliberately irrelevant, because system
+// sleep freezes the page wholesale and Chromium throttles a long-hidden page's
+// timers to roughly once a minute.
+func TestNeedsRevive(t *testing.T) {
+	shownAt := time.Now()
 	cases := []struct {
-		name    string
-		shownAt time.Time // zero = no window recorded
-		beatAt  time.Time // zero = never beat
-		want    bool
+		name       string
+		frameAt    time.Time // zero = never
+		hiddenAt   time.Time // zero = never
+		wantRevive bool
 	}{
-		{"no window recorded", time.Time{}, time.Time{}, false},
-		{"young window, no beat yet (still loading)", now.Add(-10 * time.Second), time.Time{}, false},
-		{"old window, never beat", now.Add(-2 * beatGrace), time.Time{}, true},
-		{"old window, fresh beat", now.Add(-time.Hour), now.Add(-2 * time.Second), false},
-		{"old window, beats stopped", now.Add(-time.Hour), now.Add(-2 * beatGrace), true},
-		{"beat predates this window (belongs to a previous one)", now.Add(-2 * beatGrace), now.Add(-3 * beatGrace), true},
+		{"frame after the show: compositor is painting", shownAt.Add(time.Second), time.Time{}, false},
+		{"hidden beat after the show: owes no frames", time.Time{}, shownAt.Add(time.Second), false},
+		{"both after the show", shownAt.Add(time.Second), shownAt.Add(2 * time.Second), false},
+		{"nothing at all: dead renderer", time.Time{}, time.Time{}, true},
+		{"only frames from before the show: black compositor", shownAt.Add(-time.Minute), time.Time{}, true},
+		{"only a hidden beat from before the show", time.Time{}, shownAt.Add(-time.Minute), true},
 	}
 	for _, tc := range cases {
 		b := &nativeBridge{}
-		if !tc.shownAt.IsZero() {
-			b.windowShownAt.Store(tc.shownAt.UnixNano())
+		if !tc.frameAt.IsZero() {
+			b.lastFrame.Store(tc.frameAt.UnixNano())
 		}
-		if !tc.beatAt.IsZero() {
-			b.lastBeat.Store(tc.beatAt.UnixNano())
+		if !tc.hiddenAt.IsZero() {
+			b.lastHiddenBeat.Store(tc.hiddenAt.UnixNano())
 		}
-		if got := b.webviewDead(now); got != tc.want {
-			t.Errorf("%s: webviewDead = %v, want %v", tc.name, got, tc.want)
+		if got := b.needsRevive(shownAt); got != tc.wantRevive {
+			t.Errorf("%s: needsRevive = %v, want %v", tc.name, got, tc.wantRevive)
 		}
+	}
+}
+
+// TestNeedsReviveIgnoresPreShowSilence pins the sleep/wake case explicitly: a
+// page frozen for hours (so every timestamp is ancient) that reports in right
+// after the show is healthy. Judging the pre-show gap instead would destroy
+// this window.
+func TestNeedsReviveIgnoresPreShowSilence(t *testing.T) {
+	shownAt := time.Now()
+	b := &nativeBridge{}
+	b.lastBeat.Store(shownAt.Add(-8 * time.Hour).UnixNano()) // asleep all night
+	b.lastFrame.Store(shownAt.Add(-8 * time.Hour).UnixNano())
+	if !b.needsRevive(shownAt) {
+		t.Fatal("precondition: with only pre-show evidence the verdict is still revive")
+	}
+	// The page wakes and paints a frame after the show.
+	b.lastFrame.Store(shownAt.Add(200 * time.Millisecond).UnixNano())
+	if b.needsRevive(shownAt) {
+		t.Error("a page that painted after the show must never be revived, however long it slept")
 	}
 }
 
@@ -90,82 +112,81 @@ func TestReviveAllowed(t *testing.T) {
 	}
 }
 
-// TestHeartbeatRecordsFrameTime pins the frame-timestamp derivation the
-// post-show probe depends on: lastFrame = beat arrival minus the reported rAF
-// age, and a negative age (clock skew, bad client) must not move lastFrame
-// into the future.
-func TestHeartbeatRecordsFrameTime(t *testing.T) {
+// TestHeartbeatSignals pins the three things a beat can say, including the two
+// ways a stale or hostile report must NOT erase good evidence: lastFrame only
+// moves forward, and an absurd frame age is clamped rather than trusted (any
+// local process can reach this endpoint on loopback).
+func TestHeartbeatSignals(t *testing.T) {
 	b := &nativeBridge{}
+
+	// Visible beat: records JS liveness and a frame time derived from the age.
 	before := time.Now()
 	b.Heartbeat(3000)
 	after := time.Now()
-
-	beat := time.Unix(0, b.lastBeat.Load())
-	if beat.Before(before) || beat.After(after) {
+	if beat := time.Unix(0, b.lastBeat.Load()); beat.Before(before) || beat.After(after) {
 		t.Errorf("lastBeat = %v, want within [%v, %v]", beat, before, after)
 	}
 	frame := time.Unix(0, b.lastFrame.Load())
-	wantLo, wantHi := before.Add(-3*time.Second), after.Add(-3*time.Second)
-	if frame.Before(wantLo) || frame.After(wantHi) {
+	if frame.Before(before.Add(-3*time.Second)) || frame.After(after.Add(-3*time.Second)) {
 		t.Errorf("lastFrame = %v, want ~3s before the beat", frame)
 	}
-
-	prevFrame := b.lastFrame.Load()
-	b.Heartbeat(-50)
-	if b.lastFrame.Load() != prevFrame {
-		t.Error("negative frame age must not update lastFrame")
+	if b.lastHiddenBeat.Load() != 0 {
+		t.Error("a visible beat must not record a hidden beat")
 	}
-	if time.Unix(0, b.lastBeat.Load()).Before(after) {
-		t.Error("beat with negative frame age must still record JS liveness")
+
+	// Hidden beat (negative age): records liveness + "owes no frames", and
+	// leaves the frame evidence untouched.
+	frameBefore := b.lastFrame.Load()
+	b.Heartbeat(-1)
+	if b.lastHiddenBeat.Load() == 0 {
+		t.Error("a hidden beat must be recorded so the probe expects no frames")
+	}
+	if b.lastFrame.Load() != frameBefore {
+		t.Error("a hidden beat must not touch lastFrame")
+	}
+
+	// Monotonic: a stale report (a focus beat whose rAF has not ticked yet,
+	// clock skew) must not move lastFrame backwards.
+	b.Heartbeat(0) // fresh frame, now
+	newest := b.lastFrame.Load()
+	b.Heartbeat(int64(time.Minute / time.Millisecond)) // claims a minute-old frame
+	if b.lastFrame.Load() != newest {
+		t.Error("a staler frame report must not overwrite newer frame evidence")
+	}
+
+	// Clamp: an absurd age can't push lastFrame into the distant past (which,
+	// with the monotonic rule, is the only way to fake a stall).
+	b2 := &nativeBridge{}
+	b2.Heartbeat(1 << 62)
+	if age := time.Since(time.Unix(0, b2.lastFrame.Load())); age > maxReportedFrameAge+time.Minute {
+		t.Errorf("frame age clamp failed: lastFrame is %v old", age)
 	}
 }
 
-// TestDetachHelpersGuardWindowIdentity pins the revive swap's core invariant:
+// TestProbeConstants pins the relationship the protocol depends on: the probe
+// must outlast at least two scheduled beats, so a page that came back has
+// certainly reported in before any verdict. A future tweak to one constant
+// that breaks this would otherwise silently start destroying healthy windows.
+func TestProbeConstants(t *testing.T) {
+	if frameProbeDelay <= 2*heartbeatInterval {
+		t.Errorf("frameProbeDelay (%v) must exceed two beats (%v)", frameProbeDelay, 2*heartbeatInterval)
+	}
+	if reviveCooldown <= frameProbeDelay {
+		t.Errorf("reviveCooldown (%v) must exceed one probe cycle (%v)", reviveCooldown, frameProbeDelay)
+	}
+}
+
+// TestDetachStalledGuardsWindowIdentity pins the revive swap's core invariant:
 // the pointer is detached BEFORE the old window is closed (so the replacement
-// survives the old window's WindowClosing handler), and a stalled-window
-// detach only fires for the exact window the probe judged — never for a
-// successor the user or another revive installed meanwhile.
-func TestDetachHelpersGuardWindowIdentity(t *testing.T) {
+// survives the old one's WindowClosing handler), and the detach only fires for
+// the exact window the probe judged — never for a successor the user or another
+// revive installed meanwhile.
+func TestDetachStalledGuardsWindowIdentity(t *testing.T) {
 	now := time.Now()
 	first := &application.WebviewWindow{}  // identity tokens only: no method is
-	second := &application.WebviewWindow{} // called on them in these paths
-	markDead := func(b *nativeBridge) {
-		b.windowShownAt.Store(now.Add(-2 * beatGrace).UnixNano())
-		b.lastBeat.Store(0)
-	}
+	second := &application.WebviewWindow{} // called on them in this path
 
-	// detachIfDead hands back the dead window and clears the field, so the
-	// caller closes a window the bridge no longer points at.
-	b := &nativeBridge{window: first}
-	markDead(b)
-	if got := b.detachIfDead(now); got != first {
-		t.Errorf("detachIfDead = %v, want the dead window", got)
-	}
-	if b.window != nil {
-		t.Error("detachIfDead must clear b.window before the caller closes it")
-	}
-
-	// A live (beating) window is never detached.
-	b = &nativeBridge{window: first}
-	b.windowShownAt.Store(now.Add(-time.Hour).UnixNano())
-	b.lastBeat.Store(now.Add(-time.Second).UnixNano())
-	if got := b.detachIfDead(now); got != nil {
-		t.Error("a beating window must not be detached")
-	}
-	if b.window != first {
-		t.Error("a beating window must stay attached")
-	}
-
-	// Cooldown blocks a second revive.
-	b = &nativeBridge{window: first}
-	markDead(b)
-	b.lastRevive.Store(now.Add(-reviveCooldown / 2).UnixNano())
-	if got := b.detachIfDead(now); got != nil {
-		t.Error("revive inside the cooldown must not detach")
-	}
-
-	// detachStalled is identity-keyed: a successor window is left alone.
-	b = &nativeBridge{window: second}
+	b := &nativeBridge{window: second}
 	if got := b.detachStalled(first, now); got != nil {
 		t.Error("detachStalled must not touch a different (successor) window")
 	}
@@ -177,5 +198,48 @@ func TestDetachHelpersGuardWindowIdentity(t *testing.T) {
 	}
 	if b.window != nil {
 		t.Error("detachStalled must clear b.window before the caller closes it")
+	}
+
+	// Cooldown blocks the detach entirely.
+	b = &nativeBridge{window: first}
+	b.lastRevive.Store(now.Add(-reviveCooldown / 2).UnixNano())
+	if got := b.detachStalled(first, now); got != nil {
+		t.Error("detach inside the cooldown must not fire")
+	}
+	if b.window != first {
+		t.Error("window must stay attached when the cooldown blocks the revive")
+	}
+}
+
+// TestProbeAfterShowHealthyPathAndFlag covers the probe goroutine's two
+// bookkeeping duties: a healthy page short-circuits without touching the
+// window, and probeInFlight is always released — a leak there would silently
+// disable every future probe.
+func TestProbeAfterShowHealthyPathAndFlag(t *testing.T) {
+	win := &application.WebviewWindow{} // identity token; the healthy path calls nothing on it
+	b := &nativeBridge{window: win, testProbeDelay: 10 * time.Millisecond}
+
+	// Nil window: no probe, no flag left set.
+	b.probeAfterShow(nil)
+	if b.probeInFlight.Load() {
+		t.Error("probeInFlight must not stay set when there is no window to probe")
+	}
+
+	// Healthy: a frame lands after the show, so the probe must leave the window
+	// attached and clear its flag.
+	b.lastFrame.Store(time.Now().Add(time.Second).UnixNano())
+	b.probeAfterShow(win)
+	deadline := time.Now().Add(2 * time.Second)
+	for b.probeInFlight.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if b.probeInFlight.Load() {
+		t.Fatal("probeInFlight leaked: future probes would never run")
+	}
+	if b.window != win {
+		t.Error("a healthy window must not be detached by the probe")
+	}
+	if b.lastRevive.Load() != 0 {
+		t.Error("a healthy probe must not consume the revive budget")
 	}
 }

--- a/cmd/octo-desktop/bridge_test.go
+++ b/cmd/octo-desktop/bridge_test.go
@@ -243,3 +243,29 @@ func TestProbeAfterShowHealthyPathAndFlag(t *testing.T) {
 		t.Error("a healthy probe must not consume the revive budget")
 	}
 }
+
+// TestCloseShouldQuit pins who owns the last-window-close quit on each
+// platform. Windows' framework-level quit is suppressed because it fired
+// unconditionally — killing a hub the user had asked to keep running — so the
+// close path must perform the quit itself, and ONLY when the user opted out of
+// background running. mac and Linux already route this through their own hooks
+// and must never get a second quit from here.
+func TestCloseShouldQuit(t *testing.T) {
+	cases := []struct {
+		goos      string
+		allowQuit bool
+		want      bool
+	}{
+		{"windows", true, true},   // user opted out of background running
+		{"windows", false, false}, // keep running in the tray
+		{"darwin", true, false},   // ApplicationShouldTerminateAfterLastWindowClosed owns it
+		{"darwin", false, false},
+		{"linux", true, false}, // unregisterWindow consults ShouldQuit
+		{"linux", false, false},
+	}
+	for _, tc := range cases {
+		if got := closeShouldQuit(tc.goos, tc.allowQuit); got != tc.want {
+			t.Errorf("closeShouldQuit(%q, allowQuit=%v) = %v, want %v", tc.goos, tc.allowQuit, got, tc.want)
+		}
+	}
+}

--- a/cmd/octo-desktop/bridge_test.go
+++ b/cmd/octo-desktop/bridge_test.go
@@ -38,27 +38,29 @@ func TestShellURL(t *testing.T) {
 	}
 }
 
-// TestNeedsRevive is the false-positive guard for the whole feature: destroying
-// a healthy window (losing the user's draft and stealing focus) is far worse
-// than a few more seconds of black, so every legitimate reason a page has to be
-// quiet must read as healthy. Only post-show evidence counts — how long the
-// page was silent BEFORE the show is deliberately irrelevant, because system
-// sleep freezes the page wholesale and Chromium throttles a long-hidden page's
-// timers to roughly once a minute.
-func TestNeedsRevive(t *testing.T) {
+// TestJudgePage covers the feature's central decision, whose two failure
+// directions are both expensive: a wrong "healthy" leaves the user staring at a
+// black window forever, and a wrong "black" destroys a working one (losing the
+// draft, stealing focus). Only post-show evidence counts — pre-show silence is
+// legitimate, since system sleep freezes the page and Chromium throttles a
+// long-hidden page's timers to roughly once a minute.
+func TestJudgePage(t *testing.T) {
 	shownAt := time.Now()
+	before, after := shownAt.Add(-time.Minute), shownAt.Add(time.Second)
 	cases := []struct {
-		name       string
-		frameAt    time.Time // zero = never
-		hiddenAt   time.Time // zero = never
-		wantRevive bool
+		name     string
+		frameAt  time.Time // zero = never
+		hiddenAt time.Time // zero = never
+		beatAt   time.Time // zero = never
+		want     pageVerdict
 	}{
-		{"frame after the show: compositor is painting", shownAt.Add(time.Second), time.Time{}, false},
-		{"hidden beat after the show: owes no frames", time.Time{}, shownAt.Add(time.Second), false},
-		{"both after the show", shownAt.Add(time.Second), shownAt.Add(2 * time.Second), false},
-		{"nothing at all: dead renderer", time.Time{}, time.Time{}, true},
-		{"only frames from before the show: black compositor", shownAt.Add(-time.Minute), time.Time{}, true},
-		{"only a hidden beat from before the show", time.Time{}, shownAt.Add(-time.Minute), true},
+		{"painted after the show", after, time.Time{}, after, pageHealthy},
+		{"hidden after the show: owes no frames", time.Time{}, after, after, pageHealthy},
+		{"beats, visible, never painted: black", time.Time{}, time.Time{}, after, pageBlack},
+		{"beats, frames only from before the show: black", before, time.Time{}, after, pageBlack},
+		{"beats, hidden only from before the show: black", time.Time{}, before, after, pageBlack},
+		{"nothing at all since the show", time.Time{}, time.Time{}, time.Time{}, pageSilent},
+		{"only pre-show evidence of everything", before, before, before, pageSilent},
 	}
 	for _, tc := range cases {
 		b := &nativeBridge{}
@@ -68,28 +70,56 @@ func TestNeedsRevive(t *testing.T) {
 		if !tc.hiddenAt.IsZero() {
 			b.lastHiddenBeat.Store(tc.hiddenAt.UnixNano())
 		}
-		if got := b.needsRevive(shownAt); got != tc.wantRevive {
-			t.Errorf("%s: needsRevive = %v, want %v", tc.name, got, tc.wantRevive)
+		if !tc.beatAt.IsZero() {
+			b.lastBeat.Store(tc.beatAt.UnixNano())
+		}
+		if got := b.judgePage(shownAt); got != tc.want {
+			t.Errorf("%s: judgePage = %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }
 
-// TestNeedsReviveIgnoresPreShowSilence pins the sleep/wake case explicitly: a
-// page frozen for hours (so every timestamp is ancient) that reports in right
-// after the show is healthy. Judging the pre-show gap instead would destroy
-// this window.
-func TestNeedsReviveIgnoresPreShowSilence(t *testing.T) {
+// TestJudgePageBlackFromBirth guards a hole an earlier cut of this protocol
+// had: reporting "hidden" and "no frame observed yet" through a single signal
+// made a window that was black from its first paint look healthy forever — and
+// with it a replacement window that also came up black, which is precisely when
+// the retry matters. A visible page that beats without ever painting is black.
+func TestJudgePageBlackFromBirth(t *testing.T) {
+	shownAt := time.Now()
+
+	b := &nativeBridge{}
+	for i := 0; i < 5; i++ {
+		b.Heartbeat(-1, false) // visible, rAF never fires
+	}
+	if got := b.judgePage(shownAt); got != pageBlack {
+		t.Errorf("visible page that never painted: judgePage = %v, want pageBlack", got)
+	}
+
+	b2 := &nativeBridge{}
+	for i := 0; i < 5; i++ {
+		b2.Heartbeat(-1, true) // same beats, but hidden
+	}
+	if got := b2.judgePage(shownAt); got != pageHealthy {
+		t.Errorf("hidden page: judgePage = %v, want pageHealthy", got)
+	}
+}
+
+// TestJudgePageIgnoresPreShowSilence pins the sleep/wake case explicitly: a page
+// frozen for hours (so every timestamp is ancient) that reports in right after
+// the show is healthy. Judging the pre-show gap instead would destroy it.
+func TestJudgePageIgnoresPreShowSilence(t *testing.T) {
 	shownAt := time.Now()
 	b := &nativeBridge{}
 	b.lastBeat.Store(shownAt.Add(-8 * time.Hour).UnixNano()) // asleep all night
 	b.lastFrame.Store(shownAt.Add(-8 * time.Hour).UnixNano())
-	if !b.needsRevive(shownAt) {
-		t.Fatal("precondition: with only pre-show evidence the verdict is still revive")
+	if got := b.judgePage(shownAt); got != pageSilent {
+		t.Fatalf("precondition: judgePage = %v, want pageSilent with only pre-show evidence", got)
 	}
-	// The page wakes and paints a frame after the show.
+	// The page wakes and paints after the show.
+	b.lastBeat.Store(shownAt.Add(200 * time.Millisecond).UnixNano())
 	b.lastFrame.Store(shownAt.Add(200 * time.Millisecond).UnixNano())
-	if b.needsRevive(shownAt) {
-		t.Error("a page that painted after the show must never be revived, however long it slept")
+	if got := b.judgePage(shownAt); got != pageHealthy {
+		t.Errorf("judgePage = %v, want pageHealthy: painting after the show clears it however long it slept", got)
 	}
 }
 
@@ -121,7 +151,7 @@ func TestHeartbeatSignals(t *testing.T) {
 
 	// Visible beat: records JS liveness and a frame time derived from the age.
 	before := time.Now()
-	b.Heartbeat(3000)
+	b.Heartbeat(3000, false)
 	after := time.Now()
 	if beat := time.Unix(0, b.lastBeat.Load()); beat.Before(before) || beat.After(after) {
 		t.Errorf("lastBeat = %v, want within [%v, %v]", beat, before, after)
@@ -134,10 +164,10 @@ func TestHeartbeatSignals(t *testing.T) {
 		t.Error("a visible beat must not record a hidden beat")
 	}
 
-	// Hidden beat (negative age): records liveness + "owes no frames", and
-	// leaves the frame evidence untouched.
+	// Hidden beat: records liveness + "owes no frames", and leaves the frame
+	// evidence untouched.
 	frameBefore := b.lastFrame.Load()
-	b.Heartbeat(-1)
+	b.Heartbeat(-1, true)
 	if b.lastHiddenBeat.Load() == 0 {
 		t.Error("a hidden beat must be recorded so the probe expects no frames")
 	}
@@ -145,11 +175,22 @@ func TestHeartbeatSignals(t *testing.T) {
 		t.Error("a hidden beat must not touch lastFrame")
 	}
 
+	// Visible with no frame yet: liveness only. It must NOT be filed as
+	// "owes no frames" — that is the black-window signature.
+	hiddenBefore := b.lastHiddenBeat.Load()
+	b.Heartbeat(-1, false)
+	if b.lastHiddenBeat.Load() != hiddenBefore {
+		t.Error("a visible never-painted beat must not count as hidden")
+	}
+	if b.lastFrame.Load() != frameBefore {
+		t.Error("a visible never-painted beat must not invent frame evidence")
+	}
+
 	// Monotonic: a stale report (a focus beat whose rAF has not ticked yet,
 	// clock skew) must not move lastFrame backwards.
-	b.Heartbeat(0) // fresh frame, now
+	b.Heartbeat(0, false) // fresh frame, now
 	newest := b.lastFrame.Load()
-	b.Heartbeat(int64(time.Minute / time.Millisecond)) // claims a minute-old frame
+	b.Heartbeat(int64(time.Minute/time.Millisecond), false) // claims a minute-old frame
 	if b.lastFrame.Load() != newest {
 		t.Error("a staler frame report must not overwrite newer frame evidence")
 	}
@@ -157,7 +198,7 @@ func TestHeartbeatSignals(t *testing.T) {
 	// Clamp: an absurd age can't push lastFrame into the distant past (which,
 	// with the monotonic rule, is the only way to fake a stall).
 	b2 := &nativeBridge{}
-	b2.Heartbeat(1 << 62)
+	b2.Heartbeat(1<<62, false)
 	if age := time.Since(time.Unix(0, b2.lastFrame.Load())); age > maxReportedFrameAge+time.Minute {
 		t.Errorf("frame age clamp failed: lastFrame is %v old", age)
 	}
@@ -241,6 +282,70 @@ func TestProbeAfterShowHealthyPathAndFlag(t *testing.T) {
 	}
 	if b.lastRevive.Load() != 0 {
 		t.Error("a healthy probe must not consume the revive budget")
+	}
+}
+
+// TestProbeAfterShowRevivesBlackWindow covers the branch that actually repairs
+// a black window, through the reviveFn seam (the real one needs a live Wails
+// app). It pins two things the shell's own survival depends on: the window is
+// detached from the bridge BEFORE it is handed over for closing, and the revive
+// budget is consumed so a still-broken page can't loop.
+func TestProbeAfterShowRevivesBlackWindow(t *testing.T) {
+	win := &application.WebviewWindow{}
+	got := make(chan *application.WebviewWindow, 1)
+	var detachedAtHandover bool
+
+	b := &nativeBridge{window: win, testProbeDelay: 10 * time.Millisecond}
+	b.reviveFn = func(old *application.WebviewWindow) {
+		b.windowMu.Lock()
+		detachedAtHandover = b.window == nil
+		b.windowMu.Unlock()
+		got <- old
+	}
+
+	// Beats arrive, the page claims to be visible, no frame ever lands: black.
+	b.Heartbeat(-1, false)
+	b.probeAfterShow(win)
+
+	select {
+	case old := <-got:
+		if old != win {
+			t.Errorf("revive got %v, want the probed window", old)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("a black window was never revived")
+	}
+	if !detachedAtHandover {
+		t.Error("the window must be detached before it is handed over to be closed, or its close would nil the replacement")
+	}
+	if b.lastRevive.Load() == 0 {
+		t.Error("a revive must consume the budget so a persistently broken page can't loop")
+	}
+}
+
+// TestProbeAfterShowGivesSilenceASecondChance pins the deliberate asymmetry
+// between the two unhealthy verdicts: total silence can also mean a wedged hub
+// or a main thread stuck on a huge render, both of which recover on their own,
+// so the window is only replaced if the silence persists. A page that reports in
+// during the second cycle keeps its state.
+func TestProbeAfterShowGivesSilenceASecondChance(t *testing.T) {
+	win := &application.WebviewWindow{}
+	revived := make(chan struct{}, 1)
+	b := &nativeBridge{window: win, testProbeDelay: 30 * time.Millisecond}
+	b.reviveFn = func(*application.WebviewWindow) { revived <- struct{}{} }
+
+	b.probeAfterShow(win) // no beats at all → pageSilent
+	// Report in before the second cycle elapses.
+	time.Sleep(40 * time.Millisecond)
+	b.Heartbeat(0, false)
+
+	select {
+	case <-revived:
+		t.Error("a page that reported in during the second chance must not be revived")
+	case <-time.After(300 * time.Millisecond):
+	}
+	if b.window != win {
+		t.Error("window must stay attached")
 	}
 }
 

--- a/cmd/octo-desktop/bridge_test.go
+++ b/cmd/octo-desktop/bridge_test.go
@@ -86,7 +86,12 @@ func TestJudgePage(t *testing.T) {
 // with it a replacement window that also came up black, which is precisely when
 // the retry matters. A visible page that beats without ever painting is black.
 func TestJudgePageBlackFromBirth(t *testing.T) {
-	shownAt := time.Now()
+	// Back off the show anchor: CI clocks (Windows ~0.5ms, virtualised macOS)
+	// can return the same time.Now() value for the show and the beats, and
+	// judgePage's After() is strict — equal timestamps would read as pre-show
+	// evidence. A beat in the same clock tick as the show is a non-case in
+	// production (beats arrive seconds later).
+	shownAt := time.Now().Add(-time.Millisecond)
 
 	b := &nativeBridge{}
 	for i := 0; i < 5; i++ {

--- a/cmd/octo-desktop/bridge_test.go
+++ b/cmd/octo-desktop/bridge_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -347,6 +348,66 @@ func TestProbeAfterShowGivesSilenceASecondChance(t *testing.T) {
 	if b.window != win {
 		t.Error("window must stay attached")
 	}
+}
+
+// TestProbeAfterShowCollapsesConcurrentProbes pins the probeInFlight CAS: a
+// second probe requested while one is still running must be skipped, not
+// queued — two overlapping probes would judge overlapping windows of evidence
+// and could both reach for the window. The test parks the first probe inside
+// the revive hand-off, then asks for another probe against a fresh window
+// whose evidence would revive it if a second goroutine were actually running
+// (the revive cooldown is reset so it couldn't mask the attempt).
+func TestProbeAfterShowCollapsesConcurrentProbes(t *testing.T) {
+	first := &application.WebviewWindow{}
+	second := &application.WebviewWindow{}
+	release := make(chan struct{})
+	var revives atomic.Int32
+
+	b := &nativeBridge{window: first, testProbeDelay: 10 * time.Millisecond}
+	b.reviveFn = func(*application.WebviewWindow) {
+		revives.Add(1)
+		<-release // park the first probe with probeInFlight still held
+	}
+
+	b.probeAfterShow(first)
+	// Evidence must land AFTER the show to count: visible, never painted → black.
+	b.Heartbeat(-1, false)
+
+	// Wait until the first probe is parked inside the revive hand-off.
+	deadline := time.Now().Add(2 * time.Second)
+	for revives.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if revives.Load() != 1 {
+		t.Fatal("first probe never reached the revive")
+	}
+	if !b.probeInFlight.Load() {
+		t.Fatal("probeInFlight must stay held while the first probe runs")
+	}
+
+	// A second show during the in-flight probe: its window has black evidence
+	// and (with the cooldown reset) would be revived IF a second probe
+	// goroutine were scheduled. The CAS must collapse it instead.
+	b.windowMu.Lock()
+	b.window = second
+	b.windowMu.Unlock()
+	b.lastRevive.Store(0)
+	b.probeAfterShow(second)
+	b.Heartbeat(-1, false) // black evidence for the second window, after its show
+
+	close(release) // let the first probe finish
+	time.Sleep(100 * time.Millisecond)
+	if n := revives.Load(); n != 1 {
+		t.Errorf("revives = %d, want 1 — the second probe was not collapsed", n)
+	}
+	if b.probeInFlight.Load() {
+		t.Error("probeInFlight leaked after the first probe finished")
+	}
+	b.windowMu.Lock()
+	if b.window != second {
+		t.Error("the collapsed probe must not touch the successor window")
+	}
+	b.windowMu.Unlock()
 }
 
 // TestCloseShouldQuit pins who owns the last-window-close quit on each

--- a/cmd/octo-desktop/bridge_test.go
+++ b/cmd/octo-desktop/bridge_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
 // TestShellURL pins the shell-marker query the frontend keys nativeShell off.
@@ -32,5 +35,147 @@ func TestShellURL(t *testing.T) {
 	// The marker must survive on every variant — it is the sole nativeShell signal.
 	if got := shellURL(base, "x"); !strings.Contains(got, "shell=octo-desktop") {
 		t.Fatalf("shellURL dropped the desktop marker: %q", got)
+	}
+}
+
+// TestWebviewDead pins the shell's revive decision: a window is declared dead
+// only when it is old enough to have beaten AND the beats stopped (or never
+// started). Young windows and actively-beating pages must never be revived —
+// a false positive here destroys a healthy window.
+func TestWebviewDead(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name    string
+		shownAt time.Time // zero = no window recorded
+		beatAt  time.Time // zero = never beat
+		want    bool
+	}{
+		{"no window recorded", time.Time{}, time.Time{}, false},
+		{"young window, no beat yet (still loading)", now.Add(-10 * time.Second), time.Time{}, false},
+		{"old window, never beat", now.Add(-2 * beatGrace), time.Time{}, true},
+		{"old window, fresh beat", now.Add(-time.Hour), now.Add(-2 * time.Second), false},
+		{"old window, beats stopped", now.Add(-time.Hour), now.Add(-2 * beatGrace), true},
+		{"beat predates this window (belongs to a previous one)", now.Add(-2 * beatGrace), now.Add(-3 * beatGrace), true},
+	}
+	for _, tc := range cases {
+		b := &nativeBridge{}
+		if !tc.shownAt.IsZero() {
+			b.windowShownAt.Store(tc.shownAt.UnixNano())
+		}
+		if !tc.beatAt.IsZero() {
+			b.lastBeat.Store(tc.beatAt.UnixNano())
+		}
+		if got := b.webviewDead(now); got != tc.want {
+			t.Errorf("%s: webviewDead = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestReviveAllowed pins the destroy/create rate limit: a first revive is
+// always allowed, a second inside the cooldown is not — a persistently broken
+// page must not put the shell into a reload loop.
+func TestReviveAllowed(t *testing.T) {
+	now := time.Now()
+	b := &nativeBridge{}
+	if !b.reviveAllowed(now) {
+		t.Error("first revive should be allowed")
+	}
+	b.lastRevive.Store(now.Add(-reviveCooldown / 2).UnixNano())
+	if b.reviveAllowed(now) {
+		t.Error("revive inside the cooldown should be blocked")
+	}
+	b.lastRevive.Store(now.Add(-2 * reviveCooldown).UnixNano())
+	if !b.reviveAllowed(now) {
+		t.Error("revive after the cooldown should be allowed")
+	}
+}
+
+// TestHeartbeatRecordsFrameTime pins the frame-timestamp derivation the
+// post-show probe depends on: lastFrame = beat arrival minus the reported rAF
+// age, and a negative age (clock skew, bad client) must not move lastFrame
+// into the future.
+func TestHeartbeatRecordsFrameTime(t *testing.T) {
+	b := &nativeBridge{}
+	before := time.Now()
+	b.Heartbeat(3000)
+	after := time.Now()
+
+	beat := time.Unix(0, b.lastBeat.Load())
+	if beat.Before(before) || beat.After(after) {
+		t.Errorf("lastBeat = %v, want within [%v, %v]", beat, before, after)
+	}
+	frame := time.Unix(0, b.lastFrame.Load())
+	wantLo, wantHi := before.Add(-3*time.Second), after.Add(-3*time.Second)
+	if frame.Before(wantLo) || frame.After(wantHi) {
+		t.Errorf("lastFrame = %v, want ~3s before the beat", frame)
+	}
+
+	prevFrame := b.lastFrame.Load()
+	b.Heartbeat(-50)
+	if b.lastFrame.Load() != prevFrame {
+		t.Error("negative frame age must not update lastFrame")
+	}
+	if time.Unix(0, b.lastBeat.Load()).Before(after) {
+		t.Error("beat with negative frame age must still record JS liveness")
+	}
+}
+
+// TestDetachHelpersGuardWindowIdentity pins the revive swap's core invariant:
+// the pointer is detached BEFORE the old window is closed (so the replacement
+// survives the old window's WindowClosing handler), and a stalled-window
+// detach only fires for the exact window the probe judged — never for a
+// successor the user or another revive installed meanwhile.
+func TestDetachHelpersGuardWindowIdentity(t *testing.T) {
+	now := time.Now()
+	first := &application.WebviewWindow{}  // identity tokens only: no method is
+	second := &application.WebviewWindow{} // called on them in these paths
+	markDead := func(b *nativeBridge) {
+		b.windowShownAt.Store(now.Add(-2 * beatGrace).UnixNano())
+		b.lastBeat.Store(0)
+	}
+
+	// detachIfDead hands back the dead window and clears the field, so the
+	// caller closes a window the bridge no longer points at.
+	b := &nativeBridge{window: first}
+	markDead(b)
+	if got := b.detachIfDead(now); got != first {
+		t.Errorf("detachIfDead = %v, want the dead window", got)
+	}
+	if b.window != nil {
+		t.Error("detachIfDead must clear b.window before the caller closes it")
+	}
+
+	// A live (beating) window is never detached.
+	b = &nativeBridge{window: first}
+	b.windowShownAt.Store(now.Add(-time.Hour).UnixNano())
+	b.lastBeat.Store(now.Add(-time.Second).UnixNano())
+	if got := b.detachIfDead(now); got != nil {
+		t.Error("a beating window must not be detached")
+	}
+	if b.window != first {
+		t.Error("a beating window must stay attached")
+	}
+
+	// Cooldown blocks a second revive.
+	b = &nativeBridge{window: first}
+	markDead(b)
+	b.lastRevive.Store(now.Add(-reviveCooldown / 2).UnixNano())
+	if got := b.detachIfDead(now); got != nil {
+		t.Error("revive inside the cooldown must not detach")
+	}
+
+	// detachStalled is identity-keyed: a successor window is left alone.
+	b = &nativeBridge{window: second}
+	if got := b.detachStalled(first, now); got != nil {
+		t.Error("detachStalled must not touch a different (successor) window")
+	}
+	if b.window != second {
+		t.Error("successor window must stay attached")
+	}
+	if got := b.detachStalled(second, now); got != second {
+		t.Errorf("detachStalled = %v, want the probed window", got)
+	}
+	if b.window != nil {
+		t.Error("detachStalled must clear b.window before the caller closes it")
 	}
 }

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -244,6 +244,15 @@ func main() {
 			ApplicationShouldTerminateAfterLastWindowClosed: !settings.KeepRunningInBackground,
 		},
 		Windows: application.WindowsOptions{
+			// Wails' Windows backend posts a quit message the moment its window
+			// map empties (unregisterWindow), without consulting ShouldQuit —
+			// so closing the window terminated the whole hub even when the user
+			// asked it to keep running in the tray, and it also raced the
+			// webview revive's window swap. Suppress that and let octo's own
+			// ShouldQuit be the only authority, as it already is on mac/Linux;
+			// the close path quits explicitly when the user opted out of
+			// background running (see closeShouldQuit).
+			DisableQuitOnLastWindowClosed: true,
 			// Chromium's native-window occlusion tracker stops rendering a
 			// WebView2 whose window is minimised or fully covered; on some
 			// machines the compositor never paints again after restore,

--- a/internal/server/native_handlers.go
+++ b/internal/server/native_handlers.go
@@ -81,13 +81,22 @@ type NativeBridge interface {
 	Print() error
 
 	// Heartbeat records a liveness beat from the frontend running inside the
-	// desktop webview. frameAgeMS is how long ago the page's last
-	// requestAnimationFrame fired: it separates "JS alive and rendering" from
-	// "JS alive but the frame pipeline is stalled" — the signature of a
-	// webview whose compositor went black while the page kept running. The
-	// shell uses beat recency to decide whether to revive (destroy and
-	// re-create) the window instead of foregrounding a dead surface.
-	Heartbeat(frameAgeMS int64)
+	// desktop webview, so the shell can tell a live page from a dead or black
+	// one and revive (destroy and re-create) the window rather than
+	// foregrounding a surface that will never paint again.
+	//
+	// The beat arriving is itself the proof that JS runs. The two arguments
+	// describe the render pipeline, and they must stay distinct:
+	//   - frameAgeMS >= 0: how long ago the page observed a
+	//     requestAnimationFrame tick, i.e. frames are being produced.
+	//   - frameAgeMS < 0: the page has not observed a frame at all yet.
+	//   - hidden: the page reports itself not visible, so it legitimately owes
+	//     no frames (minimised, occluded, another desktop).
+	//
+	// A visible page that beats without ever producing a frame is the black-
+	// window signature — conflating that with "hidden" would make the failure
+	// this whole mechanism exists for undetectable.
+	Heartbeat(frameAgeMS int64, hidden bool)
 
 	// CanSelfUpdate reports whether the desktop build can replace itself in
 	// place (bundled release build on a swappable platform). Surfaced to the
@@ -276,6 +285,7 @@ func (s *Server) handleNativeMinimise(w http.ResponseWriter, r *http.Request) {
 
 type nativeHeartbeatRequest struct {
 	FrameAgeMS int64 `json:"frame_age_ms"`
+	Hidden     bool  `json:"hidden"`
 }
 
 // POST /api/native/heartbeat — liveness beat from the page inside the desktop
@@ -289,12 +299,14 @@ func (s *Server) handleNativeHeartbeat(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "native bridge not available")
 		return
 	}
-	// Body is optional-tolerant like the other native handlers; a missing or
-	// malformed one records a beat with frame age 0 (JS provably alive —
-	// the request itself is the liveness signal).
-	var req nativeHeartbeatRequest
+	// Body is optional-tolerant like the other native handlers, but the default
+	// must claim NO frame evidence: the request alone proves JS is alive and
+	// says nothing about rendering. Defaulting FrameAgeMS to its zero value
+	// would read as "a frame just landed" — the strongest health signal —
+	// letting a malformed beat mask a black window.
+	req := nativeHeartbeatRequest{FrameAgeMS: -1}
 	_ = readBodyJSON(r, &req)
-	s.cfg.Native.Heartbeat(req.FrameAgeMS)
+	s.cfg.Native.Heartbeat(req.FrameAgeMS, req.Hidden)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 

--- a/internal/server/native_handlers.go
+++ b/internal/server/native_handlers.go
@@ -80,6 +80,15 @@ type NativeBridge interface {
 	// stylesheet depends on in place after this returns.
 	Print() error
 
+	// Heartbeat records a liveness beat from the frontend running inside the
+	// desktop webview. frameAgeMS is how long ago the page's last
+	// requestAnimationFrame fired: it separates "JS alive and rendering" from
+	// "JS alive but the frame pipeline is stalled" — the signature of a
+	// webview whose compositor went black while the page kept running. The
+	// shell uses beat recency to decide whether to revive (destroy and
+	// re-create) the window instead of foregrounding a dead surface.
+	Heartbeat(frameAgeMS int64)
+
 	// CanSelfUpdate reports whether the desktop build can replace itself in
 	// place (bundled release build on a swappable platform). Surfaced to the
 	// frontend as /api/version's self_update flag so the update badge knows
@@ -262,6 +271,30 @@ func (s *Server) handleNativeMinimise(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.cfg.Native.Minimise()
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+type nativeHeartbeatRequest struct {
+	FrameAgeMS int64 `json:"frame_age_ms"`
+}
+
+// POST /api/native/heartbeat — liveness beat from the page inside the desktop
+// webview (nativeShell mode only sends it). Desktop only, loopback-gated.
+func (s *Server) handleNativeHeartbeat(w http.ResponseWriter, r *http.Request) {
+	if !isLoopbackRemote(r.RemoteAddr) {
+		writeError(w, http.StatusForbidden, "available only from the local machine")
+		return
+	}
+	if s.cfg.Native == nil {
+		writeError(w, http.StatusNotFound, "native bridge not available")
+		return
+	}
+	// Body is optional-tolerant like the other native handlers; a missing or
+	// malformed one records a beat with frame age 0 (JS provably alive —
+	// the request itself is the liveness signal).
+	var req nativeHeartbeatRequest
+	_ = readBodyJSON(r, &req)
+	s.cfg.Native.Heartbeat(req.FrameAgeMS)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 

--- a/internal/server/native_handlers_test.go
+++ b/internal/server/native_handlers_test.go
@@ -35,6 +35,8 @@ type fakeNative struct {
 	selfUpdateErr      error
 	printCalls         int
 	printErr           error
+	heartbeatCalls     int
+	gotFrameAgeMS      int64
 }
 
 func (f *fakeNative) PickFolder(_ context.Context, startDir string) (string, bool, error) {
@@ -74,6 +76,11 @@ func (f *fakeNative) Print() error {
 	f.printCalls++
 	return f.printErr
 }
+func (f *fakeNative) Heartbeat(frameAgeMS int64) {
+	f.heartbeatCalls++
+	f.gotFrameAgeMS = frameAgeMS
+}
+
 func (f *fakeNative) CanSelfUpdate() bool { return f.canSelfUpdate }
 func (f *fakeNative) SelfUpdate() error {
 	f.selfUpdateCalls++
@@ -249,6 +256,35 @@ func TestNativeToggleMaximise(t *testing.T) {
 	}
 	if fake.toggleMaxCalls != 1 {
 		t.Errorf("ToggleMaximise calls = %d, want 1", fake.toggleMaxCalls)
+	}
+}
+
+func TestNativeHeartbeatDelegatesToBridge(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	fake := &fakeNative{}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Native: fake})
+	req := httptest.NewRequest(http.MethodPost, "/api/native/heartbeat", strings.NewReader(`{"frame_age_ms":1234}`))
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+	if fake.heartbeatCalls != 1 || fake.gotFrameAgeMS != 1234 {
+		t.Errorf("Heartbeat calls = %d frameAge = %d, want 1 / 1234", fake.heartbeatCalls, fake.gotFrameAgeMS)
+	}
+
+	// A body-less beat still counts: the request itself is the liveness signal.
+	req = httptest.NewRequest(http.MethodPost, "/api/native/heartbeat", nil)
+	w = httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("body-less beat: got %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+	if fake.heartbeatCalls != 2 || fake.gotFrameAgeMS != 0 {
+		t.Errorf("body-less beat: calls = %d frameAge = %d, want 2 / 0", fake.heartbeatCalls, fake.gotFrameAgeMS)
 	}
 }
 

--- a/internal/server/native_handlers_test.go
+++ b/internal/server/native_handlers_test.go
@@ -37,6 +37,7 @@ type fakeNative struct {
 	printErr           error
 	heartbeatCalls     int
 	gotFrameAgeMS      int64
+	gotHidden          bool
 }
 
 func (f *fakeNative) PickFolder(_ context.Context, startDir string) (string, bool, error) {
@@ -76,9 +77,10 @@ func (f *fakeNative) Print() error {
 	f.printCalls++
 	return f.printErr
 }
-func (f *fakeNative) Heartbeat(frameAgeMS int64) {
+func (f *fakeNative) Heartbeat(frameAgeMS int64, hidden bool) {
 	f.heartbeatCalls++
 	f.gotFrameAgeMS = frameAgeMS
+	f.gotHidden = hidden
 }
 
 func (f *fakeNative) CanSelfUpdate() bool { return f.canSelfUpdate }
@@ -272,19 +274,36 @@ func TestNativeHeartbeatDelegatesToBridge(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("got %d, want 200 (%s)", w.Code, w.Body.String())
 	}
-	if fake.heartbeatCalls != 1 || fake.gotFrameAgeMS != 1234 {
-		t.Errorf("Heartbeat calls = %d frameAge = %d, want 1 / 1234", fake.heartbeatCalls, fake.gotFrameAgeMS)
+	if fake.heartbeatCalls != 1 || fake.gotFrameAgeMS != 1234 || fake.gotHidden {
+		t.Errorf("Heartbeat calls = %d frameAge = %d hidden = %v, want 1 / 1234 / false",
+			fake.heartbeatCalls, fake.gotFrameAgeMS, fake.gotHidden)
 	}
 
-	// A body-less beat still counts: the request itself is the liveness signal.
+	// The hidden flag rides separately from the frame age: a hidden page owes
+	// no frames, which is NOT the same as a visible page that never painted.
+	req = httptest.NewRequest(http.MethodPost, "/api/native/heartbeat", strings.NewReader(`{"frame_age_ms":-1,"hidden":true}`))
+	w = httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("hidden beat: got %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+	if fake.heartbeatCalls != 2 || fake.gotFrameAgeMS != -1 || !fake.gotHidden {
+		t.Errorf("hidden beat: calls = %d frameAge = %d hidden = %v, want 2 / -1 / true",
+			fake.heartbeatCalls, fake.gotFrameAgeMS, fake.gotHidden)
+	}
+
+	// A body-less beat still counts as liveness, but must claim NO frame
+	// evidence: defaulting the age to zero would read as "just painted" and let
+	// a malformed beat mask a black window.
 	req = httptest.NewRequest(http.MethodPost, "/api/native/heartbeat", nil)
 	w = httptest.NewRecorder()
 	serveLoopback(srv.mux, w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("body-less beat: got %d, want 200 (%s)", w.Code, w.Body.String())
 	}
-	if fake.heartbeatCalls != 2 || fake.gotFrameAgeMS != 0 {
-		t.Errorf("body-less beat: calls = %d frameAge = %d, want 2 / 0", fake.heartbeatCalls, fake.gotFrameAgeMS)
+	if fake.heartbeatCalls != 3 || fake.gotFrameAgeMS != -1 || fake.gotHidden {
+		t.Errorf("body-less beat: calls = %d frameAge = %d hidden = %v, want 3 / -1 / false",
+			fake.heartbeatCalls, fake.gotFrameAgeMS, fake.gotHidden)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -812,6 +812,7 @@ func (s *Server) registerRoutes() {
 		s.api("PUT /api/native/autostart", s.handleNativeAutostartSet)
 		s.api("POST /api/native/window/toggle-maximise", s.handleNativeToggleMaximise)
 		s.api("POST /api/native/window/minimise", s.handleNativeMinimise)
+		s.api("POST /api/native/heartbeat", s.handleNativeHeartbeat)
 		s.api("POST /api/native/window/close", s.handleNativeClose)
 		s.api("GET /api/native/window/state", s.handleNativeWindowState)
 		s.api("POST /api/native/open-external", s.handleNativeOpenExternal)

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -9,6 +9,7 @@
   import { get } from 'svelte/store'
   import * as api from './lib/api'
   import { installExternalLinkInterceptor } from './lib/externalLinks'
+  import { startNativeHeartbeat } from './lib/nativeHeartbeat'
   import { normalizeHash } from './lib/hashRouting'
   import { globalKeyIntent } from './lib/globalKeys'
   import AuthGate from './components/overlays/AuthGate.svelte'
@@ -86,7 +87,10 @@
     // Desktop shell: send http(s) link clicks to the system browser (the
     // webview can't open target="_blank" itself). Inert in a real browser.
     const uninstallLinks = installExternalLinkInterceptor()
-    const cleanup = () => { cancelled = true; uninstallLinks(); ws.disconnect() }
+    // Desktop shell: report page liveness so the shell can revive a dead or
+    // black webview instead of foregrounding it. Inert in a real browser.
+    const stopHeartbeat = startNativeHeartbeat()
+    const cleanup = () => { cancelled = true; uninstallLinks(); stopHeartbeat(); ws.disconnect() }
     checkAuth().then(async ok => {
       if (cancelled) return
       if (!ok) {

--- a/web/src/lib/nativeHeartbeat.test.ts
+++ b/web/src/lib/nativeHeartbeat.test.ts
@@ -13,8 +13,10 @@ vi.mock('./api', () => ({ request: mocks.request }))
 
 import { startNativeHeartbeat } from './nativeHeartbeat'
 
-// The shell contract: frame_age_ms < 0 means "not rendering, by design"
-// (hidden, or no frame observed yet); >= 0 is the measured age of a real frame.
+// The shell contract: frame_age_ms < 0 means no frame has been observed yet,
+// >= 0 is the measured age of a real frame, and `hidden` says separately
+// whether frames are owed at all. Keeping them apart is what lets the shell
+// distinguish a legitimately-idle hidden page from a black window.
 const NO_FRAMES = -1
 
 function lastBody() {
@@ -119,9 +121,10 @@ describe('startNativeHeartbeat inside the desktop shell', () => {
 
   it('reports no-frames until a frame is actually observed, then its age', () => {
     const stop = start()
-    // First beat: no frame has been seen yet, so the shell must not read the
-    // absence as a black window.
+    // First beat: no frame seen yet — reported as such, and NOT as hidden. A
+    // visible page that never paints is exactly what the shell must revive.
     expect(lastBody().frame_age_ms).toBe(NO_FRAMES)
+    expect(lastBody().hidden).toBe(false)
 
     // A frame lands, then the next beat reports a real (small) age.
     flushFrame()
@@ -147,15 +150,31 @@ describe('startNativeHeartbeat inside the desktop shell', () => {
     stop()
   })
 
-  it('reports no-frames while the page is hidden, whatever the frame history', () => {
+  it('flags hidden separately instead of disguising it as a frame age', () => {
     const stop = start()
     flushFrame()
     vi.advanceTimersByTime(5_000)
+    expect(lastBody().hidden).toBe(false)
     expect(lastBody().frame_age_ms).toBeGreaterThanOrEqual(0)
 
+    // Hidden: the flag flips. The frame age keeps describing the real frame
+    // history — the shell decides what to expect from the flag, and folding the
+    // two together is what previously made a black window undetectable.
     vi.spyOn(document, 'hidden', 'get').mockReturnValue(true)
     vi.advanceTimersByTime(5_000)
-    expect(lastBody().frame_age_ms).toBe(NO_FRAMES)
+    expect(lastBody().hidden).toBe(true)
+    stop()
+  })
+
+  it('keeps reporting visible + no-frames for a window that is black from birth', () => {
+    // rAF is never flushed: the compositor is dead, but the page thinks it is
+    // visible. Every beat must carry that combination, since it is the shell's
+    // only evidence of a black window.
+    const stop = start()
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(5_000)
+      expect(lastBody()).toMatchObject({ frame_age_ms: NO_FRAMES, hidden: false })
+    }
     stop()
   })
 
@@ -181,9 +200,8 @@ describe('startNativeHeartbeat inside the desktop shell', () => {
     document.dispatchEvent(new Event('visibilitychange'))
     expect(mocks.request).toHaveBeenCalledTimes(2)
 
-    // Hidden: visibilitychange must not beat (nothing to prove, and the shell
-    // treats silence after a show as needing a new window only when the page
-    // was asked to be visible).
+    // Going hidden doesn't need an immediate beat — the next scheduled one
+    // carries the flag, and the shell only ever judges a window it just showed.
     vi.spyOn(document, 'hidden', 'get').mockReturnValue(true)
     document.dispatchEvent(new Event('visibilitychange'))
     expect(mocks.request).toHaveBeenCalledTimes(2)

--- a/web/src/lib/nativeHeartbeat.test.ts
+++ b/web/src/lib/nativeHeartbeat.test.ts
@@ -13,34 +13,90 @@ vi.mock('./api', () => ({ request: mocks.request }))
 
 import { startNativeHeartbeat } from './nativeHeartbeat'
 
+// The shell contract: frame_age_ms < 0 means "not rendering, by design"
+// (hidden, or no frame observed yet); >= 0 is the measured age of a real frame.
+const NO_FRAMES = -1
+
+function lastBody() {
+  const calls = mocks.request.mock.calls
+  return JSON.parse(calls[calls.length - 1][1].body as string)
+}
+
+// rAF is driven manually so the tests can model the three states that matter:
+// frames flowing, frames stalled (black window), and page hidden.
+let rafCallbacks: Map<number, FrameRequestCallback>
+let nextRafId: number
+// Every start() is torn down in afterEach: a test that fails before its own
+// stop() would otherwise leave listeners on the shared jsdom window, and the
+// next test's focus/visibility beats would be counted several times over.
+let stops: Array<() => void>
+
+function start() {
+  const stop = startNativeHeartbeat()
+  stops.push(stop)
+  return stop
+}
+
+function flushFrame() {
+  const pending = [...rafCallbacks.entries()]
+  rafCallbacks.clear()
+  for (const [, cb] of pending) cb(performance.now())
+}
+
+beforeEach(() => {
+  rafCallbacks = new Map()
+  nextRafId = 1
+  stops = []
+  // Fake the clock but NOT requestAnimationFrame: the tests drive frames by
+  // hand, since "did a frame land" is the signal under test. performance is
+  // faked so the reported frame age advances with the virtual clock.
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date', 'performance'] })
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    const id = nextRafId++
+    rafCallbacks.set(id, cb)
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    rafCallbacks.delete(id)
+  })
+  mocks.request.mockReset()
+  mocks.request.mockResolvedValue({ ok: true })
+})
+afterEach(() => {
+  for (const stop of stops) stop()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
 describe('startNativeHeartbeat outside the desktop shell', () => {
   beforeEach(() => {
     mocks.isDesktopShell = false
-    mocks.request.mockReset()
-    mocks.request.mockResolvedValue({ ok: true })
-    vi.useFakeTimers()
   })
-  afterEach(() => vi.useRealTimers())
 
   it('sends no beats and its stop function is safe to call', () => {
-    const stop = startNativeHeartbeat()
+    const stop = start()
     vi.advanceTimersByTime(60_000)
     expect(mocks.request).not.toHaveBeenCalled()
     expect(() => stop()).not.toThrow()
+  })
+
+  it('requests no animation frames at all', () => {
+    const stop = start()
+    vi.advanceTimersByTime(60_000)
+    expect(rafCallbacks.size).toBe(0)
+    stop()
   })
 })
 
 describe('startNativeHeartbeat inside the desktop shell', () => {
   beforeEach(() => {
     mocks.isDesktopShell = true
-    mocks.request.mockReset()
-    mocks.request.mockResolvedValue({ ok: true })
-    vi.useFakeTimers()
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false)
   })
-  afterEach(() => vi.useRealTimers())
 
   it('beats immediately, then on the interval, and stops when told', () => {
-    const stop = startNativeHeartbeat()
+    const stop = start()
     expect(mocks.request).toHaveBeenCalledTimes(1) // immediate first beat
 
     vi.advanceTimersByTime(5_000)
@@ -53,30 +109,99 @@ describe('startNativeHeartbeat inside the desktop shell', () => {
     expect(mocks.request).toHaveBeenCalledTimes(3) // no beats after stop
   })
 
-  it('posts a non-negative frame age the shell can read', () => {
-    const stop = startNativeHeartbeat()
+  it('posts to the shell endpoint as JSON', () => {
+    const stop = start()
     const [path, init] = mocks.request.mock.calls[0]
     expect(path).toBe('/api/native/heartbeat')
     expect(init.method).toBe('POST')
-    const body = JSON.parse(init.body as string)
-    expect(typeof body.frame_age_ms).toBe('number')
-    expect(body.frame_age_ms).toBeGreaterThanOrEqual(0)
     stop()
   })
 
-  it('beats on window focus so a shown window proves life promptly', () => {
-    const stop = startNativeHeartbeat()
+  it('reports no-frames until a frame is actually observed, then its age', () => {
+    const stop = start()
+    // First beat: no frame has been seen yet, so the shell must not read the
+    // absence as a black window.
+    expect(lastBody().frame_age_ms).toBe(NO_FRAMES)
+
+    // A frame lands, then the next beat reports a real (small) age.
+    flushFrame()
+    vi.advanceTimersByTime(5_000)
+    const age = lastBody().frame_age_ms
+    expect(age).toBeGreaterThanOrEqual(0)
+    expect(age).toBeLessThan(5_000 + 1_000)
+    stop()
+  })
+
+  it('lets the reported frame age grow while frames are stalled (black window)', () => {
+    const stop = start()
+    flushFrame() // one good frame, then the compositor dies
+    vi.advanceTimersByTime(5_000)
+    const first = lastBody().frame_age_ms
+    // No further frames are flushed: each beat should report an older frame.
+    vi.advanceTimersByTime(5_000)
+    const second = lastBody().frame_age_ms
+    vi.advanceTimersByTime(5_000)
+    const third = lastBody().frame_age_ms
+    expect(second).toBeGreaterThan(first)
+    expect(third).toBeGreaterThan(second)
+    stop()
+  })
+
+  it('reports no-frames while the page is hidden, whatever the frame history', () => {
+    const stop = start()
+    flushFrame()
+    vi.advanceTimersByTime(5_000)
+    expect(lastBody().frame_age_ms).toBeGreaterThanOrEqual(0)
+
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(true)
+    vi.advanceTimersByTime(5_000)
+    expect(lastBody().frame_age_ms).toBe(NO_FRAMES)
+    stop()
+  })
+
+  it('samples one frame per beat rather than running a continuous rAF loop', () => {
+    const stop = start()
+    // Exactly one request outstanding after a beat; flushing it doesn't chain
+    // another (that would be the per-vsync loop this design avoids).
+    expect(rafCallbacks.size).toBe(1)
+    flushFrame()
+    expect(rafCallbacks.size).toBe(0)
+    vi.advanceTimersByTime(5_000)
+    expect(rafCallbacks.size).toBe(1)
+    stop()
+  })
+
+  it('beats on window focus and on becoming visible', () => {
+    const stop = start()
     mocks.request.mockClear()
+
     window.dispatchEvent(new Event('focus'))
     expect(mocks.request).toHaveBeenCalledTimes(1)
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(mocks.request).toHaveBeenCalledTimes(2)
+
+    // Hidden: visibilitychange must not beat (nothing to prove, and the shell
+    // treats silence after a show as needing a new window only when the page
+    // was asked to be visible).
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(true)
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(mocks.request).toHaveBeenCalledTimes(2)
     stop()
   })
 
   it('survives a failed beat without throwing', async () => {
     mocks.request.mockRejectedValue(new Error('hub unreachable'))
-    const stop = startNativeHeartbeat()
+    const stop = start()
     await vi.advanceTimersByTimeAsync(5_000)
     expect(mocks.request).toHaveBeenCalled()
     stop()
+  })
+
+  it('cancels the outstanding frame request on stop', () => {
+    const stop = start()
+    expect(rafCallbacks.size).toBe(1)
+    stop()
+    expect(rafCallbacks.size).toBe(0)
   })
 })

--- a/web/src/lib/nativeHeartbeat.test.ts
+++ b/web/src/lib/nativeHeartbeat.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// isDesktopShell is read at module scope by the heartbeat, so it's mocked per
+// suite: the whole point of the first suite is that a plain browser sends
+// nothing at all (the endpoint only exists in the desktop shell).
+const mocks = vi.hoisted(() => ({ isDesktopShell: false, request: vi.fn() }))
+vi.mock('./stores', () => ({
+  get isDesktopShell() {
+    return mocks.isDesktopShell
+  },
+}))
+vi.mock('./api', () => ({ request: mocks.request }))
+
+import { startNativeHeartbeat } from './nativeHeartbeat'
+
+describe('startNativeHeartbeat outside the desktop shell', () => {
+  beforeEach(() => {
+    mocks.isDesktopShell = false
+    mocks.request.mockReset()
+    mocks.request.mockResolvedValue({ ok: true })
+    vi.useFakeTimers()
+  })
+  afterEach(() => vi.useRealTimers())
+
+  it('sends no beats and its stop function is safe to call', () => {
+    const stop = startNativeHeartbeat()
+    vi.advanceTimersByTime(60_000)
+    expect(mocks.request).not.toHaveBeenCalled()
+    expect(() => stop()).not.toThrow()
+  })
+})
+
+describe('startNativeHeartbeat inside the desktop shell', () => {
+  beforeEach(() => {
+    mocks.isDesktopShell = true
+    mocks.request.mockReset()
+    mocks.request.mockResolvedValue({ ok: true })
+    vi.useFakeTimers()
+  })
+  afterEach(() => vi.useRealTimers())
+
+  it('beats immediately, then on the interval, and stops when told', () => {
+    const stop = startNativeHeartbeat()
+    expect(mocks.request).toHaveBeenCalledTimes(1) // immediate first beat
+
+    vi.advanceTimersByTime(5_000)
+    expect(mocks.request).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(5_000)
+    expect(mocks.request).toHaveBeenCalledTimes(3)
+
+    stop()
+    vi.advanceTimersByTime(30_000)
+    expect(mocks.request).toHaveBeenCalledTimes(3) // no beats after stop
+  })
+
+  it('posts a non-negative frame age the shell can read', () => {
+    const stop = startNativeHeartbeat()
+    const [path, init] = mocks.request.mock.calls[0]
+    expect(path).toBe('/api/native/heartbeat')
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string)
+    expect(typeof body.frame_age_ms).toBe('number')
+    expect(body.frame_age_ms).toBeGreaterThanOrEqual(0)
+    stop()
+  })
+
+  it('beats on window focus so a shown window proves life promptly', () => {
+    const stop = startNativeHeartbeat()
+    mocks.request.mockClear()
+    window.dispatchEvent(new Event('focus'))
+    expect(mocks.request).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('survives a failed beat without throwing', async () => {
+    mocks.request.mockRejectedValue(new Error('hub unreachable'))
+    const stop = startNativeHeartbeat()
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(mocks.request).toHaveBeenCalled()
+    stop()
+  })
+})

--- a/web/src/lib/nativeHeartbeat.ts
+++ b/web/src/lib/nativeHeartbeat.ts
@@ -12,9 +12,11 @@ import { request } from './api'
 // have reported in before any verdict.
 const BEAT_MS = 5000
 
-// Frame age reported when the page is hidden, or has not yet observed a frame:
-// it owes no frames then, and the shell must not read the absence as a black
-// window. Negative by contract — see Heartbeat in bridge.go.
+// Frame age reported when no frame has been observed yet. Negative by contract
+// (see Heartbeat in bridge.go). This is NOT interchangeable with the hidden
+// flag: a page that says it is visible and has never painted is precisely the
+// black window this mechanism exists to find, whereas a hidden page owes no
+// frames at all. They are sent as separate fields for that reason.
 const NO_FRAMES = -1
 
 // startNativeHeartbeat begins beating and returns a stop function. No-op (and
@@ -40,15 +42,13 @@ export function startNativeHeartbeat(): () => void {
   }
 
   const beat = () => {
-    // document.hidden and "no frame seen yet" both mean the same thing to the
-    // shell: don't expect pixels from this beat.
-    const frameAge = document.hidden || lastFrame === null
+    const frameAge = lastFrame === null
       ? NO_FRAMES
       : Math.max(0, Math.round(performance.now() - lastFrame))
     void request<{ ok: boolean }>('/api/native/heartbeat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ frame_age_ms: frameAge }),
+      body: JSON.stringify({ frame_age_ms: frameAge, hidden: document.hidden }),
     }).catch(() => {
       // Best-effort: a failed beat reads as silence, and silence after a show
       // is what the shell already treats as "needs a new window".

--- a/web/src/lib/nativeHeartbeat.ts
+++ b/web/src/lib/nativeHeartbeat.ts
@@ -1,0 +1,55 @@
+// Liveness heartbeat for the desktop-shell webview. The shell can't see into
+// the page (octo-served, no Wails runtime), so the page reports its own health:
+// the beat arriving proves JS is running, and the reported requestAnimationFrame
+// age proves the render pipeline is producing frames — a webview whose
+// compositor went black keeps running JS while its rAF stalls, and that split
+// is exactly what the shell's revive logic keys on (cmd/octo-desktop/bridge.go).
+import { isDesktopShell } from './stores'
+import { request } from './api'
+
+// Must match heartbeatInterval in cmd/octo-desktop/bridge.go: the shell's
+// post-show probe waits longer than this so a healthy page is guaranteed a
+// scheduled beat inside the probe window.
+const BEAT_MS = 5000
+
+// startNativeHeartbeat begins beating and returns a stop function. No-op (and
+// zero traffic) outside the desktop shell — the endpoint only exists there.
+export function startNativeHeartbeat(): () => void {
+  if (!isDesktopShell) return () => {}
+
+  // rAF only fires while the page is visible, so lastRaf freezing is the
+  // expected state for a hidden window; the shell compares frame times to its
+  // own Show timestamp, never to wall-clock staleness alone.
+  let lastRaf = performance.now()
+  let rafId = requestAnimationFrame(function tick(t: number) {
+    lastRaf = t
+    rafId = requestAnimationFrame(tick)
+  })
+
+  const beat = () => {
+    void request<{ ok: boolean }>('/api/native/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ frame_age_ms: Math.max(0, Math.round(performance.now() - lastRaf)) }),
+    }).catch(() => {
+      // Best-effort: a failed beat reads as silence and at worst triggers a
+      // revive — which is the right outcome if the hub is unreachable too.
+    })
+  }
+  // Focus and becoming-visible beat immediately: the shell shows the window
+  // and expects prompt evidence of life without waiting a full interval.
+  const onVisible = () => {
+    if (!document.hidden) beat()
+  }
+  const timer = setInterval(beat, BEAT_MS)
+  window.addEventListener('focus', beat)
+  document.addEventListener('visibilitychange', onVisible)
+  beat()
+
+  return () => {
+    clearInterval(timer)
+    cancelAnimationFrame(rafId)
+    window.removeEventListener('focus', beat)
+    document.removeEventListener('visibilitychange', onVisible)
+  }
+}

--- a/web/src/lib/nativeHeartbeat.ts
+++ b/web/src/lib/nativeHeartbeat.ts
@@ -2,42 +2,62 @@
 // the page (octo-served, no Wails runtime), so the page reports its own health:
 // the beat arriving proves JS is running, and the reported requestAnimationFrame
 // age proves the render pipeline is producing frames — a webview whose
-// compositor went black keeps running JS while its rAF stalls, and that split
-// is exactly what the shell's revive logic keys on (cmd/octo-desktop/bridge.go).
+// compositor went black keeps running JS while its rAF stalls, and that split is
+// what the shell's revive logic keys on (cmd/octo-desktop/bridge.go).
 import { isDesktopShell } from './stores'
 import { request } from './api'
 
 // Must match heartbeatInterval in cmd/octo-desktop/bridge.go: the shell's
-// post-show probe waits longer than this so a healthy page is guaranteed a
-// scheduled beat inside the probe window.
+// post-show probe waits a few of these, so a page that came back is certain to
+// have reported in before any verdict.
 const BEAT_MS = 5000
+
+// Frame age reported when the page is hidden, or has not yet observed a frame:
+// it owes no frames then, and the shell must not read the absence as a black
+// window. Negative by contract — see Heartbeat in bridge.go.
+const NO_FRAMES = -1
 
 // startNativeHeartbeat begins beating and returns a stop function. No-op (and
 // zero traffic) outside the desktop shell — the endpoint only exists there.
 export function startNativeHeartbeat(): () => void {
   if (!isDesktopShell) return () => {}
 
-  // rAF only fires while the page is visible, so lastRaf freezing is the
-  // expected state for a hidden window; the shell compares frame times to its
-  // own Show timestamp, never to wall-clock staleness alone.
-  let lastRaf = performance.now()
-  let rafId = requestAnimationFrame(function tick(t: number) {
-    lastRaf = t
-    rafId = requestAnimationFrame(tick)
-  })
+  // One rAF is requested per beat rather than running a continuous loop: the
+  // signal is identical (did a frame land since we asked?) at 0.2 requests per
+  // second instead of one per vsync, which matters for an app that stays open
+  // all day. A hidden or black window never runs the callback, so lastFrame
+  // simply stays behind — exactly the evidence the shell wants.
+  // null rather than 0 for "no frame seen yet": performance.now() can legally
+  // be 0, and conflating the two would report a real frame as no-frames.
+  let lastFrame: number | null = null
+  let pendingRaf = 0
+  const sampleFrame = () => {
+    if (pendingRaf) cancelAnimationFrame(pendingRaf)
+    pendingRaf = requestAnimationFrame(() => {
+      pendingRaf = 0
+      lastFrame = performance.now()
+    })
+  }
 
   const beat = () => {
+    // document.hidden and "no frame seen yet" both mean the same thing to the
+    // shell: don't expect pixels from this beat.
+    const frameAge = document.hidden || lastFrame === null
+      ? NO_FRAMES
+      : Math.max(0, Math.round(performance.now() - lastFrame))
     void request<{ ok: boolean }>('/api/native/heartbeat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ frame_age_ms: Math.max(0, Math.round(performance.now() - lastRaf)) }),
+      body: JSON.stringify({ frame_age_ms: frameAge }),
     }).catch(() => {
-      // Best-effort: a failed beat reads as silence and at worst triggers a
-      // revive — which is the right outcome if the hub is unreachable too.
+      // Best-effort: a failed beat reads as silence, and silence after a show
+      // is what the shell already treats as "needs a new window".
     })
+    sampleFrame() // ask for the frame the NEXT beat will report on
   }
-  // Focus and becoming-visible beat immediately: the shell shows the window
-  // and expects prompt evidence of life without waiting a full interval.
+
+  // Focus and becoming-visible beat immediately: the shell shows the window and
+  // wants prompt evidence, and this is also when a frame becomes possible again.
   const onVisible = () => {
     if (!document.hidden) beat()
   }
@@ -48,7 +68,7 @@ export function startNativeHeartbeat(): () => void {
 
   return () => {
     clearInterval(timer)
-    cancelAnimationFrame(rafId)
+    if (pendingRaf) cancelAnimationFrame(pendingRaf)
     window.removeEventListener('focus', beat)
     document.removeEventListener('visibilitychange', onVisible)
   }


### PR DESCRIPTION
## Problem

A Win10 user still reports the background black screen on v1.15.19 (which shipped the `CalculateNativeWinOcclusion` flag from #2150). That flag prevents *one* cause; it can't cover the others:

- a GPU process that dies across sleep/wake never repairs itself ([WebView2Feedback#3817](https://github.com/MicrosoftEdge/WebView2Feedback/issues/3817)) — JS keeps running, the window stays black;
- Wails v3 registers no `ProcessFailed` handler and the hook lives in its `internal/` tree, so the shell can't even notice a dead renderer;
- `showWindowAt` on an existing window only did `Show()+Focus()`, i.e. it foregrounded a dead surface.

Prevention is a guess about the cause. This adds recovery that doesn't need to know it.

## Design

**Separate signals, because "page alive" and "page rendering" fail independently.** The frontend beats `POST /api/native/heartbeat` every 5s in nativeShell mode (`web/src/lib/nativeHeartbeat.ts`), carrying the age of its last `requestAnimationFrame` plus an explicit `hidden` flag. The beat arriving proves JS is running; the derived frame timestamp proves the compositor is producing frames; the hidden flag says no frames are owed. Hidden and never-painted are sent as two distinct facts — a webview that is black from its first paint reports visible-but-frameless forever and must not read as healthy.

**Every verdict is judged only from evidence produced after a show** (`judgePage`), never from pre-show silence: a page has legitimate reasons to go quiet in the background (system sleep, Chromium throttling a hidden page's timers to ~1/minute), and destroying a healthy window is far worse than a few more seconds of black. Three verdicts:

- **healthy** — a frame landed, or the page reported itself hidden and owes nothing;
- **black** — beats while visible without ever painting: the black-window signature. Unambiguous, acted on at once;
- **silent** — no beats at all. Ambiguous: a wedged hub or a main thread stuck on a huge render looks identical and both recover on their own, so silence earns a second probe cycle before the window is replaced.

The probe (`probeAfterShow`) runs only for an *existing* window that was just shown — a fresh window's first load can outlast the probe window and is exempt. When the verdict stands, `detachStalled` detaches the pointer (identity-keyed, so a stale probe can't hit a successor), the replacement is created **before** the corpse is closed (Wails' Windows backend posts a quit message when its window map empties; closing first would race the shell's own survival), and the old window's `WindowClosing` sees itself as replaced and leaves the successor alone.

**Safety rails:**
- a 90s revive cooldown, so a persistently broken page can't enter a destroy/create loop;
- `probeInFlight` CAS collapses concurrent probes (pinned by test);
- window creation is single-flighted by a `creating` CAS — two shows racing on a nil window would otherwise build an orphan the frontend's close button can't reach (a mutex would deadlock: `showWindowAt` can run on the UI thread);
- `showWindowAt` re-validates the snapshot's identity under `windowMu` before calling `SetURL`/`Show`/`Focus`, so an in-flight show can't touch a window the probe just destroyed (freed-NSWindow class on macOS);
- all `b.window` loads — accessors included — go through `windowMu` (load only, never held across a window method, which would marshal to the UI thread and deadlock);
- a body-less or malformed beat records "no frame evidence", not "a frame just landed" — a malformed beat must never mask a black window.

**Cost:** an unrecoverable case loses in-page state (draft, scroll) on revive. Acceptable versus a permanently black window, and the SPA restores the session.

This also fixes Windows quitting the hub when the window closes (`DisableQuitOnLastWindowClosed` + `closeShouldQuit`: the framework's `unregisterWindow` posts a quit message without consulting `ShouldQuit`), and gives Linux a recovery path for the WebKitGTK `web-process-terminated` case Wails exposes no signal for.

## Testing

- `cmd/octo-desktop`: the `judgePage` truth table incl. black-from-birth and pre-show-silence immunity, revive cooldown, heartbeat signal handling (monotonic frames, age clamp, hidden/never-painted split), detach identity + detach-before-close invariants, the silence second-chance path, the probe-collapse CAS, and the platform quit matrix. `go test -race` green.
- `internal/server`: heartbeat handler delegation incl. body-less beats recording no frame evidence.
- `web`: vitest — zero traffic outside the desktop shell, immediate + interval beats, stop actually stops, frame-age/hidden shape, focus beat, failed beat doesn't throw.
- Cross-compiled for windows and darwin; vet/gofmt clean.

Still needs real-world validation on the reporter's Win10 machine — that's the only way to confirm which of the failure shapes they were hitting.
