### PR TITLE
chore: bump version to 1.15.21

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.20"
+var Version = "1.15.21"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release. Since v1.15.20:

- #2154 — serve resolved the memory directory once from its launch directory, so every session's memories landed in the global tier regardless of the project it was working in.
- #2155 — duplicate session prepends crashed the web sidebar with `each_key_duplicate`.
- #2156 — a dead or black desktop webview is now revived instead of shown.
- #2157 — a non-repo working directory (the default `~/Octo` workspace) no longer gets a project-memory directory of its own; it shares the global tier, so notes written while working on some other project stay visible. Adds cross-project filing: `octo memory [list|path] <dir>`, a widened memory write allowlist, and prompt guidance.
- #2158 — `$CWD` path rules in a user's permissions.yml never matched on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)