### PR TITLE
feat(web): drag the sidebar's edge to resize it, within bounds

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -3,6 +3,7 @@
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact, imagePreviewError } from '../lib/artifact-actions'
   import { hydrateArtifact, lightAppSource, pathIsInside } from '../lib/artifacts'
+  import { CENTER_MIN } from '../lib/sidebarWidth'
   import * as api from '../lib/api'
 
   // ── Session artifacts (existing) ──────────────────────────────────────────
@@ -169,7 +170,6 @@
   // center column drops under its own minimum (mirrors the design mock).
   const PANEL_WIDTH_KEY = 'octo.panelWidth'
   const PANEL_MIN = 320
-  const CENTER_MIN = 460
   let panelEl = $state<HTMLElement | null>(null)
   let panelWidth = $state(readSavedWidth())
 

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -6,6 +6,7 @@
   import { t, tr } from '../../lib/i18n'
   import { confirmDialog } from '../../lib/confirm'
   import { splitSections, swapWithinSection, parseSectionFold, type SectionFold } from '../../lib/sidebarSections'
+  import { SIDEBAR_MIN, SIDEBAR_MAX, CENTER_MIN, readSidebarWidth, saveSidebarWidth } from '../../lib/sidebarWidth'
   import { ago } from '../../lib/relTime'
   import { ws } from '../../lib/ws'
   import VersionBadge from './VersionBadge.svelte'
@@ -212,35 +213,44 @@
 
   // ── Resizable width ────────────────────────────────────────────────────────
   // Drag the right edge to widen the full sidebar; the width persists across
-  // sessions. Both bounds keep the column doing its job: below MIN a session
-  // title has no room left beside its timestamp, above MAX the sidebar starts
-  // eating the conversation it exists to navigate. Rail and hidden are fixed
-  // widths and ignore this — there is nothing to drag in either.
-  const SIDEBAR_WIDTH_KEY = 'octo.sidebarWidth'
-  const SIDEBAR_MIN = 200
-  const SIDEBAR_MAX = 480
-  const SIDEBAR_DEFAULT = 256
-  const clampWidth = (w: number) => Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, w))
-
-  let fullWidth = $state(readSavedWidth())
+  // sessions. The bounds keep the column doing its job: below SIDEBAR_MIN a
+  // session title has no room left beside its timestamp, above SIDEBAR_MAX it
+  // starts eating the conversation it exists to navigate. Rail and hidden are
+  // fixed widths and ignore this — there is nothing to drag in either.
+  let fullWidth = $state(readSidebarWidth())
   // Drag applies a new width every mousemove, so the collapse transition has to
   // step aside for the duration or the edge lags behind the cursor.
   let resizing = $state(false)
+  let asideEl = $state<HTMLElement | null>(null)
 
-  function readSavedWidth(): number {
-    const v = Number(localStorage.getItem(SIDEBAR_WIDTH_KEY))
-    // A width stored under different bounds is clamped rather than discarded:
-    // the user asked for "as wide as possible", so give them the new maximum.
-    return Number.isFinite(v) && v > 0 ? clampWidth(v) : SIDEBAR_DEFAULT
+  // SIDEBAR_MAX is only the absolute ceiling. What the drag actually stops at
+  // also depends on the room left over: an open artifacts panel plus a wide
+  // sidebar can squeeze the conversation column to nothing on a small window,
+  // so the center's minimum wins over the ceiling (same rule the panel's own
+  // grip applies from its side).
+  function maxDraggableWidth(startW: number): number {
+    const row = asideEl?.parentElement
+    const main = asideEl?.nextElementSibling as HTMLElement | null
+    if (!row || !main) return SIDEBAR_MAX
+    const rowW = row.getBoundingClientRect().width
+    // Whatever sits beyond the center column — the artifacts panel, or nothing.
+    const beyondCenter = rowW - startW - main.getBoundingClientRect().width
+    return Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, rowW - beyondCenter - CENTER_MIN))
   }
 
   function startResize(e: MouseEvent) {
+    if (e.button !== 0) return
     e.preventDefault()
     const startX = e.clientX
     const startW = fullWidth
+    const maxW = maxDraggableWidth(startW)
     resizing = true
     const move = (ev: MouseEvent) => {
-      fullWidth = clampWidth(startW + (ev.clientX - startX))
+      // A mouseup swallowed by browser chrome or a cross-origin frame never
+      // reaches us; the next move without a button held ends the drag instead
+      // of leaving the page stuck in col-resize with text unselectable.
+      if (ev.buttons === 0) { up(); return }
+      fullWidth = Math.max(SIDEBAR_MIN, Math.min(maxW, startW + (ev.clientX - startX)))
     }
     const up = () => {
       window.removeEventListener('mousemove', move)
@@ -248,7 +258,7 @@
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
       resizing = false
-      localStorage.setItem(SIDEBAR_WIDTH_KEY, String(Math.round(fullWidth)))
+      saveSidebarWidth(fullWidth)
     }
     window.addEventListener('mousemove', move)
     window.addEventListener('mouseup', up)
@@ -525,7 +535,7 @@
   </span>
 {/snippet}
 
-<aside style="width:{sidebarPx};flex:0 0 {sidebarPx};background:var(--sidebar-frost);backdrop-filter:blur(var(--frost-blur));-webkit-backdrop-filter:blur(var(--frost-blur));border-right:1px solid var(--border-secondary);overflow:hidden;position:relative;transition:{resizing ? 'none' : 'width 0.32s cubic-bezier(0.2,0,0,1),flex-basis 0.32s cubic-bezier(0.2,0,0,1)'};">
+<aside bind:this={asideEl} style="width:{sidebarPx};flex:0 0 {sidebarPx};background:var(--sidebar-frost);backdrop-filter:blur(var(--frost-blur));-webkit-backdrop-filter:blur(var(--frost-blur));border-right:1px solid var(--border-secondary);overflow:hidden;position:relative;transition:{resizing ? 'none' : 'width 0.32s cubic-bezier(0.2,0,0,1),flex-basis 0.32s cubic-bezier(0.2,0,0,1)'};">
 
   {#if $sidebar === 'full'}
   <!-- The grip sits inside the column because the <aside> clips its overflow;
@@ -920,8 +930,11 @@
    instead of reflowing through it (same reason .rail pins its own width). */
 .full { height: 100%; display: flex; flex-direction: column; min-height: 0; }
 /* A 6px strip along the divider. Absolute so it overlays the column's own rows
-   (including the draggable header, which it opts out of) rather than taking
-   layout space away from them. */
+   rather than taking layout space away from them. The no-drag is belt and
+   braces: --wails-draggable is inherited through the DOM, and the grip is a
+   sibling of the draggable header rather than a child, so it would not pick up
+   "drag" anyway — but it visually sits on top of that header, and a future
+   author moving it under one is the mistake worth pre-empting. */
 .resize-grip {
   position: absolute; right: 0; top: 0; bottom: 0; width: 6px;
   cursor: col-resize; z-index: 5; --wails-draggable: no-drag;

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -210,6 +210,54 @@
     return () => window.removeEventListener('resize', onResize)
   })
 
+  // ── Resizable width ────────────────────────────────────────────────────────
+  // Drag the right edge to widen the full sidebar; the width persists across
+  // sessions. Both bounds keep the column doing its job: below MIN a session
+  // title has no room left beside its timestamp, above MAX the sidebar starts
+  // eating the conversation it exists to navigate. Rail and hidden are fixed
+  // widths and ignore this — there is nothing to drag in either.
+  const SIDEBAR_WIDTH_KEY = 'octo.sidebarWidth'
+  const SIDEBAR_MIN = 200
+  const SIDEBAR_MAX = 480
+  const SIDEBAR_DEFAULT = 256
+  const clampWidth = (w: number) => Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, w))
+
+  let fullWidth = $state(readSavedWidth())
+  // Drag applies a new width every mousemove, so the collapse transition has to
+  // step aside for the duration or the edge lags behind the cursor.
+  let resizing = $state(false)
+
+  function readSavedWidth(): number {
+    const v = Number(localStorage.getItem(SIDEBAR_WIDTH_KEY))
+    // A width stored under different bounds is clamped rather than discarded:
+    // the user asked for "as wide as possible", so give them the new maximum.
+    return Number.isFinite(v) && v > 0 ? clampWidth(v) : SIDEBAR_DEFAULT
+  }
+
+  function startResize(e: MouseEvent) {
+    e.preventDefault()
+    const startX = e.clientX
+    const startW = fullWidth
+    resizing = true
+    const move = (ev: MouseEvent) => {
+      fullWidth = clampWidth(startW + (ev.clientX - startX))
+    }
+    const up = () => {
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      resizing = false
+      localStorage.setItem(SIDEBAR_WIDTH_KEY, String(Math.round(fullWidth)))
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }
+
+  const sidebarPx = $derived($sidebar === 'full' ? `${fullWidth}px` : $sidebar === 'rail' ? '64px' : '0px')
+
   // Dismiss any open floating UI (kebab menu, move-to-group popover, inline
   // rename) when the user clicks anywhere outside of it. Only clicks that land
   // inside a popover or a rename input are ignored (those must swallow the
@@ -477,10 +525,13 @@
   </span>
 {/snippet}
 
-<aside style="width:{$sidebar === 'full' ? '256px' : $sidebar === 'rail' ? '64px' : '0px'};flex:0 0 {$sidebar === 'full' ? '256px' : $sidebar === 'rail' ? '64px' : '0px'};background:var(--sidebar-frost);backdrop-filter:blur(var(--frost-blur));-webkit-backdrop-filter:blur(var(--frost-blur));border-right:1px solid var(--border-secondary);overflow:hidden;transition:width 0.32s cubic-bezier(0.2,0,0,1),flex-basis 0.32s cubic-bezier(0.2,0,0,1);">
+<aside style="width:{sidebarPx};flex:0 0 {sidebarPx};background:var(--sidebar-frost);backdrop-filter:blur(var(--frost-blur));-webkit-backdrop-filter:blur(var(--frost-blur));border-right:1px solid var(--border-secondary);overflow:hidden;position:relative;transition:{resizing ? 'none' : 'width 0.32s cubic-bezier(0.2,0,0,1),flex-basis 0.32s cubic-bezier(0.2,0,0,1)'};">
 
   {#if $sidebar === 'full'}
-  <div class="full">
+  <!-- The grip sits inside the column because the <aside> clips its overflow;
+       it stays flush with the divider rather than straddling it. -->
+  <div class="resize-grip" role="separator" aria-orientation="vertical" onmousedown={startResize}></div>
+  <div class="full" style="width:{fullWidth}px">
     <div class="side-header" class:native-inset={$nativeShell && isMac} style="--wails-draggable:drag">
       <button class="icon-btn" title={$t('header.toggle_left')} aria-pressed={true} onclick={() => sidebar.set('hidden')}>
         <iconify-icon icon="lucide:panel-left" width="16"></iconify-icon>
@@ -864,7 +915,18 @@
 
 
 <style>
-.full { width: 256px; height: 100%; display: flex; flex-direction: column; min-height: 0; }
+/* Width comes from the drag state inline, matching the <aside> around it, so
+   the content keeps a fixed box the aside clips during the collapse animation
+   instead of reflowing through it (same reason .rail pins its own width). */
+.full { height: 100%; display: flex; flex-direction: column; min-height: 0; }
+/* A 6px strip along the divider. Absolute so it overlays the column's own rows
+   (including the draggable header, which it opts out of) rather than taking
+   layout space away from them. */
+.resize-grip {
+  position: absolute; right: 0; top: 0; bottom: 0; width: 6px;
+  cursor: col-resize; z-index: 5; --wails-draggable: no-drag;
+}
+.resize-grip:hover { background: var(--focus-ring); }
 /* This column's own top row, starting at the very top of the window — there is
    no bar laid across the layout, so no bottom border here either: the only
    lines are the vertical dividers between columns. Carries the collapse toggle

--- a/web/src/lib/sidebarWidth.test.ts
+++ b/web/src/lib/sidebarWidth.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  parseSidebarWidth,
+  readSidebarWidth,
+  saveSidebarWidth,
+  SIDEBAR_MIN,
+  SIDEBAR_MAX,
+  SIDEBAR_DEFAULT,
+} from './sidebarWidth'
+
+// This jsdom setup exposes no localStorage at all, so every storage case here is
+// an explicit stub — which is what these tests are about anyway: the sidebar
+// must survive whatever the host gives it. A missing global lands in the same
+// catch as a browser that throws on access.
+function stubStorage(store: Record<string, string> = {}) {
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => { store[k] = v },
+  })
+  return store
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('parseSidebarWidth', () => {
+  it('falls back to the default for anything unusable', () => {
+    expect(parseSidebarWidth(null)).toBe(SIDEBAR_DEFAULT)
+    expect(parseSidebarWidth('')).toBe(SIDEBAR_DEFAULT)
+    expect(parseSidebarWidth('abc')).toBe(SIDEBAR_DEFAULT)
+    expect(parseSidebarWidth('0')).toBe(SIDEBAR_DEFAULT)
+    expect(parseSidebarWidth('-40')).toBe(SIDEBAR_DEFAULT)
+  })
+
+  it('clamps a width stored under different bounds instead of discarding it', () => {
+    expect(parseSidebarWidth('9999')).toBe(SIDEBAR_MAX)
+    expect(parseSidebarWidth('50')).toBe(SIDEBAR_MIN)
+  })
+
+  it('keeps a width already inside the bounds', () => {
+    expect(parseSidebarWidth('340')).toBe(340)
+  })
+})
+
+describe('readSidebarWidth', () => {
+  it('reads a persisted width', () => {
+    stubStorage({ 'octo.sidebarWidth': '312' })
+    expect(readSidebarWidth()).toBe(312)
+  })
+
+  it('defaults when nothing is stored', () => {
+    stubStorage()
+    expect(readSidebarWidth()).toBe(SIDEBAR_DEFAULT)
+  })
+
+  // The sidebar is always mounted, so an exception escaping here would take the
+  // whole app tree down instead of degrading to the default width.
+  it('survives storage that throws on read (privacy mode)', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('SecurityError') },
+      setItem: () => {},
+    })
+    expect(readSidebarWidth()).toBe(SIDEBAR_DEFAULT)
+  })
+
+  it('survives storage being absent entirely', () => {
+    vi.stubGlobal('localStorage', undefined)
+    expect(readSidebarWidth()).toBe(SIDEBAR_DEFAULT)
+  })
+})
+
+describe('saveSidebarWidth', () => {
+  it('rounds to whole pixels', () => {
+    const store = stubStorage()
+    saveSidebarWidth(287.6)
+    expect(store['octo.sidebarWidth']).toBe('288')
+  })
+
+  it('survives storage that throws on write', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => { throw new Error('QuotaExceededError') },
+    })
+    expect(() => saveSidebarWidth(300)).not.toThrow()
+  })
+})

--- a/web/src/lib/sidebarWidth.ts
+++ b/web/src/lib/sidebarWidth.ts
@@ -1,0 +1,43 @@
+// Sidebar width bounds and their persistence. Lives in lib/ rather than inside
+// Sidebar.svelte so the parsing rules can be tested directly (same reason
+// sidebarSections.ts sits here).
+
+export const SIDEBAR_MIN = 200
+export const SIDEBAR_MAX = 480
+export const SIDEBAR_DEFAULT = 256
+
+// The narrowest the conversation column may become. Both resizable columns
+// squeeze it, so the number lives in one place: the sidebar's grip and the
+// artifacts panel's grip each cap themselves against it.
+export const CENTER_MIN = 460
+
+const SIDEBAR_WIDTH_KEY = 'octo.sidebarWidth'
+
+export function clampSidebarWidth(w: number): number {
+  return Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, w))
+}
+
+// A width stored under different bounds is clamped rather than discarded: the
+// user asked for "as wide as possible", so give them the new maximum.
+export function parseSidebarWidth(raw: string | null): number {
+  const v = Number(raw)
+  return raw !== null && raw !== '' && Number.isFinite(v) && v > 0 ? clampSidebarWidth(v) : SIDEBAR_DEFAULT
+}
+
+export function readSidebarWidth(): number {
+  try {
+    return parseSidebarWidth(localStorage.getItem(SIDEBAR_WIDTH_KEY))
+  } catch {
+    // Storage access itself can throw (privacy mode). The sidebar is always
+    // mounted, so letting this escape would take the whole app tree down.
+    return SIDEBAR_DEFAULT
+  }
+}
+
+export function saveSidebarWidth(w: number): void {
+  try {
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(Math.round(w)))
+  } catch {
+    // Same privacy-mode case: the width still applies to this session.
+  }
+}


### PR DESCRIPTION
The full sidebar was pinned at 256px. Long session titles and project-nested
rows had nowhere to go, and on a wide display the column could not earn more
room. It now has a grip on its divider.

- **Bounds:** 200px – 480px, clamped during the drag, default 256px unchanged.
  Below the floor a session title has no space left beside its timestamp; above
  the ceiling the sidebar starts eating the conversation it exists to navigate.
- **Persisted** in `localStorage` under `octo.sidebarWidth`. A stored width from
  a build with different bounds is clamped rather than discarded — the intent
  was "as wide as possible", so it becomes the new maximum.
- **Rail and hidden modes are untouched.** Both are fixed widths with nothing to
  drag, so the grip only renders in full mode.

Follows `ArtifactsPanel`'s existing handle: same mouse-capture shape, same
`col-resize` cursor and `user-select` lock, same persistence.

Two details worth noting:

- The collapse transition is suppressed for the duration of a drag. It applies a
  new width every `mousemove`, so a 0.32s ease would leave the edge lagging
  behind the cursor.
- The grip carries `--wails-draggable: no-drag`. It overlays the sidebar header,
  which is a window-drag region in the desktop shell, and `framelessDrag`
  decides by the mousedown target's computed value.

`.full` keeps a pixel width (now driven by the drag state) rather than switching
to `100%`, so content still gets clipped by the `<aside>` during the collapse
animation instead of reflowing through it — the same reason `.rail` pins its
own width.

## Verification

`svelte-check` clean (0 errors; the 2 warnings are pre-existing `line-clamp`
notes elsewhere). Driven over CDP against an isolated `octo serve` on a throwaway
HOME — never the live backend:

| step | result |
| --- | --- |
| default width | 256 |
| drag +400px | 480 (capped) |
| drag −600px | 200 (floored) |
| drag to 340, reload | 340 (persisted) |
| collapse toggle | 1px (border only) — fixed modes unaffected |

Screenshots at both bounds confirm the header row (toggle, logo, brand, search)
and the footer (Settings, version) still fit at 200px, and that content follows
the column out to 480px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
