### PR TITLE
fix(web): the @ menu lists experts, not the absence of one

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -441,12 +441,11 @@
     }
     if (slashMode === 'agents') {
       const q = slashQuery
-      // Mirrors the sidebar's new-session picker: "Default" first, the expert
-      // agents, then a fixed create row that ignores the filter.
-      const rows: SlashItem[] = [
-        { kind: 'agent', id: 'default', name: 'Default' },
-        ...agents.map(a => ({ kind: 'agent' as const, id: a.id, name: a.name })),
-      ]
+      // The expert agents, then a fixed create row that ignores the filter.
+      // Default is not one of the rows: @ is how you pick an expert, and
+      // "no expert" is reached by clearing the mention (backspace on an empty
+      // box) or from the agent menu's own Default entry.
+      const rows: SlashItem[] = agents.map(a => ({ kind: 'agent' as const, id: a.id, name: a.name }))
       const filtered = rows
         .map(r => ({ r, score: scoreNameMatch(r.kind === 'agent' ? r.name : '', q) }))
         .filter(({ score }) => score > 0)


### PR DESCRIPTION
## Change

Typing `@` in the composer opened a menu whose first row was `@Default` — an entry for *not* picking an expert, sitting among the experts and looking like one of them. Removed: the menu is now the expert list plus the fixed create row.

`web/src/components/chat/Composer.svelte`, in the `slashMode === 'agents'` branch of `filteredItems()`.

Un-assigning still has both of its existing paths, so nothing is lost:

- backspace on an empty box (`pickAgent('default')`)
- the agent menu's own **Default** entry

## Verification

`vitest run`: 24 files / 357 tests pass. `svelte-check --threshold error`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)