### PR TITLE
fix(server): reject non-local memory filenames in resolveMemoryPath

### DIFF
--- a/internal/server/memory_handler.go
+++ b/internal/server/memory_handler.go
@@ -105,6 +105,13 @@ func (s *Server) handleDeleteMemory(w http.ResponseWriter, r *http.Request) {
 // directory must already exist, so a crafted source can't escape the root or
 // conjure new directories.
 func (s *Server) resolveMemoryPath(fname, source string) (string, bool) {
+	// Callers pass fname through Base(), but Base("..") is still ".." and
+	// Base("") is "." — joined below, one escapes the memory directory and the
+	// other addresses it directly. IsLocal rejects ".." (and absolute paths)
+	// but accepts ".", so that one needs its own check.
+	if fname == "." || !filepath.IsLocal(fname) {
+		return "", false
+	}
 	switch source {
 	case "", "inherited", "project":
 		if s.homeMemDir != "" {

--- a/internal/server/memory_listing_test.go
+++ b/internal/server/memory_listing_test.go
@@ -155,3 +155,41 @@ func TestHandleDeleteMemory_RemovesFilePermanently(t *testing.T) {
 		t.Errorf("deleted memory was staged in the trash: %d entr(ies)", len(entries))
 	}
 }
+
+// The filename is Base()'d by the handlers, but Base("..") is still ".." —
+// joined onto the memory dir it would address the dir itself or its parent.
+// resolveMemoryPath must reject any fname that isn't a local path component.
+func TestResolveMemoryPath_RejectsNonLocalFilename(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.homeMemDir = t.TempDir()
+
+	for _, fname := range []string{"..", ".", "", "/etc/passwd", "../escape.md"} {
+		if p, ok := srv.resolveMemoryPath(fname, ""); ok {
+			t.Errorf("fname %q: resolved to %q, want rejection", fname, p)
+		}
+	}
+	if _, ok := srv.resolveMemoryPath("notes.md", ""); !ok {
+		t.Errorf("fname \"notes.md\": rejected, want resolution")
+	}
+}
+
+// End-to-end: a traversal filename in the URL (encoded so the segment survives
+// routing) must 404 instead of touching the memory dir's parent.
+func TestHandleDeleteMemory_RejectsTraversalFilename(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/memories/..%2F..", nil)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (body: %s)", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [CodeQL alert #197](https://github.com/open-octo/octo-agent/security/code-scanning/197) (`go/path-injection`, high) on `internal/server/memory_handler.go`.

The memory GET/DELETE handlers sanitize the `{filename}` path value with `filepath.Base`, but `Base("..")` is still `".."` and `Base("")` is `"."` — joined onto the resolved memory directory, the former reaches the directory's **parent** and the latter addresses the directory itself, so `os.Remove` / `os.ReadFile` could be pointed one level outside the intended tier.

`resolveMemoryPath` now rejects any filename that isn't a plain local path component: `filepath.IsLocal` (a CodeQL-recognized barrier) plus an explicit `"."` check, since `IsLocal(".")` is true. Both handlers funnel through this one resolver, so GET and DELETE are covered by the same guard — mirroring the existing `"."`/`".."` slug guard already applied to the `source` param.

## Changes
- `resolveMemoryPath`: reject `fname` when `fname == "."` or `!filepath.IsLocal(fname)`.
- Tests: unit coverage for the resolver (`..`, `.`, empty, absolute, `../escape.md` rejected; plain name still resolves) and an end-to-end `DELETE /api/memories/..%2F..` → 404 case.

## Testing
- `go test -race ./internal/server/` passes; `go vet` and `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)