### PR TITLE
fix(server): add explicit containment check to memory path resolution

### DIFF
--- a/internal/server/memory_handler.go
+++ b/internal/server/memory_handler.go
@@ -112,11 +112,13 @@ func (s *Server) resolveMemoryPath(fname, source string) (string, bool) {
 	if fname == "." || !filepath.IsLocal(fname) {
 		return "", false
 	}
+	var dir string
 	switch source {
 	case "", "inherited", "project":
-		if s.homeMemDir != "" {
-			return filepath.Join(s.homeMemDir, fname), true
+		if s.homeMemDir == "" {
+			return "", false
 		}
+		dir = s.homeMemDir
 	default:
 		root, err := memory.RootDir()
 		if err != nil {
@@ -129,10 +131,19 @@ func (s *Server) resolveMemoryPath(fname, source string) (string, bool) {
 		if slug == "." || slug == ".." {
 			return "", false
 		}
-		dir := filepath.Join(root, slug)
-		if fi, err := os.Stat(dir); err == nil && fi.IsDir() {
-			return filepath.Join(dir, fname), true
+		d := filepath.Join(root, slug)
+		fi, err := os.Stat(d)
+		if err != nil || !fi.IsDir() {
+			return "", false
 		}
+		dir = d
 	}
-	return "", false
+	// Belt and braces on top of the checks above: the resolved path must stay
+	// strictly inside the memory directory. Also the containment proof static
+	// analysis (CodeQL go/path-injection) recognizes at the read/remove sinks.
+	p := filepath.Join(dir, fname)
+	if !strings.HasPrefix(p, dir+string(os.PathSeparator)) {
+		return "", false
+	}
+	return p, true
 }

--- a/internal/server/memory_handler.go
+++ b/internal/server/memory_handler.go
@@ -126,9 +126,12 @@ func (s *Server) resolveMemoryPath(fname, source string) (string, bool) {
 		}
 		// Base can still yield "." or ".." (Base("../..") == ".."), which
 		// would resolve to the root itself or its parent — reject those so a
-		// slug is always exactly one component below the root.
+		// slug is always exactly one component below the root. Same IsLocal
+		// idiom as the fname check above: for a single component it rejects
+		// exactly ".." (and absolute paths), and CodeQL recognizes it as a
+		// path-injection barrier where a plain ".." comparison is not.
 		slug := filepath.Base(source)
-		if slug == "." || slug == ".." {
+		if slug == "." || !filepath.IsLocal(slug) {
 			return "", false
 		}
 		d := filepath.Join(root, slug)


### PR DESCRIPTION
## Summary
Fixes CodeQL alert #197 (go/path-injection, high) on `memory_handler.go`'s `os.Remove`.

The handlers were already safe — `filepath.Base()` on the filename plus an `IsLocal` check, and the `source` slug pinned to a single existing directory component — but the sanitization is spread across guards CodeQL doesn't recognize as a barrier, so this family keeps re-opening (#177–#181 were dismissed as false positives).

This folds the final `Join` into `resolveMemoryPath` and rejects any resolved path that doesn't sit strictly inside the memory directory (`strings.HasPrefix(p, dir + separator)`), which is the containment proof the query's remediation guidance prescribes. Belt and braces at runtime; closes the alert family in code instead of by dismissal.

No behavior change for valid requests: every path the old code accepted still resolves identically.

## Testing
- `go test ./internal/server/` all green (includes `TestHandleDeleteMemory_RejectsTraversalFilename` and the other memory handler tests).
- `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)