### PR TITLE
chore: bump version to 1.16.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.15.22"
+var Version = "1.16.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Minor bump rather than a patch: this cycle changes user-visible structure — a
working directory now belongs to a project rather than to a task, memory is
scoped by project rather than by git, the sidebar splits into Tasks and
Projects, and GenUI (model-generated interactive UI in chat) lands.

20 commits since v1.15.22.

**Features**
- GenUI — model-generated interactive UI in chat (#2174, design #2173)
- A working directory belongs to a project, not to a task (#2171)
- Memory scoped by project, not by git (#2167)
- Sidebar splits into Tasks and Projects (#2165)
- Session is created on the first message, not on the click (#2164)
- Working-directory picker promoted to the landing page (#2182)
- Assistant memory moves into Settings' data management (#2176)
- Page-spanning title bar split into per-block chrome (#2180)

**Fixes**
- Windows: file writes steered away from PowerShell cmdlets, whose 5.1 defaults
  (ANSI from Set-Content, UTF-16LE from `>`) silently re-encode UTF-8 files (#2185)
- Windows: a just-installed pwsh that PATH lookup misses is now found, and
  PowerShell selection became one shared decision across the terminal tool,
  hook scripts, and clipboard capture (#2186)
- Raw HTML in reply text is escaped instead of rendered (#2181)
- A forwarded port is not the local machine (#2166)
- Command palette deep-links into Settings' data management (#2184)
- Assorted web polish: More popover placement (#2183), new-Light-App prompt
  wording (#2177), pinned-label hover and spacing (#2175)

**Dependencies**
- wails/v3 in cmd/octo-desktop (#2169), go-minor-patch group (#2168),
  npm-minor-patch group (#2170)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
