### PR TITLE
fix(web): a closed panel must not keep the main column hidden

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -431,7 +431,10 @@
 <div class="app">
   <div class="content">
     <Sidebar />
-    <main class="main" class:yielded={$panelExpanded}>
+    <!-- Yield the width only while the panel is actually there to take it:
+         an expanded flag left over from a closed panel would hide the main
+         column with nothing rendered beside it, i.e. a blank page. -->
+    <main class="main" class:yielded={$panelExpanded && !!$panelContent}>
       <Header />
       {#if $view === 'chat'}
         <ChatView />

--- a/web/src/lib/artifacts.test.ts
+++ b/web/src/lib/artifacts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { get } from 'svelte/store'
-import { artifacts, artifactSel, panelContent } from './stores'
+import { artifacts, artifactSel, panelContent, panelExpanded } from './stores'
 import { lightAppSource, observeArtifact, hydrateArtifact, resetArtifacts, pathIsInside } from './artifacts'
 
 // Nothing a preview document references can authenticate: the srcdoc iframe has
@@ -39,6 +39,18 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+})
+
+describe('resetArtifacts', () => {
+  it('closes an expanded panel so the main column is never hidden with nothing beside it', () => {
+    panelContent.set('lightapps')
+    panelExpanded.set(true)
+
+    resetArtifacts('sess-2')
+
+    expect(get(panelContent)).toBe(null)
+    expect(get(panelExpanded)).toBe(false)
+  })
 })
 
 describe('observeArtifact — image artifacts', () => {

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -25,7 +25,7 @@
 // inlineLocalRefs does).
 
 import { get, writable } from 'svelte/store'
-import { artifacts, panelContent, artifactSel } from './stores'
+import { artifacts, panelContent, panelExpanded, artifactSel } from './stores'
 import { renderMarkdown } from './markdown'
 import type { Artifact } from './types'
 
@@ -421,6 +421,10 @@ export function resetArtifacts(sessionId: string): void {
   artifacts.set([])
   artifactSel.set(0)
   panelContent.set(null)
+  // Closing the panel must clear the expanded flag with it, or the main column
+  // stays hidden with nothing in its place: a full-width Light App is open,
+  // switching to a chat resets the panel, and the layout paints blank.
+  panelExpanded.set(false)
   autoOpened = false
   imageRevisions.clear()
   artifactSelSession.set(sessionId)


### PR DESCRIPTION
## Symptom

Open a Light App, then click a chat in the sidebar — the whole page goes blank.

## Root cause

`LightAppsView.handleOpen` gives the Light App the full content area: `panelContent = 'lightapps'` and `panelExpanded = true`. `App.svelte` then hides the main column (`.main.yielded { display: none }`) so the panel can grow into it.

Clicking a chat switches the view, which remounts `ChatView`. Its first effect calls `resetArtifacts()`, which set `panelContent` to `null` but left `panelExpanded` at `true`. With no panel content `ArtifactsPanel` is not rendered at all (`{#if $panelContent}`), while the main column is still `display: none` — nothing is painted. The `panelExpanded` store already documents the invariant it was breaking: *"Cleared whenever the panel closes."*

The command palette's artifacts toggle (`panelContent.update(v => v ? null : 'session')`) reaches the same state from a full-width panel.

## Fix

- `resetArtifacts` clears `panelExpanded` along with the panel it closes.
- `App.svelte` gates the `yielded` class on `panelContent`, so the main column only ever yields its width while a panel is actually there to take it — that closes the command-palette path too, and any future one.

## Verification

- New unit test in `artifacts.test.ts` pins the reset invariant.
- `vitest run`: 24 files / 358 tests pass. `svelte-check --threshold error`: 0 errors.
- No real-browser walkthrough: reproducing it needs an isolated `serve` under a fake `HOME`, which this worktree session is not permitted to launch. The three lines above are the whole mechanism, and the test locks the store side of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)