### PR TITLE
feat(memory): tell the agent to save what it learned the hard way

### DIFF
--- a/dev-docs/memory-design.md
+++ b/dev-docs/memory-design.md
@@ -83,10 +83,19 @@ what the agent writes now surfaces in the *next* session, not the current one.
 The session-prompt guidance (`internal/prompt/base.md`, "Memory" section)
 covers when to save (lasting preferences, corrections + the why, validated
 judgment, project decisions and milestones — the rationale and the
-alternatives ruled out, not the diff — and external resources), what not to
-save (one-off task state, the content of code changes, secrets), grounding
-answers in memory with a brief inline attribution, and verifying a remembered
-file/flag still exists before acting on it.
+alternatives ruled out, not the diff — a non-obvious environment or tooling
+behaviour the agent worked out the hard way, and external resources), what not
+to save (one-off task state, the content of code changes, anything already in
+`.octorules`, secrets), grounding answers in memory with a brief inline
+attribution, and verifying a remembered file/flag still exists before acting
+on it.
+
+The tooling-behaviour entry is the one signal nobody hands the agent. Every
+other item on that list originates with the user — a preference stated, a
+correction given, a decision accepted — and the save-nudge below covers the
+milestone case. A trap discovered through trial and error has neither: no
+utterance to react to and no `gh pr` to fire on, which makes it the kind most
+likely to be paid for twice.
 
 ## Attention layer — structured rules, re-surfaced at the point of action
 

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -261,9 +261,10 @@ func RenderInjection(dir string, inheritedDirs ...string) string {
 	b.WriteString("\n" + IndexFile + " is the index, loaded here every session; topic files beside it hold detail and load on demand.\n\n")
 	b.WriteString("Manage memory yourself with your file tools — that directory is writable:\n")
 	b.WriteString("- When the user states a lasting preference, gives feedback or a correction, or shares something worth recalling in future sessions, save it (append to " + IndexFile + ", or to a topic file linked from it).\n")
+	b.WriteString("- Save what you worked out the hard way too: a non-obvious environment or tooling behaviour that cost you real time and would cost it again. Nobody will tell you that one — the signal is your own struggle, so it is the easiest kind to keep re-discovering.\n")
 	b.WriteString("- Keep " + IndexFile + " a concise index; move long detail into topic files.\n")
 	b.WriteString("- For a load-bearing rule you must not skip, write it in full under a '## 必须遵守' (always-apply) section, or, if it only matters for certain tasks, under a '## 触发提醒' section with a leading '(触发: keyword1, keyword2)' clause. Rules in those sections are re-surfaced to you at the point of action; everything else stays a pointer index.\n")
-	b.WriteString("- Edit or delete entries that become wrong or obsolete. Don't store one-off task details or things already in the repo / CLAUDE.md.\n")
+	b.WriteString("- Edit or delete entries that become wrong or obsolete. Don't store one-off task details, or anything already in .octorules or the repo's own docs.\n")
 	if len(inheritedDirs) > 0 {
 		b.WriteString("- When saving new memories, sort them by scope: write project-specific facts (repo conventions, tech stack, architecture) to the project memory above; write cross-project or personal preferences (coding style, tool defaults, name, role, habits) to the inherited (home) memory. If unsure, prefer the project memory — it can always be moved later.\n")
 	}

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -71,9 +71,10 @@ The moment you notice a signal worth carrying forward:
 - A correction ("don't do X") — save the rule **and** the WHY they gave (often a past incident).
 - A non-obvious choice the user accepts without pushback — validated judgment matters too, not just corrections.
 - A project decision or milestone — a direction settled, an approach **rejected** ("considered X, decided against — don't re-propose"), a phase shipped. The diff and git log already record *what* changed; save the *why*, the alternatives ruled out, and any constraint future sessions must respect.
+- A non-obvious environment or tooling behaviour you worked out the hard way — the symptom, the cause, and how to recognise it next time. Nobody will hand you this one: the signal is your own lost time, not something the user said, so it is the easiest kind to keep re-discovering.
 - An external resource and what it's for (a dashboard, ticket project, channel, repo).
 
-Do **not** save one-off task state, the content of code changes (the diff and git log already hold those), anything already in CLAUDE.md / .octorules, debug recipes already in the code, or secrets/tokens/credentials.
+Do **not** save one-off task state, the content of code changes (the diff and git log already hold those), anything already in `.octorules`, a recipe already written down where you would next go looking for it, or secrets/tokens/credentials.
 
 ### Grounding answers in memory
 

--- a/internal/skills/defaults/product_help/WORKFLOW.md
+++ b/internal/skills/defaults/product_help/WORKFLOW.md
@@ -36,6 +36,6 @@ Dependency direction is one-way: `provider → agent`, `tools → agent`, never 
 
 ## Before opening a PR
 
-Read `.octorules` and `CLAUDE.md` at the repo root — layering, conventions, and common pitfalls, most "will this land" questions answered there. Branch off latest `main` (never commit on `main` directly); one concept per PR; `make test && make vet && make fmt-check` before pushing; squash-and-merge is the default.
+Read `.octorules` at the repo root — layering, conventions, and common pitfalls, most "will this land" questions answered there. Branch off latest `main` (never commit on `main` directly); one concept per PR; `make test && make vet && make fmt-check` before pushing; squash-and-merge is the default.
 
 Full contributor guide (what reviewers look for, dependency policy, comment style): **https://octo-agent.dev/docs/community/contributing/** (`web_fetch`).


### PR DESCRIPTION
## Why

Every signal on the memory system's "when to save" list originates with the user — a preference stated, a correction given, a choice accepted, a decision settled. The one remaining case, a milestone, is covered separately by the save-nudge that fires on `gh pr create|merge`.

A trap the agent works out through trial and error has neither: nothing was said to react to, and no PR fires. So the one class of knowledge nobody hands the agent is also the one class it has no instruction to keep.

Concretely, the kind of thing that gets paid for twice:

- a test environment that silently lacks an API the code assumes
- a sanitizer that drops an element together with its contents, producing output that looks fine and says nothing
- a store subscription that fires once with an initial value before any data has loaded

None of those is a preference, a correction, or a project decision. An agent reading the list closely finds no reason to write any of them down, and rediscovers them on the next session that touches the same area.

## What changes

Adds that class to both places the criteria appear — the session prompt (`internal/prompt/base.md`) and the memory block injected next to the directory path (`internal/memory/memory.go`). Two copies existed already; this keeps them in step.

**Removes two references to CLAUDE.md, which octo does not read.** Project rules come from `.octorules` and `~/.octo/octorules.md` (`internal/prompt/prompt.go:53`); nothing in the codebase loads CLAUDE.md. Telling the agent not to save "anything already in CLAUDE.md" was backwards — that file is invisible to octo, so its contents are precisely what the agent does *not* already know. The `product_help` skill likewise pointed at CLAUDE.md for repo conventions.

**Narrows "debug recipes already in the code"**, which was broad enough to rule out the new entry: a trap noted in a comment in one file is not findable from the different file where you next hit it. It now excludes only a recipe written down where you would next go looking for it.

## What this does not do

No new trigger. The save-nudge stays scoped to `gh pr create|merge`, and this class of discovery has no comparably clean signal — the plausible ones (a tool call that failed several times then succeeded) are noisy, and the design's own reasoning applies: *"a noisy nudge trains the model to ignore it"*. Widening the criteria costs three lines; a bad trigger costs the credibility of every nudge.

## Cost

Two sentences in the session prompt and one in the memory block, both of which ship on every request. Weighed against a class of knowledge that currently has to be rediscovered every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
