### PR TITLE
fix(tools): steer Windows file writes away from PowerShell cmdlets

### DIFF
--- a/internal/tools/envnote.go
+++ b/internal/tools/envnote.go
@@ -13,10 +13,19 @@ import "runtime"
 //     is invisible until PATH is refreshed in-command or octo restarts;
 //   - installers raise a UAC dialog only a user at the screen can approve;
 //   - the default execution policy blocks Node's npm.ps1 shim.
+//
+// It also steers file writes away from the PowerShell cmdlets entirely: their
+// default encodings (ANSI from Set-Content, UTF-16LE from `>`) re-encode files
+// that were UTF-8, which users see as their source files getting corrupted.
 const shellEnvNoteWindows = "- Shell: PowerShell. Use PowerShell syntax and cmdlets " +
 	"(Get-ChildItem, Get-Content, Select-String, Remove-Item, $env:VAR), not POSIX sh. " +
 	"Chain commands with `;` rather than `&&` (Windows PowerShell 5.1 lacks `&&`). " +
 	"Prefer the built-in read_file / glob / grep tools over shelling out — they're identical across platforms.\n" +
+	"- Writing files: never create or rewrite a file with `Set-Content`, `Add-Content`, `Out-File`, `>` or `>>`. " +
+	"Windows PowerShell 5.1 writes ANSI (the host code page — GBK on a Chinese Windows) from Set-Content/Add-Content " +
+	"and UTF-16LE from `>`/Out-File, while Get-Content decodes as ANSI, so a read-modify-write pipeline such as " +
+	"`(Get-Content f) -replace 'a','b' | Set-Content f` silently re-encodes a UTF-8 file and drops every character " +
+	"the code page cannot map. Use write_file / edit_file instead — they always read and write UTF-8.\n" +
 	"- Installing tools mid-session: every terminal command runs in a fresh shell inheriting octo's " +
 	"startup PATH, so a tool installed via winget/MSI is NOT found afterwards even though the install " +
 	"succeeded. Refresh PATH inside the same command — " +

--- a/internal/tools/envnote_test.go
+++ b/internal/tools/envnote_test.go
@@ -14,7 +14,9 @@ func TestShellEnvNoteContent(t *testing.T) {
 		"GetEnvironmentVariable('Path','Machine')", // in-command PATH refresh
 		"restart octo",
 		"UAC",
-		"npm.cmd", // execution-policy workaround
+		"Set-Content", // ANSI/UTF-16 default encodings corrupt UTF-8 files
+		"write_file",  // the encoding-safe alternative it must point at
+		"npm.cmd",     // execution-policy workaround
 	} {
 		if !strings.Contains(shellEnvNoteWindows, want) {
 			t.Errorf("windows note missing %q", want)


### PR DESCRIPTION
A Windows user reported that files came back with their encoding corrupted after
the model edited them through the terminal tool.

Root cause is Windows PowerShell 5.1's file-cmdlet defaults, which are not what
either the model or the prefix we inject assumes:

| write path | Windows PowerShell 5.1 | pwsh 7 |
| --- | --- | --- |
| `Set-Content` / `Add-Content` | ANSI (host code page — GBK on a Chinese Windows) | UTF-8 no BOM |
| `Out-File` / `>` / `>>` / `Tee-Object` | UTF-16LE with BOM | UTF-8 no BOM |
| `Get-Content` (read) | decodes as ANSI | UTF-8 |

`resolvePowerShell()` prefers `pwsh` but falls back to `powershell`, and stock
Windows ships no pwsh — so most Windows users are on 5.1 and hit all three
rows. The damage mode that reaches users is the read-modify-write pipeline:

```powershell
(Get-Content foo.go) -replace 'a','b' | Set-Content foo.go
```

A UTF-8 file is decoded as GBK and re-encoded as GBK. Characters the code page
cannot map become `?` — irreversibly. Unlike a UTF-16 rewrite, which is obvious
the moment a compiler chokes, this looks like "the Chinese comments turned into
mojibake" and survives unnoticed.

`executil.PowerShellUTF8EncodingPrefix` does not help here: it sets
`[Console]::OutputEncoding` / `$OutputEncoding` / `PYTHONIOENCODING`, which
govern child-process stdio decoding, not cmdlet file-encoding defaults.

## Fix

Tell the model not to write files through the shell at all. `write_file` /
`edit_file` are UTF-8 on every platform, so the whole class of problems is
sidestepped rather than patched.

The alternative — forcing `$PSDefaultParameterValues['*:Encoding'] = 'utf8'` in
the prefix — was considered and rejected for now: 5.1 has no `utf8NoBOM`, so it
trades silent mojibake for stray BOMs that break shell scripts, some JSON
parsers, and Go files; and whether it reaches the `>` redirection operator on
5.1 needs verifying on real hardware.

## Test

Existing `TestShellEnvNoteContent` gains `Set-Content` and `write_file` to the
load-bearing-substring table so the guidance can't be dropped silently.

`gofmt -l` clean, `go vet` clean, `go test ./internal/tools/ ./cmd/octo/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
