### PR TITLE
feat(web): the task status tag toggles pause/resume

### DIFF
--- a/web/src/views/TasksView.svelte
+++ b/web/src/views/TasksView.svelte
@@ -33,22 +33,30 @@
 
   // ── data loading ─────────────────────────────────────────────────────────────
 
+  function fetchTasks(): Promise<api.TaskResponse[]> {
+    // When viewing a specific agent, filter tasks to its ownership.
+    const agentId = get(activeAgent)
+    const url = agentId !== 'default' ? `/api/tasks?agent_id=${encodeURIComponent(agentId)}` : '/api/tasks'
+    return agentId !== 'default' ? api.request<any[]>(url) : api.listTasks()
+  }
+
+  function applyTasks(list: api.TaskResponse[]) {
+    rawTasks = list
+    // Sync into shared store (ScheduledTask display shape) for other consumers
+    tasks.set(list.map(t => ({
+      name: t.name,
+      target: t.agent_id || t.agent || t.model || '',
+      cron: t.cron,
+      nextRun: t.enabled ? fmtDate(t.next_run) : '—',
+      tagStatus: t.enabled ? 'success' : 'default',
+      tagLabel: t.enabled ? tr('status.active') : tr('status.disabled'),
+    })))
+  }
+
   async function load() {
     loading = true
     try {
-      // When viewing a specific agent, filter tasks to its ownership.
-      const agentId = get(activeAgent)
-      const url = agentId !== 'default' ? `/api/tasks?agent_id=${encodeURIComponent(agentId)}` : '/api/tasks'
-      rawTasks = await (agentId !== 'default' ? api.request<any[]>(url) : api.listTasks())
-      // Sync into shared store (ScheduledTask display shape) for other consumers
-      tasks.set(rawTasks.map(t => ({
-        name: t.name,
-        target: t.agent_id || t.agent || t.model || '',
-        cron: t.cron,
-        nextRun: t.enabled ? fmtDate(t.next_run) : '—',
-        tagStatus: t.enabled ? 'success' : 'default',
-        tagLabel: t.enabled ? tr('status.active') : tr('status.disabled'),
-      })))
+      applyTasks(await fetchTasks())
     } catch (e: any) {
       showToast(e?.message ?? 'Failed to load tasks', 'error')
     } finally {
@@ -59,6 +67,28 @@
   onMount(load)
 
   // ── actions ──────────────────────────────────────────────────────────────────
+
+  let togglingId = $state<string | null>(null)
+
+  // The status tag doubles as the pause/resume control: clicking it flips the
+  // task between active and disabled.
+  async function handleToggle(t: api.TaskResponse) {
+    if (togglingId) return
+    togglingId = t.id
+    const next = !t.enabled
+    try {
+      await api.toggleTask(t.id, next)
+      applyTasks(rawTasks.map(r => (r.id === t.id ? { ...r, enabled: next } : r)))
+      showToast(next ? tr('tasks.resumed') : tr('tasks.paused_toast'))
+      // The server recomputes next_run on resume; refresh silently so the row
+      // doesn't keep showing the "—" it carried while paused.
+      fetchTasks().then(applyTasks).catch(() => {})
+    } catch (e: any) {
+      showToast(e?.message ?? 'Failed to update task', 'error')
+    } finally {
+      togglingId = null
+    }
+  }
 
   async function handleRun(t: api.TaskResponse) {
     try {
@@ -167,11 +197,18 @@
               <span class="run-line">{$t('tasks.next_run_label')} {task.enabled ? fmtDate(task.next_run) : '—'}</span>
             </div>
 
-            <!-- Status tag -->
+            <!-- Status tag — click to pause/resume -->
             <span>
-              <StatusTag status={task.enabled ? 'success' : 'default'}>
-                {task.enabled ? $t('status.active') : $t('status.disabled')}
-              </StatusTag>
+              <button
+                class="status-toggle"
+                title={task.enabled ? $t('tasks.pause') : $t('tasks.resume')}
+                disabled={togglingId !== null}
+                onclick={() => handleToggle(task)}
+              >
+                <StatusTag status={task.enabled ? 'success' : 'default'}>
+                  {task.enabled ? $t('status.active') : $t('status.disabled')}
+                </StatusTag>
+              </button>
             </span>
 
             <!-- Actions -->
@@ -250,6 +287,13 @@ p { margin: 4px 0 0; font-size: 13px; color: var(--text-secondary); max-width: 6
 .cron { font-size: 13px; color: var(--text-secondary); }
 .run-times-cell { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .run-line { font-size: 12px; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.status-toggle {
+  border: none; background: transparent; padding: 0; margin: 0;
+  font: inherit; cursor: pointer; border-radius: 999px; display: inline-flex;
+}
+.status-toggle:hover:not(:disabled) { opacity: 0.72; }
+.status-toggle:focus-visible { outline: 2px solid var(--blue-6); outline-offset: 1px; }
+.status-toggle:disabled { cursor: default; }
 .row-actions { display: flex; align-items: center; justify-content: flex-end; gap: 4px; }
 .act-btn {
   width: 28px; height: 28px; border: none; background: transparent;


### PR DESCRIPTION
The Scheduled Tasks table showed enabled/disabled as a read-only tag, so pausing a task meant opening a conversation with the `cron-task-creator` skill. Make the tag itself the control: one click flips the task between active and disabled through the existing `PATCH /api/tasks/{id}` endpoint — the same call the mobile Tasks tab already makes.

- The tag becomes a button (`title` = 暂停 / 恢复, focus ring, single-flight guard while a PATCH is in the air).
- The row updates optimistically, then a silent refetch picks up the `next_run` the server recomputes on resume; without it the row keeps the `—` it carried while paused.
- Loading is factored into `fetchTasks` / `applyTasks` so that refetch reuses the agent-scoped URL and keeps the shared `tasks` store in sync without flashing the table into its loading state.
- No new i18n keys: `tasks.pause` / `tasks.resume` / `tasks.paused_toast` / `tasks.resumed` already existed in both locales.

Verified against a real `octo serve` through a dev-server proxy: clicking 已禁用 → 活跃 flips the badge green, fills in 下次, moves the KPI counts (活跃 0→1, 已暂停 1→0), and toasts 任务已恢复; clicking again restores the disabled state. `svelte-check` clean, `vitest run` 384 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)