### PR TITLE
server: guard the mount trust-grant read for CodeQL go/path-injection

### DIFF
--- a/internal/server/project_envcontext.go
+++ b/internal/server/project_envcontext.go
@@ -122,6 +122,20 @@ func trustMountedHooks(dirs []string) {
 		if path == "" {
 			continue
 		}
+		// The mount dirs originate in the HTTP mount request, so the read
+		// below is a CodeQL go/path-injection sink. Two guards: the ".."
+		// check is the barrier the query recognizes (Join already cleans, so
+		// it can never fire at runtime), and the containment check proves the
+		// target stays strictly inside the folder whose mount was just
+		// granted — it can only reject a dir that never passed
+		// validateSourceDirs (e.g. the filesystem root). Same idiom as
+		// resolveMemoryPath.
+		if strings.Contains(path, "..") {
+			continue
+		}
+		if root := filepath.Clean(d); !strings.HasPrefix(path, root+string(os.PathSeparator)) {
+			continue
+		}
 		b, err := os.ReadFile(path)
 		if err != nil {
 			continue


### PR DESCRIPTION
## What

Fixes code scanning alert [#199](https://github.com/open-octo/octo-agent/security/code-scanning/199) (`go/path-injection`, high): `trustMountedHooks` reads `<dir>/.octo/hooks.yml` for dirs that originate in the HTTP mount request, and CodeQL taints that flow through to the `os.ReadFile` sink in `internal/server/project_envcontext.go`.

## Why this shape

The read is by design — mounting a folder *is* the hooks trust grant, and the dirs reach this function only after `validateSourceDirs` (existing accessible directory, not under the workspace root). So this is a scanner-pleaser, done the way the repo already settled for alert #197: add the guards CodeQL recognizes at the sink, with honest comments that they are vacuous at runtime.

- `strings.Contains(path, "..")` — the barrier the query recognizes; `filepath.Join` already cleans, so it can never fire at runtime.
- Containment prefix check against `filepath.Clean(d)` — proves the read target stays strictly inside the folder whose mount was just granted. The only newly rejected input is the filesystem root (`Clean("/") + "/"` can't prefix-match), which never passes `validateSourceDirs` in practice anyway.

Sibling sink `hooksTrustedAt` (same `ProjectConfigPath` + `ReadFile` shape, two functions up) was *not* flagged — its taint path runs through the registry file, not the HTTP request — so it's left untouched to keep the diff minimal.

## Verification

- `gofmt -l internal/server/` clean, `go vet ./internal/server/` clean
- `go test -race ./internal/server/ -count=1` green (the existing `project_edit_test.go` mount-grant flow — create/PATCH gestures record trust, changed content re-prompts — exercises this function end-to-end)
- CodeQL will auto-close alert #199 once this lands on main
