### PR TITLE
fix(web): put every column's top row on one axis under the traffic lights

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-  import { artifacts, panelContent, panelExpanded, artifactSel, artifactView, lightappSel, lightapps, lightappHTML, showToast } from '../lib/stores'
+  import { artifacts, panelContent, panelExpanded, artifactSel, artifactView, lightappSel, lightapps, lightappHTML, showToast, nativeShell } from '../lib/stores'
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact, imagePreviewError } from '../lib/artifact-actions'
   import { hydrateArtifact, lightAppSource, pathIsInside } from '../lib/artifacts'
   import { CENTER_MIN } from '../lib/sidebarWidth'
   import * as api from '../lib/api'
+
+  // This column never holds the traffic lights, but its top row has to sit on
+  // the same axis as the chat title beside it, which Header lifts on mac.
+  const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform)
+  const liftForTrafficLights = $derived($nativeShell && isMac)
 
   // ── Session artifacts (existing) ──────────────────────────────────────────
   const cur = $derived($artifacts[$artifactSel] ?? $artifacts[0])
@@ -245,7 +250,7 @@
   {/if}
   {#if $panelContent === 'lightapps'}
     <!-- ── Light Apps mode ───────────────────────────────────────────────── -->
-    <div class="topbar">
+    <div class="topbar" class:native-lift={liftForTrafficLights}>
       <span style="flex:1"></span>
       <span class="sandboxed-label">{$t('artifacts.sandboxed')}</span>
       {@render lightAppControls()}
@@ -280,7 +285,7 @@
   {:else if $panelContent === 'session'}
     <!-- ── Session mode (existing behavior) ────────────────────────────────── -->
     {#if !cur}
-      <div class="topbar">
+      <div class="topbar" class:native-lift={liftForTrafficLights}>
         <span style="flex:1"></span>
         {@render topbarControls()}
       </div>
@@ -289,7 +294,7 @@
         <span>{$t('artifacts.empty')}</span>
       </div>
     {:else}
-      <div class="topbar">
+      <div class="topbar" class:native-lift={liftForTrafficLights}>
         <span style="flex:1"></span>
         {#if !curIsImage}
           <div class="seg">
@@ -395,6 +400,9 @@
   flex: 0 0 auto; min-height: 44px; padding: 0 8px 0 10px;
   display: flex; align-items: center; gap: 8px;
 }
+/* The same axis lift Header and Sidebar apply on mac — see Header.native-lift
+   for why the height has to be pinned for the padding to move anything. */
+.topbar.native-lift { box-sizing: border-box; max-height: 44px; padding-bottom: 8px; }
 .file-row {
   flex: 0 0 auto; padding: 7px 10px 7px 16px;
   border-bottom: 1px solid var(--border-secondary); display: flex; align-items: center; gap: 8px;

--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -26,6 +26,12 @@
   // is Sidebar's header while the sidebar is showing (it insets itself), and
   // this row only once the sidebar is gone.
   const insetForTrafficLights = $derived($nativeShell && isMac && $sidebar === 'hidden')
+  // Making room for the lights is one thing; sitting on the same axis as them is
+  // another, and this row needs the second one whether or not it holds the first.
+  // While the sidebar shows, the lights are over ITS header — but if only that
+  // column lifted its content, the brand row and this row's chat title would sit
+  // 4px apart.
+  const liftForTrafficLights = $derived($nativeShell && isMac)
 
   // Desktop only: double-clicking the draggable header zooms the window, the way
   // a native title bar does. Wails' custom drag region doesn't wire this up, and
@@ -72,7 +78,7 @@
   })
 </script>
 
-<header class:native-inset={insetForTrafficLights} style="--wails-draggable:drag" ondblclick={onHeaderDblClick}>
+<header class:native-inset={insetForTrafficLights} class:native-lift={liftForTrafficLights} style="--wails-draggable:drag" ondblclick={onHeaderDblClick}>
   {#if $sidebar === 'hidden'}
     <button class="icon-btn" title={$t('header.toggle_left')} aria-pressed={false} onclick={toggleSidebar}>
       <iconify-icon icon="lucide:panel-left" width="16"></iconify-icon>
@@ -131,10 +137,17 @@ header {
   padding: 0 10px;
   z-index: 20;
 }
-/* Only while the sidebar is hidden — see insetForTrafficLights. Padding-bottom
-   (not padding-top) pulls the centering axis up to meet the lights' fixed
-   vertical position instead of pushing content further away from them. */
-header.native-inset { padding-left: 82px; padding-bottom: 8px; }
+/* Only while the sidebar is hidden — see insetForTrafficLights: horizontal room
+   for the lights, nothing more. */
+header.native-inset { padding-left: 82px; }
+/* Lifting the axis is the other half, and max-height is the load-bearing part of
+   it. Padding-bottom alone only moves the axis while min-height still decides the
+   row height; .chat-header-slot is taller than the 36px that would leave, so the
+   row grew to 52px instead and the axis never moved. Pinning the height makes the
+   padding actually shorten the content box. */
+header.native-lift {
+  box-sizing: border-box; max-height: 44px; padding-bottom: 8px;
+}
 /* The row is a window drag handle; every control opts back out so it stays
    clickable, leaving the blank stretches to drag the window. */
 header .icon-btn,

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -1044,9 +1044,14 @@
   padding: 0 10px;
 }
 /* Mac's traffic lights float over the window's top-left corner, which is this
-   row whenever the sidebar is showing. Padding-bottom (not padding-top) pulls
-   the centering axis up to meet their fixed vertical position. */
-.side-header.native-inset { padding-left: 82px; padding-bottom: 8px; }
+   row whenever the sidebar is showing: horizontal room for them, then the same
+   axis lift Header applies to the main column, so the brand row and the chat
+   title stay on one line. Height pinned for the same reason as there — the
+   padding has to shorten the content box, not grow the row. */
+.side-header.native-inset {
+  box-sizing: border-box; max-height: 44px;
+  padding-left: 82px; padding-bottom: 8px;
+}
 .side-header .icon-btn { --wails-draggable: no-drag; }
 .side-header :global(.logo) { color: var(--blue-6); flex: 0 0 auto; }
 .brand-name { font-size: 14px; font-weight: 600; color: var(--text-heading); flex: 0 0 auto; }


### PR DESCRIPTION
On mac the desktop shell's traffic lights float over the window's top-left
corner at a fixed height, and Sidebar's header inset itself with
`padding-bottom` to bring its content up onto that axis. Two things were wrong
with that, both visible in the shell today: the sidebar toggle jumps 4px when
the sidebar opens or closes, and while the sidebar shows, the brand row and the
chat title next to it sit on different lines.

## The padding could not lift what it was asked to lift

`padding-bottom` only moves the content axis while `min-height` is what decides
the row height. The main column's header hosts `.chat-header-slot`, which is
taller than the 36px the padding leaves — so the row grew to 52px and the axis
never moved. The collapsed-sidebar row was never on the lights' axis at all.

Pinning the height (`border-box` + `max-height: 44px`) makes the padding
shorten the content box instead of growing the row, which is what it was
written to do.

## Alignment is between columns, not just under the lights

The lift was conditional on the sidebar being hidden — i.e. on this row being
the one the lights sit over. But whether two rows line up is a question about
both columns: with the sidebar showing, its brand row lifted and the chat title
beside it did not, leaving them 4px apart.

So the axis lift now applies whenever the shell is mac, and only the horizontal
82px inset stays tied to the sidebar being hidden. The toggle stops jumping
between states as a consequence — both rows finally share one axis rather than
being lifted by whichever rule happened to apply.

`ArtifactsPanel`'s top row gets the same treatment. It is nowhere near the
lights, but it sits beside the chat title, and lifting the other two columns
without it would just move the misalignment one column to the right.

## Measured

1440×900, `?shell=octo-desktop`, content mid-Y:

| | toggle | brand | chat title | panel |
|---|---|---|---|---|
| sidebar full | 18 | 18 | 18 | 18 |
| sidebar hidden | 18 | — | 18 | 18 |

Row heights are 44 everywhere (the collapsed main header was 52). Before this
change: toggle 18 expanded / 22 collapsed, chat title 22 in both, panel 22.

Plain web mode (no `shell` param) lifts nothing — every row stays exactly where
it was, axis 22, verified in both sidebar states and with the panel open.

`svelte-check`: 0 errors (the 2 warnings are pre-existing `line-clamp` ones in
`LightAppsView.svelte`). Re-measured after rebasing onto #2194, which also
touches Sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
