### PR TITLE
fix(tools): find a just-installed pwsh that PATH lookup misses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Five-layer stack with one-directional dependencies:
    Provider wire quirks are encapsulated here — the agent layer never branches on protocol.
 
 5. **Tools (`internal/tools/`)** — concrete `ToolExecutor` implementations.
-   - `terminal.go` — current canonical example. Tool name `terminal` rather than `bash` because the implementation shells out via the platform shell — `sh -c` on macOS/Linux, PowerShell (`pwsh`, else `powershell`) on Windows — not a hard `/bin/bash` dependency. The shell is selected in one place: `shellCommand` in `sandbox.go`. The model is told which shell it's on via the environment context (`cmd/octo/envcontext.go`).
+   - `terminal.go` — current canonical example. Tool name `terminal` rather than `bash` because the implementation shells out via the platform shell — `sh -c` on macOS/Linux, PowerShell (`pwsh`, else `powershell`) on Windows — not a hard `/bin/bash` dependency. The shell binary is selected in one place — `executil.PowerShell()` — shared by the terminal tool, hook scripts, and clipboard capture so a session never straddles two PowerShells; `shellCommand` in `sandbox.go` is the single place the command is wrapped. The model is told which shell it's on via the environment context (`cmd/octo/envcontext.go`).
    - `DefaultRegistry` dispatches by tool name. `DefaultTools()` returns the set sent to the LLM (tools are on by default; `--no-tools` disables them).
 
 ## Adding capability

--- a/cmd/octo/clipimg_windows.go
+++ b/cmd/octo/clipimg_windows.go
@@ -14,15 +14,11 @@ import (
 )
 
 // captureClipboardImage reads an image from the Windows clipboard via
-// PowerShell, saving it to a temp PNG and reading it back. Prefers pwsh
-// (PowerShell 7+) and falls back to the built-in powershell.exe — the same
-// selection the terminal tool makes. Returns a friendly error when the
-// clipboard holds no image.
+// PowerShell, saving it to a temp PNG and reading it back. The shell comes from
+// executil.PowerShell — the same selection the terminal tool makes. Returns a
+// friendly error when the clipboard holds no image.
 func captureClipboardImage() (data []byte, mime string, err error) {
-	shell := "powershell"
-	if p, e := exec.LookPath("pwsh"); e == nil {
-		shell = p
-	}
+	shell := executil.PowerShell()
 
 	tmp, err := os.CreateTemp("", "octo-clip-*.png")
 	if err != nil {

--- a/internal/executil/powershell.go
+++ b/internal/executil/powershell.go
@@ -1,8 +1,78 @@
 package executil
 
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+)
+
 // PowerShellUTF8EncodingPrefix is prepended to every Windows PowerShell command
 // so that child-process output is interpreted and forwarded as UTF-8.  Without
 // this, a Chinese Windows host (default codepage 936 / GBK) decodes UTF-8 bytes
 // from Python or other tools as GBK, producing the diamond-question-mark
 // garbling users see in terminal output.
 const PowerShellUTF8EncodingPrefix = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8; $env:PYTHONIOENCODING='utf-8'; `
+
+// PowerShell returns the Windows shell to run commands through: PowerShell 7+
+// (`pwsh`) when present — it's the modern, cross-platform build, supports
+// `&&`/`||` pipeline chaining, and defaults its file cmdlets to UTF-8 rather
+// than 5.1's ANSI and UTF-16 — else Windows PowerShell 5.1 (`powershell`),
+// which ships with every supported Windows and is always available as the
+// fallback.
+//
+// It lives here rather than beside any one caller because three entry points
+// need the same answer — the terminal tool (internal/tools), hook scripts
+// (internal/hooks), and clipboard image capture (cmd/octo) — and they must not
+// disagree about which PowerShell a session is on.
+//
+// Resolved once per process: the answer cannot change without a restart, and
+// every terminal command would otherwise pay the lookup.
+func PowerShell() string { return resolvePowerShell() }
+
+var resolvePowerShell = sync.OnceValue(func() string {
+	return powerShellIn(os.Getenv("ProgramFiles"), os.Getenv("ProgramFiles(x86)"))
+})
+
+// powerShellIn is PowerShell's logic with the MSI search roots injected, so a
+// test can exercise the selection without a real PowerShell 7 install.
+//
+// PATH lookup alone is not enough. A pwsh installed after this process started
+// — notably by the installer's own EnsurePowerShell7 step, whose winget run
+// finishes moments before the installer launches the app — is on the machine
+// PATH but not on the environment block this process inherited, so LookPath
+// misses it and the memoization above caches that miss for the whole session.
+// Probing the MSI's fixed install location covers that, and covers every
+// install channel rather than just octo-setup.exe.
+func powerShellIn(msiRoots ...string) string {
+	if path, err := exec.LookPath("pwsh"); err == nil {
+		return path
+	}
+	if path := probePwshMSI(msiRoots...); path != "" {
+		return path
+	}
+	return "powershell"
+}
+
+// probePwshMSI returns the pwsh.exe the PowerShell 7 MSI installs under one of
+// the given Program Files roots, or "" when none holds one. Store-distributed
+// pwsh needs no probing: it sits under WindowsApps behind an execution alias
+// that is on PATH from the start, which LookPath resolves.
+//
+// The major-version directory is part of the MSI layout and is hardcoded, so
+// this silently stops finding pwsh when PowerShell 8 lands under `PowerShell\8`.
+func probePwshMSI(roots ...string) string {
+	for _, dir := range roots {
+		// A relative root would make exec.Cmd resolve the shell against the
+		// session's working directory (cmd.Dir), running a pwsh.exe out of
+		// whatever repo the user happens to be in.
+		if dir == "" || !filepath.IsAbs(dir) {
+			continue
+		}
+		path := filepath.Join(dir, "PowerShell", "7", "pwsh.exe")
+		if st, err := os.Stat(path); err == nil && !st.IsDir() {
+			return path
+		}
+	}
+	return ""
+}

--- a/internal/executil/powershell_test.go
+++ b/internal/executil/powershell_test.go
@@ -1,0 +1,113 @@
+package executil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// pwshName is the filename LookPath resolves on this platform, so the tests
+// that plant a fake pwsh run everywhere rather than being Windows-gated.
+func pwshName() string {
+	if runtime.GOOS == "windows" {
+		return "pwsh.exe"
+	}
+	return "pwsh"
+}
+
+// plantPwsh writes an executable fake pwsh at root's MSI location and returns
+// its path.
+func plantPwsh(t *testing.T, root string) string {
+	t.Helper()
+	path := filepath.Join(root, "PowerShell", "7", "pwsh.exe")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, nil, 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+// TestPowerShellIn_ProbesMSIWhenPathMisses is the regression that matters: a
+// pwsh installed after this process started is on the machine PATH but not on
+// the inherited environment block, so PATH lookup alone leaves the session on
+// PowerShell 5.1 for good (the answer is memoized).
+func TestPowerShellIn_ProbesMSIWhenPathMisses(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	if got := powerShellIn(); got != "powershell" {
+		t.Errorf("no pwsh anywhere should fall back to \"powershell\", got %q", got)
+	}
+
+	root := t.TempDir()
+	want := plantPwsh(t, root)
+	if got := powerShellIn(root); got != want {
+		t.Errorf("powerShellIn = %q, want the probed MSI path %q", got, want)
+	}
+}
+
+// TestPowerShellIn_PathWinsOverProbe pins the precedence: a pwsh the user put
+// on PATH (a different version, a preview build) must not be displaced by the
+// MSI at its fixed location.
+func TestPowerShellIn_PathWinsOverProbe(t *testing.T) {
+	onPath := t.TempDir()
+	chosen := filepath.Join(onPath, pwshName())
+	if err := os.WriteFile(chosen, nil, 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Setenv("PATH", onPath)
+
+	root := t.TempDir()
+	plantPwsh(t, root)
+
+	got := powerShellIn(root)
+	if got != chosen {
+		t.Errorf("powerShellIn = %q, want the PATH pwsh %q", got, chosen)
+	}
+}
+
+// TestProbePwshMSI covers the probe's own edges. Path-shaped only, so it runs
+// on every platform.
+func TestProbePwshMSI(t *testing.T) {
+	first, second := t.TempDir(), t.TempDir()
+
+	if got := probePwshMSI(first, second); got != "" {
+		t.Errorf("no pwsh installed should probe to \"\", got %q", got)
+	}
+	if got := probePwshMSI("", ""); got != "" {
+		t.Errorf("unset Program Files roots should probe to \"\", got %q", got)
+	}
+
+	// A relative root is skipped rather than joined, even when it does hold a
+	// pwsh: exec.Cmd resolves a relative shell path against the session's
+	// working directory, which would run a pwsh.exe out of the user's repo.
+	cwd := t.TempDir()
+	plantPwsh(t, cwd)
+	t.Chdir(cwd)
+	if got := probePwshMSI("."); got != "" {
+		t.Errorf("a relative root must be skipped, got %q", got)
+	}
+
+	// A directory named pwsh.exe must not satisfy the probe.
+	if err := os.MkdirAll(filepath.Join(first, "PowerShell", "7", "pwsh.exe"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if got := probePwshMSI(first, second); got != "" {
+		t.Errorf("a pwsh.exe directory should not count, got %q", got)
+	}
+
+	// A later root still wins when the earlier ones hold nothing usable.
+	want := plantPwsh(t, second)
+	if got := probePwshMSI(first, second); got != want {
+		t.Errorf("probe = %q, want %q", got, want)
+	}
+
+	// Earlier roots take precedence: ProgramFiles before ProgramFiles(x86).
+	earlier := t.TempDir()
+	earlierWant := plantPwsh(t, earlier)
+	if got := probePwshMSI(earlier, second); got != earlierWant {
+		t.Errorf("probe = %q, want the earlier root's %q", got, earlierWant)
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -240,16 +240,13 @@ func runShellRaw(ctx context.Context, cmd string, stdin []byte, deadline time.Du
 	return res
 }
 
-// shellCmd wraps cmd in the platform shell: PowerShell on Windows (preferring
-// pwsh 7+, falling back to the always-present powershell 5.1), POSIX sh -c
-// elsewhere. Mirrors internal/tools' shell selection so a hook script behaves
-// like a command the terminal tool would run.
+// shellCmd wraps cmd in the platform shell: PowerShell on Windows, POSIX sh -c
+// elsewhere. The shell comes from executil.PowerShell — the same selection the
+// terminal tool makes — so a hook script behaves like a command the terminal
+// tool would run rather than landing on a different PowerShell.
 func shellCmd(ctx context.Context, cmd string) *exec.Cmd {
 	if runtime.GOOS == "windows" {
-		shell := "powershell"
-		if _, err := exec.LookPath("pwsh"); err == nil {
-			shell = "pwsh"
-		}
+		shell := executil.PowerShell()
 		c := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", executil.PowerShellUTF8EncodingPrefix+cmd)
 		executil.SetNoWindow(c)
 		return c

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/sandbox"
@@ -129,7 +128,7 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 	if runtime.GOOS == "windows" {
 		// -NoProfile: reproducible env (don't run the user's $PROFILE).
 		// -NonInteractive: never block on a PowerShell prompt mid-command.
-		ps := resolvePowerShell()
+		ps := executil.PowerShell()
 		projectDir := WorkingDirOrCWD(ctx)
 		// Wrap Remove-Item to copy to trash first (parity with the POSIX rm
 		// wrapper) and shadow Stop-Process/taskkill so the self-kill guard
@@ -242,46 +241,4 @@ func applyWorkingDir(ctx context.Context, cmd *exec.Cmd) {
 	if dir := WorkingDir(ctx); dir != "" {
 		cmd.Dir = dir
 	}
-}
-
-// resolvePowerShell picks the Windows shell once: PowerShell 7+ (`pwsh`) when
-// present — it's the modern, cross-platform build, supports `&&`/`||` pipeline
-// chaining, and defaults its file cmdlets to UTF-8 rather than 5.1's ANSI and
-// UTF-16 — else Windows PowerShell 5.1 (`powershell`), which ships with every
-// supported Windows and is always available as the fallback.
-//
-// PATH lookup alone is not enough. A pwsh installed after this process started
-// — notably by the installer's own EnsurePowerShell7 step, whose winget run
-// finishes moments before the installer launches the app — is on the machine
-// PATH but not on the environment block this process inherited, so LookPath
-// misses it and sync.OnceValue caches that miss for the whole session. Probing
-// the MSI's fixed install location covers that, and covers every install
-// channel rather than just octo-setup.exe.
-var resolvePowerShell = sync.OnceValue(func() string {
-	if path, err := exec.LookPath("pwsh"); err == nil {
-		return path
-	}
-	if path := probePwshMSI(os.Getenv("ProgramFiles"), os.Getenv("ProgramW6432")); path != "" {
-		return path
-	}
-	return "powershell"
-})
-
-// probePwshMSI returns the pwsh.exe the PowerShell 7 MSI installs under one of
-// the given Program Files roots, or "" when none holds one. Store-distributed
-// pwsh lives under WindowsApps behind an execution alias that LookPath already
-// resolves, so only the MSI layout needs probing. Both roots are consulted
-// because ProgramW6432 is the 64-bit directory when octo itself is a 32-bit
-// process, where ProgramFiles points at "Program Files (x86)".
-func probePwshMSI(roots ...string) string {
-	for _, dir := range roots {
-		if dir == "" {
-			continue
-		}
-		path := filepath.Join(dir, "PowerShell", "7", "pwsh.exe")
-		if st, err := os.Stat(path); err == nil && !st.IsDir() {
-			return path
-		}
-	}
-	return ""
 }

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -245,12 +245,43 @@ func applyWorkingDir(ctx context.Context, cmd *exec.Cmd) {
 }
 
 // resolvePowerShell picks the Windows shell once: PowerShell 7+ (`pwsh`) when
-// present — it's the modern, cross-platform build and supports `&&`/`||`
-// pipeline chaining — else Windows PowerShell 5.1 (`powershell`), which ships
-// with every supported Windows and is always available as the fallback.
+// present — it's the modern, cross-platform build, supports `&&`/`||` pipeline
+// chaining, and defaults its file cmdlets to UTF-8 rather than 5.1's ANSI and
+// UTF-16 — else Windows PowerShell 5.1 (`powershell`), which ships with every
+// supported Windows and is always available as the fallback.
+//
+// PATH lookup alone is not enough. A pwsh installed after this process started
+// — notably by the installer's own EnsurePowerShell7 step, whose winget run
+// finishes moments before the installer launches the app — is on the machine
+// PATH but not on the environment block this process inherited, so LookPath
+// misses it and sync.OnceValue caches that miss for the whole session. Probing
+// the MSI's fixed install location covers that, and covers every install
+// channel rather than just octo-setup.exe.
 var resolvePowerShell = sync.OnceValue(func() string {
 	if path, err := exec.LookPath("pwsh"); err == nil {
 		return path
 	}
+	if path := probePwshMSI(os.Getenv("ProgramFiles"), os.Getenv("ProgramW6432")); path != "" {
+		return path
+	}
 	return "powershell"
 })
+
+// probePwshMSI returns the pwsh.exe the PowerShell 7 MSI installs under one of
+// the given Program Files roots, or "" when none holds one. Store-distributed
+// pwsh lives under WindowsApps behind an execution alias that LookPath already
+// resolves, so only the MSI layout needs probing. Both roots are consulted
+// because ProgramW6432 is the 64-bit directory when octo itself is a 32-bit
+// process, where ProgramFiles points at "Program Files (x86)".
+func probePwshMSI(roots ...string) string {
+	for _, dir := range roots {
+		if dir == "" {
+			continue
+		}
+		path := filepath.Join(dir, "PowerShell", "7", "pwsh.exe")
+		if st, err := os.Stat(path); err == nil && !st.IsDir() {
+			return path
+		}
+	}
+	return ""
+}

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -36,43 +36,6 @@ func TestShellCommand_PlatformShell(t *testing.T) {
 	}
 }
 
-// TestProbePwshMSI covers the PATH-independent PowerShell 7 lookup: a pwsh
-// installed after octo started is on the machine PATH but not on this
-// process's inherited environment, so the MSI location is probed directly.
-// Path-shaped only, so it runs on every platform.
-func TestProbePwshMSI(t *testing.T) {
-	x86, win64 := t.TempDir(), t.TempDir()
-
-	if got := probePwshMSI(x86, win64); got != "" {
-		t.Errorf("no pwsh installed should probe to \"\", got %q", got)
-	}
-	if got := probePwshMSI("", ""); got != "" {
-		t.Errorf("unset Program Files roots should probe to \"\", got %q", got)
-	}
-
-	// A directory named pwsh.exe must not satisfy the probe.
-	dir := filepath.Join(x86, "PowerShell", "7", "pwsh.exe")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if got := probePwshMSI(x86, win64); got != "" {
-		t.Errorf("a pwsh.exe directory should not count, got %q", got)
-	}
-
-	// The 64-bit root wins when only it holds a real pwsh — the 32-bit-process
-	// case where ProgramFiles points at "Program Files (x86)".
-	want := filepath.Join(win64, "PowerShell", "7", "pwsh.exe")
-	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(want, nil, 0o755); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	if got := probePwshMSI(x86, win64); got != want {
-		t.Errorf("probe = %q, want %q", got, want)
-	}
-}
-
 // TestWithBundledBinPath_AppendsAfterExistingSystemPath confirms the bundled
 // dir lands at the END of PATH, so a system-installed tool of the same name
 // still wins — the bundled copy is a fallback, never a shadow.

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -36,6 +36,43 @@ func TestShellCommand_PlatformShell(t *testing.T) {
 	}
 }
 
+// TestProbePwshMSI covers the PATH-independent PowerShell 7 lookup: a pwsh
+// installed after octo started is on the machine PATH but not on this
+// process's inherited environment, so the MSI location is probed directly.
+// Path-shaped only, so it runs on every platform.
+func TestProbePwshMSI(t *testing.T) {
+	x86, win64 := t.TempDir(), t.TempDir()
+
+	if got := probePwshMSI(x86, win64); got != "" {
+		t.Errorf("no pwsh installed should probe to \"\", got %q", got)
+	}
+	if got := probePwshMSI("", ""); got != "" {
+		t.Errorf("unset Program Files roots should probe to \"\", got %q", got)
+	}
+
+	// A directory named pwsh.exe must not satisfy the probe.
+	dir := filepath.Join(x86, "PowerShell", "7", "pwsh.exe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if got := probePwshMSI(x86, win64); got != "" {
+		t.Errorf("a pwsh.exe directory should not count, got %q", got)
+	}
+
+	// The 64-bit root wins when only it holds a real pwsh — the 32-bit-process
+	// case where ProgramFiles points at "Program Files (x86)".
+	want := filepath.Join(win64, "PowerShell", "7", "pwsh.exe")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(want, nil, 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := probePwshMSI(x86, win64); got != want {
+		t.Errorf("probe = %q, want %q", got, want)
+	}
+}
+
 // TestWithBundledBinPath_AppendsAfterExistingSystemPath confirms the bundled
 // dir lands at the END of PATH, so a system-installed tool of the same name
 // still wins — the bundled copy is a fallback, never a shadow.

--- a/internal/tools/windows_saferm_test.go
+++ b/internal/tools/windows_saferm_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/trash"
 )
 
@@ -24,7 +25,7 @@ func TestWindowsSafeRm_EndToEnd(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("windows Remove-Item wrapper only")
 	}
-	ps := resolvePowerShell()
+	ps := executil.PowerShell()
 	if _, err := exec.LookPath(ps); err != nil {
 		t.Skipf("no PowerShell (%s) available", ps)
 	}


### PR DESCRIPTION
Follow-up to #2185, which told the model to stop writing files through
PowerShell cmdlets because Windows PowerShell 5.1 defaults them to ANSI and
UTF-16. This closes the other half: making sure we actually run PowerShell 7
when it is installed.

## The gap

`resolvePowerShell` (internal/tools/sandbox.go) only consulted PATH, and it is
a `sync.OnceValue` — so a miss is cached for the entire process lifetime.

The installer walks straight into that. At `ssPostInstall`
(packaging/windows/octo.iss) it runs, in order:

1. `EnsurePowerShell7` — `winget install --id Microsoft.PowerShell`
2. `LaunchApp` — `Exec` of `octo-desktop.exe`

The launched app is a child of the installer, so it inherits the environment
block the installer captured at startup, before winget added
`C:\Program Files\PowerShell\7\` to the machine PATH. The desktop app is the
serve process, so the entire session right after install runs on 5.1 — with
exactly the encoding defaults #2185 exists to warn about — even though pwsh is
sitting on disk. It takes a later launch from Explorer, which handles
`WM_SETTINGCHANGE`, before the install takes effect.

## Fix

When `LookPath("pwsh")` fails, probe the MSI's fixed layout:
`%ProgramFiles%\PowerShell\7\pwsh.exe`. `ProgramW6432` is checked too, so a
32-bit octo (where `ProgramFiles` is `Program Files (x86)`) still finds the
64-bit install.

Fixing it here rather than in the installer means every install channel
benefits — scoop, `winget install octo`, a bare exe download — not just
`octo-setup.exe`.

Store-distributed pwsh needs nothing: it sits under `WindowsApps` behind an
execution alias that `LookPath` already resolves.

## Test

`TestProbePwshMSI` covers the not-installed, unset-roots, 64-bit-root-wins, and
`pwsh.exe`-is-a-directory cases. Path-shaped only, so it runs on every
platform rather than being Windows-gated.

`gofmt -l` clean, `go vet` clean, `go test ./internal/tools/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
