### PR TITLE
fix(server): task timestamps are published as real UTC

### DIFF
--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -744,15 +744,19 @@ func (s *Server) taskToResponse(t scheduler.Task) taskResponse {
 		Notify:    t.Notify,
 		Enabled:   t.Enabled,
 	}
+	// A bare trailing "Z" is a literal in a Go layout, not the UTC designator,
+	// so formatting a local time with it used to claim local wall-clock as UTC
+	// and every client shifted these stamps by the local offset. Convert first,
+	// then let RFC3339 write the real "Z".
 	if !t.CreatedAt.IsZero() {
-		r.CreatedAt = t.CreatedAt.Format("2006-01-02T15:04:05Z")
+		r.CreatedAt = t.CreatedAt.UTC().Format(time.RFC3339)
 	}
 	if !t.LastRun.IsZero() {
-		r.LastRun = t.LastRun.Format("2006-01-02T15:04:05Z")
+		r.LastRun = t.LastRun.UTC().Format(time.RFC3339)
 	}
 	if s.scheduler != nil {
 		if next := s.scheduler.NextRun(t.ID); !next.IsZero() {
-			r.NextRun = next.Format("2006-01-02T15:04:05Z")
+			r.NextRun = next.UTC().Format(time.RFC3339)
 		}
 	}
 	r.SessionID = t.SessionID

--- a/internal/server/tasks_handlers_test.go
+++ b/internal/server/tasks_handlers_test.go
@@ -302,3 +302,50 @@ func TestCreateSession_EmptyAgentID_DefaultsToDefault(t *testing.T) {
 		t.Errorf("EffectiveAgentID() = %q, want %q", got, "default")
 	}
 }
+
+// TestTaskToResponse_TimestampsAreUTC guards the timestamp layout: the API
+// stamps used to be formatted with a bare trailing "Z", which Go treats as a
+// literal rather than the UTC designator, so a task created at 19:25 +08:00
+// was published as "19:25Z" and every client rendered it 8 hours late.
+func TestTaskToResponse_TimestampsAreUTC(t *testing.T) {
+	shanghai := time.FixedZone("CST", 8*60*60)
+	srv := &Server{}
+	got := srv.taskToResponse(scheduler.Task{
+		ID:        "task_1",
+		Name:      "n",
+		CreatedAt: time.Date(2026, 8, 19, 19, 25, 59, 0, shanghai),
+		LastRun:   time.Date(2026, 8, 19, 19, 42, 35, 0, shanghai),
+	})
+	if want := "2026-08-19T11:25:59Z"; got.CreatedAt != want {
+		t.Errorf("created_at = %q, want %q", got.CreatedAt, want)
+	}
+	if want := "2026-08-19T11:42:35Z"; got.LastRun != want {
+		t.Errorf("last_run = %q, want %q", got.LastRun, want)
+	}
+}
+
+// TestTaskToResponse_NextRunIsTheSchedulerInstant: next_run comes from the live
+// cron entry (a local-zone time), so it must survive serialisation as the same
+// instant rather than as local wall-clock relabelled UTC.
+func TestTaskToResponse_NextRunIsTheSchedulerInstant(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.initScheduler()
+
+	task := scheduler.Task{Name: "next-run", Cron: "0 */5 * * * *", Prompt: "p", Enabled: true}
+	if err := srv.scheduler.Add(&task); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	want := srv.scheduler.NextRun(task.ID)
+	if want.IsZero() {
+		t.Fatal("scheduler reported no next run for an enabled task")
+	}
+	got, err := time.Parse(time.RFC3339, srv.taskToResponse(task).NextRun)
+	if err != nil {
+		t.Fatalf("parse next_run: %v", err)
+	}
+	if !got.Equal(want.Truncate(time.Second)) {
+		t.Errorf("next_run = %v, want the scheduler instant %v", got, want.Truncate(time.Second))
+	}
+}


### PR DESCRIPTION
`taskToResponse` formatted `created_at`, `last_run` and `next_run` with the layout `"2006-01-02T15:04:05Z"`. A bare trailing `Z` is a **literal** in a Go layout, not the UTC designator (that's `Z07:00`), so local wall-clock time went out labelled as UTC and every client shifted it by the local offset.

On a +08:00 host, live from `/api/tasks`:

```
on disk : "last_run": "2026-08-19T19:42:35.957+08:00"   (correct — encoding/json writes the offset)
API     : "last_run": "2026-08-19T19:42:35Z"            (19:42 local relabelled as UTC)
web UI  : 上次：8月20日 03:42                            (8 hours late)
```

Same for `next_run`: a task resumed at 20:15 local announced its next run for 8月21日 04:20 instead of 8月20日 20:20.

The fix converts to UTC before formatting and uses `time.RFC3339` so the designator is written by the layout. Purely the response layer — storage was always right, and clients that parse these as instants need no change.

Two tests: exact expected strings for `created_at` / `last_run` built from a fixed +08:00 zone (deterministic in any CI timezone), and `next_run` compared against the instant the scheduler reports.

`go build ./...`, `go vet`, `gofmt -l` clean; `./internal/server/` and `./internal/scheduler/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)