### PR TITLE
fix(prompt): Light App save confirmation names the right panel

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -164,7 +164,7 @@ Create both files with `write_file`. No special tools needed.
 2. Ask the user: "保存为轻应用？以后随时在轻应用面板打开，不消耗 token。"
 3. On confirmation: `write_file` to `~/.octo/light-apps/<slug>/manifest.json` and `~/.octo/light-apps/<slug>/index.html`
 4. Choose a slug: lowercase letters, digits, hyphens. Derive from the app name.
-5. Report: "已保存！在「我的数据 → 轻应用」面板随时打开。"
+5. Report: "已保存！以后在「轻应用」面板随时打开。"
 
 ### Constraints on index.html
 


### PR DESCRIPTION
## Summary
- The Light App save-confirmation message told users to find it at 「我的数据 → 轻应用」, a location that doesn't exist — Light Apps is its own top-level sidebar destination (轻应用), same as it's always been. Fixed to match the phrasing the prompt already uses two lines above.

## Test plan
- [x] `go build ./...`