### PR TITLE
fix(skills): move web-access site experience out of the wiped defaults root

### DIFF
--- a/internal/skills/defaults.go
+++ b/internal/skills/defaults.go
@@ -74,6 +74,10 @@ func materializeDefaults(root, version string, force bool) error {
 	// The default root is exclusively octo-managed (users override in
 	// ~/.octo/skills), so a wholesale wipe-and-rewrite is safe and keeps the
 	// set in lockstep with the binary — stale skills removed, renames handled.
+	// One exception predates that rule: earlier web-access versions had the
+	// agent write site-experience notes inside the managed tree; rescue those
+	// into the persistent sibling directory before the wipe destroys them.
+	rescueSitePatterns(root)
 	if err := os.RemoveAll(root); err != nil {
 		return err
 	}
@@ -101,4 +105,37 @@ func materializeDefaults(root, version string, force bool) error {
 	// Stamp last: if a write above failed mid-way the stamp is absent/stale, so
 	// the next run retries rather than trusting a partial materialization.
 	return os.WriteFile(filepath.Join(root, defaultStampFile), []byte(version), 0o644)
+}
+
+// rescueSitePatterns moves site-experience notes an earlier web-access skill
+// accumulated under the managed default root (web-access/references/
+// site-patterns/) into the persistent sibling directory ~/.octo/site-patterns,
+// where the skill reads and writes them today. They are user data written by
+// the agent, not shipped skill content, so the wipe-and-rewrite must not eat
+// them. Best-effort: an existing file in the destination wins (it is the copy
+// the skill has been updating since the move).
+func rescueSitePatterns(root string) {
+	legacy := filepath.Join(root, "web-access", "references", "site-patterns")
+	entries, err := os.ReadDir(legacy)
+	if err != nil {
+		return
+	}
+	dest := filepath.Join(filepath.Dir(root), "site-patterns")
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		target := filepath.Join(dest, e.Name())
+		if _, err := os.Stat(target); err == nil {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(legacy, e.Name()))
+		if err != nil {
+			continue
+		}
+		if err := os.MkdirAll(dest, 0o755); err != nil {
+			return
+		}
+		_ = os.WriteFile(target, data, 0o644)
+	}
 }

--- a/internal/skills/defaults/web-access/.gitignore
+++ b/internal/skills/defaults/web-access/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
 *.log
-references/site-patterns/*.md

--- a/internal/skills/defaults/web-access/README.md
+++ b/internal/skills/defaults/web-access/README.md
@@ -12,7 +12,7 @@
 
 ## 站点经验
 
-`references/site-patterns/<domain>.md` 按域名存放操作经验（本地、gitignored、跨 session 复用）。
+`~/.octo/site-patterns/<domain>.md` 按域名存放操作经验（本地、跨 session 持久）。放在 octo 管理的 `~/.octo/skills-default/` 之外，版本升级的 wipe-and-rewrite 不会清掉它。
 
 ## 已移除
 

--- a/internal/skills/defaults/web-access/SKILL.md
+++ b/internal/skills/defaults/web-access/SKILL.md
@@ -125,7 +125,7 @@ action 级用法（observe / click / eval / record / replay 等的参数与语�
 
 ## 站点经验
 
-操作中积累的特定网站经验，按域名存在 `references/site-patterns/<domain>.md`（本地、gitignored、跨 session 复用）。
+操作中积累的特定网站经验，按域名存在 `~/.octo/site-patterns/<domain>.md`（本地目录，独立于技能文件，跨 session 与版本升级持久复用）。
 
 确定目标网站后，若已有对应站点经验文件，读取它获取先验（平台特征、有效模式、已知陷阱）。经验标注发现日期，当作"可能有效的提示"而非"保证正确的事实"——按经验失败就回退通用模式并更新文件。
 

--- a/internal/skills/defaults_test.go
+++ b/internal/skills/defaults_test.go
@@ -134,6 +134,47 @@ func TestMaterializeDefaults_UnderscorePrefixedFilesShip(t *testing.T) {
 	}
 }
 
+func TestMaterializeDefaults_RescuesLegacySitePatterns(t *testing.T) {
+	// Earlier web-access versions had the agent write per-domain
+	// site-experience notes inside the managed default root, which the
+	// version-bump wipe destroyed. The rewrite must move them to the
+	// persistent sibling ~/.octo/site-patterns first.
+	octoDir := t.TempDir()
+	root := filepath.Join(octoDir, "skills-default")
+	useDefaultRoot(t, root)
+	if err := MaterializeDefaults("v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	legacy := filepath.Join(root, "web-access", "references", "site-patterns")
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(legacy, "example.com.md"), "legacy notes")
+	mustWrite(t, filepath.Join(legacy, "stale.com.md"), "older notes")
+
+	// A file already in the persistent directory wins over the legacy copy.
+	dest := filepath.Join(octoDir, "site-patterns")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(dest, "stale.com.md"), "current notes")
+
+	if err := MaterializeDefaults("v2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if b, err := os.ReadFile(filepath.Join(dest, "example.com.md")); err != nil || string(b) != "legacy notes" {
+		t.Errorf("example.com.md = %q, %v; want rescued legacy notes", string(b), err)
+	}
+	if b, err := os.ReadFile(filepath.Join(dest, "stale.com.md")); err != nil || string(b) != "current notes" {
+		t.Errorf("stale.com.md = %q, %v; want the persistent copy kept", string(b), err)
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("legacy site-patterns dir should be gone after the rewrite")
+	}
+}
+
 func TestDiscover_DefaultSkillSurfacesAndIsOverridable(t *testing.T) {
 	defaultRoot := filepath.Join(t.TempDir(), "skills-default")
 	useDefaultRoot(t, defaultRoot)


### PR DESCRIPTION
## Why

The web-access skill accumulates per-domain site-experience notes (`references/site-patterns/<domain>.md`), but it wrote them inside `~/.octo/skills-default` — the octo-managed directory that `materializeDefaults` wipes wholesale on every version change. The notes survived across sessions but not across upgrades, silently defeating the feature.

## What

- The skill now reads/writes `~/.octo/site-patterns/<domain>.md`, a sibling of the managed root the wipe never touches. `write_file` expands `~/` and MkdirAll's parents, so no bootstrap is needed; SKILL.md and README updated.
- `materializeDefaults` rescues any `*.md` left in the legacy location into the new directory **before** wiping, so installs upgrading to this version keep whatever they had accumulated. A file already present in the destination wins (it's the copy the skill has been updating since the move). Best-effort, consistent with materialization itself.
- Drop the now-unused `references/site-patterns/.gitkeep` and its `.gitignore` entry.

## Tests

- New `TestMaterializeDefaults_RescuesLegacySitePatterns`: legacy notes moved on version bump, destination copy not overwritten, legacy dir gone after the rewrite.
- `go vet` / `gofmt` clean; `internal/skills` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)