### PR TITLE
feat(web): assistant memory moves into Settings' data management

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -24,7 +24,6 @@
   import TasksView from './views/TasksView.svelte'
   import McpView from './views/McpView.svelte'
   import ChannelsView from './views/ChannelsView.svelte'
-  import ProfileView from './views/ProfileView.svelte'
   import LightAppsView from './views/LightAppsView.svelte'
   import CommandPalette from './components/overlays/CommandPalette.svelte'
   import McpModal from './components/overlays/McpModal.svelte'
@@ -53,7 +52,7 @@
   // delete leaves behind. Read synchronously at module init, before any list
   // can arrive.
   let autoSelectDone = typeof location !== 'undefined' && hashPicksChatTarget(location.hash)
-  const VALID_VIEWS = ['chat', 'agents', 'skills', 'workflows', 'browser', 'tasks', 'mcp', 'channels', 'profile', 'lightapps']
+  const VALID_VIEWS = ['chat', 'agents', 'skills', 'workflows', 'browser', 'tasks', 'mcp', 'channels', 'lightapps']
 
   function applyHash() {
     const h = location.hash.replace(/^#\/?/, '')
@@ -450,8 +449,6 @@
         <McpView />
       {:else if $view === 'channels'}
         <ChannelsView />
-      {:else if $view === 'profile'}
-        <ProfileView />
       {:else if $view === 'lightapps'}
         <LightAppsView />
       {/if}

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -52,7 +52,6 @@
     { icon: 'ant-design:thunderbolt-outlined', label: 'nav.skills', v: 'skills' },
     { icon: 'ant-design:api-outlined', label: 'nav.mcp', v: 'mcp' },
     { icon: 'ant-design:partition-outlined', label: 'nav.workflows', v: 'workflows' },
-    { icon: 'ant-design:user-outlined', label: 'nav.memory', v: 'profile' },
     { icon: 'ant-design:global-outlined', label: 'nav.browser', v: 'browser' },
     { icon: 'ant-design:mobile-outlined', label: 'nav.channels', v: 'channels' },
   ]

--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -34,6 +34,13 @@
     close()
   }
 
+  // Assistant Memory moved into Settings' 数据管理 — no standalone view left
+  // to route to, so this opens Settings instead of a dead view.set('profile').
+  function openMemorySettings() {
+    settingsModalOpen.set(true)
+    close()
+  }
+
   function newSession() {
     close()
     createNewSession()
@@ -49,7 +56,7 @@
     { id: 'browser', icon: 'ant-design:global-outlined', label: () => $t('nav.browser'), shortcut: '', run: () => goTo('browser') },
     { id: 'mcp', icon: 'ant-design:api-outlined', label: () => $t('nav.mcp'), shortcut: '', run: () => goTo('mcp') },
     { id: 'channels', icon: 'ant-design:mobile-outlined', label: () => $t('nav.channels'), shortcut: '', run: () => goTo('channels') },
-    { id: 'memory', icon: 'ant-design:user-outlined', label: () => $t('nav.memory'), shortcut: '', run: () => goTo('profile') },
+    { id: 'memory', icon: 'ant-design:user-outlined', label: () => $t('nav.memory'), shortcut: '', run: () => openMemorySettings() },
     { id: 'files', icon: 'ant-design:folder-open-outlined', label: () => $t('nav.file_recall'), shortcut: '', run: () => goTo('files') },
     { id: 'lightapps', icon: 'ant-design:appstore-outlined', label: () => $t('nav.light_apps'), shortcut: '', run: () => goTo('lightapps') },
     { id: 'artifacts', icon: 'ant-design:file-text-outlined', label: () => $t('artifacts.toggle'), shortcut: '', run: () => { panelContent.update(v => v ? null : 'session') } },

--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -4,6 +4,7 @@
   import EndpointsSection from '../settings/EndpointsSection.svelte'
   import QrCode from '../ui/QrCode.svelte'
   import FileRecallView from '../../views/FileRecallView.svelte'
+  import ProfileView from '../../views/ProfileView.svelte'
   import { get } from 'svelte/store'
   import { showToast, nativeShell, settingsModalOpen, onboardPhase, sessions, sessionGroups, collapsedSessions, activeSessionId, view, clearPendingSessionOpts } from '../../lib/stores'
   import type { Session, SessionGroup } from '../../lib/types'
@@ -58,7 +59,7 @@
   // files). Reset whenever the category (or the whole modal) changes, so
   // leaving and returning to 数据管理 always lands on the list, not wherever
   // you left off.
-  let dataSubView = $state<'none' | 'archived' | 'trash'>('none')
+  let dataSubView = $state<'none' | 'archived' | 'trash' | 'memory'>('none')
   let archiveSearch = $state('')
   // '' = every project, 'none' = no project, else a project's group id.
   let archiveProjectFilter = $state('')
@@ -606,13 +607,20 @@
               </div>
               <button class="link-btn" onclick={() => (dataSubView = 'trash')}>{$t('settings.data.manage')}</button>
             </div>
+            <div class="data-row">
+              <div class="data-row-main">
+                <iconify-icon icon="ant-design:user-outlined" width="15"></iconify-icon>
+                <span class="setl">{$t('nav.memory')}</span>
+              </div>
+              <button class="link-btn" onclick={() => (dataSubView = 'memory')}>{$t('settings.data.manage')}</button>
+            </div>
           {:else}
             <div class="data-subhead">
               <button class="back-btn" onclick={resetDataView}>
                 <iconify-icon icon="ant-design:left-outlined" width="14"></iconify-icon>
               </button>
               <span class="data-subtitle">
-                {dataSubView === 'archived' ? $t('settings.data.archived') : $t('nav.file_recall')}
+                {dataSubView === 'archived' ? $t('settings.data.archived') : dataSubView === 'memory' ? $t('nav.memory') : $t('nav.file_recall')}
               </span>
             </div>
             {#if dataSubView === 'archived'}
@@ -674,6 +682,8 @@
                   {/each}
                 {/if}
               {/if}
+            {:else if dataSubView === 'memory'}
+              <ProfileView embedded />
             {:else}
               <FileRecallView embedded />
             {/if}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type View = 'chat' | 'agents' | 'skills' | 'workflows' | 'tasks' | 'browser' | 'mcp' | 'channels' | 'profile' | 'files' | 'lightapps'
+export type View = 'chat' | 'agents' | 'skills' | 'workflows' | 'tasks' | 'browser' | 'mcp' | 'channels' | 'files' | 'lightapps'
 export type SidebarMode = 'full' | 'rail' | 'hidden'
 export type MemTab = 'soul' | 'user' | 'memories'
 export type ArtifactView = 'preview' | 'code'

--- a/web/src/views/ProfileView.svelte
+++ b/web/src/views/ProfileView.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { memTab, showToast, openAgentSession } from '../lib/stores'
+  import { memTab, showToast, openAgentSession, settingsModalOpen } from '../lib/stores'
   import StatusTag from '../components/ui/StatusTag.svelte'
   import { renderMarkdown } from '../lib/markdown'
   import * as api from '../lib/api'
   import type { Memory } from '../lib/types'
   import { t, tr } from '../lib/i18n'
+
+  // embedded=true when mounted inside Settings' 数据管理 pane rather than as a
+  // standalone view — same pattern as FileRecallView.
+  let { embedded = false }: { embedded?: boolean } = $props()
 
   // --- state ---
   interface SoulData {
@@ -95,7 +99,10 @@
 
   // Agentic-first: open a fresh chat and auto-send the curate command. soul/user
   // run the onboard skill scoped to that one file; memories opens a freeform turn.
+  // Closing the modal is a no-op when this view isn't embedded in it — but
+  // embedded, the chat this opens would otherwise be stuck behind Settings.
   function openAssistantChat(prompt: string, name = 'Profile update') {
+    settingsModalOpen.set(false)
     openAgentSession(prompt, name)
   }
 
@@ -121,12 +128,14 @@
   })
 </script>
 
-<div class="page">
-  <div class="inner">
+<div class="page" class:embedded>
+  <div class="inner" class:embedded>
+    {#if !embedded}
     <div class="page-header">
       <h2>{$t('profile.title')}</h2>
       <p>{$t('profile.subtitle')}</p>
     </div>
+    {/if}
 
     <!-- Tabs -->
     <div class="tabs">
@@ -248,7 +257,9 @@
 
 <style>
 .page { flex: 1; overflow-y: auto; min-height: 0; background: var(--bg-layout); }
+.page.embedded { flex: none; overflow: visible; background: none; }
 .inner { max-width: 780px; margin: 0 auto; padding: 26px 28px 40px; display: flex; flex-direction: column; gap: 20px; }
+.inner.embedded { max-width: none; margin: 0; padding: 0; }
 .page-header { display: flex; flex-direction: column; }
 h2 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-heading); }
 p { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 60ch; }


### PR DESCRIPTION
## Summary
- Assistant Memory (soul/user/memories) moves from a standalone top-level view into Settings → 数据管理, alongside Archived Sessions and File Recall.
- `ProfileView` gains an `embedded` prop matching `FileRecallView`'s pattern; its own page header is hidden inside Settings, and starting a chat from soul/user/memories now closes the modal first.
- The standalone `/profile` view, its Sidebar More-popover entry, and its slot in the `View` union are removed. `CommandPalette`'s memory command opens Settings instead of routing to the now-removed view.

## Test plan
- [x] `npx svelte-check --threshold error` — 0 errors
- [x] `npx vitest run` — 342 passing
- [x] `make build`
- [x] Verified visually via isolated CDP walkthrough: More popover no longer shows 助手记忆; Settings → 数据管理 shows a third row for it; opening it renders the same soul/user/memories tabs embedded; clicking "让助手更新此内容" closes the modal and opens the chat session