### PR TITLE
fix(web): hold a panel steady while its new version streams in

### DIFF
--- a/web/src/lib/genui/projection.test.ts
+++ b/web/src/lib/genui/projection.test.ts
@@ -58,6 +58,30 @@ describe('projectPanels', () => {
     expect((panels.get('a')?.spec.items[0] as any).text).toBe('A2')
     expect((panels.get('b')?.spec.items[0] as any).text).toBe('B1')
   })
+
+  it('holds the previous version steady while a new one is still streaming', () => {
+    // The incomplete fence's partial spec already carries the id, but the
+    // silent classification can't hold until the fence closes — without the
+    // guard the anchor jumps to the hidden streaming message and the panel
+    // unmounts mid-update.
+    const seed = msg('assistant', fence('p', 'v1'))
+    const streamingReply = msg('assistant', '```octo-ui\n{"id":"p","items":[{"type":"text","text":"v2 partial"')
+    streamingReply.streaming = true
+    const panels = projectPanels([seed, action('p'), streamingReply])
+    const p = panels.get('p')
+    expect((p?.spec.items[0] as any).text).toBe('v1')
+    expect(p?.anchorMsgId).toBe(seed.id)
+    expect(p?.versions).toBe(1)
+    expect(isAnchor(panels, p!.spec, seed.id, 0)).toBe(true)
+  })
+
+  it('still renders a first version live while its fence streams', () => {
+    const streaming = msg('assistant', '```octo-ui\n{"id":"p","items":[{"type":"text","text":"building"}')
+    streaming.streaming = true
+    const p = projectPanels([streaming]).get('p')
+    expect(p?.anchorMsgId).toBe(streaming.id)
+    expect((p?.spec.items[0] as any).text).toBe('building')
+  })
 })
 
 describe('isAnchor', () => {

--- a/web/src/lib/genui/projection.ts
+++ b/web/src/lib/genui/projection.ts
@@ -50,6 +50,16 @@ export function projectPanels(messages: ChatMessage[]): Map<string, PanelProject
       if (!id) continue
 
       const prev = out.get(id)
+      // An incomplete fence never replaces an existing version. While a new
+      // version streams in, its partial spec already carries the id, but the
+      // silent classification can't hold yet (isSilentReply requires a
+      // complete fence) — so the anchor would jump to a message the
+      // transcript hides, unmounting the panel mid-update, then jump back
+      // once the fence closes. Keeping the previous complete version until
+      // the new one finishes makes an update a single atomic swap. A panel's
+      // FIRST version has no fallback to show, so it still renders its
+      // partial spec live as it streams.
+      if (!seg.complete && prev) continue
       out.set(id, {
         spec: seg.spec as GenuiSpec,
         // A silent reply keeps the existing anchor. The `?? msg.id` fallback


### PR DESCRIPTION
## Problem

Acting on a GenUI panel, the user sees the panel flicker, vanish entirely for several seconds, then suddenly reappear once the reply finishes.

Root cause: an incomplete ```octo-ui fence's partially-parsed spec already carries the panel id (`fence-split.ts` partial-parse path), so `projectPanels` counted the still-streaming reply as a new version. But `isSilentReply` requires a **complete** fence, so mid-stream the reply classified as a visible re-presentation — moving the anchor onto the streaming message. That message is exactly the one the transcript hides during a silent turn, so the panel unmounted from its anchor and rendered nowhere until the fence closed and classification flipped back.

The bug predates #2217 but was invisible before it: the forced scroll-to-bottom meant nobody was ever looking at the panel while it updated.

## Fix

In `projectPanels`, an incomplete fence never replaces an existing version. While a new version streams, the previous complete spec stays rendered at its anchor (under the "updating panel…" chip from #2217), and the update lands as a single atomic swap when the fence completes. A panel's **first** version has no fallback to show, so it keeps today's behavior of rendering its partial spec live as it streams.

## Verification

- Two new projection tests: streaming new version leaves spec/anchor/version-count untouched; a first version still renders live mid-stream.
- `vitest run`: 521 tests pass (was 519)
- `svelte-check`: 0 errors (2 pre-existing warnings in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)