### PR TITLE
fix(web): escape raw HTML in reply text instead of rendering it

### DIFF
--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -255,6 +255,23 @@ describe('observeArtifact — markdown image references', () => {
     )
   })
 
+  it('inlines a raw <img> tag the document wrote itself', async () => {
+    // The document's own HTML is content inside the sandboxed preview iframe,
+    // so it survives rendering — chat bubbles escape it instead (markdown.ts).
+    // Without that, the tag never reaches the inliner and the image silently
+    // does not render.
+    const fetchMock = stubFetch('# Report\n\n<img src="chart.png" width="400">\n')
+
+    await observeHydrated('/tmp/report.md')
+
+    const [entry] = get(artifacts)
+    expect(entry.preview).toContain('src="data:image/png;base64,')
+    expect(entry.preview).not.toContain('&lt;img')
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/sessions/${SID}/artifacts?path=${encodeURIComponent('/tmp/chart.png')}`,
+    )
+  })
+
   it('resolves "." and ".." segments', async () => {
     const fetchMock = stubFetch('![shot](../shots/./a.png)\n')
 

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -661,7 +661,11 @@ async function buildTextBody(
 	  }else{legacy()}
 	});
 	<\/script>`
-    const body = await inlineLocalRefs(renderMarkdown(code), sessionId, path, 'fragment')
+    // rawHtml: the document's own tags are content here, not injection — this
+    // iframe is sandboxed and styled by MD_STYLES alone, and inlineLocalRefs
+    // below has to see an <img src="chart.png"> to rewrite it to a data: URI.
+    // The chat's own bubbles get the escaping default instead (markdown.ts).
+    const body = await inlineLocalRefs(renderMarkdown(code, true, { rawHtml: true }), sessionId, path, 'fragment')
     preview = `<style>${MD_STYLES}</style><body style="${bodyStyle}">${body}${COPY_SCRIPT}</body>`
   } else {
     // code kind: show with theme-aware monospace style

--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { marked } from 'marked'
 import { renderMarkdown } from './markdown'
 
@@ -154,8 +154,42 @@ describe('renderMarkdown: raw HTML in reply text', () => {
     expect(out).not.toContain('<div')
     expect(out).not.toContain('<button')
     expect(out).not.toContain('<style')
-    expect(out).toContain('&lt;div class="backdrop" role="presentation"')
+    expect(out).toContain('&lt;div class=')
     expect(out).toContain('&lt;style&gt;')
+  })
+
+  it('escapes HTML inside the overridden table and blockquote renderers', () => {
+    // renderer.table / renderer.blockquote are this module's own overrides, so
+    // they are the likeliest place for a future change to let markup back in.
+    const table = renderMarkdown('| A |\n|---|\n| <div class="modal">x</div> |')
+    expect(table).toContain('<table>')
+    // The wrapper <div class="table-scroll"> is this renderer's own output; the
+    // cell's markup is what must not have become an element.
+    expect(table).not.toContain('<div class="modal"')
+    expect(table).toContain('&lt;div class="modal"&gt;')
+
+    const quote = renderMarkdown('> quoted <div class="backdrop">x</div>')
+    expect(quote).toContain('<blockquote')
+    expect(quote).not.toContain('<div class="backdrop"')
+    expect(quote).toContain('&lt;div class=')
+  })
+
+  it('escapes HTML inside a think block', () => {
+    // The same overlay payload can arrive in reasoning text, which is parsed by
+    // a separate marked.parse call.
+    const out = renderMarkdown('<think>trying <style>.backdrop{position:fixed}</style></think>done')
+    expect(out).toContain('<details class="think-block"')
+    expect(out).not.toContain('<style')
+    expect(out).toContain('&lt;style&gt;')
+  })
+
+  it('escapes inline formatting tags too, by design', () => {
+    // <br>/<kbd>/<details> are harmless on their own, but the rule is "no
+    // element from reply text reaches the app's document" rather than a
+    // per-tag allowlist. Pinned so it is a decision, not an oversight.
+    const out = renderMarkdown('| A |\n|---|\n| one<br>two |')
+    expect(out).not.toContain('<br>')
+    expect(out).toContain('&lt;br&gt;')
   })
 
   it('escapes inline HTML too', () => {
@@ -191,5 +225,50 @@ describe('renderMarkdown: raw HTML in reply text', () => {
     const out = renderMarkdown('```html\n<div class="modal">x</div>\n```')
     expect(out).toContain('class="code-block"')
     expect(out).not.toContain('<div class="modal">x</div>')
+  })
+})
+
+describe('renderMarkdown: rawHtml opt-out', () => {
+  // The markdown artifact preview renders into a sandboxed srcdoc iframe with
+  // its own stylesheet, where a document's own tags are content — and
+  // artifacts.ts's local-ref inlining needs to see <img src="…"> to rewrite it.
+  it('keeps the source tags as markup when asked', () => {
+    const out = renderMarkdown('<img src="chart.png">', true, { rawHtml: true })
+    expect(out).toContain('<img src="chart.png"')
+    expect(out).not.toContain('&lt;img')
+  })
+
+  it('keeps <details> usable in a rendered document', () => {
+    const out = renderMarkdown('<details><summary>more</summary>body</details>', true, { rawHtml: true })
+    expect(out).toContain('<details>')
+    expect(out).toContain('<summary>')
+  })
+
+  it('still drops scripts and event handlers in rawHtml mode', () => {
+    // rawHtml relaxes the escape, not DOMPurify.
+    const out = renderMarkdown('<script>alert(1)</script><img src=x onerror=alert(1)>', true, { rawHtml: true })
+    expect(out).not.toContain('<script')
+    expect(out).not.toContain('onerror')
+  })
+
+  it('does not leak the mode into the next render', () => {
+    // The renderer is a module-level singleton; the flag has to be per-call or
+    // one artifact preview would disable escaping for every chat bubble after
+    // it.
+    renderMarkdown('<div class="backdrop">x</div>', true, { rawHtml: true })
+    const out = renderMarkdown('<div class="backdrop">x</div>')
+    expect(out).not.toContain('<div')
+    expect(out).toContain('&lt;div class=')
+  })
+
+  it('restores escaping even when the parse throws', () => {
+    const spy = vi.spyOn(marked, 'parse').mockImplementation(() => {
+      throw new Error('boom')
+    })
+    expect(() => renderMarkdown('x', true, { rawHtml: true })).toThrow('boom')
+    spy.mockRestore()
+    const out = renderMarkdown('<div class="backdrop">x</div>')
+    expect(out).not.toContain('<div')
+    expect(out).toContain('&lt;div class=')
   })
 })

--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -93,10 +93,13 @@ describe('renderMarkdown: link labels (#2088)', () => {
   })
 
   it('sanitizes dangerous HTML in link labels', () => {
-    // Inline HTML in the label now flows through parseInline like everywhere
-    // else in the document; the final DOMPurify pass is what keeps it safe.
+    // Inline HTML in the label flows through parseInline like everywhere else
+    // in the document, so renderer.html escapes it into text: the tag never
+    // becomes an element, and the onerror text that survives is inert (the
+    // DOMPurify pass behind it stays as the second line of defence).
     const out = renderMarkdown('[a <img src=x onerror=alert(1)> c](https://example.com)')
-    expect(out).not.toContain('onerror')
+    expect(out).not.toContain('<img')
+    expect(out).toContain('&lt;img src=x onerror=alert(1)&gt;')
     const out2 = renderMarkdown('[x <script>alert(1)</script>](https://example.com)')
     expect(out2).not.toContain('<script>')
   })
@@ -124,5 +127,69 @@ describe('renderMarkdown: renderer installed once (#2089)', () => {
     expect(after.link).toBe(before.link)
     expect(after.blockquote).toBe(before.blockquote)
     expect(after.table).toBe(before.table)
+  })
+})
+
+describe('renderMarkdown: raw HTML in reply text', () => {
+  // A model wrote GitDiffModal.svelte and narrated it inline, without a code
+  // fence. The component's own markup and <style> reached the chat DOM, where
+  // the app's global CSS turned them into a live full-screen overlay.
+  const modalSrc = [
+    '写 GitDiffModal.svelte（全屏弹窗）。',
+    '',
+    '<div class="backdrop" role="presentation" onclick={close}>',
+    '  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">',
+    "    <button class=\"btn\" onclick={() => act('revert')} disabled={busy}>Revert</button>",
+    '  </div>',
+    '</div>',
+    '',
+    '<style>.backdrop { position: fixed; inset: 0; z-index: 9999; }</style>',
+  ].join('\n')
+
+  it('escapes block-level HTML instead of building real nodes', () => {
+    const out = renderMarkdown(modalSrc)
+    // No element survives — only escaped text. Attribute-looking substrings
+    // (role="dialog") are fine inside a text node; what must not appear is a
+    // tag that opens one.
+    expect(out).not.toContain('<div')
+    expect(out).not.toContain('<button')
+    expect(out).not.toContain('<style')
+    expect(out).toContain('&lt;div class="backdrop" role="presentation"')
+    expect(out).toContain('&lt;style&gt;')
+  })
+
+  it('escapes inline HTML too', () => {
+    const out = renderMarkdown('the wrapper is <span class="chat-overlay">here</span> ok')
+    expect(out).not.toContain('<span')
+    expect(out).toContain('&lt;span class="chat-overlay"&gt;here&lt;/span&gt;')
+  })
+
+  it('keeps escaping tags DOMPurify would have allowed', () => {
+    // <img>/<a> survive sanitization, so only the renderer-level escape keeps
+    // them out of the DOM.
+    const out = renderMarkdown('<img src="x"> and <a href="https://example.com">link</a>')
+    expect(out).not.toContain('<img')
+    expect(out).not.toContain('<a href=')
+    expect(out).toContain('&lt;img src="x"&gt;')
+  })
+
+  it('still renders markdown-authored structure around escaped HTML', () => {
+    const out = renderMarkdown('**bold** then <div>raw</div> then `code`')
+    expect(out).toContain('<strong>bold</strong>')
+    expect(out).toContain('<code>code</code>')
+    expect(out).toContain('&lt;div&gt;raw&lt;/div&gt;')
+  })
+
+  it('leaves think blocks working — they are extracted before marked runs', () => {
+    const out = renderMarkdown('<think>weighing **options**</think>answer')
+    expect(out).toContain('<details class="think-block"')
+    expect(out).toContain('<strong>options</strong>')
+    expect(out).not.toContain('&lt;think&gt;')
+  })
+
+  it('renders fenced HTML as a code block, not as markup', () => {
+    const out = renderMarkdown('```html\n<div class="modal">x</div>\n```')
+    expect(out).toContain('class="code-block"')
+    expect(out).not.toContain('<div class="modal">x</div>')
   })
 })

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -99,6 +99,21 @@ renderer.table = function (token: Tokens.Table) {
   return `<div class="table-scroll"><table><thead>${header}</thead>${body}</table></div>`
 }
 
+// Raw HTML in reply text is shown as text, never handed to the DOM. marked
+// routes both block-level and inline HTML tokens through renderer.html, and
+// letting them pass meant a model writing a .svelte/.html file inline (no code
+// fence — some harnesses narrate and paste at once) put real nodes into the
+// chat: a GitDiffModal.svelte source dropped a live <div class="backdrop">/
+// <div class="modal"> plus its <style> into the bubble, where the app's global
+// CSS made it a fixed full-screen overlay covering the page. DOMPurify does not
+// stop that — it strips scripts, event handlers and javascript: URLs, not
+// layout markup or CSS — so the escape has to happen at the renderer.
+// Returning false here would make marked.use() fall back to the default
+// pass-through renderer; an escaped string (empty included) never does.
+renderer.html = function ({ text }: Tokens.HTML | Tokens.Tag) {
+  return escapeHtml(text)
+}
+
 marked.use({ renderer })
 
 export function renderMarkdown(text: string, showReasoning = true): string {

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -99,24 +99,42 @@ renderer.table = function (token: Tokens.Table) {
   return `<div class="table-scroll"><table><thead>${header}</thead>${body}</table></div>`
 }
 
-// Raw HTML in reply text is shown as text, never handed to the DOM. marked
-// routes both block-level and inline HTML tokens through renderer.html, and
-// letting them pass meant a model writing a .svelte/.html file inline (no code
-// fence — some harnesses narrate and paste at once) put real nodes into the
-// chat: a GitDiffModal.svelte source dropped a live <div class="backdrop">/
-// <div class="modal"> plus its <style> into the bubble, where the app's global
-// CSS made it a fixed full-screen overlay covering the page. DOMPurify does not
-// stop that — it strips scripts, event handlers and javascript: URLs, not
-// layout markup or CSS — so the escape has to happen at the renderer.
+// Raw HTML in a reply is shown as text, never handed to the DOM (#2181). A
+// model writing a .svelte/.html file inline — no code fence around the source —
+// otherwise dropped real nodes into the chat: a GitDiffModal.svelte source put a
+// live <div class="backdrop">/<div class="modal"> plus its <style> in the
+// bubble, where the app's global CSS turned it into a fixed full-screen overlay.
+// DOMPurify is no defence against that shape — it strips scripts, event handlers
+// and javascript: URLs, not layout markup or CSS — so the escape belongs at the
+// renderer, which is also where marked funnels BOTH block-level and inline HTML
+// tokens. Inline formatting tags (<br>, <kbd>, <details>) become visible text
+// too; that bluntness is deliberate, since the risk is any element reaching the
+// app's document, not a specific tag list.
+//
+// A markdown artifact preview opts back out via renderMarkdown's rawHtml: it
+// renders in a sandboxed srcdoc iframe carrying its own stylesheet, so a
+// document's own <img src="chart.png"> is content there, not an injection (and
+// artifacts.ts's local-ref inlining has to see that tag to rewrite it). marked's
+// renderer is a module-level singleton — installing it per call leaks wrapper
+// chains (#2089) — so the mode is a flag flipped around the synchronous parse.
+let rawHtmlAllowed = false
+
 // Returning false here would make marked.use() fall back to the default
 // pass-through renderer; an escaped string (empty included) never does.
 renderer.html = function ({ text }: Tokens.HTML | Tokens.Tag) {
-  return escapeHtml(text)
+  return rawHtmlAllowed ? text : escapeHtml(text)
 }
 
 marked.use({ renderer })
 
-export function renderMarkdown(text: string, showReasoning = true): string {
+/** rawHtml keeps the source's own HTML tags as markup instead of escaping them
+ * into text. Only for a target that is not the app's own document — see the
+ * renderer.html note above. */
+export function renderMarkdown(
+  text: string,
+  showReasoning = true,
+  opts: { rawHtml?: boolean } = {}
+): string {
   if (!text) return ""
 
   // 1. Extract <think>...</think> blocks, replace with placeholders
@@ -130,14 +148,23 @@ export function renderMarkdown(text: string, showReasoning = true): string {
     return `${PLACEHOLDER}${index}\x00`
   })
 
-  // 2. Parse remaining text with marked
-  const renderedMain = marked.parse(textWithPlaceholders) as string
+  rawHtmlAllowed = opts.rawHtml === true
+  let renderedMain: string
+  let thinkBlocks: string[]
+  try {
+    // 2. Parse remaining text with marked
+    renderedMain = marked.parse(textWithPlaceholders) as string
 
-  // 3. Build think block HTML for each segment
-  const thinkBlocks = thinkSegments.map((segment) => {
-    const renderedSegment = DOMPurify.sanitize(marked.parse(segment) as string)
-    return `<details class="think-block"><summary class="think-summary"><iconify-icon icon="ant-design:bulb-outlined" width="13"></iconify-icon>Thoughts</summary><div class="think-body">${renderedSegment}</div></details>`
-  })
+    // 3. Build think block HTML for each segment
+    thinkBlocks = thinkSegments.map((segment) => {
+      const renderedSegment = DOMPurify.sanitize(marked.parse(segment) as string)
+      return `<details class="think-block"><summary class="think-summary"><iconify-icon icon="ant-design:bulb-outlined" width="13"></iconify-icon>Thoughts</summary><div class="think-body">${renderedSegment}</div></details>`
+    })
+  } finally {
+    // Escaping is the default the chat depends on: a throw mid-parse must not
+    // leave the singleton renderer in pass-through mode for the next caller.
+    rawHtmlAllowed = false
+  }
 
   // 4. Replace placeholders with think block HTML, then sanitize the combined
   //    output. DOMPurify removes dangerous markup (script, event handlers,


### PR DESCRIPTION
## Problem

A user reported that a chat reply suddenly covered the page with a modal overlay, and suspected XSS.

It is not script execution — DOMPurify does strip `<script>`, event handlers and `javascript:` URLs. What actually happened is HTML + CSS injection:

- the model was writing a `GitDiffModal.svelte` component and narrated while pasting, so part of the source landed in the reply text with no code fence around it;
- `marked` hands both block-level and inline HTML tokens to `renderer.html`, whose default emits them verbatim;
- DOMPurify keeps layout markup and `<style>`, so the component's own `<div class="backdrop">` / `<div class="modal" role="dialog">` became real nodes and `.backdrop { position: fixed; inset: 0; z-index: 9999 }` became a global rule — a live full-screen overlay in the chat.

DevTools on the report showed exactly that tree inside the assistant bubble, `<style>` element included. Reproduced locally against `renderMarkdown` byte-for-byte, down to the stray `" e.stopPropagation()}> "` text node the HTML parser leaves when it closes the tag early at the `>` of `=>`.

Beyond the broken layout, surviving CSS is enough to repaint the UI and paint convincing fake chrome, so this is worth closing off rather than treating as a cosmetic glitch.

## Fix

Override `renderer.html` to escape the token text. Raw HTML in reply text now renders as visible text, and only markdown-authored structure reaches the DOM. Both block and inline HTML tokens go through this one method, so the single override covers both. Fenced HTML is untouched — it never becomes an `html` token. DOMPurify stays in place as the second line of defence.

All three `{@html renderMarkdown(...)}` consumers (`ChatView`, `mobile/ChatDetail`, `ProfileView`) share the function, so they are all covered; the desktop shell reuses the same `webdist`.

Trade-off: a model that leans on `<br>`, `<kbd>` or `<details>` for layout now shows those tags as text. That is the deliberate choice — same as the major chat UIs.

## Tests

`web/src/lib/markdown.test.ts` — new suite covering the reported component source (no `<div>`/`<button>`/`<style>` element survives), inline HTML, tags DOMPurify would have allowed (`<img>`, `<a>`), markdown structure still rendering around escaped HTML, `<think>` blocks still working (they are extracted before `marked` runs), and fenced HTML still rendering as a code block.

One existing assertion changed: the #2088 link-label test asserted the absence of the `"onerror"` substring, which the escape leaves behind as inert text; it now asserts the absence of the `<img>` element instead.

`npx vitest run` → 348 passed (24 files). `npx svelte-check` → 0 errors (2 pre-existing CSS warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)