### PR TITLE
fix(trash): deletes the user asks for are permanent, and say so first

### DIFF
--- a/dev-docs/trash-recall-design.md
+++ b/dev-docs/trash-recall-design.md
@@ -1,13 +1,16 @@
 # Trash / file recall
 
 Octo never lets an agent-issued deletion or overwrite destroy work irreversibly.
-Every destructive filesystem action the agent takes — an `rm`, a `write_file`
-that clobbers an existing file, a programmatic delete of a skill or workflow —
-first stages the old bytes in a per-project trash under
-`~/.octo/trash/`, from which they can be listed, restored, or permanently
-discarded. This is the "an AI agent that can't lose your work" guarantee: the
-recovery path exists in every interface (CLI, TUI, Web), and the moment right
-after a destructive action offers a one-step undo.
+Every destructive filesystem action the agent takes — an `rm`, a `write_file` or
+`edit_file` that clobbers an existing file — first stages the old bytes in a
+per-project trash under `~/.octo/trash/`, from which they can be listed,
+restored, or permanently discarded. This is the "an AI agent that can't lose your
+work" guarantee: the recovery path exists in every interface (CLI, TUI, Web), and
+the moment right after a destructive action offers a one-step undo.
+
+The trash covers what the *agent* does, not what the *user* asks for. Deleting a
+session, skill, workflow, scheduled task, or memory from the UI is permanent —
+see "Deletes the user asks for" below.
 
 The package lives at `internal/trash/`. Every interface reaches it through that
 package; nothing else touches the on-disk layout directly.
@@ -50,9 +53,10 @@ the scheme can evolve without migration.
 ```
 
 `deleted_by` records which surface removed the file (`rm`, `write_file`,
-`edit_file`, `skill`, `workflow`, `scheduler`, `memory`) and `kind`
-is `delete` or `overwrite`. Older sidecars that predate these fields read back
-as zero values — every reader treats them as optional.
+`edit_file`) and `kind` is `delete` or `overwrite`. Older sidecars that predate
+these fields read back as zero values — every reader treats them as optional,
+and entries staged by surfaces that no longer use the trash (`session`, `skill`,
+`workflow`, `scheduler`, `memory`) still list and restore normally.
 
 ### Human-readable labels
 
@@ -81,13 +85,31 @@ skipped for pathologically large files) so listing stays fast.
 | POSIX `rm` in a shell command | `__octo_safe_rm` wrapper injected by `shellCommand` (`internal/tools/sandbox.go`) hard-links (falls back to copy) each existing target into `$OCTO_TRASH_DIR`, then runs the real `command rm`. |
 | Windows `Remove-Item` (and its aliases) | `windowsSafeRmWrapper` shadows the cmdlet, calls `octo __trash-backup -- <path>…` to stage targets, then runs the real cmdlet. |
 | `write_file` / `edit_file` overwriting an existing file | The tool calls `trash.Backup` before writing, unless the file is tracked by git and clean (git already holds a recoverable copy). Default on; `trash.overwrite_backup: false` disables it. |
-| Programmatic deletes (skill, workflow, scheduler, memory) | `trash.Move` — stages then removes, atomically when possible. |
 
-Deleting a session is the exception: `agent.DeleteSession` unlinks the
-transcript outright. A session the user deletes is one they meant to be gone,
-and every delete affordance already says so ("this cannot be undone"), so
-keeping a shadow copy under `~/.octo/trash/` would contradict the promise the UI
-makes. Session transcripts still reach the trash the ordinary way — an `rm` in a
+### Deletes the user asks for
+
+Nothing else stages. When the user deletes a session, a skill, a workflow, a
+scheduled task, or a memory, the file (or, for a skill, its directory) is
+unlinked outright:
+
+| Object | Delete path |
+|---|---|
+| Session transcript | `agent.DeleteSession` → `os.Remove` |
+| Skill | `skills.Registry.Delete` → `os.RemoveAll` |
+| Workflow | `tools.DeleteWorkflow` → `os.Remove` |
+| Scheduled task | `scheduler.Delete` → `os.Remove` |
+| Memory | `handleDeleteMemory` → `os.Remove` |
+
+These are deliberate acts on the user's own configuration, not collateral damage
+from an agent editing files, so a shadow copy under `~/.octo/trash/` would be
+retention the user didn't ask for and can't see. What they get instead is a
+warning before the fact: every one of these deletes goes through a confirm
+dialog that says the delete cannot be undone (`skills.confirm_delete`,
+`workflows.confirm_delete`, `tasks.confirm_delete`, `profile.confirm_forget`,
+`sidebar.confirm_delete`). The web UI is the only surface that offers these
+deletes, so the confirmation covers all of them.
+
+Session transcripts can still land in the trash the ordinary way — an `rm` in a
 shell command stages them like any other file — which is why labels below still
 parse session titles.
 

--- a/dev-docs/trash-recall-design.md
+++ b/dev-docs/trash-recall-design.md
@@ -2,8 +2,8 @@
 
 Octo never lets an agent-issued deletion or overwrite destroy work irreversibly.
 Every destructive filesystem action the agent takes — an `rm`, a `write_file`
-that clobbers an existing file, a programmatic delete of a session, skill, or
-workflow — first stages the old bytes in a per-project trash under
+that clobbers an existing file, a programmatic delete of a skill or workflow —
+first stages the old bytes in a per-project trash under
 `~/.octo/trash/`, from which they can be listed, restored, or permanently
 discarded. This is the "an AI agent that can't lose your work" guarantee: the
 recovery path exists in every interface (CLI, TUI, Web), and the moment right
@@ -50,7 +50,7 @@ the scheme can evolve without migration.
 ```
 
 `deleted_by` records which surface removed the file (`rm`, `write_file`,
-`edit_file`, `session`, `skill`, `workflow`, `scheduler`, `memory`) and `kind`
+`edit_file`, `skill`, `workflow`, `scheduler`, `memory`) and `kind`
 is `delete` or `overwrite`. Older sidecars that predate these fields read back
 as zero values — every reader treats them as optional.
 
@@ -81,7 +81,15 @@ skipped for pathologically large files) so listing stays fast.
 | POSIX `rm` in a shell command | `__octo_safe_rm` wrapper injected by `shellCommand` (`internal/tools/sandbox.go`) hard-links (falls back to copy) each existing target into `$OCTO_TRASH_DIR`, then runs the real `command rm`. |
 | Windows `Remove-Item` (and its aliases) | `windowsSafeRmWrapper` shadows the cmdlet, calls `octo __trash-backup -- <path>…` to stage targets, then runs the real cmdlet. |
 | `write_file` / `edit_file` overwriting an existing file | The tool calls `trash.Backup` before writing, unless the file is tracked by git and clean (git already holds a recoverable copy). Default on; `trash.overwrite_backup: false` disables it. |
-| Programmatic deletes (session, skill, workflow, scheduler, memory) | `trash.Move` — stages then removes, atomically when possible. |
+| Programmatic deletes (skill, workflow, scheduler, memory) | `trash.Move` — stages then removes, atomically when possible. |
+
+Deleting a session is the exception: `agent.DeleteSession` unlinks the
+transcript outright. A session the user deletes is one they meant to be gone,
+and every delete affordance already says so ("this cannot be undone"), so
+keeping a shadow copy under `~/.octo/trash/` would contradict the promise the UI
+makes. Session transcripts still reach the trash the ordinary way — an `rm` in a
+shell command stages them like any other file — which is why labels below still
+parse session titles.
 
 ### Preserving `rm` semantics
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/open-octo/octo-agent/internal/trash"
 )
 
 // Session is a named conversation that persists to disk as a JSONL transcript
@@ -1684,7 +1682,8 @@ func ResolveSessionID(input string) (string, error) {
 		input, len(matches), strings.Join(matches, "\n  "))
 }
 
-// DeleteSession removes the transcript file for the given session id. id may be
+// DeleteSession permanently removes the transcript file for the given session
+// id — session deletes bypass the trash, so there is nothing to recall. id may be
 // a bare id or one with a .jsonl/.json suffix; absolute paths are rejected, and
 // any id that would resolve outside the sessions directory (e.g. via "..") is
 // refused so a caller-supplied id can't reach arbitrary files. A missing file
@@ -1707,12 +1706,8 @@ func DeleteSession(id string) error {
 		return err
 	}
 	path := filepath.Join(dir, stem+".jsonl")
-	if _, err := os.Stat(path); err == nil {
-		if err := trash.Move(path, dir, trash.Options{DeletedBy: "session", Kind: "delete"}); err != nil {
-			return fmt.Errorf("session: trash %s: %w", path, err)
-		}
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("session: stat %s: %w", path, err)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("session: remove %s: %w", path, err)
 	}
 	return nil
 }

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -753,7 +754,7 @@ func TestSession_UsedTools_EmptyMessagesIsFalse(t *testing.T) {
 }
 
 func TestDeleteSession(t *testing.T) {
-	setTempHome(t)
+	home := setTempHome(t)
 
 	s := NewSession("claude-haiku-4-5-20251001", "")
 	s.Messages = []Message{{Role: RoleUser, Content: "hi"}}
@@ -766,6 +767,18 @@ func TestDeleteSession(t *testing.T) {
 	}
 	if _, err := LoadSession(s.ID); err == nil {
 		t.Fatal("session still loadable after delete")
+	}
+
+	// The transcript is gone for good — a session delete bypasses the trash.
+	trashed := 0
+	_ = filepath.WalkDir(filepath.Join(home, ".octo", "trash"), func(_ string, d fs.DirEntry, err error) error {
+		if err == nil && !d.IsDir() {
+			trashed++
+		}
+		return nil
+	})
+	if trashed != 0 {
+		t.Errorf("deleted session staged %d file(s) in the trash, want 0", trashed)
 	}
 
 	// Deleting a missing session is not an error (idempotent).

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/open-octo/octo-agent/internal/trash"
 	"github.com/robfig/cron/v3"
 )
 
@@ -203,12 +202,8 @@ func (s *Scheduler) Delete(id string) error {
 	s.mu.Unlock()
 	s.unschedule(id)
 	p := filepath.Join(s.dir, id+".json")
-	if _, err := os.Stat(p); err == nil {
-		if err := trash.Move(p, s.dir, trash.Options{DeletedBy: "scheduler", Kind: "delete"}); err != nil {
-			return fmt.Errorf("trash task %s: %w", p, err)
-		}
-	} else if !os.IsNotExist(err) {
-		return err
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove task %s: %w", p, err)
 	}
 	return nil
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -235,6 +235,10 @@ func TestDisableRemovesEntryAndStopsRuns(t *testing.T) {
 }
 
 func TestDeleteRemovesEntryAndStopsRuns(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
 	s, r := newTestScheduler(t)
 	if err := s.Add(&Task{ID: "t1", Name: "n", Cron: "0 0 9 * * *", Prompt: "p", Enabled: true}); err != nil {
 		t.Fatalf("Add: %v", err)
@@ -250,6 +254,14 @@ func TestDeleteRemovesEntryAndStopsRuns(t *testing.T) {
 	fire()
 	if got := len(r.calls()); got != 0 {
 		t.Fatalf("runner calls after delete = %d, want 0", got)
+	}
+
+	// The task file is gone for good — deletes the user asks for skip the trash.
+	if _, err := os.Stat(filepath.Join(s.dir, "t1.json")); !os.IsNotExist(err) {
+		t.Errorf("task file still on disk after delete: err = %v", err)
+	}
+	if entries, err := os.ReadDir(filepath.Join(home, ".octo", "trash")); err == nil && len(entries) > 0 {
+		t.Errorf("deleted task was staged in the trash: %d entr(ies)", len(entries))
 	}
 }
 

--- a/internal/server/memory_handler.go
+++ b/internal/server/memory_handler.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/memory"
-	"github.com/open-octo/octo-agent/internal/trash"
 )
 
 // ─── GET /api/memories/{filename} ───────────────────────────────────────────
@@ -65,7 +64,7 @@ func (s *Server) handleDeleteMemory(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if err := trash.Move(p, filepath.Dir(p), trash.Options{DeletedBy: "memory", Kind: "delete"}); err != nil {
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/memory_listing_test.go
+++ b/internal/server/memory_listing_test.go
@@ -119,3 +119,39 @@ func TestHandleGetMemory_SlugSourceAndTraversal(t *testing.T) {
 		t.Fatalf("unknown slug: status = %d, want 404", w.Code)
 	}
 }
+
+// Forgetting a memory unlinks the file — the user asked for it and the panel
+// warned that it can't be undone, so nothing is staged in the trash.
+func TestHandleDeleteMemory_RemovesFilePermanently(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	root, err := memory.RootDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	slug := "someproj-99887766"
+	if err := os.MkdirAll(filepath.Join(root, slug), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, slug, "notes.md")
+	if err := os.WriteFile(path, []byte("stale note"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/memories/notes.md?source="+slug, nil)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("memory file still on disk after delete: err = %v", err)
+	}
+	if entries, err := os.ReadDir(filepath.Join(tmp, ".octo", "trash")); err == nil && len(entries) > 0 {
+		t.Errorf("deleted memory was staged in the trash: %d entr(ies)", len(entries))
+	}
+}

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"github.com/open-octo/octo-agent/internal/agentprofile"
-	"github.com/open-octo/octo-agent/internal/trash"
 	"gopkg.in/yaml.v3"
 )
 
@@ -308,11 +307,10 @@ func (r *Registry) Delete(name string) error {
 	delete(r.skills, name)
 	delete(r.disabled, name)
 
-	// Move to trash before permanently deleting.
+	// Deleting a skill is permanent — the UI says so before asking.
 	if s.Dir != "" {
-		projDir := filepath.Dir(s.Dir)
-		if err := trash.Move(s.Dir, projDir, trash.Options{DeletedBy: "skill", Kind: "delete"}); err != nil {
-			return fmt.Errorf("trash skill directory %s: %w", s.Dir, err)
+		if err := os.RemoveAll(s.Dir); err != nil {
+			return fmt.Errorf("remove skill directory %s: %w", s.Dir, err)
 		}
 	}
 	return nil

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -56,6 +56,37 @@ func TestReload_PicksUpLateSkill(t *testing.T) {
 	}
 }
 
+// Deleting a skill wipes its directory outright — no copy is staged in the
+// trash, because the user asked for the delete and the UI warned them it can't
+// be undone.
+func TestDelete_RemovesDirectoryPermanently(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	useDefaultRoot(t, t.TempDir())
+	userRoot := t.TempDir()
+	useUserRoot(t, userRoot)
+	writeSkill(t, userRoot, "scratch", "---\nname: scratch\ndescription: throwaway\n---\nbody")
+
+	r := Discover()
+	if _, ok := r.Get("scratch"); !ok {
+		t.Fatal("scratch should be discovered before delete")
+	}
+	if err := r.Delete("scratch"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := r.Get("scratch"); ok {
+		t.Error("deleted skill still resolves via Get")
+	}
+	if _, err := os.Stat(filepath.Join(userRoot, "scratch")); !os.IsNotExist(err) {
+		t.Errorf("skill directory still on disk after delete: err = %v", err)
+	}
+	if entries, err := os.ReadDir(filepath.Join(home, ".octo", "trash")); err == nil && len(entries) > 0 {
+		t.Errorf("deleted skill was staged in the trash: %d entr(ies)", len(entries))
+	}
+}
+
 func TestDiscover_Empty(t *testing.T) {
 	useUserRoot(t, filepath.Join(t.TempDir(), "nonexistent"))
 	r := Discover()

--- a/internal/tools/workflow_registry.go
+++ b/internal/tools/workflow_registry.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"github.com/open-octo/octo-agent/internal/trash"
 )
 
 // ErrWorkflowNotFound and ErrBuiltinWorkflow let callers (e.g. the HTTP
@@ -302,8 +300,8 @@ func DeleteWorkflow(name string) error {
 	if w.path == "" {
 		return fmt.Errorf("workflow %q has no on-disk file", name)
 	}
-	if err := trash.Move(w.path, filepath.Dir(w.path), trash.Options{DeletedBy: "workflow", Kind: "delete"}); err != nil {
-		return fmt.Errorf("trash workflow file %s: %w", w.path, err)
+	if err := os.Remove(w.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove workflow file %s: %w", w.path, err)
 	}
 	return nil
 }

--- a/internal/tools/workflow_registry_test.go
+++ b/internal/tools/workflow_registry_test.go
@@ -279,7 +279,7 @@ func TestDeleteWorkflow_UnknownName(t *testing.T) {
 	}
 }
 
-func TestDeleteWorkflow_RemovesUserFileAndTrashesIt(t *testing.T) {
+func TestDeleteWorkflow_RemovesUserFilePermanently(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
@@ -299,20 +299,15 @@ func TestDeleteWorkflow_RemovesUserFileAndTrashesIt(t *testing.T) {
 		t.Error("deleted workflow still resolves via GetNamedWorkflow")
 	}
 
-	// Trashed, not permanently destroyed — mirrors skills.Registry.Delete.
+	// Permanent — a workflow the user deleted leaves no shadow copy behind.
 	trashed, err := trash.List()
 	if err != nil {
 		t.Fatal(err)
 	}
-	found := false
 	for _, e := range trashed {
 		if e.Original == path {
-			found = true
-			break
+			t.Errorf("deleted workflow was staged in the trash: %+v", e)
 		}
-	}
-	if !found {
-		t.Errorf("deleted workflow file not found in trash: entries = %+v", trashed)
 	}
 }
 

--- a/internal/trash/trash.go
+++ b/internal/trash/trash.go
@@ -44,7 +44,9 @@ const (
 // what removed a file. All fields are optional; the zero value is fine.
 type Options struct {
 	// DeletedBy names the surface that removed the file: "rm", "write_file",
-	// "edit_file", "session", "skill", "workflow", "scheduler", "memory".
+	// "edit_file". Older sidecars may carry surfaces that no longer stage
+	// anything ("session", "skill", "workflow", "scheduler", "memory") — those
+	// deletes are permanent now, but their existing entries still read back.
 	DeletedBy string
 	// Kind is "delete" or "overwrite".
 	Kind string

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -253,17 +253,17 @@ export const en: Record<string, string> = {
   "mcp.tool_count": "{n} tool(s)",
   "mcp.btn.edit_with_agent": "Edit with Agent",
   // Skills view
-  "skills.confirm_delete": "Delete skill \"{name}\"?",
+  "skills.confirm_delete": "Delete skill \"{name}\"? This cannot be undone.",
   "skills.toast_deleted": "Skill \"{name}\" deleted — /reload an open session, or start a new one, for the change to take effect there",
   "skills.toast_imported": "Skill \"{name}\" imported — /reload an open session, or start a new one, to use it there",
   "skills.toast_toggled": "Skill \"{name}\" updated — /reload an open session, or start a new one, for the change to take effect there",
   // Workflows view
-  "workflows.confirm_delete": "Delete workflow \"{name}\"?",
+  "workflows.confirm_delete": "Delete workflow \"{name}\"? This cannot be undone.",
   "workflows.toast_deleted": "Workflow \"{name}\" deleted",
   // Tasks view
   "tasks.toast_started": "Task started",
   "tasks.toast_deleted": "Task deleted",
-  "tasks.confirm_delete": "Delete scheduled task \"{name}\"?",
+  "tasks.confirm_delete": "Delete scheduled task \"{name}\"? This cannot be undone.",
   // Channels view
   "channels.not_configured": "Not configured",
   "status.stopped": "Stopped",
@@ -477,6 +477,7 @@ export const en: Record<string, string> = {
   "profile.user": "User",
   "profile.memories": "Memories",
   "profile.forget": "Forget",
+  "profile.confirm_forget": "Forget the memory \"{name}\"? This cannot be undone.",
   "profile.update": "Have the Assistant Update This",
   "profile.session_soul": "Update soul.md",
   "profile.session_user": "Update user.md",
@@ -1159,12 +1160,12 @@ export const zh: Record<string, string> = {
   "mcp.tool_count": "{n} 个工具",
   "mcp.btn.edit_with_agent": "请 Agent 修改",
   // 技能视图
-  "skills.confirm_delete": "删除技能 \"{name}\"?",
+  "skills.confirm_delete": "删除技能 \"{name}\"？删除后无法恢复。",
   "skills.toast_deleted": "技能 \"{name}\" 已删除 —— 对已打开的会话执行 /reload，或新建一个会话，才能生效",
   "skills.toast_imported": "技能 \"{name}\" 已导入 —— 对已打开的会话执行 /reload，或新建一个会话，才能使用",
   "skills.toast_toggled": "技能 \"{name}\" 已更新 —— 对已打开的会话执行 /reload，或新建一个会话，才能生效",
   // 工作流视图
-  "workflows.confirm_delete": "删除工作流 \"{name}\"?",
+  "workflows.confirm_delete": "删除工作流 \"{name}\"？删除后无法恢复。",
   "workflows.toast_deleted": "工作流 \"{name}\" 已删除",
   // 任务视图
   "tasks.toast_started": "任务已启动",
@@ -1294,7 +1295,7 @@ export const zh: Record<string, string> = {
   "tasks.resume": "恢复",
   "tasks.paused_toast": "任务已暂停",
   "tasks.resumed": "任务已恢复",
-  "tasks.confirm_delete": "确认删除定时任务 \"{name}\"？",
+  "tasks.confirm_delete": "确认删除定时任务 \"{name}\"？删除后无法恢复。",
   "tasks.modal_edit": "编辑定时任务",
   "tasks.modal_new": "新建定时任务",
   "tasks.field_name": "名称",
@@ -1379,6 +1380,7 @@ export const zh: Record<string, string> = {
   "profile.user": "用户",
   "profile.memories": "记忆",
   "profile.forget": "忘记",
+  "profile.confirm_forget": "忘记记忆 \"{name}\"？删除后无法恢复。",
   "profile.update": "让助手更新此内容",
   "profile.session_soul": "更新 soul.md",
   "profile.session_user": "更新 user.md",

--- a/web/src/views/ProfileView.svelte
+++ b/web/src/views/ProfileView.svelte
@@ -4,6 +4,7 @@
   import StatusTag from '../components/ui/StatusTag.svelte'
   import { renderMarkdown } from '../lib/markdown'
   import * as api from '../lib/api'
+  import { confirmDialog } from '../lib/confirm'
   import type { Memory } from '../lib/types'
   import { t, tr } from '../lib/i18n'
 
@@ -85,6 +86,7 @@
   }
 
   async function forgetMemory(f: Memory) {
+    if (!(await confirmDialog(tr('profile.confirm_forget').replace('{name}', f.name)))) return
     try {
       // #1109: was a raw fetch() with no res.ok check — a failing delete
       // (404/500) still reported "Memory removed" and the row reappeared on


### PR DESCRIPTION
The trash exists so an agent can't destroy work irreversibly. It had drifted past that: deleting a session, a skill, a workflow, a scheduled task, or a memory — all things the *user* asks for from the UI — staged a copy under `~/.octo/trash` too. That copy is retention nobody asked for and can't easily see, and it filled the File Recall view with skill directories and task JSON the user had already decided to get rid of.

## What changes

Deletes the user requests now unlink outright:

| Object | Delete path |
|---|---|
| Session transcript | `agent.DeleteSession` → `os.Remove` |
| Skill | `skills.Registry.Delete` → `os.RemoveAll` |
| Workflow | `tools.DeleteWorkflow` → `os.Remove` |
| Scheduled task | `scheduler.Delete` → `os.Remove` |
| Memory | `handleDeleteMemory` → `os.Remove` |

In exchange the warning moves to before the fact. `skills.confirm_delete`, `workflows.confirm_delete` and `tasks.confirm_delete` now say the delete cannot be undone, and forgetting a memory — which deleted on a single click, with no prompt at all — gains a confirmation of its own (`profile.confirm_forget`). Both locales. The web UI is the only surface that offers these deletes, so that covers every entry point.

The trash keeps covering what the *agent* does: shell `rm` (POSIX wrapper and the Windows cmdlet shadow) and `write_file` / `edit_file` overwrites, with inline undo unchanged. Entries staged by the old surfaces still list and restore normally — `trash.Options.DeletedBy` documents those values as legacy rather than dropping them.

`dev-docs/trash-recall-design.md` gains a "Deletes the user asks for" section stating the boundary and why.

## Test

- New: `skills.TestDelete_RemovesDirectoryPermanently`, `server.TestHandleDeleteMemory_RemovesFilePermanently`; `agent.TestDeleteSession` and `scheduler.TestDeleteRemovesEntryAndStopsRuns` extended to assert the trash stays empty.
- `TestDeleteWorkflow_RemovesUserFileAndTrashesIt` → `..._RemovesUserFilePermanently`, assertion inverted.
- `go vet ./...`, `go test ./...`, `npx svelte-check` (0 errors) and `npx vitest run` (384 tests) all clean.
