### PR TITLE
fix(web): close the artifacts panel when navigating to another view

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -110,6 +110,20 @@
     }
   }
 
+  // Navigating to a different view closes the artifacts panel — expanded, it
+  // would otherwise keep covering the content area the new view just took
+  // over (the main column stays display:none while the panel is expanded).
+  // Guarded on an actual change: view.set re-fires subscribers on same-value
+  // sets, and flows that open the panel without navigating (a Light App
+  // opening over its own view, the header/palette toggles) must not be undone.
+  let prevView = get(view)
+  view.subscribe(v => {
+    if (v === prevView) return
+    prevView = v
+    panelExpanded.set(false)
+    panelContent.set(null)
+  })
+
   onMount(() => {
     // Access-key gate, BEFORE any gated call. Loopback visits pass instantly
     // (the server exempts them); a networked server without a valid key prompts


### PR DESCRIPTION
## Summary
Switching main-menu views (e.g. chat → scheduled tasks) left the artifacts panel open. Expanded, it kept covering the content area the new view had just taken over — the main column stays `display:none` while the panel is expanded, so the new view was completely hidden.

Fix: a single `view` subscription in `App.svelte` closes the panel (`panelExpanded` + `panelContent`) whenever the view actually changes. One central point covers every navigation entry (wide sidebar menu, narrow rail buttons, "more" popover, command palette, settings jumps).

Guarded on an actual value change, because `view.set` re-fires subscribers on same-value sets and some flows legitimately open the panel without navigating — a Light App expanding over its own view, the header/palette panel toggles. Those must not be undone.

## Testing
- `svelte-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)