### PR TITLE
fix(web): artifacts panel stays the artifacts panel off a session

### DIFF
--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, cmdkOpen, sidebar, nativeShell, panelContent, activeSessionId, settingsModalOpen } from '../../lib/stores'
+  import { cmdkOpen, sidebar, nativeShell, panelContent, settingsModalOpen } from '../../lib/stores'
   import { t } from '../../lib/i18n'
   import { ws, wsState } from '../../lib/ws'
   import { notificationsEnabled, setNotificationsEnabled } from '../../lib/notifications'
@@ -14,17 +14,12 @@
     sidebar.update(s => s === 'hidden' ? 'full' : 'hidden')
   }
 
-  // Toggle the Artifacts panel sidebar.
-  // With a session active → its artifacts (the empty state included); light
-  // apps only when no session is selected.
+  // Toggle the Artifacts panel sidebar. Always the artifacts pane — with no
+  // session selected that's just its empty state, same as a session with none.
   function togglePanel() {
     const cur = $panelContent
     if (cur) { panelContent.set(null); return }
-    if ($view === 'chat' && $activeSessionId) {
-      panelContent.set('session')
-    } else {
-      panelContent.set('lightapps')
-    }
+    panelContent.set('session')
   }
 
   // The bell toggles desktop notifications on/off — the same preference the

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -2371,7 +2371,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       </button>
       <button class="hdr-btn" title={$t('artifacts.toggle')} onclick={() => {
         if ($panelContent) panelContent.set(null)
-        else panelContent.set(id ? 'session' : 'lightapps')
+        else panelContent.set('session')
       }}>
         <iconify-icon icon="lucide:box" width="13"></iconify-icon>
         <span class="btn-label">{$t('artifacts.toggle')}</span>


### PR DESCRIPTION
## Summary
- The sidebar panel toggle (title bar and in-chat header) fell back to showing the Light Apps list when no chat session was selected — e.g. opening it from the Light Apps page itself. Removed that special case: both toggles now always open the Artifacts panel, which already has its own empty state for "nothing to preview" and covers this exactly the same way it covers a session with no artifacts yet.
- `panelContent === 'lightapps'` itself is untouched — LightAppsView's "打开" action on a specific app still uses it.

## Test plan
- [x] `npx svelte-check --threshold error` — 0 errors
- [x] `npx vitest run` — 342 passing
- [x] `make build`
- [x] Verified visually: opened Light Apps page, clicked the 制品面板 toggle — panel now shows Artifacts' empty state instead of the Light Apps list