### PR TITLE
feat(web): hide "Save to Light App" for artifacts already saved as one

### DIFF
--- a/internal/server/lightapps_handlers.go
+++ b/internal/server/lightapps_handlers.go
@@ -28,6 +28,10 @@ type lightAppManifest struct {
 	Description string `json:"description"`
 	Icon        string `json:"icon,omitempty"`
 	CreatedAt   string `json:"created_at"`
+	// SourcePath is the absolute path of the session artifact this app was
+	// saved from, when it was. The web UI matches it against the artifact on
+	// display to hide the redundant "Save to Light App" action.
+	SourcePath string `json:"source_path,omitempty"`
 }
 
 // handleListLightApps lists all Light Apps by scanning ~/.octo/light-apps/ for
@@ -140,6 +144,7 @@ func (s *Server) handleCreateLightApp(w http.ResponseWriter, r *http.Request) {
 		Description string `json:"description"`
 		Icon        string `json:"icon"`
 		HTML        string `json:"html"`
+		SourcePath  string `json:"source_path"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
 		if strings.Contains(err.Error(), "http: request body too large") {
@@ -190,6 +195,7 @@ func (s *Server) handleCreateLightApp(w http.ResponseWriter, r *http.Request) {
 		Description: in.Description,
 		Icon:        in.Icon,
 		CreatedAt:   now,
+		SourcePath:  in.SourcePath,
 	}
 
 	mData, err := json.MarshalIndent(m, "", "  ")

--- a/internal/server/lightapps_handlers_test.go
+++ b/internal/server/lightapps_handlers_test.go
@@ -126,6 +126,41 @@ func TestGetLightApp_PathTraversal(t *testing.T) {
 	}
 }
 
+// TestCreateLightApp_SourcePathRoundTrip: source_path persists into the
+// manifest and comes back through the create response and the listing — the
+// web UI relies on it to hide "Save to Light App" for already-saved artifacts.
+func TestCreateLightApp_SourcePathRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	body := `{"name":"Quicksort Viz","html":"<html>ok</html>","source_path":"/work/quicksort-visualizer.html"}`
+	w := doJSON(t, srv, "POST", "/api/light-apps", body)
+	if w.Code != 201 {
+		t.Fatalf("create: expected 201, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var created lightAppManifest
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if created.SourcePath != "/work/quicksort-visualizer.html" {
+		t.Errorf("create response source_path: got %q", created.SourcePath)
+	}
+
+	w = doJSON(t, srv, "GET", "/api/light-apps", "")
+	if w.Code != 200 {
+		t.Fatalf("list: expected 200, got %d", w.Code)
+	}
+	var out struct{ Apps []lightAppManifest }
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Apps) != 1 || out.Apps[0].SourcePath != "/work/quicksort-visualizer.html" {
+		t.Errorf("listing source_path round-trip failed: %+v", out.Apps)
+	}
+}
+
 // TestDeleteLightApp_Success: deletes an app and confirms it's gone from listing.
 func TestDeleteLightApp_Success(t *testing.T) {
 	home := t.TempDir()

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -69,16 +69,12 @@
       // Save what the panel previews, not the raw source: a Light App renders
       // in the same kind of sandboxed iframe, where relative image paths
       // resolve against nothing (#1890).
-      const app = await api.createLightApp({ name, html: lightAppSource(cur) })
+      // source_path marks the app as saved from this artifact, which is what
+      // hides the Save button for it from here on (curSavedAsLA).
+      const app = await api.createLightApp({ name, html: lightAppSource(cur), source_path: cur.path })
       showToast(`Light App "${app.name}" saved`, 'success')
       saveToLADialog = false
-      // If the panel is in lightapps mode, refresh the list.
-      if ($panelContent === 'lightapps') {
-        try {
-          const list = await api.listLightApps()
-          lightapps.set(list)
-        } catch { /* ignore */ }
-      }
+      lightapps.update(list => [...list.filter(a => a.slug !== app.slug), app])
     } catch (e: any) {
       showToast(`Save failed: ${e.message}`, 'error')
     } finally {
@@ -104,7 +100,11 @@
     if (laDir !== null || laDirAttempted) return
     laDirAttempted = true
     try {
-      laDir = await api.getLightAppsDir()
+      // One request answers with both the directory and the apps; the apps
+      // land in the store so curSavedAsLA below can match source paths.
+      const { apps, dir } = await api.getLightAppList()
+      laDir = dir
+      lightapps.set(apps)
     } catch {
       laDir = ''
       laDirAttempted = false
@@ -113,6 +113,11 @@
 
   const curIsLightApp = $derived(curIsHTML && pathIsInside(cur?.path ?? '', laDir ?? ''))
 
+  // Already saved as a Light App: some app records this artifact's path as
+  // its source (manifest source_path). Equally redundant to save again — the
+  // slug exists, so the server would 409 anyway.
+  const curSavedAsLA = $derived(curIsHTML && !!cur?.path && $lightapps.some(a => a.source_path === cur.path))
+
   $effect(() => {
     if ($panelContent === 'session' && curIsHTML) void ensureLaDir()
   })
@@ -120,7 +125,7 @@
   // The Save dialog must not outlive the button: once the lookup settles and
   // the artifact turns out to be inside the Light Apps directory, close it.
   $effect(() => {
-    if (curIsLightApp) saveToLADialog = false
+    if (curIsLightApp || curSavedAsLA) saveToLADialog = false
   })
 
   // ── Light Apps (new) ──────────────────────────────────────────────────────
@@ -364,7 +369,7 @@
           <iconify-icon icon="ant-design:download-outlined" width="14"></iconify-icon>
           {$t('artifacts.download')}
         </button>
-        {#if curIsHTML && !curIsLightApp}
+        {#if curIsHTML && !curIsLightApp && !curSavedAsLA}
           <button class="wbtn" disabled={!cur.loaded || cur.loadFailed} onclick={openSaveToLA}>
             <iconify-icon icon="ant-design:save-outlined" width="14"></iconify-icon>
             {$t('artifacts.save_to_lightapp')}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -800,6 +800,9 @@ export interface LightApp {
   description: string
   icon: string
   created_at: string
+  // Absolute path of the session artifact the app was saved from, if any —
+  // used to hide "Save to Light App" for artifacts that already were.
+  source_path?: string
 }
 
 export interface LightAppDetail {
@@ -830,11 +833,20 @@ export async function getLightAppsDir(): Promise<string> {
   return lightAppsDirCache
 }
 
+// Apps and directory from the one request the endpoint already answers with
+// both — for callers that need the pair (the session panel checks an artifact
+// against the dir AND the apps' source paths).
+export async function getLightAppList(): Promise<LightAppList> {
+  const d = await request<LightAppList>('/api/light-apps')
+  lightAppsDirCache = d.dir || ''
+  return { apps: d.apps ?? [], dir: lightAppsDirCache }
+}
+
 export async function getLightApp(slug: string): Promise<LightAppDetail> {
   return request<LightAppDetail>(`/api/light-apps/${encodeURIComponent(slug)}`)
 }
 
-export async function createLightApp(opts: { name: string; description?: string; html: string }): Promise<LightApp> {
+export async function createLightApp(opts: { name: string; description?: string; html: string; source_path?: string }): Promise<LightApp> {
   return request<LightApp>('/api/light-apps', { method: 'POST', ...json({ ...opts, icon: '📄' }) })
 }
 


### PR DESCRIPTION
## Summary
After saving an artifact as a Light App, the panel footer kept offering "Save to Light App" — a redundant action that would only 409 on the existing slug.

- The Light App manifest gains a `source_path` field (`omitempty`, old manifests unaffected): the absolute path of the session artifact the app was saved from. The create endpoint accepts it; the list endpoint returns it.
- The panel sends `source_path` on save and hides the button when any app's `source_path` matches the artifact on display (`curSavedAsLA`). Durable across reloads and reopened sessions.
- Zero extra requests: `ensureLaDir` already hit `/api/light-apps` for the directory and discarded the apps; the new `api.getLightAppList()` keeps both from that one response.
- A fresh save pushes the created app into the store directly, so the button disappears immediately; the save-name dialog auto-closes with it.

Known edge: if the agent rewrites the artifact after it was saved, the button stays hidden — re-saving would 409 on the slug anyway; saving an updated copy goes through deleting the old app first.

## Testing
- New `TestCreateLightApp_SourcePathRoundTrip` (create response + listing round-trip); `go test ./internal/server/` all green.
- `svelte-check`: 0 errors; web vitest: 519 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)