### PR TITLE
fix(web): command palette deep-links into Settings' data management

### DIFF
--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cmdkOpen, view, sessions, activeSessionId, skills, openAgentSession, createNewSession, panelContent, settingsModalOpen, isDesktopShell } from '../../lib/stores'
+  import { cmdkOpen, view, sessions, activeSessionId, skills, openAgentSession, createNewSession, panelContent, settingsModalOpen, openSettingsAt, isDesktopShell } from '../../lib/stores'
   import { t } from '../../lib/i18n'
 
   let query = $state('')
@@ -34,10 +34,13 @@
     close()
   }
 
-  // Assistant Memory moved into Settings' 数据管理 — no standalone view left
-  // to route to, so this opens Settings instead of a dead view.set('profile').
-  function openMemorySettings() {
-    settingsModalOpen.set(true)
+  // Assistant Memory, the file recycle bin and archived sessions all moved
+  // into Settings' 数据管理 — no standalone views left to route to, so these
+  // deep-link straight to the sub-view instead of dropping the user on the
+  // Settings landing page (or, for 'files', on a dead view.set that rendered
+  // an empty main area).
+  function openDataSettings(sub: string) {
+    openSettingsAt('data', sub)
     close()
   }
 
@@ -56,8 +59,9 @@
     { id: 'browser', icon: 'ant-design:global-outlined', label: () => $t('nav.browser'), shortcut: '', run: () => goTo('browser') },
     { id: 'mcp', icon: 'ant-design:api-outlined', label: () => $t('nav.mcp'), shortcut: '', run: () => goTo('mcp') },
     { id: 'channels', icon: 'ant-design:mobile-outlined', label: () => $t('nav.channels'), shortcut: '', run: () => goTo('channels') },
-    { id: 'memory', icon: 'ant-design:user-outlined', label: () => $t('nav.memory'), shortcut: '', run: () => openMemorySettings() },
-    { id: 'files', icon: 'ant-design:folder-open-outlined', label: () => $t('nav.file_recall'), shortcut: '', run: () => goTo('files') },
+    { id: 'archived', icon: 'ant-design:inbox-outlined', label: () => $t('settings.data.archived'), shortcut: '', run: () => openDataSettings('archived') },
+    { id: 'files', icon: 'ant-design:folder-open-outlined', label: () => $t('nav.file_recall'), shortcut: '', run: () => openDataSettings('trash') },
+    { id: 'memory', icon: 'ant-design:user-outlined', label: () => $t('nav.memory'), shortcut: '', run: () => openDataSettings('memory') },
     { id: 'lightapps', icon: 'ant-design:appstore-outlined', label: () => $t('nav.light_apps'), shortcut: '', run: () => goTo('lightapps') },
     { id: 'artifacts', icon: 'ant-design:file-text-outlined', label: () => $t('artifacts.toggle'), shortcut: '', run: () => { panelContent.update(v => v ? null : 'session') } },
     { id: 'settings', icon: 'ant-design:setting-outlined', label: () => $t('nav.settings'), shortcut: '', run: () => { close(); settingsModalOpen.set(true) } },

--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -6,7 +6,7 @@
   import FileRecallView from '../../views/FileRecallView.svelte'
   import ProfileView from '../../views/ProfileView.svelte'
   import { get } from 'svelte/store'
-  import { showToast, nativeShell, settingsModalOpen, onboardPhase, sessions, sessionGroups, collapsedSessions, activeSessionId, view, clearPendingSessionOpts } from '../../lib/stores'
+  import { showToast, nativeShell, settingsModalOpen, settingsTarget, onboardPhase, sessions, sessionGroups, collapsedSessions, activeSessionId, view, clearPendingSessionOpts } from '../../lib/stores'
   import type { Session, SessionGroup } from '../../lib/types'
   import { setLocale, t, tr } from '../../lib/i18n'
   import { getMode, setMode, type ThemeMode } from '../../lib/theme'
@@ -244,8 +244,13 @@
   // the modal last closed.
   $effect(() => {
     if ($settingsModalOpen) {
-      cat = 'general'
+      // A deep link (command palette, in-app shortcut) picks the category and
+      // 数据管理 sub-view; a plain open falls back to the default landing.
+      const target = get(settingsTarget)
+      cat = (target?.cat as typeof cat) ?? 'general'
       resetDataView()
+      if (target?.dataSubView) dataSubView = target.dataSubView as typeof dataSubView
+      if (target) settingsTarget.set(null)
       loadConfig()
       loadVersion()
       if (get(nativeShell)) api.getAutostart().then(v => (autostart = v)).catch(() => {})

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -38,6 +38,16 @@ export const cmdkOpen = writable(false)
 export const mcpModalOpen = writable(false)
 // Drives the Settings modal (replaces the old full-page 'settings' view).
 export const settingsModalOpen = writable(false)
+// Optional deep link consumed by the next Settings open: which category, and
+// for 数据管理 which sub-view. Callers that just want the modal set only
+// settingsModalOpen and land on the default category. The modal clears this
+// once applied, so a later plain open isn't stuck on the old target.
+export interface SettingsTarget { cat: string; dataSubView?: string }
+export const settingsTarget = writable<SettingsTarget | null>(null)
+export function openSettingsAt(cat: string, dataSubView?: string) {
+  settingsTarget.set({ cat, dataSubView })
+  settingsModalOpen.set(true)
+}
 export interface ToastEntry { id: number; msg: string; type: string }
 export const toasts = writable<ToastEntry[]>([])
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type View = 'chat' | 'agents' | 'skills' | 'workflows' | 'tasks' | 'browser' | 'mcp' | 'channels' | 'files' | 'lightapps'
+export type View = 'chat' | 'agents' | 'skills' | 'workflows' | 'tasks' | 'browser' | 'mcp' | 'channels' | 'lightapps'
 export type SidebarMode = 'full' | 'rail' | 'hidden'
 export type MemTab = 'soul' | 'user' | 'memories'
 export type ArtifactView = 'preview' | 'code'


### PR DESCRIPTION
## Problem

Assistant Memory, the file recycle bin and archived sessions all live inside Settings > 数据管理 now, but the command palette never followed:

- **助手记忆** opened Settings on its landing category, leaving the user to find the entry themselves.
- **文件回收站** still ran `view.set('files')`. `App.svelte` no longer renders that view (and dropped it from `VALID_VIEWS`), so the item blanked the main area — a dead route.
- **Archived sessions** had no palette entry at all.

## Change

- New `settingsTarget` store: an optional deep link the next Settings open consumes to pick its category and 数据管理 sub-view, then clears. Callers that only set `settingsModalOpen` keep landing on the default category.
- All three palette entries route through it, in the same order the 数据管理 list uses.
- Drop the unused `'files'` member of the `View` union so the dead route can't be written again.

No new i18n keys — the archived entry reuses `settings.data.archived`.

## Verification

- `npx svelte-check` — 0 errors
- `npx vitest run` — 24 files, 342 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)