### PR TITLE
fix(permission): normalize the engine's cwd to the matcher's separators

### DIFF
--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -244,6 +244,13 @@ func New(configPath string, cwd string, mode Mode, allowWriteRoots ...string) (*
 		// will just not match anything.
 		cwd, _ = os.Getwd()
 	}
+	// Store the working directory in the form the matcher speaks. Candidate
+	// paths are slash-normalized by absPath before matching and pathMatch
+	// splits on "/", but `$CWD` in a rule is expanded with this string
+	// verbatim — so on Windows, where os.Getwd() yields `C:\Users\...`, a
+	// `$CWD/**` rule produced a back-slashed glob that could never match and
+	// silently degraded every such rule to the implicit ask.
+	cwd = filepath.ToSlash(cwd)
 	if mode == "" {
 		mode = ModeInteractive
 	}

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -1014,3 +1014,43 @@ func TestResolveUnattendedDefaultMode_ExplicitConfigHonored(t *testing.T) {
 		}
 	}
 }
+
+// TestPathRules_NativeSeparators pins that path rules work when the engine is
+// given directories in the host's native form. Every path here is built with
+// t.TempDir/filepath.Join, so on Windows they carry backslashes — the shape
+// that used to match nothing: candidates are slash-normalized by absPath and
+// pathMatch splits on "/", while `$CWD` expansion and the allowWriteRoots
+// globs used the raw strings. On Unix the separator is already "/", so this
+// test is a tautology there and earns its keep on the Windows CI runner.
+func TestPathRules_NativeSeparators(t *testing.T) {
+	cwd := t.TempDir()
+	memRoot := filepath.Join(t.TempDir(), ".octo", "memories")
+
+	cfg := filepath.Join(t.TempDir(), "permissions.yml")
+	if err := os.WriteFile(cfg, []byte("write_file:\n  - allow: { path: [\"$CWD/**\"] }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e, err := New(cfg, cwd, ModeInteractive, memRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A user rule written as $CWD/** must match a file under the working dir.
+	inCWD := filepath.Join(cwd, "sub", "main.go")
+	if got := e.Check("write_file", map[string]any{"path": inCWD}); got != Allow {
+		t.Errorf("write_file %q: got %s, want allow ($CWD rule must survive native separators)", inCWD, got)
+	}
+
+	// An allowWriteRoots entry must match a file under that root.
+	inRoot := filepath.Join(memRoot, "someproj-0badf00d", "MEMORY.md")
+	if got := e.Check("write_file", map[string]any{"path": inRoot}); got != Allow {
+		t.Errorf("write_file %q: got %s, want allow (write root must survive native separators)", inRoot, got)
+	}
+
+	// And the widening still stops where it should.
+	outside := filepath.Join(filepath.Dir(memRoot), "config.yml")
+	if got := e.Check("write_file", map[string]any{"path": outside}); got == Allow {
+		t.Errorf("write_file %q: got allow, want ask/deny", outside)
+	}
+}


### PR DESCRIPTION
## Problem

Follow-up to #2157, which fixed the same class of bug for `allowWriteRoots` but left the other half in place.

`$CWD` in a path rule is expanded with the engine's working directory **verbatim** (`permission.go:455`), while the candidate path is slash-normalized by `absPath` and `pathMatch` splits on `/`. On Windows `os.Getwd()` returns `C:\Users\...`, so a rule written `$CWD/**` becomes a back-slashed glob that can never match — every such rule silently degrades to the implicit ask (and to a deny under `ModeStrict`).

Reproduced on macOS by feeding the engine a Windows-shaped cwd, which isolates the one OS-dependent step (`ToSlash`):

```
$CWD rule + back-slashed cwd:  ask    ← should be allow
$CWD rule + slash cwd:         allow  ← control
```

Blast radius is smaller than the whitelist bug: `defaults.yml` mentions `$CWD` only in comments, so no shipped rule uses it. This affects user-written `permissions.yml` rules on Windows.

## Fix

Store the cwd slash-normalized in `New` — the same treatment `allowWriteRoots` already gets. All four consumers of `Engine.cwd` are match or cache-key paths (`signature` ×2, `absPath`, `expandCWD`); nothing hands it to the OS, so the stored form is free to change. `absPath`'s own `ToSlash` of cwd becomes redundant but stays — it is also reachable with a caller-supplied cwd.

## Tests

`TestPathRules_NativeSeparators` builds every path with `t.TempDir`/`filepath.Join`, so they carry the host's native separator. On the Windows CI runner that means backslashes — the shape that used to match nothing — and it covers both `$CWD` expansion and the `allowWriteRoots` normalization from #2157, which until now had no test exercising its Windows shape at all. On Unix the separator is already `/`, so the test is a tautology there.

Verified: `go test ./...`, `-race` on the three touched packages, `gofmt`, plus `GOOS=windows go build ./...` and `GOOS=windows go vet`. The Windows behavior itself is verified by CI running this test on windows-latest, not locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)