### PR TITLE
chore: bump version to 1.15.22

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.21"
+var Version = "1.15.22"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release. v1.15.21 was tagged but its goreleaser run was cancelled before publishing, so no release exists for it — this ships that content plus everything merged since.

Since v1.15.20:

- #2154 — serve resolved the memory directory once from its launch directory, so every session's memories landed in the global tier no matter which project it was working in.
- #2155 — duplicate session prepends crashed the web sidebar with `each_key_duplicate`.
- #2156 — a dead or black desktop webview is revived instead of shown.
- #2157 — a non-repo working directory (the default `~/Octo` workspace) no longer gets a project-memory directory of its own; it shares the global tier. Adds cross-project filing: `octo memory [list|path] <dir>`, a widened memory write allowlist, and prompt guidance.
- #2158 — `$CWD` path rules in a user's permissions.yml never matched on Windows.
- #2160 — the working directory is set from one surface instead of two: the composer chip opens the folder picker directly, and the picker's path bar accepts a typed or pasted path.
- #2161 — `chat.cancel` was undefined in both locales, so a tooltip rendered the raw key; adds a sweep that fails CI on the next missing key.
- #2162 — the session archive action wears an archive box instead of an align arrow, and reads 归档 / Archive throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)