### PR TITLE
fix(server): a forwarded port is not the local machine

### DIFF
--- a/dev-docs/serve-auth-design.md
+++ b/dev-docs/serve-auth-design.md
@@ -68,7 +68,15 @@ mux. Decision order:
    - `RemoteAddr` is loopback, determined by `net.SplitHostPort` +
      `net.ParseIP(...).IsLoopback()` — this covers `127.0.0.0/8`, `::1`,
      and the IPv4-mapped `::ffff:127.0.0.1`; a string-prefix match does
-     not. `X-Forwarded-For` is never consulted — a spoofable header must
+     not. A spoofable header is never consulted to WIDEN this — the peer
+     address cannot come from a header. It is consulted only to withdraw the
+     exemption: any forwarding header (`X-Forwarded-For`, `Forwarded`, `Via`,
+     octo's own `X-Octo-Forwarded`, …) means a relay sits in the path, and a
+     relay's loopback dial must not inherit the trust of someone at the
+     keyboard. Faking one costs the sender the exemption; it can never buy it.
+     The residual case is a plain TCP forward that rewrites `Host` and adds no
+     headers (`ssh -L`), which is indistinguishable from a local request —
+     see isLocalRequest. A spoofable header must
      not widen the exemption.
    - `Host` is local: `localhost` or a loopback IP literal (any port,
      compared case-insensitively, trailing dot stripped), or a host named
@@ -212,6 +220,10 @@ a separate-origin frontend authenticates with explicit headers.
     200; via query parameter → 200 on `/ws`, 401 elsewhere
   - any source, wrong key → 401
   - `X-Forwarded-For: 127.0.0.1` from non-loopback, no key → 401
+  - any forwarding header from loopback, no key → 401 (a relayed request
+    cannot use the exemption)
+  - a forwarding header from loopback WITH a valid key → 200 (the key is the
+    gate for a relayed peer; octo's own tunnel sends exactly this shape)
   - `--cors '*'` configured: foreign Origin from loopback still 403
 - Route-coverage assertion: every registered `/api/*` mux entry except
   `/api/health` and `/api/version` returns 401 to a keyless non-loopback

--- a/docs/src/content/docs/reference/security.md
+++ b/docs/src/content/docs/reference/security.md
@@ -25,7 +25,8 @@ scope.
 | LAN / internet attacker calling an exposed API | Loopback-only default bind; 256-bit access key (constant-time compare) on every non-loopback request |
 | Malicious website CSRF-ing `http://localhost:8088` from your browser | `Origin` must be local or `--cors`-allowlisted (a literal `*` is never honored); auth cookie is `SameSite=Strict` |
 | DNS rebinding (attacker domain resolving to 127.0.0.1) | The loopback exemption requires a local `Host` header |
-| Spoofed client IPs | `X-Forwarded-For` is never consulted for the loopback exemption |
+| Spoofed client IPs | The peer address is never taken from a header; `X-Forwarded-For` and friends can only *remove* the loopback exemption, never grant it |
+| A forwarded port (ngrok, a reverse proxy, octo's own tunnel) | Forwarding headers and a non-loopback `Host` both withdraw the exemption, so a remote client cannot inherit local trust |
 | XSSI reads of uploaded files | `X-Content-Type-Options: nosniff` on served uploads |
 | Agent wiping the OS with a destructive command | Permission engine with hardcoded `deny` rules for `rm -rf /`, `dd`, `mkfs`, `fdisk`, `format`, `shutdown`, `reboot`, `kill -9 -1`, system-directory removal (`rm -rf /usr`, `rmdir /s /q C:\Windows` and every other deletion spelling targeting `C:\Windows` / `C:\ProgramData` / `C:\Program Files`, including the PowerShell `ri`/`del`/`erase` aliases), plus `diskpart`, `bcdedit`, `reg delete`, `vssadmin delete`, `wbadmin delete`; these cannot be overridden by `~/.octo/permissions.yml` |
 | Agent writing to system directories | `write_file`/`edit_file` hardcoded `deny` for `/bin`, `/sbin`, `/usr`, `/System`, `/boot`, `/lib`, `/Windows`, `C:/Windows`, `C:/Windows/System32`, `C:/Windows/SysWOW64`, `C:/ProgramData`, etc. across Unix, macOS, and Windows |

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -109,6 +109,64 @@ func isLoopbackRemote(remoteAddr string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+// HeaderForwarded is the header octo's own managed tunnel stamps on every
+// request it replays into the local server (internal/tunnel/bridge.go defines
+// the same literal — a one-string constant is not worth a package dependency
+// between the two). The tunnel dials loopback and, having dropped the phone's
+// Host, dials it under a loopback Host too, so without this marker a phone
+// across the relay is indistinguishable from a browser on this machine.
+const HeaderForwarded = "X-Octo-Forwarded"
+
+// forwardedHeaders are set by something that relayed the request: reverse
+// proxies and tunnel clients (nginx, caddy, ngrok, cloudflared, and octo's own
+// tunnel) all add at least one. Their presence means the peer we see is the
+// relay, not the client, whichever address it dials us from.
+//
+// These headers are client-spoofable, which is exactly why they are only ever
+// read to NARROW what a request may do — see isLocalRequest. isLoopbackRemote
+// deliberately never consults them, because there the answer would WIDEN the
+// loopback exemption, and a forged header must never buy privilege. Faking one
+// here can only cost the sender the local-peer capabilities, never grant them.
+var forwardedHeaders = []string{
+	"X-Forwarded-For",
+	"X-Forwarded-Host",
+	"X-Forwarded-Proto",
+	"X-Real-Ip",
+	"Forwarded",
+	HeaderForwarded,
+}
+
+// isLocalRequest reports whether a request genuinely came from this machine —
+// the question behind every local-peer capability: the unauthenticated loopback
+// exemption, the OS-dialog and filesystem routes, referencing a file by its real
+// path instead of uploading it, and the `local` flag the frontend switches those
+// affordances on.
+//
+// A loopback peer address alone does not answer it. Anything that forwards a
+// port — ngrok, cloudflared, a local reverse proxy, `ssh -L`, octo's own tunnel
+// — runs on this machine and dials us from loopback, so a remote client arrives
+// looking local. Two more signals narrow it down:
+//
+//   - a forwarding header means a relay is in the path (see forwardedHeaders);
+//   - the Host the client actually asked for must name this machine, which rules
+//     out a tunnel or proxy that passes the public hostname through.
+//
+// What remains uncoverable is a plain TCP forward that rewrites Host to loopback
+// and adds no headers — `ssh -L 8088:localhost:8088` is byte-for-byte a local
+// request by the time it reaches us. Capabilities gated on this must therefore
+// stay recoverable rather than assume the answer is certain.
+func isLocalRequest(r *http.Request) bool {
+	if !isLoopbackRemote(r.RemoteAddr) {
+		return false
+	}
+	for _, h := range forwardedHeaders {
+		if r.Header.Get(h) != "" {
+			return false
+		}
+	}
+	return isLocalName(canonicalHost(r.Host))
+}
+
 // canonicalHost lowercases a Host header (or origin host) and strips the
 // port, IPv6 brackets, and any trailing dot.
 func canonicalHost(hostport string) string {
@@ -230,6 +288,17 @@ func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 		if !isLoopbackRemote(r.RemoteAddr) {
 			writeError(w, http.StatusUnauthorized, "unauthorized")
 			return
+		}
+		// A relayed request reaches us from loopback too (see isLocalRequest):
+		// without this, exposing the port through ngrok or a proxy handed the
+		// unauthenticated exemption to whoever found the URL — an access key
+		// configured on the server does not close it, since this branch is the
+		// fallback for requests that carry no key at all.
+		for _, h := range forwardedHeaders {
+			if r.Header.Get(h) != "" {
+				writeError(w, http.StatusUnauthorized, "unauthorized")
+				return
+			}
 		}
 		if !s.hostAllowed(r.Host) {
 			writeError(w, http.StatusForbidden, "forbidden host")

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -117,10 +117,12 @@ func isLoopbackRemote(remoteAddr string) bool {
 // across the relay is indistinguishable from a browser on this machine.
 const HeaderForwarded = "X-Octo-Forwarded"
 
-// forwardedHeaders are set by something that relayed the request: reverse
-// proxies and tunnel clients (nginx, caddy, ngrok, cloudflared, and octo's own
-// tunnel) all add at least one. Their presence means the peer we see is the
-// relay, not the client, whichever address it dials us from.
+// forwardedHeaders are set by something that relayed the request. ngrok,
+// cloudflared, Caddy and octo's own tunnel all add at least one; nginx does NOT
+// unless configured to (a bare proxy_pass sets only Host), which is why it
+// lands in the uncoverable case described on isLocalRequest rather than here.
+// Their presence means the peer we see is the relay, not the client, whichever
+// address it dials us from.
 //
 // These headers are client-spoofable, which is exactly why they are only ever
 // read to NARROW what a request may do — see isLocalRequest. isLoopbackRemote
@@ -133,6 +135,7 @@ var forwardedHeaders = []string{
 	"X-Forwarded-Proto",
 	"X-Real-Ip",
 	"Forwarded",
+	"Via",
 	HeaderForwarded,
 }
 
@@ -156,15 +159,20 @@ var forwardedHeaders = []string{
 // request by the time it reaches us. Capabilities gated on this must therefore
 // stay recoverable rather than assume the answer is certain.
 func isLocalRequest(r *http.Request) bool {
-	if !isLoopbackRemote(r.RemoteAddr) {
-		return false
-	}
+	return isLoopbackRemote(r.RemoteAddr) && !isForwarded(r) && isLocalName(canonicalHost(r.Host))
+}
+
+// isForwarded reports whether any forwarding header is present at all — by
+// count, not by value. A client that sends an empty X-Forwarded-For which the
+// relay then appends its own value to would otherwise hide behind Get()
+// returning only the first, empty, value.
+func isForwarded(r *http.Request) bool {
 	for _, h := range forwardedHeaders {
-		if r.Header.Get(h) != "" {
-			return false
+		if len(r.Header.Values(h)) > 0 {
+			return true
 		}
 	}
-	return isLocalName(canonicalHost(r.Host))
+	return false
 }
 
 // canonicalHost lowercases a Host header (or origin host) and strips the
@@ -294,11 +302,9 @@ func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 		// unauthenticated exemption to whoever found the URL — an access key
 		// configured on the server does not close it, since this branch is the
 		// fallback for requests that carry no key at all.
-		for _, h := range forwardedHeaders {
-			if r.Header.Get(h) != "" {
-				writeError(w, http.StatusUnauthorized, "unauthorized")
-				return
-			}
+		if isForwarded(r) {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
 		}
 		if !s.hostAllowed(r.Host) {
 			writeError(w, http.StatusForbidden, "forbidden host")

--- a/internal/server/local_peer_capabilities_test.go
+++ b/internal/server/local_peer_capabilities_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The three capabilities gated on being the local machine, each checked against
+// a request that reaches the server over loopback but did not originate there —
+// the shape octo's own tunnel bridge sends. Each of these was reachable by a
+// paired phone before the marker existed.
+
+// A relayed peer must not drive the host's OS dialogs, however well it
+// authenticates. Authenticating is what gets it past requireAuth to the
+// handler's own guard, which is the thing under test.
+func TestNativeRoutes_RefuseARelayedPeer(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Native: &fakeNative{retPath: "/x"}})
+
+	// One per kind of capability rather than all fourteen: they share the
+	// predicate, and these cover a dialog, a window action, and self-update.
+	for _, path := range []string{
+		"/api/native/pick-folder",
+		"/api/native/pick-file",
+		"/api/native/window/minimise",
+		"/api/native/self-update",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{}`))
+			req.RemoteAddr = "127.0.0.1:50000" // the bridge dials loopback
+			req.Host = "127.0.0.1:8088"        // …under a loopback Host
+			req.Header.Set(HeaderForwarded, "relay")
+			req.Header.Set("Authorization", "Bearer "+srv.AccessKey())
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+			if w.Code != http.StatusForbidden {
+				t.Errorf("relayed peer: got %d, want 403 (%s)", w.Code, strings.TrimSpace(w.Body.String()))
+			}
+		})
+	}
+}
+
+// The same routes still work for the desktop shell and a localhost browser,
+// which is the whole point of not simply removing them.
+func TestNativeRoutes_AllowAGenuinelyLocalPeer(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Native: &fakeNative{retPath: "/picked"}})
+	req := httptest.NewRequest(http.MethodPost, "/api/native/pick-folder", strings.NewReader(`{}`))
+	req.RemoteAddr = "127.0.0.1:50000"
+	req.Host = "127.0.0.1:8088"
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("local peer: got %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+}
+
+// conn.loopback decides whether a message may name a file by its real path on
+// the host's disk — the heaviest of the three, since it reads the host's
+// filesystem on behalf of whoever sent the message. A relayed WebSocket must
+// not carry it.
+func TestWSUpgrade_RelayedConnectionIsNotLoopback(t *testing.T) {
+	cases := []struct {
+		name string
+		hdr  map[string]string
+		host string
+		want bool
+	}{
+		{"direct localhost browser", nil, "127.0.0.1:8088", true},
+		{"octo tunnel", map[string]string{HeaderForwarded: "relay"}, "127.0.0.1:8088", false},
+		{"behind a proxy", map[string]string{"X-Forwarded-For": "203.0.113.7"}, "127.0.0.1:8088", false},
+		{"public host passed through", nil, "x.ngrok-free.app", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+			req.RemoteAddr = "127.0.0.1:50000"
+			req.Host = tc.host
+			for k, v := range tc.hdr {
+				req.Header.Set(k, v)
+			}
+			// The upgrade path stamps this onto the connection; assert the
+			// predicate it stamps rather than standing up a real WebSocket,
+			// which would need a hijackable ResponseWriter.
+			if got := isLocalRequest(req); got != tc.want {
+				t.Errorf("conn.loopback would be %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// And the consequence of that flag, at the layer that acts on it: a real local
+// path is honoured only for a local peer. Without this the relayed case would
+// hand the agent an absolute path on the host's disk.
+func TestParseUserFiles_LocalPathOnlyForALocalPeer(t *testing.T) {
+	files := []wsUserFile{{Name: "notes.md", LocalPath: "/etc/hosts"}}
+
+	local := parseUserFiles(files, true, false)
+	if len(local.notes) == 0 && len(local.blocks) == 0 {
+		t.Error("a local peer's real path should be honoured")
+	}
+
+	relayed := parseUserFiles(files, false, false)
+	for _, n := range relayed.notes {
+		if strings.Contains(n, "/etc/hosts") {
+			t.Errorf("relayed peer got the host path through: %q", n)
+		}
+	}
+}

--- a/internal/server/local_peer_capabilities_test.go
+++ b/internal/server/local_peer_capabilities_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -101,16 +103,26 @@ func TestWSUpgrade_RelayedConnectionIsNotLoopback(t *testing.T) {
 // path is honoured only for a local peer. Without this the relayed case would
 // hand the agent an absolute path on the host's disk.
 func TestParseUserFiles_LocalPathOnlyForALocalPeer(t *testing.T) {
-	files := []wsUserFile{{Name: "notes.md", LocalPath: "/etc/hosts"}}
+	// A file that really exists, since parseUserFiles stats the path before
+	// honouring it — and one built with the platform's own separators, so this
+	// means the same thing on Windows as it does elsewhere.
+	hostFile := filepath.Join(t.TempDir(), "on-the-host.md")
+	if err := os.WriteFile(hostFile, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	files := []wsUserFile{{Name: "notes.md", LocalPath: hostFile}}
 
 	local := parseUserFiles(files, true, false)
-	if len(local.notes) == 0 && len(local.blocks) == 0 {
+	if len(local.notes) == 0 {
 		t.Error("a local peer's real path should be honoured")
 	}
 
 	relayed := parseUserFiles(files, false, false)
+	if len(relayed.notes) != 0 || len(relayed.blocks) != 0 {
+		t.Errorf("relayed peer got something through: notes=%v blocks=%d", relayed.notes, len(relayed.blocks))
+	}
 	for _, n := range relayed.notes {
-		if strings.Contains(n, "/etc/hosts") {
+		if strings.Contains(n, hostFile) {
 			t.Errorf("relayed peer got the host path through: %q", n)
 		}
 	}

--- a/internal/server/local_request_test.go
+++ b/internal/server/local_request_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// jsonBool reads one boolean field out of a JSON response body.
+func jsonBool(t *testing.T, body []byte, field string) bool {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("decode body: %v (%s)", err, body)
+	}
+	b, ok := m[field].(bool)
+	if !ok {
+		t.Fatalf("field %q is not a bool in %s", field, body)
+	}
+	return b
+}
+
+// localReq builds a request with an explicit peer address, Host, and headers —
+// the three things isLocalRequest weighs.
+func localReq(target, remoteAddr string, hdr map[string]string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req.RemoteAddr = remoteAddr
+	for k, v := range hdr {
+		if k == "Host" {
+			req.Host = v
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+	return req
+}
+
+// A loopback peer address alone does not make a request local. Everything that
+// forwards a port runs on this machine and dials us from loopback, so a remote
+// client arrives looking local unless something else gives the relay away.
+func TestIsLocalRequest(t *testing.T) {
+	cases := []struct {
+		name       string
+		target     string
+		remoteAddr string
+		hdr        map[string]string
+		want       bool
+	}{
+		{"direct localhost", "http://localhost:8088/api/version", "127.0.0.1:50000", nil, true},
+		{"direct 127.0.0.1", "http://127.0.0.1:8088/api/version", "127.0.0.1:50000", nil, true},
+		{"direct IPv6 loopback", "http://[::1]:8088/api/version", "[::1]:50000", nil, true},
+		{"direct IPv4-mapped peer", "http://127.0.0.1:8088/api/version", "[::ffff:127.0.0.1]:50000", nil, true},
+
+		// A browser on another machine: settled before this change, pinned here
+		// so the added signals can't accidentally start admitting it.
+		{"remote peer", "http://192.168.1.5:8088/api/version", "192.168.1.9:50000", nil, false},
+
+		// ngrok's default shape: its agent runs here and dials loopback, but it
+		// passes the public hostname through.
+		{"tunnel keeps public host", "http://x.ngrok-free.app/api/version", "127.0.0.1:50000", nil, false},
+
+		// …and with Host rewritten to loopback, the forwarding headers are what
+		// remains to give it away.
+		{"tunnel rewrites host, XFF remains", "http://127.0.0.1:8088/api/version", "127.0.0.1:50000",
+			map[string]string{"X-Forwarded-For": "203.0.113.7"}, false},
+		{"X-Forwarded-Host", "http://127.0.0.1:8088/api/version", "127.0.0.1:50000",
+			map[string]string{"X-Forwarded-Host": "x.example"}, false},
+		{"X-Forwarded-Proto", "http://127.0.0.1:8088/api/version", "127.0.0.1:50000",
+			map[string]string{"X-Forwarded-Proto": "https"}, false},
+		{"X-Real-Ip", "http://127.0.0.1:8088/api/version", "127.0.0.1:50000",
+			map[string]string{"X-Real-Ip": "203.0.113.7"}, false},
+		{"Forwarded", "http://127.0.0.1:8088/api/version", "127.0.0.1:50000",
+			map[string]string{"Forwarded": "for=203.0.113.7"}, false},
+
+		// octo's own managed tunnel, which drops the phone's Host and dials
+		// loopback — the marker its bridge stamps is the only difference.
+		{"octo tunnel marker", "http://127.0.0.1:8088/api/version", "127.0.0.1:50000",
+			map[string]string{HeaderForwarded: "relay"}, false},
+
+		// DNS rebinding: an attacker domain resolving to 127.0.0.1 is not local.
+		{"foreign host", "http://attacker.example:8088/api/version", "127.0.0.1:50000", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isLocalRequest(localReq(tc.target, tc.remoteAddr, tc.hdr)); got != tc.want {
+				t.Errorf("isLocalRequest = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Spoofing a forwarding header can only cost the sender the local-peer
+// capabilities, never grant them — the asymmetry that makes reading a
+// client-controlled header safe here at all.
+func TestIsLocalRequest_SpoofedHeaderOnlyNarrows(t *testing.T) {
+	// A genuinely local caller who forges the header just loses local status.
+	if isLocalRequest(localReq("http://127.0.0.1:8088/api/version", "127.0.0.1:50000",
+		map[string]string{"X-Forwarded-For": "127.0.0.1"})) {
+		t.Error("a forged forwarding header must not be ignored")
+	}
+	// A remote caller stripping every header still isn't local: the peer
+	// address is not theirs to choose.
+	if isLocalRequest(localReq("http://localhost:8088/api/version", "203.0.113.9:50000", nil)) {
+		t.Error("a remote peer claiming a loopback Host must not become local")
+	}
+}
+
+// /api/version is unauthenticated and its `local` flag is what the frontend
+// keys real-path file/folder selection off, so it must not report a relayed
+// peer as local.
+func TestHandleVersion_LocalFlag(t *testing.T) {
+	srv := mustServer(t, Config{AccessKey: testAccessKey})
+
+	check := func(name string, hdr map[string]string, want bool) {
+		t.Helper()
+		w := authRequest(t, srv, http.MethodGet, "http://127.0.0.1:8088/api/version", "127.0.0.1:50000", hdr)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: status %d", name, w.Code)
+		}
+		if got := jsonBool(t, w.Body.Bytes(), "local"); got != want {
+			t.Errorf("%s: local = %v, want %v", name, got, want)
+		}
+	}
+
+	check("direct", nil, true)
+	check("behind a proxy", map[string]string{"X-Forwarded-For": "203.0.113.7"}, false)
+	check("octo tunnel", map[string]string{HeaderForwarded: "relay"}, false)
+}
+
+// The unauthenticated loopback exemption is the highest-stakes consumer: a
+// forwarded port used to hand it to whoever found the URL, and a configured
+// access key does not close it — this branch is the fallback for requests that
+// carry no key at all.
+func TestRequireAuth_ForwardedRequestLosesExemption(t *testing.T) {
+	srv := mustServer(t, Config{AccessKey: testAccessKey})
+
+	// Baseline: the exemption still works for a genuine local caller.
+	if w := authRequest(t, srv, http.MethodGet, "http://127.0.0.1:8088/api/sessions", "127.0.0.1:50000", nil); w.Code != http.StatusOK {
+		t.Fatalf("direct loopback: got %d, want 200", w.Code)
+	}
+
+	for _, h := range forwardedHeaders {
+		t.Run(h, func(t *testing.T) {
+			w := authRequest(t, srv, http.MethodGet, "http://127.0.0.1:8088/api/sessions", "127.0.0.1:50000",
+				map[string]string{h: "1"})
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("got %d, want 401", w.Code)
+			}
+		})
+	}
+
+	// A forwarded request that DOES carry the key is fine — the key is the
+	// gate for remote peers, and narrowing the exemption must not break it.
+	w := authRequest(t, srv, http.MethodGet, "http://127.0.0.1:8088/api/sessions", "127.0.0.1:50000",
+		map[string]string{"X-Forwarded-For": "203.0.113.7", "X-Access-Key": testAccessKey})
+	if w.Code != http.StatusOK {
+		t.Errorf("forwarded request with a valid key: got %d, want 200", w.Code)
+	}
+}

--- a/internal/server/local_request_test.go
+++ b/internal/server/local_request_test.go
@@ -153,9 +153,67 @@ func TestRequireAuth_ForwardedRequestLosesExemption(t *testing.T) {
 
 	// A forwarded request that DOES carry the key is fine — the key is the
 	// gate for remote peers, and narrowing the exemption must not break it.
+	// This is the shape octo's own tunnel bridge sends (its marker plus the
+	// host's key), so it is also the regression test for phones across the
+	// relay: they must authenticate, while still not counting as local.
 	w := authRequest(t, srv, http.MethodGet, "http://127.0.0.1:8088/api/sessions", "127.0.0.1:50000",
 		map[string]string{"X-Forwarded-For": "203.0.113.7", "X-Access-Key": testAccessKey})
 	if w.Code != http.StatusOK {
 		t.Errorf("forwarded request with a valid key: got %d, want 200", w.Code)
+	}
+	w = authRequest(t, srv, http.MethodGet, "http://127.0.0.1:8088/api/sessions", "127.0.0.1:50000",
+		map[string]string{HeaderForwarded: "relay", "X-Access-Key": testAccessKey})
+	if w.Code != http.StatusOK {
+		t.Errorf("tunnel-shaped request with a valid key: got %d, want 200", w.Code)
+	}
+}
+
+// Presence of a forwarding header is judged by count, not by first value: a
+// client that prepends an empty X-Forwarded-For which the relay then appends
+// its own value to would otherwise hide behind Get() returning only the first,
+// empty, one. Whether a given relay appends or coalesces is not ours to assume.
+func TestIsLocalRequest_DuplicateHeaderWithEmptyFirstValue(t *testing.T) {
+	req := localReq("http://127.0.0.1:8088/api/version", "127.0.0.1:50000", nil)
+	req.Header.Add("X-Forwarded-For", "")
+	req.Header.Add("X-Forwarded-For", "203.0.113.7")
+	if req.Header.Get("X-Forwarded-For") != "" {
+		t.Fatal("fixture broken: Get should return the empty first value")
+	}
+	if isLocalRequest(req) {
+		t.Error("an empty first value must not mask the relay's own")
+	}
+}
+
+// Host forms that look loopback-ish but are not, alongside the ones that are.
+// All of these reach canonicalHost/isLocalName; pinning them keeps a future
+// normalization tweak from quietly opening a DNS-rebinding path.
+func TestIsLocalRequest_HostEdgeForms(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"localhost:8088", true},
+		{"LOCALHOST:8088", true},  // case-insensitive
+		{"localhost.:8088", true}, // fully-qualified root dot
+		{"127.0.0.1:8088", true},
+		{"[::1]:8088", true},
+		{"[::ffff:127.0.0.1]:8088", true},
+		{"0.0.0.0:8088", false},    // parses, but is not loopback
+		{"127.1:8088", false},      // shorthand net.ParseIP rejects
+		{"2130706433:8088", false}, // decimal-encoded 127.0.0.1
+		{"attacker.example:8088", false},
+		{"localhost.attacker.example:8088", false},
+		{"", false}, // HTTP/1.0 with no Host
+	}
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			// Host is set explicitly rather than through the URL, so forms Go's
+			// URL parser would reject still reach the predicate.
+			req := localReq("http://127.0.0.1:8088/api/version", "127.0.0.1:50000",
+				map[string]string{"Host": tc.host})
+			if got := isLocalRequest(req); got != tc.want {
+				t.Errorf("Host %q: isLocalRequest = %v, want %v", tc.host, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/server/native_handlers.go
+++ b/internal/server/native_handlers.go
@@ -121,10 +121,11 @@ type nativePickFolderRequest struct {
 // reusing that endpoint's validation and the cwd-chip refresh rather than
 // duplicating them here. Registered only when a NativeBridge is present.
 func (s *Server) handleNativePickFolder(w http.ResponseWriter, r *http.Request) {
-	// Same-machine only, matching /api/fs/list. In the desktop build every
-	// request is loopback anyway; the guard just refuses to drive a native
-	// dialog on behalf of some other peer if the port were ever reachable.
-	if !isLoopbackRemote(r.RemoteAddr) {
+	// Same-machine only. In the desktop build every request is genuinely local
+	// anyway; the guard refuses to drive a native dialog on behalf of some other
+	// peer if the port is reachable — including a phone across octo's own
+	// tunnel, which dials the server from loopback (see isLocalRequest).
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "native dialogs are available only from the local machine")
 		return
 	}
@@ -154,7 +155,7 @@ func (s *Server) handleNativePickFolder(w http.ResponseWriter, r *http.Request) 
 // return the chosen absolute path. The frontend attaches it by real path (no
 // upload) so the agent reads it in place. Registered only with a bridge.
 func (s *Server) handleNativePickFile(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "native dialogs are available only from the local machine")
 		return
 	}
@@ -188,7 +189,7 @@ type nativeNotifyRequest struct {
 // Best-effort: it always returns ok; the bridge swallows delivery failures.
 // Registered only with a bridge.
 func (s *Server) handleNativeNotify(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "native notifications are available only from the local machine")
 		return
 	}
@@ -215,7 +216,7 @@ type nativeAutostartRequest struct {
 
 // GET /api/native/autostart — report launch-at-login state (desktop only).
 func (s *Server) handleNativeAutostartGet(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "available only from the local machine")
 		return
 	}
@@ -233,7 +234,7 @@ func (s *Server) handleNativeAutostartGet(w http.ResponseWriter, r *http.Request
 
 // PUT /api/native/autostart — set launch-at-login (desktop only).
 func (s *Server) handleNativeAutostartSet(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "available only from the local machine")
 		return
 	}
@@ -256,7 +257,7 @@ func (s *Server) handleNativeAutostartSet(w http.ResponseWriter, r *http.Request
 // POST /api/native/window/toggle-maximise — maximise/restore the desktop window
 // (the double-click-titlebar zoom). Desktop only, loopback-gated.
 func (s *Server) handleNativeToggleMaximise(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "available only from the local machine")
 		return
 	}
@@ -271,7 +272,7 @@ func (s *Server) handleNativeToggleMaximise(w http.ResponseWriter, r *http.Reque
 // POST /api/native/window/minimise — minimise the desktop window to the
 // taskbar/dock. Desktop only, loopback-gated.
 func (s *Server) handleNativeMinimise(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "available only from the local machine")
 		return
 	}
@@ -291,7 +292,7 @@ type nativeHeartbeatRequest struct {
 // POST /api/native/heartbeat — liveness beat from the page inside the desktop
 // webview (nativeShell mode only sends it). Desktop only, loopback-gated.
 func (s *Server) handleNativeHeartbeat(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "available only from the local machine")
 		return
 	}
@@ -314,7 +315,7 @@ func (s *Server) handleNativeHeartbeat(w http.ResponseWriter, r *http.Request) {
 // decides whether the hub actually terminates or keeps running in the tray.
 // Desktop only, loopback-gated.
 func (s *Server) handleNativeClose(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "available only from the local machine")
 		return
 	}
@@ -330,7 +331,7 @@ func (s *Server) handleNativeClose(w http.ResponseWriter, r *http.Request) {
 // maximised. Lets the frontend keep its maximise icon in sync after Aero Snap,
 // keyboard shortcuts, etc. Desktop only, loopback-gated.
 func (s *Server) handleNativeWindowState(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "available only from the local machine")
 		return
 	}
@@ -366,7 +367,7 @@ func openExternalSchemeAllowed(scheme string) bool {
 }
 
 func (s *Server) handleNativeOpenExternal(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "available only from the local machine")
 		return
 	}
@@ -396,7 +397,7 @@ func (s *Server) handleNativeOpenExternal(w http.ResponseWriter, r *http.Request
 // native routes: a remote peer must not drive the desktop host's update — the
 // badge sends remote users to the download page instead.
 func (s *Server) handleNativeSelfUpdate(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "available only from the local machine")
 		return
 	}
@@ -428,7 +429,7 @@ type nativeSaveFileRequest struct {
 // nothing. Loopback-gated like the other native routes; registered only with a
 // bridge.
 func (s *Server) handleNativeSaveFile(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "native dialogs are available only from the local machine")
 		return
 	}
@@ -468,7 +469,7 @@ func (s *Server) handleNativeSaveFile(w http.ResponseWriter, r *http.Request) {
 // afterwards. Loopback-gated like the other native routes; registered only with
 // a bridge.
 func (s *Server) handleNativePrint(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r.RemoteAddr) {
+	if !isLocalRequest(r) {
 		writeError(w, http.StatusForbidden, "native dialogs are available only from the local machine")
 		return
 	}

--- a/internal/server/version_upgrade_handlers.go
+++ b/internal/server/version_upgrade_handlers.go
@@ -44,12 +44,14 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		"needs_update": needs,
 		"cli_command":  "octo",
 		// native is true in the Wails desktop build (a NativeBridge is wired):
-		// the frontend can use OS dialogs/notifications. local is true whenever
-		// the browser is on this machine (loopback) — desktop or localhost web —
+		// the frontend can use OS dialogs/notifications. local is true when the
+		// browser is genuinely on this machine — desktop or localhost web —
 		// telling the frontend to pick files/folders by real path instead of
-		// uploading. Remote web gets neither and falls back to upload.
+		// uploading. A peer that merely reaches us over loopback because
+		// something forwards the port (ngrok, a proxy, octo's own tunnel) is not
+		// local and falls back to upload; see isLocalRequest.
 		"native": s.cfg.Native != nil,
-		"local":  isLoopbackRemote(r.RemoteAddr),
+		"local":  isLocalRequest(r),
 		// upgrade_mode tells the badge which update mechanism this server offers:
 		// "cli" — the in-place binary swap of POST /api/version/upgrade (octo
 		// serve); "installer" — the desktop build, whose binary can't be swapped

--- a/internal/server/ws_hub.go
+++ b/internal/server/ws_hub.go
@@ -47,10 +47,11 @@ type wsConn struct {
 	conn       *websocket.Conn
 	send       chan []byte
 	subscribed map[string]struct{} // subscribed session IDs
-	// loopback is whether the peer is on this machine (127.0.0.0/8, ::1). Fixed
-	// at upgrade from RemoteAddr (never X-Forwarded-For). Gates referencing a
-	// file by its real local path — safe only when the browser and agent share
-	// a filesystem; a remote client falls back to upload.
+	// loopback is whether the peer is genuinely on this machine — see
+	// isLocalRequest, which a bare loopback peer address does not establish on
+	// its own. Fixed at upgrade. Gates referencing a file by its real local
+	// path, safe only when the browser and agent share a filesystem; a remote
+	// client (including a phone across the tunnel) falls back to upload.
 	loopback bool
 }
 
@@ -188,7 +189,7 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		conn:       conn,
 		send:       make(chan []byte, 256),
 		subscribed: make(map[string]struct{}),
-		loopback:   isLoopbackRemote(r.RemoteAddr),
+		loopback:   isLocalRequest(r),
 	}
 
 	s.wsHub.register <- c

--- a/internal/tunnel/bridge.go
+++ b/internal/tunnel/bridge.go
@@ -105,9 +105,11 @@ func (b *bridge) doHTTP(f shimFrame) {
 		}
 		req.Header.Set(k, v)
 	}
-	// Set AFTER the phone's headers are copied, so a phone cannot clear or
-	// forge it: this request came off the relay, however it is dressed.
+	// Both set AFTER the phone's headers are copied, so a phone can neither
+	// clear the marker nor substitute its own key: this request came off the
+	// relay, however it is dressed, and it authenticates as this host.
 	req.Header.Set(headerForwarded, headerForwardedValue)
+	b.t.authorize(req.Header)
 	resp, err := b.t.httpClient.Do(req)
 	if err != nil {
 		b.send(httpError(f.ID, err))
@@ -139,6 +141,17 @@ const (
 	headerForwardedValue = "relay"
 )
 
+// authorize adds the host's access key so the local server accepts a relayed
+// request. A tunnel configured without a key sends none, which the server will
+// refuse — better a clear 401 than silently reopening the exemption the marker
+// above just closed.
+func (t *Tunnel) authorize(h http.Header) {
+	if t.cfg.AccessKey == "" {
+		return
+	}
+	h.Set("X-Access-Key", t.cfg.AccessKey)
+}
+
 // skipRequestHeader drops headers the loopback HTTP client must set itself; the
 // phone's copy of them would be wrong or rejected.
 func skipRequestHeader(k string) bool {
@@ -150,8 +163,13 @@ func skipRequestHeader(k string) bool {
 }
 
 func (b *bridge) openWS(f shimFrame) {
-	conn, _, err := websocket.DefaultDialer.DialContext(b.ctx, b.t.wsBase+f.Path,
-		http.Header{headerForwarded: []string{headerForwardedValue}})
+	// The phone's own headers never reach this dial, so the handshake carries
+	// exactly what the bridge puts on it: the relay marker and the access key.
+	// The key cannot ride the query string here — mobile/src/shim.ts forwards
+	// only the path — so the header is the whole mechanism.
+	h := http.Header{headerForwarded: []string{headerForwardedValue}}
+	b.t.authorize(h)
+	conn, _, err := websocket.DefaultDialer.DialContext(b.ctx, b.t.wsBase+f.Path, h)
 	if err != nil {
 		b.send(shimFrame{Kind: shimWSError, ID: f.ID, Message: err.Error()})
 		return

--- a/internal/tunnel/bridge.go
+++ b/internal/tunnel/bridge.go
@@ -105,6 +105,9 @@ func (b *bridge) doHTTP(f shimFrame) {
 		}
 		req.Header.Set(k, v)
 	}
+	// Set AFTER the phone's headers are copied, so a phone cannot clear or
+	// forge it: this request came off the relay, however it is dressed.
+	req.Header.Set(headerForwarded, headerForwardedValue)
 	resp, err := b.t.httpClient.Do(req)
 	if err != nil {
 		b.send(httpError(f.ID, err))
@@ -123,6 +126,19 @@ func httpError(id string, err error) shimFrame {
 	return shimFrame{Kind: shimHTTPResp, ID: id, Status: http.StatusBadGateway, Headers: map[string]string{}, Body: strPtr(err.Error())}
 }
 
+// headerForwarded marks every request this bridge replays into the local
+// server as relayed. internal/server declares the same literal as
+// server.HeaderForwarded and treats its presence as proof the peer is not on
+// this machine — necessary because the bridge dials loopback and drops the
+// phone's Host (see skipRequestHeader), so a phone across the relay would
+// otherwise be indistinguishable from a browser on the host, and would inherit
+// the local-peer capabilities: the unauthenticated loopback exemption, the OS
+// dialogs, and referencing files by their real path on the host's disk.
+const (
+	headerForwarded      = "X-Octo-Forwarded"
+	headerForwardedValue = "relay"
+)
+
 // skipRequestHeader drops headers the loopback HTTP client must set itself; the
 // phone's copy of them would be wrong or rejected.
 func skipRequestHeader(k string) bool {
@@ -134,7 +150,8 @@ func skipRequestHeader(k string) bool {
 }
 
 func (b *bridge) openWS(f shimFrame) {
-	conn, _, err := websocket.DefaultDialer.DialContext(b.ctx, b.t.wsBase+f.Path, nil)
+	conn, _, err := websocket.DefaultDialer.DialContext(b.ctx, b.t.wsBase+f.Path,
+		http.Header{headerForwarded: []string{headerForwardedValue}})
 	if err != nil {
 		b.send(shimFrame{Kind: shimWSError, ID: f.ID, Message: err.Error()})
 		return

--- a/internal/tunnel/header_parity_test.go
+++ b/internal/tunnel/header_parity_test.go
@@ -1,0 +1,23 @@
+package tunnel
+
+import (
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/server"
+)
+
+// The two packages declare the marker's name independently — a one-string
+// constant is not worth a production dependency between them — so nothing but
+// this assertion stops them drifting apart. Drift is silent and expensive: the
+// bridge would keep stamping a header the server no longer recognises, and
+// every phone across the relay would quietly regain local-peer standing (real
+// paths on the host's disk, the OS dialogs, the unauthenticated exemption).
+//
+// The import lives in a test file, so internal/tunnel still ships with no
+// dependency on internal/server.
+func TestForwardedHeaderNameMatchesServer(t *testing.T) {
+	if headerForwarded != server.HeaderForwarded {
+		t.Fatalf("marker name drifted: tunnel has %q, server expects %q",
+			headerForwarded, server.HeaderForwarded)
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -94,9 +94,11 @@ type Config struct {
 	// Its host:port is the base the bridge dials for both loopback HTTP (/api)
 	// and loopback WebSocket (/ws) calls.
 	LoopbackURL string
-	// AccessKey would authenticate a non-loopback client. The bridge dials
-	// 127.0.0.1, which the server exempts from the key check, so it is unused for
-	// now; kept for a future non-loopback bind.
+	// AccessKey authenticates every request the bridge replays into the local
+	// server. Required: the bridge marks its traffic as relayed (see
+	// bridge.go's headerForwarded), which costs it the server's
+	// loopback-without-a-key exemption — as it should, since the client on the
+	// other end is a phone across the internet, not someone at this keyboard.
 	AccessKey string
 	// Identity supplies the host's Noise static keypair (and, if TunnelID is
 	// unset, the tunnel id). Load it with LoadOrCreateIdentity to persist it in

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -42,12 +42,13 @@ func startStubLoopback(t *testing.T) *httptest.Server {
 	// relayed request is distinguishable from a genuine local one.
 	mux.HandleFunc("/api/hdr", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, `{"forwarded":%q}`, r.Header.Get(headerForwarded))
+		fmt.Fprintf(w, `{"forwarded":%q,"key":%q}`,
+			r.Header.Get(headerForwarded), r.Header.Get("X-Access-Key"))
 	})
 	// Same, for a tunnelled /ws stream: the marker rides the handshake, so it is
 	// reported once on connect rather than per message.
 	mux.HandleFunc("/ws-hdr", func(w http.ResponseWriter, r *http.Request) {
-		marker := r.Header.Get(headerForwarded)
+		marker := r.Header.Get(headerForwarded) + "/" + r.Header.Get("X-Access-Key")
 		ws, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return
@@ -305,6 +306,11 @@ func (p *mockPhone) recvShim(t *testing.T) shimFrame {
 	return shimFrame{}
 }
 
+// testAccessKey is the host key the bridge must present on everything it
+// replays: marking its traffic as relayed costs it the server's
+// loopback-without-a-key exemption, so without this the phone gets 401s.
+const testAccessKey = "tunnel-test-key-0123456789abcdef"
+
 func newPairedPhone(t *testing.T) *mockPhone {
 	t.Helper()
 	stub := startStubLoopback(t)
@@ -314,6 +320,7 @@ func newPairedPhone(t *testing.T) *mockPhone {
 		TunnelID:    "tunnel-A",
 		PairTokens:  []string{"tok-1"},
 		LoopbackURL: wsScheme(stub) + "/ws",
+		AccessKey:   testAccessKey,
 		Logf:        func(string, ...any) {},
 	})
 	if err != nil {
@@ -452,7 +459,7 @@ func TestHostTunnel_HTTPStampsForwardedMarker(t *testing.T) {
 	if resp.Kind != shimHTTPResp || resp.ID != "h1" {
 		t.Fatalf("got %+v, want an http-resp for h1", resp)
 	}
-	want := `{"forwarded":"` + headerForwardedValue + `"}`
+	want := `{"forwarded":"` + headerForwardedValue + `","key":"` + testAccessKey + `"}`
 	if resp.Body == nil || *resp.Body != want {
 		t.Errorf("body = %v, want %s", resp.Body, want)
 	}
@@ -475,9 +482,9 @@ func TestHostTunnel_PhoneCannotForgeForwardedMarker(t *testing.T) {
 	if resp.Kind != shimHTTPResp || resp.ID != "h2" {
 		t.Fatalf("got %+v, want an http-resp for h2", resp)
 	}
-	want := `{"forwarded":"` + headerForwardedValue + `"}`
+	want := `{"forwarded":"` + headerForwardedValue + `","key":"` + testAccessKey + `"}`
 	if resp.Body == nil || *resp.Body != want {
-		t.Errorf("body = %v, want the bridge's own value %s", resp.Body, want)
+		t.Errorf("body = %v, want the bridge's own values %s", resp.Body, want)
 	}
 }
 
@@ -489,7 +496,7 @@ func TestHostTunnel_WSStampsForwardedMarker(t *testing.T) {
 
 	phone.sendShim(t, shimFrame{Kind: shimWSOpen, ID: "w9", Path: "/ws-hdr"})
 
-	want := "forwarded:" + headerForwardedValue
+	want := "forwarded:" + headerForwardedValue + "/" + testAccessKey
 	for {
 		f := phone.recvShim(t)
 		if f.Kind == shimWSError {

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -38,6 +38,28 @@ func startStubLoopback(t *testing.T) *httptest.Server {
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, `{"method":%q,"body":%q}`, r.Method, string(body))
 	})
+	// Reports the forwarding marker the bridge stamped, so a test can prove a
+	// relayed request is distinguishable from a genuine local one.
+	mux.HandleFunc("/api/hdr", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{"forwarded":%q}`, r.Header.Get(headerForwarded))
+	})
+	// Same, for a tunnelled /ws stream: the marker rides the handshake, so it is
+	// reported once on connect rather than per message.
+	mux.HandleFunc("/ws-hdr", func(w http.ResponseWriter, r *http.Request) {
+		marker := r.Header.Get(headerForwarded)
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		_ = ws.WriteMessage(websocket.TextMessage, []byte("forwarded:"+marker))
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
 	// Echoes each WebSocket message with a "reply-to:" prefix.
 	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 		ws, err := upgrader.Upgrade(w, r, nil)
@@ -413,5 +435,72 @@ func TestRelayDialBase_RuleParity(t *testing.T) {
 		if got := relayDialBase(c.relay, c.tunnel); got != c.want {
 			t.Errorf("relayDialBase(%q, %q) = %q, want %q", c.relay, c.tunnel, got, c.want)
 		}
+	}
+}
+
+// The bridge dials loopback and drops the phone's Host, so without a marker a
+// phone across the relay is indistinguishable from a browser on the host — and
+// would inherit every local-peer capability (the unauthenticated loopback
+// exemption, OS dialogs, referencing files by their real path on the host's
+// disk). internal/server reads this header as proof the peer is remote.
+func TestHostTunnel_HTTPStampsForwardedMarker(t *testing.T) {
+	phone := newPairedPhone(t)
+
+	phone.sendShim(t, shimFrame{Kind: shimHTTPReq, ID: "h1", Method: "GET", Path: "/api/hdr"})
+
+	resp := phone.recvShim(t)
+	if resp.Kind != shimHTTPResp || resp.ID != "h1" {
+		t.Fatalf("got %+v, want an http-resp for h1", resp)
+	}
+	want := `{"forwarded":"` + headerForwardedValue + `"}`
+	if resp.Body == nil || *resp.Body != want {
+		t.Errorf("body = %v, want %s", resp.Body, want)
+	}
+}
+
+// A phone must not be able to clear or rewrite the marker: the bridge sets it
+// after copying the phone's headers, so whatever the phone sent loses.
+func TestHostTunnel_PhoneCannotForgeForwardedMarker(t *testing.T) {
+	phone := newPairedPhone(t)
+
+	phone.sendShim(t, shimFrame{
+		Kind:    shimHTTPReq,
+		ID:      "h2",
+		Method:  "GET",
+		Path:    "/api/hdr",
+		Headers: map[string]string{headerForwarded: ""},
+	})
+
+	resp := phone.recvShim(t)
+	if resp.Kind != shimHTTPResp || resp.ID != "h2" {
+		t.Fatalf("got %+v, want an http-resp for h2", resp)
+	}
+	want := `{"forwarded":"` + headerForwardedValue + `"}`
+	if resp.Body == nil || *resp.Body != want {
+		t.Errorf("body = %v, want the bridge's own value %s", resp.Body, want)
+	}
+}
+
+// A tunnelled /ws stream carries the marker on its handshake too — that is the
+// connection the phone does all its real work over, and the one whose loopback
+// flag gates referencing files by their real path.
+func TestHostTunnel_WSStampsForwardedMarker(t *testing.T) {
+	phone := newPairedPhone(t)
+
+	phone.sendShim(t, shimFrame{Kind: shimWSOpen, ID: "w9", Path: "/ws-hdr"})
+
+	want := "forwarded:" + headerForwardedValue
+	for {
+		f := phone.recvShim(t)
+		if f.Kind == shimWSError {
+			t.Fatalf("ws-open failed: %s", f.Message)
+		}
+		if f.Kind != shimWSMessage || f.ID != "w9" {
+			continue
+		}
+		if f.Data != want {
+			t.Errorf("ws greeting = %q, want %q", f.Data, want)
+		}
+		return
 	}
 }

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -511,3 +511,27 @@ func TestHostTunnel_WSStampsForwardedMarker(t *testing.T) {
 		return
 	}
 }
+
+// A phone cannot suppress the marker by sending it under a different casing: Go
+// canonicalizes header names, so its lower-case attempt lands on the same key
+// the bridge then overwrites. Nor can it substitute its own access key.
+func TestHostTunnel_LowercaseForgeAttemptStillMarked(t *testing.T) {
+	phone := newPairedPhone(t)
+
+	phone.sendShim(t, shimFrame{
+		Kind:    shimHTTPReq,
+		ID:      "h3",
+		Method:  "GET",
+		Path:    "/api/hdr",
+		Headers: map[string]string{"x-octo-forwarded": "", "x-access-key": "phone-chosen-key"},
+	})
+
+	resp := phone.recvShim(t)
+	if resp.Kind != shimHTTPResp || resp.ID != "h3" {
+		t.Fatalf("got %+v, want an http-resp for h3", resp)
+	}
+	want := `{"forwarded":"` + headerForwardedValue + `","key":"` + testAccessKey + `"}`
+	if resp.Body == nil || *resp.Body != want {
+		t.Errorf("body = %v, want the bridge's own values %s", resp.Body, want)
+	}
+}

--- a/internal/tunnel/wakeup.go
+++ b/internal/tunnel/wakeup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -149,7 +150,11 @@ func (t *Tunnel) watchActivity(ctx context.Context) {
 }
 
 func (t *Tunnel) watchActivityOnce(ctx context.Context) error {
-	ws, _, err := websocket.DefaultDialer.DialContext(ctx, t.wsBase+"/ws", nil)
+	// Authenticated like the bridge's own dials: this is a loopback client with
+	// no key otherwise, and the exemption that used to carry it is gone.
+	h := http.Header{}
+	t.authorize(h)
+	ws, _, err := websocket.DefaultDialer.DialContext(ctx, t.wsBase+"/ws", h)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Every local-peer capability keyed off `isLoopbackRemote` — the peer's TCP address and nothing else. But anything that forwards a port runs on this machine and dials the server from loopback, so a remote client arrived looking local. Expose the port through ngrok and whoever finds the URL is treated as sitting at the keyboard.

## What that reached

Measured against a real `octo serve` (isolated `HOME`, separate port; curl reproduces each shape exactly):

| shape | `local` flag | no-key `/api/sessions` |
|---|---|---|
| direct `127.0.0.1` | `true` | 200 |
| ngrok, Host passed through | **`true`** | 403 (host guard caught it) |
| ngrok + `X-Forwarded-For` | **`true`** | 401 |
| ngrok `--host-header=rewrite` | **`true`** | **200** |
| octo's own tunnel (a phone) | **`true`** | — |

The fourth row is the sharp one: with Host rewritten to loopback the request sailed through the unauthenticated exemption, and `/api/fs/list` listed the **server's root directory** to a remote caller. That is not an exotic configuration — it is ngrok's `--host-header=rewrite`, and nginx's *default* `proxy_set_header Host $proxy_host`. A configured access key does not close it, because the exemption is the fallback for requests carrying no key at all.

The same address-only test also governed `conn.loopback` on the WebSocket (whether a message may reference a file by its real path on the host's disk) and the 14 `/api/native/*` routes (OS dialogs, window control, self-update).

## octo's own tunnel had it worst

`internal/tunnel/bridge.go` drops the phone's Host (`skipRequestHeader`) and dials loopback, so a phone across the relay was indistinguishable from a browser on the host. It now stamps `X-Octo-Forwarded` on every request and `/ws` handshake it replays — set **after** the phone's own headers are copied, so the phone can neither clear nor forge it.

Phones keep working; they authenticate with the access key. They just stop counting as local. Verified: `/api/sessions` → 200, `local` → false.

## The fix

One predicate, `isLocalRequest`: a loopback peer, **no** forwarding header, **and** a Host that names this machine. All of the above route through it.

The forwarding headers are client-spoofable, which is precisely why they are only ever read to **narrow** what a request may do. `isLoopbackRemote` still refuses to consult them — there the answer would *widen* the exemption, and a forged header must never buy privilege. Faking one here can cost the sender local-peer capabilities, never grant them; there is a test pinning both directions.

## After

| shape | `local` | no-key `/api/sessions` | `/api/fs/list` |
|---|---|---|---|
| direct `127.0.0.1` | `true` ✅ | 200 ✅ | — |
| ngrok, Host passed through | `false` | 403 | — |
| ngrok + XFF | `false` | 401 | — |
| ngrok `--host-header=rewrite` | `false` | **401** | **401** |
| octo tunnel, no key | `false` | 401 | — |
| octo tunnel, with key | `false` | **200** ✅ | — |
| forwarded + valid key | — | **200** ✅ | — |

The last two rows are the no-regression checks: narrowing the exemption must not break peers that authenticate properly.

## One shape stays uncoverable

A plain TCP forward that rewrites Host and adds no headers — `ssh -L 8088:localhost:8088` — is byte-for-byte a local request by the time it arrives. There is no signal left to read. It is documented on `isLocalRequest`, with the consequence spelled out: capabilities gated on this must stay recoverable rather than assume the answer is certain.

## Verification

`go test -race ./...` clean, `go vet` and `gofmt` clean. New tests: `isLocalRequest` across 13 shapes, the spoofing asymmetry in both directions, the `local` flag per shape, the exemption per forwarding header (plus the valid-key non-regression), and three on the tunnel side — HTTP marker, WS-handshake marker, and that a phone cannot forge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
