### PR TITLE
fix(web): assistant memory leads Settings' data management list

### DIFF
--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -597,6 +597,16 @@
 
         {:else if cat === 'data'}
           {#if dataSubView === 'none'}
+            <!-- Memory leads: it's the row users come here to edit, while the
+                 archive and the recycle bin are visited only when something
+                 needs recovering. -->
+            <div class="data-row">
+              <div class="data-row-main">
+                <iconify-icon icon="ant-design:user-outlined" width="15"></iconify-icon>
+                <span class="setl">{$t('nav.memory')}</span>
+              </div>
+              <button class="link-btn" onclick={() => (dataSubView = 'memory')}>{$t('settings.data.manage')}</button>
+            </div>
             <div class="data-row">
               <div class="data-row-main">
                 <iconify-icon icon="lucide:archive" width="15"></iconify-icon>
@@ -611,13 +621,6 @@
                 <span class="setl">{$t('nav.file_recall')}</span>
               </div>
               <button class="link-btn" onclick={() => (dataSubView = 'trash')}>{$t('settings.data.manage')}</button>
-            </div>
-            <div class="data-row">
-              <div class="data-row-main">
-                <iconify-icon icon="ant-design:user-outlined" width="15"></iconify-icon>
-                <span class="setl">{$t('nav.memory')}</span>
-              </div>
-              <button class="link-btn" onclick={() => (dataSubView = 'memory')}>{$t('settings.data.manage')}</button>
             </div>
           {:else}
             <div class="data-subhead">


### PR DESCRIPTION
助手记忆 was last of the three rows under Settings → 数据管理. It is the row users
open that panel to edit; 已归档任务 and 文件回收站 are visited only when something
needs recovering, so they now follow it instead of pushing it to the bottom.

Before / after:

| | 1 | 2 | 3 |
|---|---|---|---|
| before | 已归档任务 | 文件回收站 | 助手记忆 |
| after | 助手记忆 | 已归档任务 | 文件回收站 |

Pure markup reorder inside the `dataSubView === 'none'` branch — three
`.data-row` blocks moved, no styling, wiring, or sub-view changes. The command
palette's deep-links (#2184) address the sub-views by name, not by position, so
they are unaffected.

`svelte-check` clean (0 errors; the 2 warnings are pre-existing `line-clamp`
notes in AgentsView / LightAppsView).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
