### PR TITLE
refactor(server): drop project notes

### DIFF
--- a/dev-docs/projects-design.md
+++ b/dev-docs/projects-design.md
@@ -12,9 +12,9 @@ octo 的工作目录曾是纯粹的**每会话**属性（`agent.Session.WorkingD
 
 | 做 | 不做 |
 |---|---|
-| 项目携带 `working_dir` + `notes` | 项目级默认模型 / 专家 / 权限模式 |
+| 项目携带 `working_dir` | 项目级默认模型 / 专家 / 权限模式 |
 | 项目目录强绑定，实时生效 | CLI / TUI 感知项目 |
-| `notes` 注入项目内会话的 system prompt | 嵌套项目、一个会话属于多个项目 |
+| 每个项目一个记忆层 | 嵌套项目、一个会话属于多个项目 |
 | Web + 桌面 UI | IM channel / cron 显式绑定项目 |
 
 **每个 cron task 就是一个项目**：调度器为它建一个同名项目，工作目录 `<workspace>/<任务名>`（`cronProjectDir`，按需创建，`TaskID` 记录来源）。这解决了一个实打实的 bug——调度器不像 HTTP 创建路径那样 seed 工作目录，所以运行会话既没有自己的目录、簇也没有，一路落到**服务器的启动目录**：机器上所有定时任务都在 `octo serve` 恰好启动的那个目录里跑，两个任务写同名文件会互相覆盖。一任务一目录同时给了它自己的记忆层（记忆按项目划作用域）。
@@ -45,8 +45,6 @@ CLI 只认**项目目录**，不认会话自己的 `WorkingDir`。因为 `applyD
 
 解析只发生一次，和这段代码里其它所有东西一样——REPL 内切换会话不重算，与 CLI 既有的"每进程组一次系统提示词"模型一致。重定位会打印一行说明：静默地在别处跑工具会让人莫名其妙。
 
-CLI 只重定位目录，**不注入项目 notes**——同一会话在 CLI 和 Web 下的 system prompt 因此不同。这是范围裁剪的直接推论（CLI 每进程组一次提示词，且不走服务端的组装点），不是遗漏。
-
 CLI 仍然**没有**修改工作目录的入口。`SetWorkingDir` 只有 `internal/server` 三个调用点，所以不存在"在别处改了目录、Web 里不生效"的反向静默失效；项目的目录只能在创建它的地方定。CLI/TUI 也不调 `SetComposedSystem`（每进程组一次提示词），因此用 TUI 跑一条项目会话不会把目录写进 `ComposedForCWD` 去污染 Web 侧的冻结身份。
 
 ## 数据模型
@@ -63,8 +61,6 @@ type sessionGroup struct {
 	// WorkingDir 非空 ⇒ 这个组是一个「项目」，组内所有会话的工具都在
 	// 这里运行，记忆也按它划作用域。
 	WorkingDir string `json:"working_dir,omitempty"`
-	// Notes 是项目级说明，注入组内会话 system prompt 的项目记忆层。
-	Notes string `json:"notes,omitempty"`
 	// TaskID 非空 ⇒ 这个项目是为该 cron 任务创建的。只用于启动时的修复
 	// （给写在这之前、还没有目录的簇补上目录），不参与任何 UI 或权限判定。
 	TaskID string `json:"task_id,omitempty"`
@@ -114,26 +110,24 @@ func (s *Server) resolveSessionDir(sessionID string, own string) string {
 
 这是本设计唯一的硬点。
 
-`Session.ComposedSystem` 在首个 turn 冻结，之后每个 turn 复用同一字符串，为的是保住 provider 的 prompt cache 前缀（`server.go:1284-1298`）。而**工作目录本身就烘焙在里面**——`buildEnvContext(cwd)` 产出的 `- Working directory: /path` 是 composed prompt 的一部分。项目级 `notes` 同理。
+`Session.ComposedSystem` 在首个 turn 冻结，之后每个 turn 复用同一字符串，为的是保住 provider 的 prompt cache 前缀。而**工作目录本身就烘焙在里面**——`buildEnvContext(cwd)` 产出的 `- Working directory: /path` 是 composed prompt 的一部分。
 
 所以改项目目录后，工具 cwd 会立刻跟着变（`buildAgent` 每 turn 重设 `a.CWD`），但 system prompt 里还写着老目录。模型会看到两个互相矛盾的事实。
 
 **这个缺口今天已经存在**：`handleUpdateSessionWorkingDir`（`handlers.go:1517`）改单会话工作目录时也没有解冻 prompt。项目功能必须修掉它，否则强绑定语义在模型眼里是假的。
 
-### 方案：把 cwd 和 notes 纳入冻结身份
+### 方案：把 cwd 纳入冻结身份
 
-已有先例——模型切换会强制重新冻结，因为 MCP manifest 依赖模型的上下文窗口（`IsComposedFor` 检查的是模型而不只是"是否为空"）。cwd 和 notes 是完全同构的第三、第四个维度。
+已有先例——模型切换会强制重新冻结，因为 MCP manifest 依赖模型的上下文窗口（`IsComposedFor` 检查的是模型而不只是"是否为空"）。cwd 是完全同构的第二个维度。
 
 ```go
-// agent 层：冻结时记下它是针对哪个 cwd / 哪份 notes 组装的
-ComposedForCWD   string `json:"composed_for_cwd,omitempty"`
-ComposedForNotes string `json:"composed_for_notes,omitempty"` // notes 的 sha256 前 12 位
+// agent 层：冻结时记下它是针对哪个 cwd 组装的
+ComposedForCWD string `json:"composed_for_cwd,omitempty"`
 
-func (s *Session) IsComposedFor(model, cwd, notesHash string) bool {
+func (s *Session) IsComposedFor(model, cwd string) bool {
 	return s.ComposedSystem != "" &&
 		s.ComposedForModel == model &&
-		s.ComposedForCWD == cwd &&
-		s.ComposedForNotes == notesHash
+		s.ComposedForCWD == cwd
 }
 ```
 
@@ -147,11 +141,7 @@ func (s *Session) IsComposedFor(model, cwd, notesHash string) bool {
 
 ### 缓存代价
 
-改项目目录 = 组内所有会话下一 turn 的 prompt 前缀变化 = 各失效一次 prompt cache。改目录是低频操作，可接受。但这也意味着**不要**把频繁变动的东西塞进 `notes`。
-
-### notes 的注入位置
-
-`prompt.ComposePair(base, cwd, envCtx, skills, mcpTools, memory, coauthor, expertMode)` 的 `memory` 参数就是 L1 项目记忆层。把 notes 拼在 `memInjection` 前面即可，不需要改 `ComposePair` 签名。
+改项目目录 = 组内所有会话下一 turn 的 prompt 前缀变化 = 各失效一次 prompt cache。改目录是低频操作，可接受。
 
 ## 新会话的创建行为
 
@@ -159,7 +149,7 @@ func (s *Session) IsComposedFor(model, cwd, notesHash string) bool {
 
 入口是项目头的「+」按钮：`POST /api/sessions` 带 `group_id`，服务端**先入组、再走 seed 逻辑**——顺序是语义的一部分，守卫查的就是"这个会话在不在项目里"。把尚未落盘的会话 ID 先写进 registry 是安全的：registry 只存裸 ID，后续 Save 失败留下的死 ID 按既有设计无害（前端与活会话列表交叉过滤）。未知 `group_id` 直接 404，不产出孤儿会话。
 
-**会话的归属在创建时决定，之后不可改。** `PUT /api/sessions/{id}/group` 一律 409。因为"移动"不是一件事而是四件，且事后无法让它们一致：工具的目录、记忆层、烘焙进 system prompt 的项目 notes、hooks 与沙箱的信任根，全都由项目派生。被移动过的会话会留下一份"前半段在别处跑、读的是另一个项目的 notes"的记录，而保住 prompt cache 的冻结判据分辨不出这种情况（判据是 cwd + notesHash，会话自己的目录恰好等于项目目录时甚至不会重组）。在创建时决定，这四件事对会话的整个生命周期都成立。
+**会话的归属在创建时决定，之后不可改。** `PUT /api/sessions/{id}/group` 一律 409。因为"移动"不是一件事而是三件，且事后无法让它们一致：工具的目录、记忆层、hooks 与沙箱的信任根，全都由项目派生。被移动过的会话会留下一份"前半段在别处跑"的记录，而保住 prompt cache 的冻结判据分辨不出这种情况（判据是 cwd，会话自己的目录恰好等于项目目录时甚至不会重组）。在创建时决定，这三件事对会话的整个生命周期都成立。
 
 因此存量里"先建会话、再拖进项目"产生的会话（带着 seeded 的 `~/Octo`，被项目遮蔽）是历史形态，不会再新增。
 
@@ -172,13 +162,12 @@ type updateSessionGroupRequest struct {
 	Name       *string `json:"name,omitempty"`
 	Collapsed  *bool   `json:"collapsed,omitempty"`
 	WorkingDir *string `json:"working_dir,omitempty"` // 不可置空（400）——降级的目标已不存在
-	Notes      *string `json:"notes,omitempty"`
 }
 ```
 
 目录校验（`expandDir` + `os.Stat` + `IsDir`）今天内联在 `handleUpdateSessionWorkingDir` 里，抽成共享 helper，两个入口的报错文案保持一致。
 
-`GET /api/session-groups` 与会话列表接口顺带返回 `working_dir` / `notes`，前端不额外发请求。
+`GET /api/session-groups` 与会话列表接口顺带返回 `working_dir`，前端不额外发请求。
 
 ## UI
 
@@ -195,14 +184,14 @@ type updateSessionGroupRequest struct {
 
 - **新建项目**：先选目录再建，因为项目就是目录。目录决定名字（basename），已有同目录项目则复用而不是造重复。侧栏顶部按钮和会话行的「移动到项目 → 新建项目」走同一条 `resolveProjectForDir`。
 - **项目头**：只有名字、会话数，以及 hover 时出现的两个动作：`···`（菜单：改名 / 上移 / 下移 / 删除项目）和 `+`（在这个项目里开新会话——落地页 + 该项目已选中）。曾经并排六个图标（上移/下移/重命名/删除/+/设置），整行读起来像一条工具栏后面挂了个名字。
-- **没有「项目设置」弹窗，行下也不再显示目录**。目录在创建项目时由落地页选定，之后不可改（和会话归属一样在创建时定死），所以那个弹窗里只剩下一件事可做——改 `notes`——而项目记忆层（agent 自己会写）已经覆盖了同一件事。目录仍然通过项目名（默认取目录 basename）、名字的 tooltip，以及会话里 Composer 的目录 chip 呈现。`PATCH /api/session-groups/{id}` 的 `working_dir` / `notes` 字段保留，供脚本和 agent 使用；`notes` 非空时照旧注入 system prompt。
+- **没有「项目设置」弹窗，行下也不再显示目录**。目录在创建项目时由落地页选定，之后不可改（和会话归属一样在创建时定死）。项目级说明这件事由项目记忆层承担——agent 自己会写、自己会读，不需要用户再手填一份。目录仍然通过项目名（默认取目录 basename）、名字的 tooltip，以及会话里 Composer 的目录 chip 呈现。`PATCH /api/session-groups/{id}` 的 `working_dir` 字段保留，供脚本和 agent 使用。
 - **删除项目连带删除它的会话**：`DELETE /api/session-groups/{id}?sessions=delete`，一个请求做完，失败不会留下"项目还在、会话已没"的中间态（会话先删——留下一个可见的空项目行比留下一堆无处可达的会话好）。确认框带标题、会话条数和红色确认按钮；空项目走另一份文案且不标危险。不带这个参数时会话保留并变回任务。
 - **Composer 的 cwd chip**：会话属于项目时显示项目目录，且**置为只读**，点击提示「由项目〈名字〉统一管理」。这一条不能省——否则用户改了没反应，就是一次静默失效。
 - **没有"移入 / 移出项目"**。会话行没有这个动作，弹层也一并去掉了。要在某个项目里干活就在那个项目里新建会话（项目头的「+」），或者在落地页选它的目录。删除项目会把它的会话变回任务——这是会话离开项目的唯一途径。
 
 ## 多 tab 同步
 
-registry 的每次成功写盘（分组增删改、成员移动、pin、项目目录/notes 编辑）都会全局广播 `session_groups_changed`，钩在唯一写点 `saveRegistry` 上（`notifyGroupsChanged`，Server `initWS` 时装配）——而不是散在每个 handler 里，这样 cron 的编程式写入和将来的新写路径都不会漏。事件**不带 payload**：客户端收到后重新拉 `GET /api/session-groups`，registry 的形状不用在客户端镜像一份。
+registry 的每次成功写盘（分组增删改、成员移动、pin、项目目录编辑）都会全局广播 `session_groups_changed`，钩在唯一写点 `saveRegistry` 上（`notifyGroupsChanged`，Server `initWS` 时装配）——而不是散在每个 handler 里，这样 cron 的编程式写入和将来的新写路径都不会漏。事件**不带 payload**：客户端收到后重新拉 `GET /api/session-groups`，registry 的形状不用在客户端镜像一份。
 
 没有它，一个 tab 里改掉的项目目录在其它 tab 里保持陈旧——sidebar 头和 composer chip（从 groups store 派生）会误报工具实际运行的位置。执行侧永远正确（解析在服务端），这纯粹是显示同步。发起方 tab 自己也会收到广播并重拉一次，幂等无害。
 
@@ -213,7 +202,6 @@ registry 的每次成功写盘（分组增删改、成员移动、pin、项目�
 - `PUT /api/sessions/{id}/group` 对任何目标（项目、空、不存在）都返回 409，且不改动既有归属。
 - 项目遮蔽而不覆写会话盘上的 `WorkingDir`：删项目后回落，重新加载可见原值未被改写。
 - 改项目目录后，下一 turn 的 composed system prompt 里的 `Working directory:` 跟着变。
-- 改 `notes` 触发重新组装；不改则复用冻结值（保住 prompt cache）。
 - 普通分组被解散、其会话变回任务；带目录的会话随后被 `adoptTaskWorkingDirs` 归入项目（顺序）。
 - 运行簇在没有 `TaskID` 时靠 scheduler 回填存活；已有 `TaskID` 时不依赖 scheduler。
 - 两个 pass 各自幂等（每次启动都跑）。

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -48,22 +47,17 @@ type Session struct {
 	// re-freezes instead of no-op-ing when the model at call time differs
 	// from this field.
 	//
-	// ComposedForCWD and ComposedForNotes are the same idea for the other two
-	// inputs that can change under a live session. The working directory is
-	// baked into the prompt's env context ("- Working directory: …"), and the
-	// project notes (session-groups.json) are baked into its memory layer — so
-	// retargeting a session's directory, or moving it into a project with a
-	// different one, must re-freeze or the model keeps reading a path its
-	// tools no longer run in. ComposedForNotes holds a short hash rather than
-	// the notes themselves: it is only ever compared, never rendered, and the
-	// notes can be arbitrarily long. Both are empty for sessions frozen before
-	// these fields existed, which simply re-freezes them once on their next
-	// turn.
+	// ComposedForCWD is the same idea for the other input that can change
+	// under a live session: the working directory is baked into the prompt's
+	// env context ("- Working directory: …"), so retargeting a session's
+	// directory — or moving it into a project with a different one — must
+	// re-freeze or the model keeps reading a path its tools no longer run in.
+	// Empty for sessions frozen before the field existed, which simply
+	// re-freezes them once on their next turn.
 	ComposedSystem     string `json:"composed_system,omitempty"`
 	ComposedLeanSystem string `json:"composed_lean_system,omitempty"`
 	ComposedForModel   string `json:"composed_for_model,omitempty"`
 	ComposedForCWD     string `json:"composed_for_cwd,omitempty"`
-	ComposedForNotes   string `json:"composed_for_notes,omitempty"`
 	Title              string `json:"title,omitempty"`
 	Source             string `json:"source,omitempty"` // how the session was created: "" (manual) | "cron" | "channel" | "setup"
 	// AgentID is the ID of the agent profile (agentprofile.Profile) that owns
@@ -556,7 +550,6 @@ type sessionRecord struct {
 	ComposedLeanSystem string    `json:"composed_lean_system,omitempty"`
 	ComposedForModel   string    `json:"composed_for_model,omitempty"`
 	ComposedForCWD     string    `json:"composed_for_cwd,omitempty"`
-	ComposedForNotes   string    `json:"composed_for_notes,omitempty"`
 	Title              string    `json:"title,omitempty"`
 	Source             string    `json:"source,omitempty"`
 	ModelConfig        string    `json:"model_config,omitempty"`
@@ -586,7 +579,7 @@ func (s *Session) metaRecord() sessionRecord {
 		goal = &g
 	}
 	s.mu.Unlock()
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, ComposedSystem: s.ComposedSystem, ComposedLeanSystem: s.ComposedLeanSystem, ComposedForModel: s.ComposedForModel, ComposedForCWD: s.ComposedForCWD, ComposedForNotes: s.ComposedForNotes, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, AgentID: s.AgentID, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, ComposedSystem: s.ComposedSystem, ComposedLeanSystem: s.ComposedLeanSystem, ComposedForModel: s.ComposedForModel, ComposedForCWD: s.ComposedForCWD, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, AgentID: s.AgentID, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
 }
 
 // MarkHookStarted records that SessionStart has fired for this session, so a
@@ -925,20 +918,19 @@ func (s *Session) SetPermissionMode(mode string) error {
 // which compose once per process and never touch System again: a skill or
 // profile edit now takes effect in a new session, not a running one.
 //
-// model, cwd and notesHash are the freeze's identity — see ComposedForModel
-// and ComposedForCWD for why each matters. A no-op only when already frozen
-// for THIS exact triple; a call with any of them different (a mid-session
-// model switch, a retargeted working directory, an edited project note)
-// overwrites the freeze instead, since all three are baked into the prompt
-// while the per-turn tools array and tool cwd are always computed fresh — a
-// stale freeze would silently drift out of sync with them. Same
-// append-or-rewrite persistence mechanics as SetPermissionMode.
-func (s *Session) SetComposedSystem(system, lean, model, cwd, notesHash string) error {
-	if s.IsComposedFor(model, cwd, notesHash) {
+// model and cwd are the freeze's identity — see ComposedForModel and
+// ComposedForCWD for why each matters. A no-op only when already frozen for
+// THIS exact pair; a call with either different (a mid-session model switch, a
+// retargeted working directory) overwrites the freeze instead, since both are
+// baked into the prompt while the per-turn tools array and tool cwd are always
+// computed fresh — a stale freeze would silently drift out of sync with them.
+// Same append-or-rewrite persistence mechanics as SetPermissionMode.
+func (s *Session) SetComposedSystem(system, lean, model, cwd string) error {
+	if s.IsComposedFor(model, cwd) {
 		return nil
 	}
 	s.ComposedSystem, s.ComposedLeanSystem, s.ComposedForModel = system, lean, model
-	s.ComposedForCWD, s.ComposedForNotes = cwd, notesHash
+	s.ComposedForCWD = cwd
 	if s.persisted == 0 {
 		// See SetWorkingDir: a meta-only transcript must be rewritten now, since
 		// the load-modify-discard handler won't get a "next Save"; a session with
@@ -963,35 +955,21 @@ func (s *Session) SetComposedSystem(system, lean, model, cwd, notesHash string) 
 		return fmt.Errorf("session: open %s: %w", path, err)
 	}
 	defer f.Close()
-	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "composed_system", ComposedSystem: system, ComposedLeanSystem: lean, ComposedForModel: model, ComposedForCWD: cwd, ComposedForNotes: notesHash}); err != nil {
+	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "composed_system", ComposedSystem: system, ComposedLeanSystem: lean, ComposedForModel: model, ComposedForCWD: cwd}); err != nil {
 		return fmt.Errorf("session: append composed_system: %w", err)
 	}
 	return nil
 }
 
 // IsComposedFor reports whether the session's system prompt is already frozen
-// for this model / working directory / project-notes triple — the condition
-// SetComposedSystem itself uses to decide overwrite-vs-no-op, exposed so
-// callers (buildAgent, runChannelTurns) can skip the memory/skills/MCP
-// recompute entirely when the freeze would just be reused rather than
-// replaced.
-func (s *Session) IsComposedFor(model, cwd, notesHash string) bool {
+// for this model / working directory pair — the condition SetComposedSystem
+// itself uses to decide overwrite-vs-no-op, exposed so callers (buildAgent,
+// runChannelTurns) can skip the memory/skills/MCP recompute entirely when the
+// freeze would just be reused rather than replaced.
+func (s *Session) IsComposedFor(model, cwd string) bool {
 	return s.ComposedSystem != "" &&
 		s.ComposedForModel == model &&
-		s.ComposedForCWD == cwd &&
-		s.ComposedForNotes == notesHash
-}
-
-// ComposedNotesHash is the canonical hash of a project-notes string for the
-// ComposedForNotes freeze field. Empty notes hash to "" so a session with no
-// project (the overwhelmingly common case) carries no value at all and its
-// meta line stays byte-identical to a pre-projects one.
-func ComposedNotesHash(notes string) string {
-	if notes == "" {
-		return ""
-	}
-	sum := sha256.Sum256([]byte(notes))
-	return hex.EncodeToString(sum[:6])
+		s.ComposedForCWD == cwd
 }
 
 // ClearComposedSystem un-freezes the composed system prompt so the next turn
@@ -1007,7 +985,7 @@ func (s *Session) ClearComposedSystem() error {
 		return nil
 	}
 	s.ComposedSystem, s.ComposedLeanSystem, s.ComposedForModel = "", "", ""
-	s.ComposedForCWD, s.ComposedForNotes = "", ""
+	s.ComposedForCWD = ""
 	if s.persisted == 0 {
 		if path, perr := s.SavePath(); perr == nil {
 			if _, statErr := os.Stat(path); statErr == nil {
@@ -1372,7 +1350,7 @@ func LoadSession(id string) (*Session, error) {
 		case "meta":
 			s.ID, s.CreatedAt, s.Model, s.System = rec.ID, rec.CreatedAt, rec.Model, rec.System
 			s.ComposedSystem, s.ComposedLeanSystem, s.ComposedForModel = rec.ComposedSystem, rec.ComposedLeanSystem, rec.ComposedForModel // a rewritten file carries it in its meta header
-			s.ComposedForCWD, s.ComposedForNotes = rec.ComposedForCWD, rec.ComposedForNotes
+			s.ComposedForCWD = rec.ComposedForCWD
 			s.Title = rec.Title // a compacted file carries the title in its meta header
 			s.Source = rec.Source
 			s.ModelConfig = rec.ModelConfig
@@ -1402,10 +1380,10 @@ func LoadSession(id string) (*Session, error) {
 		case "context_tokens":
 			s.LastContextTokens = rec.LastContextTokens // last one wins, like title
 		case "composed_system":
-			// Last one wins — a mid-session model switch, a retargeted working
-			// directory, or an edited project note each append a new record.
+			// Last one wins — a mid-session model switch or a retargeted
+			// working directory each append a new record.
 			s.ComposedSystem, s.ComposedLeanSystem, s.ComposedForModel = rec.ComposedSystem, rec.ComposedLeanSystem, rec.ComposedForModel
-			s.ComposedForCWD, s.ComposedForNotes = rec.ComposedForCWD, rec.ComposedForNotes
+			s.ComposedForCWD = rec.ComposedForCWD
 		case "message":
 			if rec.Message != nil {
 				s.Messages = append(s.Messages, *rec.Message)

--- a/internal/agent/session_persist_test.go
+++ b/internal/agent/session_persist_test.go
@@ -289,7 +289,7 @@ func TestSetComposedSystem_FreezesAppendsAndRoundTrips(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	if err := s.SetComposedSystem("full prompt", "lean prompt", "model-a", "", ""); err != nil {
+	if err := s.SetComposedSystem("full prompt", "lean prompt", "model-a", ""); err != nil {
 		t.Fatalf("SetComposedSystem: %v", err)
 	}
 	if s.ComposedSystem != "full prompt" || s.ComposedLeanSystem != "lean prompt" || s.ComposedForModel != "model-a" {
@@ -311,7 +311,7 @@ func TestSetComposedSystem_FreezesAppendsAndRoundTrips(t *testing.T) {
 	// Already-frozen no-op: a second call for the SAME model must not
 	// overwrite or append.
 	before := len(data)
-	if err := s.SetComposedSystem("different prompt", "different lean", "model-a", "", ""); err != nil {
+	if err := s.SetComposedSystem("different prompt", "different lean", "model-a", ""); err != nil {
 		t.Fatal(err)
 	}
 	if s.ComposedSystem != "full prompt" {
@@ -349,17 +349,17 @@ func TestSetComposedSystem_ModelSwitchForcesRefreeze(t *testing.T) {
 	if err := s.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if err := s.SetComposedSystem("prompt for model-a", "lean for model-a", "model-a", "", ""); err != nil {
+	if err := s.SetComposedSystem("prompt for model-a", "lean for model-a", "model-a", ""); err != nil {
 		t.Fatalf("SetComposedSystem: %v", err)
 	}
-	if !s.IsComposedFor("model-a", "", "") {
+	if !s.IsComposedFor("model-a", "") {
 		t.Fatal("expected IsComposedFor(\"model-a\") after freezing for model-a")
 	}
-	if s.IsComposedFor("model-b", "", "") {
+	if s.IsComposedFor("model-b", "") {
 		t.Fatal("IsComposedFor(\"model-b\") must be false when frozen for model-a")
 	}
 
-	if err := s.SetComposedSystem("prompt for model-b", "lean for model-b", "model-b", "", ""); err != nil {
+	if err := s.SetComposedSystem("prompt for model-b", "lean for model-b", "model-b", ""); err != nil {
 		t.Fatalf("SetComposedSystem for model-b: %v", err)
 	}
 	if s.ComposedSystem != "prompt for model-b" || s.ComposedForModel != "model-b" {
@@ -398,7 +398,7 @@ func TestSetComposedSystem_PersistedZeroRewritesWhenFileExists(t *testing.T) {
 	shadow := NewSession(s.Model, s.System)
 	shadow.ID = s.ID
 
-	if err := shadow.SetComposedSystem("rewritten prompt", "rewritten lean", "m", "", ""); err != nil {
+	if err := shadow.SetComposedSystem("rewritten prompt", "rewritten lean", "m", ""); err != nil {
 		t.Fatalf("SetComposedSystem: %v", err)
 	}
 
@@ -424,7 +424,7 @@ func TestClearComposedSystem_UnfreezesAndRoundTrips(t *testing.T) {
 	if err := s.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if err := s.SetComposedSystem("full prompt", "lean prompt", "model-a", "", ""); err != nil {
+	if err := s.SetComposedSystem("full prompt", "lean prompt", "model-a", ""); err != nil {
 		t.Fatalf("SetComposedSystem: %v", err)
 	}
 
@@ -445,7 +445,7 @@ func TestClearComposedSystem_UnfreezesAndRoundTrips(t *testing.T) {
 	// And it can be frozen again after clearing — round-trips too, confirming
 	// the third composed_system record (freeze, clear, re-freeze) replays
 	// correctly rather than getting lost among the earlier ones.
-	if err := reloaded.SetComposedSystem("second prompt", "second lean", "model-a", "", ""); err != nil {
+	if err := reloaded.SetComposedSystem("second prompt", "second lean", "model-a", ""); err != nil {
 		t.Fatalf("SetComposedSystem after clear: %v", err)
 	}
 	if reloaded.ComposedSystem != "second prompt" {
@@ -472,17 +472,17 @@ func TestSetComposedSystem_CwdChangeForcesRefreeze(t *testing.T) {
 	if err := s.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if err := s.SetComposedSystem("prompt in /a", "lean in /a", "m", "/a", ""); err != nil {
+	if err := s.SetComposedSystem("prompt in /a", "lean in /a", "m", "/a"); err != nil {
 		t.Fatalf("SetComposedSystem: %v", err)
 	}
-	if !s.IsComposedFor("m", "/a", "") {
+	if !s.IsComposedFor("m", "/a") {
 		t.Fatal("expected the freeze to hold for its own cwd")
 	}
-	if s.IsComposedFor("m", "/b", "") {
+	if s.IsComposedFor("m", "/b") {
 		t.Fatal("a freeze composed against /a must not be reused for /b")
 	}
 
-	if err := s.SetComposedSystem("prompt in /b", "lean in /b", "m", "/b", ""); err != nil {
+	if err := s.SetComposedSystem("prompt in /b", "lean in /b", "m", "/b"); err != nil {
 		t.Fatalf("SetComposedSystem after cwd change: %v", err)
 	}
 	if s.ComposedSystem != "prompt in /b" || s.ComposedForCWD != "/b" {
@@ -496,43 +496,13 @@ func TestSetComposedSystem_CwdChangeForcesRefreeze(t *testing.T) {
 	if reloaded.ComposedForCWD != "/b" || reloaded.ComposedSystem != "prompt in /b" {
 		t.Fatalf("cwd freeze did not round-trip: got %q / %q", reloaded.ComposedForCWD, reloaded.ComposedSystem)
 	}
-	if !reloaded.IsComposedFor("m", "/b", "") {
+	if !reloaded.IsComposedFor("m", "/b") {
 		t.Fatal("reloaded session should still be frozen for /b")
 	}
 }
 
-// TestSetComposedSystem_NotesChangeForcesRefreeze: project notes are injected
-// into the prompt, so editing them must invalidate the freeze — while leaving
-// them alone must not, or every turn would lose the provider's prompt cache.
-func TestSetComposedSystem_NotesChangeForcesRefreeze(t *testing.T) {
-	setTempHome(t)
-	s := NewSession("m", "")
-	s.Messages = []Message{NewUserMessage("hi"), NewAssistantMessage("hello")}
-	if err := s.Save(); err != nil {
-		t.Fatalf("Save: %v", err)
-	}
-	first := ComposedNotesHash("ship behind a flag")
-	second := ComposedNotesHash("ship behind a flag, and never touch billing")
-	if first == "" || first == second {
-		t.Fatalf("notes hashes should be non-empty and distinct: %q vs %q", first, second)
-	}
-	if ComposedNotesHash("") != "" {
-		t.Fatal("empty notes must hash to the empty string so unprojected sessions carry no value")
-	}
-
-	if err := s.SetComposedSystem("prompt", "lean", "m", "/a", first); err != nil {
-		t.Fatalf("SetComposedSystem: %v", err)
-	}
-	if !s.IsComposedFor("m", "/a", first) {
-		t.Fatal("unchanged notes must reuse the freeze (prompt cache)")
-	}
-	if s.IsComposedFor("m", "/a", second) {
-		t.Fatal("edited notes must invalidate the freeze")
-	}
-}
-
-// TestClearComposedSystem_ClearsFreezeIdentity: /reload must drop the cwd and
-// notes stamps too, or the next turn could match a stale identity.
+// TestClearComposedSystem_ClearsFreezeIdentity: /reload must drop the cwd stamp
+// too, or the next turn could match a stale identity.
 func TestClearComposedSystem_ClearsFreezeIdentity(t *testing.T) {
 	setTempHome(t)
 	s := NewSession("m", "")
@@ -540,17 +510,16 @@ func TestClearComposedSystem_ClearsFreezeIdentity(t *testing.T) {
 	if err := s.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	notes := ComposedNotesHash("some notes")
-	if err := s.SetComposedSystem("prompt", "lean", "m", "/a", notes); err != nil {
+	if err := s.SetComposedSystem("prompt", "lean", "m", "/a"); err != nil {
 		t.Fatalf("SetComposedSystem: %v", err)
 	}
 	if err := s.ClearComposedSystem(); err != nil {
 		t.Fatalf("ClearComposedSystem: %v", err)
 	}
-	if s.ComposedForCWD != "" || s.ComposedForNotes != "" {
-		t.Fatalf("clear left freeze identity behind: cwd=%q notes=%q", s.ComposedForCWD, s.ComposedForNotes)
+	if s.ComposedForCWD != "" {
+		t.Fatalf("clear left freeze identity behind: cwd=%q", s.ComposedForCWD)
 	}
-	if s.IsComposedFor("m", "/a", notes) {
+	if s.IsComposedFor("m", "/a") {
 		t.Fatal("a cleared session must not report as frozen")
 	}
 }

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -539,7 +539,7 @@ func TestCmdReload_ClearsComposedSystemAndRefusesWhileRunning(t *testing.T) {
 
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 	sess := mgr.GetOrCreateSession(ev, nil)
-	if err := sess.Store.SetComposedSystem("full prompt", "lean prompt", "stub-model", "", ""); err != nil {
+	if err := sess.Store.SetComposedSystem("full prompt", "lean prompt", "stub-model", ""); err != nil {
 		t.Fatalf("SetComposedSystem: %v", err)
 	}
 

--- a/internal/server/projects_test.go
+++ b/internal/server/projects_test.go
@@ -242,27 +242,6 @@ func TestProject_RejectsBadDir(t *testing.T) {
 	}
 }
 
-// TestProject_RejectsOversizedNotes: notes land in every member session's
-// system prompt, so the server bounds them instead of silently eating context.
-func TestProject_RejectsOversizedNotes(t *testing.T) {
-	srv := groupTestServer(t)
-	projectDir := t.TempDir()
-	gid := newProjectGroup(t, srv, "Work", projectDir)
-
-	big := strings.Repeat("x", maxProjectNotes+1)
-	rec, _ := doGroupReq(t, srv, http.MethodPatch, "/api/session-groups/"+gid, map[string]any{"notes": big})
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("oversized notes: status %d, want 400", rec.Code)
-	}
-
-	// At the limit is fine.
-	ok := strings.Repeat("x", maxProjectNotes)
-	rec, _ = doGroupReq(t, srv, http.MethodPatch, "/api/session-groups/"+gid, map[string]any{"notes": ok})
-	if rec.Code != http.StatusOK {
-		t.Errorf("notes at limit: status %d, want 200: %s", rec.Code, rec.Body.String())
-	}
-}
-
 // TestProject_BlocksPerSessionDirOverride: a session in a project must not
 // accept a per-session dir that the resolver would ignore anyway.
 func TestProject_BlocksPerSessionDirOverride(t *testing.T) {
@@ -300,32 +279,6 @@ func TestProject_LegacyRegistryLoadsAsPlainGroup(t *testing.T) {
 	}
 	if got := srv.sessionCwd(sess); got != ownDir {
 		t.Errorf("legacy group member: cwd = %q, want own dir %q", got, ownDir)
-	}
-}
-
-// TestProject_NotesReachTheSystemPrompt checks the notes are rendered into the
-// prompt's memory layer for a session in the project, and only for it.
-func TestProject_NotesReachTheSystemPrompt(t *testing.T) {
-	srv := groupTestServer(t)
-	projectDir := t.TempDir()
-	inProject := saveSessionWithDir(t, "")
-	outside := saveSessionWithDir(t, "")
-
-	gid := newProjectGroup(t, srv, "Work", projectDir)
-	fileInProject(t, gid, inProject.ID)
-	const notes = "Ship behind a flag; never touch the billing tables."
-	if rec, _ := doGroupReq(t, srv, http.MethodPatch, "/api/session-groups/"+gid, map[string]any{"notes": notes}); rec.Code != http.StatusOK {
-		t.Fatalf("set notes: status %d", rec.Code)
-	}
-
-	if got := projectNotesFor(inProject.ID); got != notes {
-		t.Errorf("notes for session in project = %q, want %q", got, notes)
-	}
-	if got := projectNotesFor(outside.ID); got != "" {
-		t.Errorf("notes leaked to a session outside the project: %q", got)
-	}
-	if rendered := renderProjectNotes(notes); !strings.Contains(rendered, notes) {
-		t.Errorf("rendered notes lost the text: %s", rendered)
 	}
 }
 
@@ -502,9 +455,9 @@ func TestProject_RegistryWritesNotifyTabs(t *testing.T) {
 			rec, _ := doGroupReq(t, srv, http.MethodPost, "/api/sessions", map[string]any{"group_id": gid})
 			return rec
 		}},
-		{"edit notes", func() *httptest.ResponseRecorder {
+		{"collapse project", func() *httptest.ResponseRecorder {
 			gid := projectIDByName(t, srv, "Work")
-			rec, _ := doGroupReq(t, srv, http.MethodPatch, "/api/session-groups/"+gid, map[string]any{"notes": "n"})
+			rec, _ := doGroupReq(t, srv, http.MethodPatch, "/api/session-groups/"+gid, map[string]any{"collapsed": true})
 			return rec
 		}},
 		{"pin session", func() *httptest.ResponseRecorder {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1334,13 +1334,11 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	// window, and the per-turn tools array is always computed fresh for the
 	// current model regardless of the freeze, so a stale manifest would drift
 	// out of sync with what's actually offered.
-	// The freeze is keyed on cwd and project notes as well as the model: both
-	// are baked into the prompt (the env context's working directory, the
-	// project-notes block below) and both can change under a live session.
-	// One registry lookup for both facts the project contributes to this turn:
-	// its notes (baked into the prompt) and its directory (what scopes memory).
-	notes, projectDir := projectNotesAndDir(sess.ID)
-	if sess.IsComposedFor(model, cwd, agent.ComposedNotesHash(notes)) {
+	// The freeze is keyed on cwd as well as the model: the env context's
+	// working directory is baked into the prompt and can change under a live
+	// session.
+	projectDir := ProjectDirForSession(sess.ID)
+	if sess.IsComposedFor(model, cwd) {
 		a.System, a.LeanSystem = sess.ComposedSystem, sess.ComposedLeanSystem
 	} else {
 		// L1: project memory embedded in the system prompt, snapshotted once.
@@ -1360,9 +1358,6 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 		if g := tools.MemoryBackendGuidance(); g != "" {
 			memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
 		}
-		if notes != "" {
-			memInjection = strings.TrimSpace(renderProjectNotes(notes) + "\n\n" + memInjection)
-		}
 		// A profile with its own system prompt replaces the server's base
 		// prompt (default agent: unchanged, s.system).
 		profile := s.profileForAgent(sess.EffectiveAgentID())
@@ -1373,7 +1368,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 			expertMode = true
 		}
 		a.System, a.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
-		if err := sess.SetComposedSystem(a.System, a.LeanSystem, model, cwd, agent.ComposedNotesHash(notes)); err != nil {
+		if err := sess.SetComposedSystem(a.System, a.LeanSystem, model, cwd); err != nil {
 			slog.Warn("freeze composed system prompt", "session", sess.ID, "err", err)
 		}
 	}
@@ -3427,11 +3422,11 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// /model, applied above via applyChannelModel) DOES force a re-freeze —
 	// see IsComposedFor's doc comment for why a stale MCP manifest can't just
 	// be left frozen under the old model.
-	// cwd and project notes join the model in the freeze identity — a channel
-	// session dragged into a project in the Web UI picks the change up on its
-	// next turn, the same as a web one.
-	notes, projectDir := projectNotesAndDir(sess.Store.ID)
-	if sess.Store.IsComposedFor(sess.Agent.Model, cwd, agent.ComposedNotesHash(notes)) {
+	// cwd joins the model in the freeze identity — a channel session dragged
+	// into a project in the Web UI picks the change up on its next turn, the
+	// same as a web one.
+	projectDir := ProjectDirForSession(sess.Store.ID)
+	if sess.Store.IsComposedFor(sess.Agent.Model, cwd) {
 		sess.Agent.System, sess.Agent.LeanSystem = sess.Store.ComposedSystem, sess.Store.ComposedLeanSystem
 	} else {
 		// Per-project memory dir, same as buildAgent gives web turns — an IM
@@ -3444,9 +3439,6 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		if g := tools.MemoryBackendGuidance(); g != "" {
 			memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
 		}
-		if notes != "" {
-			memInjection = strings.TrimSpace(renderProjectNotes(notes) + "\n\n" + memInjection)
-		}
 		// A profile with its own system prompt replaces the server's base
 		// prompt (default agent: unchanged, s.system).
 		base := s.system
@@ -3456,7 +3448,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 			expertMode = true
 		}
 		sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(base, cwd, envCtx, s.curSkillsManifestForProfile(profile), tools.MCPManifestFor(sess.Agent.Model, profile), memInjection, s.effectiveCoauthor(cfg), expertMode)
-		if err := sess.Store.SetComposedSystem(sess.Agent.System, sess.Agent.LeanSystem, sess.Agent.Model, cwd, agent.ComposedNotesHash(notes)); err != nil {
+		if err := sess.Store.SetComposedSystem(sess.Agent.System, sess.Agent.LeanSystem, sess.Agent.Model, cwd); err != nil {
 			slog.Warn("freeze composed system prompt", "session", string(sess.Key), "err", err)
 		}
 	}

--- a/internal/server/session_groups.go
+++ b/internal/server/session_groups.go
@@ -24,8 +24,8 @@ import (
 // user-facing concept — a "plain group", a name with sessions under it and no
 // directory, used to exist and no longer does: it split the sidebar into three
 // kinds of row for two kinds of thing, and offered organisation that carried
-// none of what a project carries (a directory for the tools, a memory tier, a
-// notes block). dissolvePlainGroups retires the ones already on disk.
+// none of what a project carries (a directory for the tools, a memory tier).
+// dissolvePlainGroups retires the ones already on disk.
 //
 // The registry lives entirely in one file
 // (~/.octo/session-groups.json) and never touch the session transcript format
@@ -67,10 +67,6 @@ type sessionGroup struct {
 	// already expanded and absolute — the write paths resolve and validate it,
 	// so every reader can use it verbatim.
 	WorkingDir string `json:"working_dir,omitempty"`
-	// Notes is project-level context injected into the system prompt of every
-	// session in the project, alongside the project-memory layer. Only
-	// meaningful on a project.
-	Notes string `json:"notes,omitempty"`
 	// TaskID, when set, is the scheduled task this project was created for. It
 	// is what lets the startup pass repair such a project (backfilling the
 	// directory a task written before this had none) rather than dissolving it.
@@ -83,22 +79,6 @@ func (g sessionGroup) isProject() bool { return g.WorkingDir != "" }
 // isCronCluster reports whether this project was created for a scheduled task.
 // Used by the startup repair pass, not to gate anything the user can do.
 func (g sessionGroup) isCronCluster() bool { return g.TaskID != "" }
-
-// maxProjectNotes caps the notes field. Notes are injected verbatim into the
-// system prompt of EVERY session in the project, so an oversized value would
-// silently eat context across all of them; 16 KiB is far beyond any sane
-// project brief while still an obvious mistake-catcher.
-const maxProjectNotes = 16 * 1024
-
-// validateProjectNotes trims and bounds a user-supplied notes value. The
-// returned error is user-facing.
-func validateProjectNotes(raw string) (string, error) {
-	notes := strings.TrimSpace(raw)
-	if len(notes) > maxProjectNotes {
-		return "", fmt.Errorf("notes too long: %d bytes (max %d) — notes are injected into every session's system prompt, keep them brief", len(notes), maxProjectNotes)
-	}
-	return notes, nil
-}
 
 // groupFile is the on-disk shape of the registry. Group order is array order.
 // PinnedSessionIDs is the Web-UI "pinned" set — sessions the user floated to a
@@ -408,33 +388,6 @@ func ProjectExistsForDir(dir string) bool {
 	return false
 }
 
-// projectNotesFor returns the project notes that apply to sessionID, or "".
-func projectNotesFor(sessionID string) string {
-	if p := projectForSession(sessionID); p != nil {
-		return p.Notes
-	}
-	return ""
-}
-
-// projectNotesAndDir returns both facts a turn needs from the project owning
-// sessionID — its notes and its working directory — in one registry lookup.
-// Both are empty when the session belongs to no project. The notes go into the
-// prompt; the directory is what scopes the session's memory (see
-// Server.sessionMemDir).
-func projectNotesAndDir(sessionID string) (notes, dir string) {
-	if p := projectForSession(sessionID); p != nil {
-		return p.Notes, p.WorkingDir
-	}
-	return "", ""
-}
-
-// renderProjectNotes wraps project notes for the system prompt's memory layer.
-// The heading gives the model a frame for what it is reading — otherwise a
-// bare paragraph of project context reads as an instruction from the user.
-func renderProjectNotes(notes string) string {
-	return "# Project notes\n\nContext for the project this session belongs to:\n\n" + notes
-}
-
 // newGroupID returns a short random group id ("g-" + 8 hex chars).
 func newGroupID() string {
 	var b [4]byte
@@ -609,7 +562,6 @@ type createSessionGroupRequest struct {
 	// project is a directory. Creating without one used to be how a plain group
 	// was made, and that concept is gone.
 	WorkingDir string `json:"working_dir"`
-	Notes      string `json:"notes,omitempty"`
 }
 
 func (s *Server) handleCreateSessionGroup(w http.ResponseWriter, r *http.Request) {
@@ -632,11 +584,6 @@ func (s *Server) handleCreateSessionGroup(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, verr.Error())
 		return
 	}
-	notes, nerr := validateProjectNotes(req.Notes)
-	if nerr != nil {
-		writeError(w, http.StatusBadRequest, nerr.Error())
-		return
-	}
 
 	groupMu.Lock()
 	defer groupMu.Unlock()
@@ -645,7 +592,7 @@ func (s *Server) handleCreateSessionGroup(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	g := sessionGroup{ID: newGroupID(), Name: name, SessionIDs: []string{}, WorkingDir: workingDir, Notes: notes}
+	g := sessionGroup{ID: newGroupID(), Name: name, SessionIDs: []string{}, WorkingDir: workingDir}
 	groups = append(groups, g)
 	if err := saveSessionGroups(groups); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -657,8 +604,8 @@ func (s *Server) handleCreateSessionGroup(w http.ResponseWriter, r *http.Request
 // ─── PATCH /api/session-groups/{id} ─────────────────────────────────────────
 
 // updateSessionGroupRequest carries the editable group fields. All are
-// optional pointers so a request can rename, toggle collapsed, retarget the
-// project directory, or edit the notes, without one clobbering the others.
+// optional pointers so a request can rename, toggle collapsed, or retarget the
+// project directory, without one clobbering the others.
 type updateSessionGroupRequest struct {
 	Name      *string `json:"name,omitempty"`
 	Collapsed *bool   `json:"collapsed,omitempty"`
@@ -667,7 +614,6 @@ type updateSessionGroupRequest struct {
 	// demote to — deleting the project is the way to break it up, which leaves
 	// its sessions as tasks.
 	WorkingDir *string `json:"working_dir,omitempty"`
-	Notes      *string `json:"notes,omitempty"`
 }
 
 func (s *Server) handleUpdateSessionGroup(w http.ResponseWriter, r *http.Request) {
@@ -681,8 +627,8 @@ func (s *Server) handleUpdateSessionGroup(w http.ResponseWriter, r *http.Request
 		writeInvalidJSONBody(w, err)
 		return
 	}
-	if req.Name == nil && req.Collapsed == nil && req.WorkingDir == nil && req.Notes == nil {
-		writeError(w, http.StatusBadRequest, "name, collapsed, working_dir or notes is required")
+	if req.Name == nil && req.Collapsed == nil && req.WorkingDir == nil {
+		writeError(w, http.StatusBadRequest, "name, collapsed or working_dir is required")
 		return
 	}
 	var name string
@@ -707,15 +653,6 @@ func (s *Server) handleUpdateSessionGroup(w http.ResponseWriter, r *http.Request
 			return
 		}
 		workingDir = dir
-	}
-	var notes string
-	if req.Notes != nil {
-		n, nerr := validateProjectNotes(*req.Notes)
-		if nerr != nil {
-			writeError(w, http.StatusBadRequest, nerr.Error())
-			return
-		}
-		notes = n
 	}
 
 	groupMu.Lock()
@@ -744,9 +681,6 @@ func (s *Server) handleUpdateSessionGroup(w http.ResponseWriter, r *http.Request
 	}
 	if req.WorkingDir != nil {
 		groups[idx].WorkingDir = workingDir
-	}
-	if req.Notes != nil {
-		groups[idx].Notes = notes
 	}
 	if err := saveSessionGroups(groups); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -888,15 +822,14 @@ func (s *Server) handleReorderSessionGroups(w http.ResponseWriter, r *http.Reque
 // directory on the landing page, or by the "+" on a project — and is fixed after
 // that.
 //
-// It is fixed because moving is not one change but four, and they cannot be
-// made to agree after the fact: the tools' directory, the memory tier, the
-// project notes baked into the system prompt, and the hooks/sandbox root all
-// derive from the project. A moved session would keep a transcript half of which
-// ran somewhere else and read another project's notes, and the freeze that keeps
-// the prompt cache warm cannot tell that apart from an ordinary turn (it is
-// keyed on cwd + notes, so a session whose own directory already equals the
-// project's would not even re-compose). Deciding at creation makes the four
-// facts true for the whole life of the session.
+// It is fixed because moving is not one change but three, and they cannot be
+// made to agree after the fact: the tools' directory, the memory tier, and the
+// hooks/sandbox root all derive from the project. A moved session would keep a
+// transcript half of which ran somewhere else, and the freeze that keeps the
+// prompt cache warm cannot tell that apart from an ordinary turn (it is keyed on
+// cwd, so a session whose own directory already equals the project's would not
+// even re-compose). Deciding at creation makes the three facts true for the
+// whole life of the session.
 func (s *Server) handleSetSessionGroup(w http.ResponseWriter, r *http.Request) {
 	writeError(w, http.StatusConflict,
 		"a session's project is decided when it is created — start a new session in the project instead")

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -106,7 +106,7 @@ export async function listSessionGroups(): Promise<{ groups: SessionGroup[]; pin
 }
 
 // Pass working_dir to create the group as a project outright.
-export async function createSessionGroup(name: string, project?: { working_dir?: string; notes?: string }): Promise<SessionGroup> {
+export async function createSessionGroup(name: string, project?: { working_dir?: string }): Promise<SessionGroup> {
   const d = await request<{ group: SessionGroup }>('/api/session-groups', { method: 'POST', ...json({ name, ...project }) })
   return d.group
 }
@@ -114,7 +114,7 @@ export async function createSessionGroup(name: string, project?: { working_dir?:
 // working_dir: '' demotes a project back to a plain group.
 export async function updateSessionGroup(
   id: string,
-  patch: { name?: string; collapsed?: boolean; working_dir?: string; notes?: string },
+  patch: { name?: string; collapsed?: boolean; working_dir?: string },
 ): Promise<SessionGroup> {
   const d = await request<{ group: SessionGroup }>(`/api/session-groups/${id}`, { method: 'PATCH', ...json(patch) })
   return d.group

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -58,7 +58,6 @@ export interface SessionGroup {
   collapsed?: boolean
   /** Set on a project — the directory its sessions run in. */
   working_dir?: string
-  notes?: string
   /** Set on a scheduled task's run cluster, which the user cannot edit. */
   task_id?: string
 }


### PR DESCRIPTION
Project notes were a text field on a project, injected verbatim into the system prompt of every session filed under it. Nothing in the UI has set them since the project-settings modal was removed: the sidebar's only PATCH calls are rename and collapse, and the create-project flow sends a name and a directory. The design doc already recorded why the modal went — the one thing left in it was editing notes, and the project memory layer covers the same ground, except the agent writes and reads that one itself instead of asking the user to keep a brief in sync by hand.

So this is a dead field with a live cost: it sat in the freeze identity, so every turn hashed it, and it read as a supported feature to anyone extending projects.

## Removed

- `Notes` on `sessionGroup`, its 16 KiB bound (`maxProjectNotes`) and `validateProjectNotes`
- `projectNotesFor`, `renderProjectNotes`, and the injection into `memInjection` at both compose sites — web turns (`buildAgent`) and channel turns (`runChannelTurns`)
- The `notes` members of the create/update session-group requests, and the field from the frontend's `SessionGroup` type and both API signatures
- `projectNotesAndDir` collapsed into the existing `ProjectDirForSession`: the directory was the other half it returned, and that half is what scopes a session's memory

## Freeze identity goes back to (model, cwd)

`notesHash` existed only for notes, so `ComposedForNotes` leaves the `Session` struct and the `composed_system` record, `ComposedNotesHash` is deleted, and `SetComposedSystem` / `IsComposedFor` lose their last parameter.

Nothing on disk needs migrating. The hash was `omitempty` and only ever written for a project that actually had notes, so a transcript that never had one is byte-identical either way, and an unknown `composed_for_notes` field on an older one is simply ignored on load. A session frozen with notes baked into its prompt keeps that frozen prompt — which it would have anyway, since the freeze is the point — and one re-freeze (a model switch, a retargeted directory, `/reload`) drops them.

## Behaviour change

`PATCH /api/session-groups/{id}` with only a `notes` field now 400s ("name, collapsed or working_dir is required") rather than appearing to store it.

## Verification

`go test ./...`, `go vet ./...`, `gofmt -l .`, `svelte-check` (0 errors), `vitest` (517 passed).

Tests: the two notes-specific tests are deleted (`TestProject_RejectsOversizedNotes`, `TestProject_NotesReachTheSystemPrompt`, `TestSetComposedSystem_NotesChangeForcesRefreeze`); `TestClearComposedSystem_ClearsFreezeIdentity` keeps its point with the cwd stamp alone; and the registry-write notification sweep swaps its "edit notes" step for a collapse toggle so it still covers the PATCH path.

`dev-docs/projects-design.md` is updated to match — the scope table, the freeze-identity section, and the reason a session's project is fixed at creation (three derived facts now, not four).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
