### PR TITLE
fix(web): pinned label hover feedback + tighter gap above it

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -873,7 +873,7 @@
   font-size: 10px; font-weight: 600; white-space: nowrap;
   max-width: 64px; overflow: hidden; text-overflow: ellipsis;
 }
-.scroll { flex: 1; min-height: 0; overflow: hidden; padding: 12px 12px 8px; display: flex; flex-direction: column; gap: 18px; }
+.scroll { flex: 1; min-height: 0; overflow: hidden; padding: 12px 12px 8px; display: flex; flex-direction: column; gap: 10px; }
 .nav-group { display: flex; flex-direction: column; gap: 2px; flex: 0 0 auto; }
 /* Sessions is the only group with no forced grow-to-fill (flex-grow:0, unlike
    the "1 1 auto" this used to be) — a short list sizes to its own content

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -920,6 +920,11 @@
   border-radius: 6px;
 }
 .grp-header:hover { background: var(--hover-neutral); }
+/* Pinned is the one .grp-header with no click target of its own — just a
+   label — so it needs the same hover feedback .sec-header gives Projects
+   and Recent, rather than relying on the (here, purely cosmetic) background
+   tint alone. */
+.grp-header:hover .grp-name.muted { color: var(--text-secondary); }
 .grp-caret {
   width: 16px; flex: 0 0 16px; display: flex; align-items: center; justify-content: center;
   color: var(--text-tertiary); cursor: pointer;


### PR DESCRIPTION
## Summary
- Pinned's label now darkens on hover the same way Projects/Recent's section headers do, instead of relying on the background tint alone (it's the one `.grp-header` with no click target of its own).
- Tightened `.scroll`'s gap from 18px to 10px — its only use besides between session-list sections is the single gap above Pinned, where 18px read as a stray dead zone.

## Test plan
- [x] `npx svelte-check --threshold error` — 0 errors
- [x] `npx vitest run` — 287 passing
- [x] `make build`
- [x] Verified visually via isolated CDP walkthrough (hover color change confirmed via `getComputedStyle`, gap confirmed via screenshot)