### PR TITLE
web: lay project picker items out as icon + name on one row

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -1575,6 +1575,9 @@
    primitives the model/reasoning pickers use, widened to the bar. */
 .dir-bar-wrap { position: relative; display: block; }
 .proj-menu { left: 0; right: 0; min-width: 0; max-height: 320px; overflow-y: auto; }
+/* Icon + name on one line — the column default exists for menu items that
+   stack a description under the name; these items have none. */
+.proj-menu .menu-item { flex-direction: row; align-items: center; gap: 6px; }
 .proj-search {
   width: calc(100% - 16px); margin: 6px 8px; padding: 6px 8px;
   background: var(--bg-layout); border: 1px solid var(--border-secondary);


### PR DESCRIPTION
## Problem

In the landing-page project picker, every item rendered with the folder icon on its own line above the project name, so each entry took two rows.

## Cause

The shared `.menu-item` primitive defaults to `flex-direction: column` — that layout exists for menu items that stack a description under the name (e.g. the skill menu). Project picker items only have an icon and a name, so the icon wrapped onto its own line.

## Fix

Add a scoped rule so `.proj-menu` items lay out horizontally:

```css
.proj-menu .menu-item { flex-direction: row; align-items: center; gap: 6px; }
```

Other menus keep the column default; no behavior change outside the project picker.

## Verification

- `npm run build` in `web/` passes (CSS-only change).