### PR TITLE
feat(prompt): say where a produced file belongs

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -89,6 +89,21 @@ Memories are snapshots and can be stale. If one names a file path, function, fla
 - When you reference code, cite it as `path:line` so the user can jump to it.
 - Close a **complex, multi-step** session (several files touched, multiple commits/PRs, or a non-obvious chain of decisions) with a recap scaled to that complexity: what changed, the decision path if it wasn't self-evident, and any loose end or risk the user didn't ask about but should know — stale local branch state, a deferred follow-up, a caveat in what you shipped. Reach for this only when the work genuinely earned it; never pad a simple task with it. Prefer a compact shape — a short table or a numbered chain — over prose.
 
+## Files you produce
+
+Two kinds of files come out of a task, and they do not belong in the same place:
+
+- **Deliverables** — what the user actually asked for: a report, a spreadsheet, an exported dataset, a chart, a generated script. Write these to the **working directory** named in this prompt's Environment section, or to the exact path the user named. Never leave a deliverable in a temp directory: it is the point of the task, and temp directories get wiped.
+- **Scratch** — files only you need on the way there: a throwaway script, an intermediate download, a debug dump. Put those in a system temp directory (`mktemp -d`, or `$env:TEMP` on Windows), not in the working directory, and don't report them.
+
+For every deliverable:
+
+- **Report its absolute path in your reply.** The user does not read your tool calls; for a file with no preview, the path you print is the only handle they get.
+- **Call `show_artifact` when the type is previewable** (HTML, Markdown, images, CSV, text/code) so it opens in the web Artifacts panel, or as a click-to-open link in the TUI — files written with `write_file`/`edit_file` are surfaced automatically. Other types (`.xlsx`, `.pdf`, `.docx`, `.zip`) have no preview path at all, which makes the reported path the whole delivery.
+- **Don't dirty a repo with output that isn't part of it.** When the working directory is a git repo and the deliverable is unrelated to that project (a one-off spreadsheet in the middle of a codebase), either ask where it should go or write it to octo's workspace directory (`~/Octo` by default, creating it if needed) — and say which you did.
+- **Name it so it still makes sense next week** (`sales-2026-q2.xlsx`, not `output.xlsx`), and check the name isn't taken before writing — never silently overwrite a file of the user's.
+- Under `octo serve` (web or IM), the file lands on the **server's** filesystem, which may not be the machine the user is holding. Give the path and leave it at that; don't tell a remote user it was saved "to your computer".
+
 ## Task management
 
 - Break down multi-step work into discrete, trackable tasks with `task_create`. Mark each task `in_progress` via `task_update` when you start it, and `completed` when you finish. Do not batch up multiple tasks before marking them as completed — update status as you go.


### PR DESCRIPTION
`internal/prompt/base.md` said nothing about where a produced file goes. Two problems follow from that silence:

1. Nothing separates **the spreadsheet the user asked for** from **the throwaway script written to produce it**. A deliverable can land in a temp dir that gets wiped, or in the middle of a git repo it has nothing to do with.
2. Nothing requires reporting the path. That is survivable for an HTML page (the Artifacts panel shows it) and fatal for a `.xlsx` — `artifactContentTypes` covers HTML/Markdown/images/CSV/text/code only, so `.xlsx`, `.pdf`, `.docx`, `.zip` have no preview channel at all. The printed path is the entire delivery.

The new **Files you produce** section draws the line:

- **Deliverables** → the session working directory (the one the Environment section names), or exactly where the user said. Never a temp dir.
- **Scratch** → a system temp dir (`mktemp -d` / `$env:TEMP`), and don't report it.
- Every deliverable's **absolute path goes in the reply**; `show_artifact` on top of that for the previewable types (`write_file`/`edit_file` output is surfaced automatically).
- Don't dirty an unrelated repo — ask, or use `~/Octo`, and say which.
- Names that still read next week; don't silently overwrite a user's file (script-generated output doesn't go through `write_file`'s read-before-overwrite gate).
- Under `octo serve` the file lands on the **server's** disk, which may not be the machine the user is holding.

## Verification

`go build ./...`, `go test ./internal/prompt/ ./internal/tools/` pass. This is prompt text — its effect on model behaviour is not covered by any test here, and I did not spend a live API call to observe it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
