### PR TITLE
fix(web): nudge the More popover right and shorten its label

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -46,7 +46,7 @@
     const r = anchor.getBoundingClientRect()
     morePos = mode === 'rail'
       ? { top: r.top, left: r.right + 6, width: 168 }
-      : { top: r.bottom + 2, left: r.left, width: r.width + 8 }
+      : { top: r.bottom + 2, left: r.left + 8, width: r.width + 8 }
     morePopoverOpen = true
   }
   // Everything reachable but not reached often. The four destinations that ARE

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -927,7 +927,7 @@ export const zh: Record<string, string> = {
   "nav.light_apps": "轻应用",
   "nav.file_recall": "文件回收站",
   "nav.settings": "设置",
-  "nav.manage": "更多配置",
+  "nav.manage": "更多",
   "nav.agents": "专家",
   "nav.workbench": "智能体工作台",
   "agents.desc": "为不同任务创建和管理自定义专家角色",


### PR DESCRIPTION
## What

Two small touches to the expanded sidebar's **More** entry:

- The popover opened flush with its row's left edge, so it read as hanging off the rail rather than dropping from the row. Offset it 8px to the right.
- Chinese label 更多配置 → 更多. The menu holds more than configuration; the English side already said just "More".

Rail (collapsed) mode is untouched.

## Test

`svelte-check` clean; verified visually against a local `octo serve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)