### PR TITLE
feat(agent): carry tool outputs, text blocks, and final result in sub-agent events

### DIFF
--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -298,20 +298,43 @@ func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (r
 
 	childCtx := tools.WithSubAgentMarker(ctx)
 
-	// When the manager stamped an event sink into ctx (TUI live panel), stream
-	// the child's tool-level activity to it. Only tool_started/tool_error are
-	// forwarded — not per-token text — to keep event volume sane with several
-	// sub-agents running at once. No sink (headless) => nil handler => no
-	// events; unlike Run, a nil-handler RunStream still keeps a streamed
-	// partial reply in history when a round dies on an error.
+	// When the manager stamped an event sink into ctx (live panels), stream
+	// the child's activity to it: tool dispatches with their (capped) outputs,
+	// and the assistant's text as whole blocks — deltas are aggregated locally
+	// and flushed on the next tool dispatch or at turn end, never per token, to
+	// keep event volume sane with several sub-agents running at once. No sink
+	// (headless) => nil handler => no events; unlike Run, a nil-handler
+	// RunStream still keeps a streamed partial reply in history when a round
+	// dies on an error.
 	var handler agent.EventHandler
 	if sink := tools.SubAgentEventSink(ctx); sink != nil {
+		var textBuf strings.Builder
+		flushText := func() {
+			if textBuf.Len() == 0 {
+				return
+			}
+			sink(tools.SubAgentEvent{Kind: "text", Text: tools.ClipForEvent(textBuf.String(), tools.SubAgentEventTextCap)})
+			textBuf.Reset()
+		}
 		handler = func(ev agent.AgentEvent) {
 			switch ev.Kind {
+			case agent.EventTextDelta:
+				textBuf.WriteString(ev.Text)
 			case agent.EventToolStarted:
-				sink(tools.SubAgentEvent{Kind: "tool", ToolName: ev.ToolName, ToolInput: ev.Input})
+				flushText()
+				sink(tools.SubAgentEvent{Kind: "tool", ToolID: ev.ToolID, ToolName: ev.ToolName, ToolInput: ev.Input})
+			case agent.EventToolDone:
+				sink(tools.SubAgentEvent{Kind: "tool_done", ToolID: ev.ToolID, ToolName: ev.ToolName,
+					ToolOutput: tools.ClipForEvent(ev.Output, tools.SubAgentEventOutputCap)})
 			case agent.EventToolError:
-				sink(tools.SubAgentEvent{Kind: "tool_error", ToolName: ev.ToolName})
+				out := ev.Err
+				if ev.Output != "" {
+					out += "\n" + ev.Output
+				}
+				sink(tools.SubAgentEvent{Kind: "tool_error", ToolID: ev.ToolID, ToolName: ev.ToolName,
+					ToolOutput: tools.ClipForEvent(out, tools.SubAgentEventOutputCap)})
+			case agent.EventTurnDone:
+				flushText()
 			}
 		}
 	}

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -736,3 +736,91 @@ func TestAgentSpawner_SessionDirPersistsTranscript(t *testing.T) {
 		t.Error("Continue should have appended more records to the session file")
 	}
 }
+
+// trailSender scripts a two-round child for the event-trail test: round 1
+// streams a text delta then returns a tool_use block; round 2 streams the
+// final answer. Implementing ToolStreamingSender makes the child loop emit
+// real EventTextDelta events (the buffered fallback wouldn't).
+type trailSender struct{ calls int32 }
+
+func (s *trailSender) SendMessages(_ context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	return agent.Reply{Content: "unused"}, nil
+}
+
+func (s *trailSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition) (agent.Reply, error) {
+	return agent.Reply{Content: "unused"}, nil
+}
+
+func (s *trailSender) StreamMessagesWithTools(
+	_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition,
+	onChunk func(string), _ agent.ToolInputDeltaFunc, _ agent.ThinkingDeltaFunc,
+) (agent.Reply, error) {
+	if atomic.AddInt32(&s.calls, 1) == 1 {
+		onChunk("Let me look. ")
+		return agent.Reply{
+			Blocks: []agent.ContentBlock{
+				agent.NewTextBlock("Let me look. "),
+				agent.NewToolUseBlock("t1", "echo_tool", map[string]any{"q": "x"}),
+			},
+			StopReason: "tool_use",
+		}, nil
+	}
+	onChunk("All done.")
+	return agent.Reply{Content: "All done.", StopReason: "end_turn"}, nil
+}
+
+// echoExecutor returns a fixed payload for any tool call.
+type echoExecutor struct{}
+
+func (echoExecutor) Execute(_ context.Context, _ string, _ map[string]any) (agent.ToolResult, error) {
+	return agent.ToolResult{Text: "TOOL-OUTPUT-PAYLOAD"}, nil
+}
+
+func TestAgentSpawner_EventTrailCarriesOutputsAndText(t *testing.T) {
+	parent := agent.New(&trailSender{}, "parent-model")
+	childTools := []agent.ToolDefinition{{Name: "echo_tool"}}
+	sp := NewSpawner(parent, echoExecutor{}, func(context.Context) []agent.ToolDefinition { return childTools })
+
+	var events []tools.SubAgentEvent
+	ctx := tools.WithSubAgentEventSink(context.Background(), func(ev tools.SubAgentEvent) {
+		events = append(events, ev)
+	})
+
+	res, err := sp.Spawn(ctx, tools.SpawnRequest{Description: "trail", Prompt: "go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Reply != "All done." {
+		t.Fatalf("Reply = %q", res.Reply)
+	}
+
+	var kinds []string
+	for _, ev := range events {
+		kinds = append(kinds, ev.Kind)
+	}
+	want := []string{"text", "tool", "tool_done", "text"}
+	if len(kinds) != len(want) {
+		t.Fatalf("event kinds = %v, want %v", kinds, want)
+	}
+	for i := range want {
+		if kinds[i] != want[i] {
+			t.Fatalf("event kinds = %v, want %v", kinds, want)
+		}
+	}
+
+	if events[0].Text != "Let me look. " {
+		t.Errorf("first text = %q", events[0].Text)
+	}
+	if events[1].ToolID != "t1" || events[1].ToolName != "echo_tool" {
+		t.Errorf("tool event = %+v", events[1])
+	}
+	if q, _ := events[1].ToolInput["q"].(string); q != "x" {
+		t.Errorf("tool input = %v", events[1].ToolInput)
+	}
+	if events[2].ToolID != "t1" || events[2].ToolOutput != "TOOL-OUTPUT-PAYLOAD" {
+		t.Errorf("tool_done event = %+v", events[2])
+	}
+	if events[3].Text != "All done." {
+		t.Errorf("final text = %q", events[3].Text)
+	}
+}

--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -489,14 +489,17 @@ func toolNames(defs []agent.ToolDefinition) []string {
 	return names
 }
 
-// toolInputSpawner emits a "tool" SubAgentEvent carrying ToolInput, the way
+// toolInputSpawner emits the trail of SubAgentEvents the way
 // internal/app/spawner.go's real spawner does when a sub-agent dispatches a
-// tool call.
+// tool call: the tool with its input, its completion with the output, and an
+// assistant text block.
 type toolInputSpawner struct{}
 
 func (toolInputSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
 	if sink := tools.SubAgentEventSink(ctx); sink != nil {
-		sink(tools.SubAgentEvent{Kind: "tool", ToolName: "read_file", ToolInput: map[string]any{"path": "go.mod"}})
+		sink(tools.SubAgentEvent{Kind: "tool", ToolID: "t1", ToolName: "read_file", ToolInput: map[string]any{"path": "go.mod"}})
+		sink(tools.SubAgentEvent{Kind: "tool_done", ToolID: "t1", ToolName: "read_file", ToolOutput: "module contents"})
+		sink(tools.SubAgentEvent{Kind: "text", Text: "found it"})
 	}
 	return tools.SpawnResult{Reply: "ok"}, nil
 }
@@ -574,10 +577,24 @@ func TestPrepareToolTurn_SubAgentToolEventCarriesToolInput(t *testing.T) {
 				if !ok || input["path"] != "go.mod" {
 					t.Fatalf("tool_input = %v, want {path: go.mod}", ev["tool_input"])
 				}
+				if ev["tool_id"] != "t1" {
+					t.Fatalf("tool_id = %v, want t1", ev["tool_id"])
+				}
 				gotToolEvent = true
+			case "tool_done":
+				if ev["tool_id"] != "t1" || ev["tool_output"] != "module contents" {
+					t.Fatalf("tool_done payload = %v", ev)
+				}
+			case "text":
+				if ev["text"] != "found it" {
+					t.Fatalf("text payload = %v", ev)
+				}
 			case "done":
 				if !gotToolEvent {
 					t.Fatal("got the done event before the tool event")
+				}
+				if ev["result"] != "ok" {
+					t.Fatalf("done result = %v, want the final reply", ev["result"])
 				}
 				return
 			}

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -144,17 +144,7 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 			if s.wsHub == nil {
 				return
 			}
-			s.wsHub.broadcast(sid, map[string]any{
-				"type":        "sub_agent_event",
-				"session_id":  sid,
-				"agent_id":    ev.AgentID,
-				"description": ev.Description,
-				"agent_type":  ev.AgentType,
-				"kind":        ev.Kind,
-				"tool_name":   ev.ToolName,
-				"tool_input":  ev.ToolInput,
-				"stop_reason": ev.StopReason,
-			})
+			s.wsHub.broadcast(sid, subAgentEventPayload(sid, ev))
 		},
 		SubAgentOnExit: func(ev tools.SubAgentNotification) {
 			if s.wsHub == nil {
@@ -190,4 +180,25 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	})
 
 	return ctx, executor, mgr, cleanup, nil
+}
+
+// subAgentEventPayload is the single WS wire shape for one sub-agent runtime
+// event — shared by the live broadcast above and the late-join replay in
+// replayLiveState so the two can never drift.
+func subAgentEventPayload(sessionID string, ev tools.SubAgentEvent) map[string]any {
+	return map[string]any{
+		"type":        "sub_agent_event",
+		"session_id":  sessionID,
+		"agent_id":    ev.AgentID,
+		"description": ev.Description,
+		"agent_type":  ev.AgentType,
+		"kind":        ev.Kind,
+		"tool_id":     ev.ToolID,
+		"tool_name":   ev.ToolName,
+		"tool_input":  ev.ToolInput,
+		"tool_output": ev.ToolOutput,
+		"text":        ev.Text,
+		"stop_reason": ev.StopReason,
+		"result":      ev.Result,
+	}
 }

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -335,16 +335,12 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 				if ev.Kind == "done" {
 					continue
 				}
-				if b, err := json.Marshal(map[string]any{
-					"type":        "sub_agent_event",
-					"session_id":  sessionID,
-					"agent_id":    sa.ID,
-					"description": ev.Description,
-					"agent_type":  ev.AgentType,
-					"kind":        ev.Kind,
-					"tool_name":   ev.ToolName,
-					"tool_input":  ev.ToolInput,
-				}); err == nil {
+				// Retained events already carry the agent id stamped by the
+				// manager's eventSink; fall back to the listing id for safety.
+				if ev.AgentID == "" {
+					ev.AgentID = sa.ID
+				}
+				if b, err := json.Marshal(subAgentEventPayload(sessionID, ev)); err == nil {
 					select {
 					case conn.send <- b:
 					default:

--- a/internal/tools/subagent_event.go
+++ b/internal/tools/subagent_event.go
@@ -7,28 +7,59 @@ import "context"
 // SubAgentNotification, which is the one-shot completion record: events stream
 // while the sub-agent works, the notification fires once when it finishes.
 //
-// Only tool-level activity is carried — not per-token text — so a live panel
-// can show each sub-agent's tool-call chain without the event volume of N
-// concurrent sub-agents streaming their prose.
+// Only block-level activity is carried — never per-token text — so a live
+// panel can show each sub-agent's full trail (tools with their outputs, the
+// interim text replies, the final result) without the event volume of N
+// concurrent sub-agents streaming their prose token by token. Every free-text
+// payload is capped at emission (see the SubAgentEvent*Cap constants).
 type SubAgentEvent struct {
 	AgentID     string // manager handle, e.g. "agent_1"
 	Description string // human-readable label from sub_agent
 	AgentType   string // subagent_type, e.g. "explore" (empty for workflow-spawned agents)
 	// Kind is one of:
 	//   "started"    — the sub-agent began a task (or a Continue round)
-	//   "tool"       — it dispatched a tool (ToolName set)
-	//   "tool_error" — a tool returned an error (ToolName set)
+	//   "tool"       — it dispatched a tool (ToolID/ToolName/ToolInput set)
+	//   "tool_done"  — a tool finished (ToolID/ToolName set; ToolOutput carries
+	//                  the capped result text)
+	//   "tool_error" — a tool returned an error (ToolID/ToolName set; ToolOutput
+	//                  carries the capped error text plus any partial output)
+	//   "text"       — the sub-agent produced one assistant text block (Text set)
 	//   "done"       — the round finished (sync return or async completion);
-	//                  live panels drop the entry on this
-	Kind      string
-	ToolName  string
-	ToolInput map[string]any // optional: the tool's input arguments for UI display
+	//                  live panels drop the entry on this. Result carries the
+	//                  capped final reply.
+	Kind       string
+	ToolID     string // pairs "tool" with its "tool_done"/"tool_error"
+	ToolName   string
+	ToolInput  map[string]any // optional: the tool's input arguments for UI display
+	ToolOutput string         // "tool_done"/"tool_error": capped result / error text
+	Text       string         // "text": one completed assistant text block, capped
 	// StopReason is the agent's final stop reason on a "done" event (e.g.
 	// "end_turn", "tool_use", "max_turns", "max_tokens", "promoted"). Empty or
 	// sentinel values like "error" / "killed" indicate the agent exited
 	// abnormally so the live panel can render it differently from a clean
 	// completion.
 	StopReason string
+	Result     string // "done": the final reply, capped to SubAgentEventResultCap
+}
+
+// Payload caps applied at emission. They bound both the WS frame size and the
+// per-agent retention buffer: with maxSubAgentEvents (200) events retained the
+// worst case is ~1 MiB per agent. The full untruncated reply is still held by
+// the manager (maxSubAgentResultBytes) and served through agent_status.
+const (
+	SubAgentEventOutputCap = 4 * 1024  // per tool_done/tool_error output
+	SubAgentEventTextCap   = 8 * 1024  // per assistant text block
+	SubAgentEventResultCap = 64 * 1024 // final reply on "done"
+)
+
+// ClipForEvent bounds a free-text event payload to max bytes, marking the cut.
+// Byte-oriented like the other truncation helpers in this codebase; a rune
+// split at the boundary is acceptable for display-only payloads.
+func ClipForEvent(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…[truncated]"
 }
 
 type subAgentSinkKey struct{}

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -563,9 +563,14 @@ func (m *SubAgentManager) eventSink(id, description, agentType string) func(SubA
 			ev.AgentType = agentType
 		}
 		// Surface the agent's final disposition on "done" so live panels can
-		// distinguish a clean completion from an error or a user kill.
+		// distinguish a clean completion from an error or a user kill, and
+		// carry the (capped) final reply so panels can render the result
+		// without a follow-up fetch.
 		if ev.Kind == "done" {
-			_, status, _, _, stopReason := agent.readState()
+			result, status, _, _, stopReason := agent.readState()
+			if ev.Result == "" && result != "" {
+				ev.Result = ClipForEvent(result, SubAgentEventResultCap)
+			}
 			if stopReason != "" {
 				ev.StopReason = stopReason
 			} else if strings.HasPrefix(status, "exited: ") {

--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -589,5 +590,60 @@ func TestKillAfterAgentExited(t *testing.T) {
 	}
 	if killEvent.StopReason != "killed" {
 		t.Errorf("kill done StopReason = %q, want killed", killEvent.StopReason)
+	}
+}
+
+func TestEventSinkDoneCarriesResult(t *testing.T) {
+	m := NewSubAgentManager(&fixedSpawner{result: SpawnResult{Reply: "the final answer", AgentID: "child-1", StopReason: "end_turn"}})
+
+	var mu sync.Mutex
+	var events []SubAgentEvent
+	m.SetOnEvent(func(ev SubAgentEvent) { mu.Lock(); events = append(events, ev); mu.Unlock() })
+
+	exited := make(chan struct{})
+	m.SetOnExit(func(SubAgentNotification) { close(exited) })
+
+	if _, err := m.Start(SpawnRequest{Description: "d", Prompt: "p"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("onExit never fired")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		var last SubAgentEvent
+		n := len(events)
+		if n > 0 {
+			last = events[n-1]
+		}
+		mu.Unlock()
+		if n > 0 && last.Kind == "done" {
+			if last.Result != "the final answer" {
+				t.Fatalf("done Result = %q, want the final reply", last.Result)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no done event observed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestClipForEventCaps(t *testing.T) {
+	long := strings.Repeat("x", SubAgentEventOutputCap+100)
+	got := ClipForEvent(long, SubAgentEventOutputCap)
+	if len(got) >= len(long) {
+		t.Fatalf("ClipForEvent did not truncate: len=%d", len(got))
+	}
+	if !strings.HasSuffix(got, "…[truncated]") {
+		t.Fatalf("ClipForEvent output missing truncation marker: %q", got[len(got)-30:])
+	}
+	if short := ClipForEvent("short", SubAgentEventOutputCap); short != "short" {
+		t.Fatalf("ClipForEvent mangled short input: %q", short)
 	}
 }


### PR DESCRIPTION
## Summary

Part **1/5** of [dev-docs/agent-run-panel-design.md](https://github.com/open-octo/octo-agent/pull/2231): enrich the sub-agent event stream so panels can show full output, not just tool names and args.

- `SubAgentEvent` gains `ToolID` / `ToolOutput` / `Text` / `Result` and two new kinds: `tool_done`, `text`.
- The spawner's child event handler forwards `EventToolDone`/`EventToolError` with their (capped) output, and aggregates streamed text deltas into **block-level** `text` events, flushed on the next tool dispatch or at turn end — never per token, so the original event-volume constraint stands.
- The manager's `eventSink` attaches the capped final reply to the `done` event (the full 1 MiB retention copy is still served via `agent_status`).
- The server's two `sub_agent_event` emission sites (live broadcast in `prepareToolTurn` and late-join replay in `replayLiveState`) now share one payload builder, so the wire shape can't drift.
- Payload caps at emission: 4 KiB per tool output, 8 KiB per text block, 64 KiB for the result — bounding both WS frames and the 200-event per-agent retention buffer (~1 MiB worst case).

## Compatibility

- TUI: `handleSubAgentEvent`'s switch ignores the new kinds — no change.
- Web: `applySubAgentEvent` no-ops on unknown kinds; the frontend adopts them in part 4.
- IM: unaffected (no panel).

## Tests

- `TestAgentSpawner_EventTrailCarriesOutputsAndText` — end-to-end trail through a streaming two-round child: text → tool → tool_done → text, with outputs and ToolID pairing.
- `TestEventSinkDoneCarriesResult` — done event carries the final reply.
- `TestClipForEventCaps` — truncation marker + no-op below cap.
- Extended `TestPrepareToolTurn_SubAgentToolEventCarriesToolInput` to assert the new WS fields (`tool_id`, `tool_output`, `text`, `result`).

`make test` (race) / `go vet` / `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)