### PR TITLE
web: open Light Apps in the side panel instead of maximized

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -237,16 +237,6 @@
   </button>
 {/snippet}
 
-<!-- A light app opens maximized, so there is no narrow state to shrink back to
-     and nothing for an expand/collapse pair to toggle between. One close
-     button instead — and only one, since the panel toggle beside it would have
-     done exactly the same thing here. -->
-{#snippet lightAppControls()}
-  <button class="icon-btn" title={$t('common.close')} onclick={closePanel}>
-    <iconify-icon icon="ant-design:close-outlined" width="15"></iconify-icon>
-  </button>
-{/snippet}
-
 <aside class="panel" bind:this={panelEl} style={$panelExpanded ? 'flex:1 1 auto' : `width:${panelWidth}px;flex-basis:${panelWidth}px`}>
   <!-- Expanded, there is no neighbour left to drag against, so the handle goes
        with it rather than sitting there inert against the sidebar. -->
@@ -258,7 +248,7 @@
     <div class="topbar" class:native-lift={liftForTrafficLights}>
       <span style="flex:1"></span>
       <span class="sandboxed-label">{$t('artifacts.sandboxed')}</span>
-      {@render lightAppControls()}
+      {@render topbarControls()}
     </div>
 
     <div class="body">

--- a/web/src/views/LightAppsView.svelte
+++ b/web/src/views/LightAppsView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { showToast, openAgentSession, panelContent, panelExpanded, lightapps, lightappSel, lightappHTML } from '../lib/stores'
+  import { showToast, openAgentSession, panelContent, lightapps, lightappSel, lightappHTML } from '../lib/stores'
   import * as api from '../lib/api'
   import type { LightApp } from '../lib/api'
   import { t, tr } from '../lib/i18n'
@@ -25,17 +25,16 @@
 
   async function handleOpen(slug: string) {
     try {
-      // Load Light App data into global stores, then hand the whole content
-      // area to it. A light app is a program to use, not a preview to glance
-      // at beside something else, so it opens at full size rather than in a
-      // narrow strip the user would have to widen every time.
+      // Load Light App data into global stores, then open it in the side
+      // panel at its regular width — many light apps are laid out for a
+      // narrow column, and the panel's own maximize button is there for
+      // the ones that want the full content area.
       const detail = await api.getLightApp(slug)
       lightappHTML.update(m => ({ ...m, [slug]: detail.html }))
       // If not already loaded, populate the list.
       if ($lightapps.length === 0) lightapps.set(apps)
       lightappSel.set(slug)
       panelContent.set('lightapps')
-      panelExpanded.set(true)
     } catch (e: any) {
       showToast(`Failed to open: ${e.message}`, 'error')
     }


### PR DESCRIPTION
## Problem

Light Apps opened maximized, taking over the whole content area on open, with a bespoke close-only topbar (the maximize button was deliberately hidden). Apps laid out for a narrow column look broken at full width, and users reported the forced-maximized behavior as unusable.

## Change

- `LightAppsView.handleOpen` no longer sets `panelExpanded` — a light app opens in the side panel at its regular (user-resizable, persisted) width.
- The Light Apps panel mode now reuses the standard `topbarControls()` snippet (maximize/collapse + close), and the special-purpose `lightAppControls()` snippet is removed.

Users who want full width can still get it via the panel's maximize button.

## Verification

- `npm run build` ✓
- `npm test` — 521 tests pass ✓
- Manually verified via `octo serve` on the branch: light app opens narrow, maximize/restore and close buttons work.
