### PR TITLE
server: add read-only git diff endpoints for the review panel

### DIFF
--- a/internal/server/diff_git.go
+++ b/internal/server/diff_git.go
@@ -1,0 +1,338 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/open-octo/octo-agent/internal/executil"
+)
+
+// All git subprocess calls behind the Git Diff panel live here
+// (dev-docs/git-diff-panel-design.md). Every command is read-only — status,
+// diff, rev-parse — because an agent session must never touch the user's git
+// index. That rules out `git add -N` for untracked files; they are synthesised
+// into new-file patches instead (synthUntrackedPatch).
+
+const (
+	// diffProbeTimeout bounds repository detection. Mounted folders on a dead
+	// network share must not each burn the full data timeout.
+	diffProbeTimeout = 2 * time.Second
+	// diffDataTimeout bounds status and diff for one repository.
+	diffDataTimeout = 15 * time.Second
+	// untrackedMaxBytes caps how much of an untracked file is read into a
+	// synthesised patch.
+	untrackedMaxBytes = 1 << 20
+	// binarySniffBytes is git's own heuristic window: a NUL byte in the first
+	// 8 KB means binary.
+	binarySniffBytes = 8 << 10
+	// emptyTreeSHA is git's fixed empty-tree object, used as the diff base in a
+	// repository with no commits so the merged worktree view still works.
+	emptyTreeSHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+)
+
+// errGitMissing reports that there is no git binary on this machine.
+var errGitMissing = errors.New("git not available")
+
+// gitAvailable reports whether git can be found at all, so the handler can
+// answer once instead of every repository failing separately.
+func gitAvailable() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+// runGit runs a read-only git command in dir and returns stdout.
+func runGit(dir string, timeout time.Duration, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	// core.quotepath=false keeps non-ASCII filenames verbatim UTF-8 instead of
+	// git's \NNN octal escapes, which would otherwise reach the UI mangled.
+	full := append([]string{"-C", dir, "-c", "core.quotepath=false"}, args...)
+	cmd := exec.CommandContext(ctx, "git", full...)
+	executil.SetNoWindow(cmd)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", errGitMissing
+		}
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("git %s timed out", args[0])
+		}
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("git %s: %s", args[0], firstLine(msg))
+	}
+	return stdout.String(), nil
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// gitRepoRoot resolves dir to the root of the repository containing it, or
+// reports false when dir is not inside one. Cheap stat gate first, same as
+// folderGitBranch: no subprocess for the common non-repository case. A linked
+// worktree carries .git as a file, which rev-parse handles natively.
+func gitRepoRoot(dir string) (string, bool) {
+	if dir == "" || !dirInsideGitRepo(dir) {
+		return "", false
+	}
+	out, err := runGit(dir, diffProbeTimeout, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", false
+	}
+	root := strings.TrimSpace(out)
+	if root == "" {
+		return "", false
+	}
+	return filepath.Clean(root), true
+}
+
+// diffRepoRootsForSession resolves the repositories a session may review: its
+// own working directory plus its project's workspace and mounted source dirs.
+// Callers never pass paths — that is the whole point (see handleGetSessionDiff)
+// — so this is the only place the set is decided.
+func (s *Server) diffRepoRootsForSession(sessionID string) []string {
+	var dirs []string
+	if cwd := s.sessionCwdByID(sessionID); cwd != "" {
+		dirs = append(dirs, cwd)
+	}
+	if p := projectForSession(sessionID); p != nil {
+		if p.WorkingDir != "" {
+			dirs = append(dirs, p.WorkingDir)
+		}
+		dirs = append(dirs, p.SourceDirs...)
+	}
+
+	var roots []string
+	seen := map[string]bool{}
+	for _, dir := range dirs {
+		root, ok := gitRepoRoot(dir)
+		if !ok || seen[root] {
+			continue
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+// statusEntry is one `git status --porcelain=v1 -z` record.
+type statusEntry struct {
+	x, y     byte
+	path     string
+	origPath string // renames and copies only
+}
+
+func (e statusEntry) untracked() bool { return e.x == '?' && e.y == '?' }
+
+// staged reports whether the index side carries a change.
+func (e statusEntry) staged() bool { return e.x != ' ' && e.x != '?' }
+
+// status collapses the two porcelain columns into the single letter the panel
+// shows. A worktree deletion wins over whatever the index says, because the
+// net effect against HEAD is that the file is gone.
+func (e statusEntry) status() string {
+	switch {
+	case e.untracked():
+		return "?"
+	case e.y == 'D':
+		return "D"
+	case e.x == 'U' || e.y == 'U':
+		return "M" // unmerged renders as a modification
+	case e.x != ' ':
+		return string(e.x)
+	default:
+		return string(e.y)
+	}
+}
+
+// gitStatus lists the repository's changed files.
+//
+// -z sidesteps git's filename quoting entirely, and -uall expands untracked
+// directories into individual files — a bare `?? dir/` entry has no content to
+// render.
+func gitStatus(root string) ([]statusEntry, error) {
+	out, err := runGit(root, diffDataTimeout, "status", "--porcelain=v1", "-z", "-uall")
+	if err != nil {
+		return nil, err
+	}
+	return parseStatusZ(out), nil
+}
+
+// parseStatusZ decodes the NUL-separated porcelain v1 stream. Rename and copy
+// records span two fields, and in -z form the order is reversed relative to the
+// human format: the new path comes first, then the original.
+func parseStatusZ(out string) []statusEntry {
+	fields := strings.Split(out, "\x00")
+	var entries []statusEntry
+	for i := 0; i < len(fields); i++ {
+		f := fields[i]
+		if len(f) < 4 {
+			continue
+		}
+		e := statusEntry{x: f[0], y: f[1], path: f[3:]}
+		if e.x == 'R' || e.x == 'C' || e.y == 'R' || e.y == 'C' {
+			if i+1 < len(fields) {
+				i++
+				e.origPath = fields[i]
+			}
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+// gitDiffBase returns the revision to diff the worktree against: HEAD normally,
+// the empty tree in a repository with no commits yet. Diffing against a tree
+// (rather than falling back to --cached) keeps the merged staged+unstaged view
+// intact in a fresh repository too.
+func gitDiffBase(root string) string {
+	if _, err := runGit(root, diffProbeTimeout, "rev-parse", "--verify", "--quiet", "HEAD"); err != nil {
+		return emptyTreeSHA
+	}
+	return "HEAD"
+}
+
+// gitDiff runs the merged staged+unstaged diff, optionally scoped to one path.
+func gitDiff(root string, paths ...string) (string, error) {
+	args := []string{"diff", gitDiffBase(root), "--unified=3", "--find-renames", "--no-color"}
+	if len(paths) > 0 {
+		args = append(args, "--")
+		args = append(args, paths...)
+	}
+	return runGit(root, diffDataTimeout, args...)
+}
+
+// gitHeadInfo reports the branch to show in the panel header, plus the short
+// commit when HEAD is detached and the branch name is therefore useless.
+func gitHeadInfo(root string) (branch, commit string) {
+	if out, err := runGit(root, diffProbeTimeout, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+		branch = strings.TrimSpace(out)
+	}
+	if branch == "" || branch == "HEAD" {
+		// Detached, or a repository with no commits where rev-parse fails but
+		// the branch ref already exists.
+		if out, err := runGit(root, diffProbeTimeout, "branch", "--show-current"); err == nil {
+			if cur := strings.TrimSpace(out); cur != "" {
+				return cur, ""
+			}
+		}
+	}
+	if branch == "HEAD" {
+		if out, err := runGit(root, diffProbeTimeout, "rev-parse", "--short", "HEAD"); err == nil {
+			commit = strings.TrimSpace(out)
+		}
+	}
+	return branch, commit
+}
+
+// resolveInRepo confines a repo-relative path to the repository root. The
+// prefix check runs twice — once on the cleaned join and once after resolving
+// symlinks — so neither `../` segments nor a symlink pointing outside the
+// repository can escape (same model as resolveArtifactPath).
+func resolveInRepo(root, rel string) (string, bool) {
+	if rel == "" || filepath.IsAbs(rel) {
+		return "", false
+	}
+	root = filepath.Clean(root)
+	abs := filepath.Clean(filepath.Join(root, rel))
+	if !isInsideDir(root, abs) {
+		return "", false
+	}
+	real, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		// A dangling symlink or a file removed between status and read: not
+		// something to serve, but not an escape either.
+		return "", false
+	}
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		realRoot = root
+	}
+	if !isInsideDir(realRoot, real) {
+		return "", false
+	}
+	return abs, true
+}
+
+// isInsideDir reports whether path lies within dir. Both must be clean.
+func isInsideDir(dir, path string) bool {
+	if path == dir {
+		return true
+	}
+	return strings.HasPrefix(path, dir+string(filepath.Separator))
+}
+
+// synthUntrackedPatch builds a new-file unified diff for an untracked file by
+// reading it, rather than staging it with `git add -N`: the panel is read-only
+// and must leave the user's index exactly as the agent left it.
+//
+// It reports binary for anything with a NUL byte in the first 8 KB, and
+// truncated when the file is larger than untrackedMaxBytes.
+func synthUntrackedPatch(root, rel string) (patch *diffPatch, binary, truncated bool, err error) {
+	abs, ok := resolveInRepo(root, rel)
+	if !ok {
+		return nil, false, false, fmt.Errorf("path outside repository")
+	}
+	fi, err := os.Lstat(abs)
+	if err != nil {
+		return nil, false, false, err
+	}
+	if !fi.Mode().IsRegular() {
+		// Directories are expanded by -uall; symlinks and devices have no
+		// reviewable content.
+		return nil, false, false, fmt.Errorf("not a regular file")
+	}
+
+	f, err := os.Open(abs)
+	if err != nil {
+		return nil, false, false, err
+	}
+	defer f.Close()
+	buf := make([]byte, untrackedMaxBytes)
+	n, err := io.ReadFull(f, buf)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil, false, false, err
+	}
+	content := buf[:n]
+
+	sniff := content
+	if len(sniff) > binarySniffBytes {
+		sniff = sniff[:binarySniffBytes]
+	}
+	if bytes.IndexByte(sniff, 0) >= 0 {
+		return nil, true, false, nil
+	}
+	truncated = fi.Size() > untrackedMaxBytes
+
+	var lines []diffLine
+	if len(content) > 0 {
+		for _, l := range strings.Split(strings.TrimSuffix(string(content), "\n"), "\n") {
+			lines = append(lines, diffLine{Kind: "add", Content: l})
+		}
+	}
+	var hunks []diffHunk
+	if len(lines) > 0 {
+		hunks = []diffHunk{{
+			Header: fmt.Sprintf("@@ -0,0 +1,%d @@", len(lines)),
+			Lines:  lines,
+		}}
+	}
+	return newDiffPatch("/dev/null", rel, hunks), false, truncated, nil
+}

--- a/internal/server/diff_handler.go
+++ b/internal/server/diff_handler.go
@@ -65,10 +65,16 @@ func (s *Server) handleGetSessionFileDiff(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// First whitelist: the repository must be one this session actually
-	// resolves to, decided here and not by the caller.
-	root := filepath.Clean(repo)
-	if !containsString(s.diffRepoRootsForSession(id), root) {
+	// Both query parameters are matched against server-derived values and then
+	// discarded: root below comes from diffRepoRootsForSession (git's own
+	// rev-parse output) and entry.path from git status, so nothing the caller
+	// wrote reaches a subprocess or a file operation. Same model as
+	// handleGetArtifact, which opens the transcript's copy of a path rather
+	// than the request's.
+	//
+	// First whitelist: the repository must be one this session resolves to.
+	root, ok := matchedRoot(s.diffRepoRootsForSession(id), repo)
+	if !ok {
 		writeError(w, http.StatusForbidden, "repository not in this session's scope")
 		return
 	}
@@ -97,7 +103,7 @@ func (s *Server) handleGetSessionFileDiff(w http.ResponseWriter, r *http.Request
 	if !entry.untracked() {
 		// Scope the diff to this file. A rename needs both sides on the
 		// pathspec, otherwise git reports it as an unrelated add.
-		paths := []string{rel}
+		paths := []string{entry.path}
 		if entry.origPath != "" {
 			paths = append(paths, entry.origPath)
 		}
@@ -106,7 +112,7 @@ func (s *Server) handleGetSessionFileDiff(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		patch = indexPatches(parseUnifiedDiff(out))[rel]
+		patch = indexPatches(parseUnifiedDiff(out))[entry.path]
 	}
 
 	file := buildDiffFile(root, *entry, patch, diffFileNoLimit)
@@ -282,11 +288,16 @@ func countPatchLines(p *diffPatch) int {
 	return n
 }
 
-func containsString(list []string, want string) bool {
-	for _, v := range list {
-		if v == want {
-			return true
+// matchedRoot finds the session-resolved repository root the caller named and
+// returns the server's own string for it, not the caller's. Handing the
+// resolved copy onward is what keeps request data out of the git subprocess —
+// the comparison authorises, the returned value is what gets used.
+func matchedRoot(roots []string, want string) (string, bool) {
+	want = filepath.Clean(want)
+	for _, root := range roots {
+		if root == want {
+			return root, true
 		}
 	}
-	return false
+	return "", false
 }

--- a/internal/server/diff_handler.go
+++ b/internal/server/diff_handler.go
@@ -1,0 +1,292 @@
+package server
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+)
+
+// ─── GET /api/sessions/{id}/diff ────────────────────────────────────────────
+//
+// Serves the uncommitted changes in the repositories a session can touch, for
+// the sidebar Git Diff review panel (dev-docs/git-diff-panel-design.md).
+//
+// The aggregate endpoint takes a session id and nothing else: the directory set
+// is resolved server-side, the same model handleNativeOpenFolder uses, because
+// a caller-controlled path here would be an arbitrary-file-read hole. The
+// single-file endpoint does take a repo and path, and both are checked back
+// against a freshly resolved root set and a live git status.
+
+func (s *Server) handleGetSessionDiff(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing session id")
+		return
+	}
+	if _, err := agent.LoadSession(id); err != nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	if !gitAvailable() {
+		writeError(w, http.StatusInternalServerError, errGitMissing.Error())
+		return
+	}
+
+	roots := s.diffRepoRootsForSession(id)
+	if r.URL.Query().Get("summary") == "1" {
+		writeJSON(w, http.StatusOK, buildDiffSummary(roots))
+		return
+	}
+	writeJSON(w, http.StatusOK, buildDiffResponse(roots))
+}
+
+// ─── GET /api/sessions/{id}/diff/file?repo=…&path=… ─────────────────────────
+//
+// One file's complete diff, for a file the aggregate response truncated or
+// omitted. The per-file line cap does not apply — the user asked for all of it
+// — but the untracked read cap and the binary skip still do.
+
+func (s *Server) handleGetSessionFileDiff(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	repo := strings.TrimSpace(r.URL.Query().Get("repo"))
+	rel := strings.TrimSpace(r.URL.Query().Get("path"))
+	if id == "" || repo == "" || rel == "" {
+		writeError(w, http.StatusBadRequest, "missing session id, repo or path")
+		return
+	}
+	if _, err := agent.LoadSession(id); err != nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	if !gitAvailable() {
+		writeError(w, http.StatusInternalServerError, errGitMissing.Error())
+		return
+	}
+
+	// First whitelist: the repository must be one this session actually
+	// resolves to, decided here and not by the caller.
+	root := filepath.Clean(repo)
+	if !containsString(s.diffRepoRootsForSession(id), root) {
+		writeError(w, http.StatusForbidden, "repository not in this session's scope")
+		return
+	}
+
+	entries, err := gitStatus(root)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	// Second whitelist: the path must be a file git currently reports as
+	// changed, so an unchanged file elsewhere in the repository is not readable
+	// through this endpoint.
+	var entry *statusEntry
+	for i := range entries {
+		if entries[i].path == rel {
+			entry = &entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		writeError(w, http.StatusNotFound, "path is not a changed file in this repository")
+		return
+	}
+
+	var patch *filePatch
+	if !entry.untracked() {
+		// Scope the diff to this file. A rename needs both sides on the
+		// pathspec, otherwise git reports it as an unrelated add.
+		paths := []string{rel}
+		if entry.origPath != "" {
+			paths = append(paths, entry.origPath)
+		}
+		out, err := gitDiff(root, paths...)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		patch = indexPatches(parseUnifiedDiff(out))[rel]
+	}
+
+	file := buildDiffFile(root, *entry, patch, diffFileNoLimit)
+	writeJSON(w, http.StatusOK, map[string]any{"file": file})
+}
+
+// diffFileNoLimit disables per-file truncation for the single-file endpoint.
+const diffFileNoLimit = -1
+
+// buildDiffSummary runs status only — no diff, no file reads — because the
+// badge just needs counts.
+func buildDiffSummary(roots []string) diffSummaryResponse {
+	resp := diffSummaryResponse{Repos: []diffRepoSummary{}}
+	for _, root := range roots {
+		repo := diffRepoSummary{Root: root, Name: filepath.Base(root), Files: []diffFileSummary{}}
+		entries, err := gitStatus(root)
+		if err != nil {
+			repo.Error = err.Error()
+			resp.Repos = append(resp.Repos, repo)
+			continue
+		}
+		if len(entries) == 0 {
+			continue
+		}
+		for _, e := range entries {
+			repo.Files = append(repo.Files, diffFileSummary{
+				Path:   e.path,
+				Status: e.status(),
+				Staged: e.staged(),
+			})
+		}
+		resp.Repos = append(resp.Repos, repo)
+	}
+	return resp
+}
+
+// buildDiffResponse collects every repository's changes and applies both
+// truncation layers. A repository whose git commands fail keeps its slot with
+// an error attached rather than failing the whole response.
+func buildDiffResponse(roots []string) diffResponse {
+	resp := diffResponse{Repos: []diffRepo{}}
+	budget := diffResponseMaxLines
+
+	for _, root := range roots {
+		repo := diffRepo{Root: root, Name: filepath.Base(root), Files: []diffFile{}}
+		repo.Branch, repo.Commit = gitHeadInfo(root)
+
+		entries, err := gitStatus(root)
+		if err != nil {
+			repo.Error = err.Error()
+			resp.Repos = append(resp.Repos, repo)
+			continue
+		}
+		if len(entries) == 0 {
+			// A clean repository is not worth a group header.
+			continue
+		}
+
+		out, err := gitDiff(root)
+		if err != nil {
+			repo.Error = err.Error()
+			resp.Repos = append(resp.Repos, repo)
+			continue
+		}
+		byPath := indexPatches(parseUnifiedDiff(out))
+
+		for _, e := range entries {
+			limit := diffFileMaxLines
+			if budget <= 0 {
+				limit = 0 // budget spent: metadata only
+			}
+			f := buildDiffFile(root, e, byPath[e.path], limit)
+			if f.Truncated {
+				resp.TruncatedFiles++
+			}
+			if f.Omitted {
+				resp.OmittedFiles++
+			}
+			if f.Patch != nil {
+				budget -= countPatchLines(f.Patch)
+			}
+			repo.Files = append(repo.Files, f)
+		}
+		resp.Repos = append(resp.Repos, repo)
+	}
+	return resp
+}
+
+// indexPatches keys parsed patches by the path git status reports, which is the
+// post-change path for renames.
+func indexPatches(patches []*filePatch) map[string]*filePatch {
+	m := make(map[string]*filePatch, len(patches))
+	for _, p := range patches {
+		key := p.newPath
+		if key == "/dev/null" {
+			key = p.oldPath // deletion
+		}
+		m[key] = p
+	}
+	return m
+}
+
+// buildDiffFile turns one status entry plus its patch into a file list item.
+// limit is the per-file line cap, 0 to render metadata only, or diffFileNoLimit
+// for no cap at all.
+func buildDiffFile(root string, e statusEntry, p *filePatch, limit int) diffFile {
+	f := diffFile{
+		Path:    e.path,
+		OldPath: e.origPath,
+		Status:  e.status(),
+		Staged:  e.staged(),
+	}
+
+	if e.untracked() {
+		if limit == 0 {
+			f.Omitted = true
+			return f
+		}
+		patch, binary, readTruncated, err := synthUntrackedPatch(root, e.path)
+		if err != nil {
+			// Vanished or unreadable between status and read: report it as a
+			// file with no renderable content instead of failing the repo.
+			f.Binary = true
+			return f
+		}
+		if binary {
+			f.Binary = true
+			return f
+		}
+		f.Adds = countPatchLines(patch)
+		f.TotalLines = f.Adds
+		f.Patch = patch
+		f.Truncated = readTruncated
+		if limit != diffFileNoLimit {
+			if cut, _ := truncatePatch(f.Patch, limit); cut {
+				f.Truncated = true
+			}
+		}
+		return f
+	}
+
+	if p == nil {
+		// In the index but with no content delta: a pure rename, or a mode-only
+		// change. Nothing to render, and not an error.
+		return f
+	}
+	f.Binary = p.binary
+	f.Adds, f.Dels, f.TotalLines = p.adds, p.dels, p.totalLines
+	if p.binary {
+		return f
+	}
+	if limit == 0 {
+		f.Omitted = true
+		return f
+	}
+	f.Patch = newDiffPatch(p.oldPath, p.newPath, p.hunks)
+	if limit != diffFileNoLimit {
+		if cut, _ := truncatePatch(f.Patch, limit); cut {
+			f.Truncated = true
+		}
+	}
+	return f
+}
+
+func countPatchLines(p *diffPatch) int {
+	if p == nil {
+		return 0
+	}
+	n := 0
+	for _, h := range p.Hunks {
+		n += len(h.Lines)
+	}
+	return n
+}
+
+func containsString(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/diff_handler_test.go
+++ b/internal/server/diff_handler_test.go
@@ -1,0 +1,609 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+)
+
+// The diff endpoints run real git against real repositories: mocking git would
+// only test our idea of its output, and porcelain/rename/no-commit behaviour is
+// exactly what can surprise us.
+
+func gitRepo(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "t"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		git(t, dir, args...)
+	}
+}
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// diffSession persists a session pinned to dir, which is what sessionCwdByID
+// resolves for a cold session.
+func diffSession(t *testing.T, dir string) string {
+	t.Helper()
+	sess := agent.NewSession("stub-model", "")
+	sess.WorkingDir = dir
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
+	return sess.ID
+}
+
+// resolvedRoot is dir as git reports it. On macOS t.TempDir() sits under /var,
+// a symlink to /private/var, and `rev-parse --show-toplevel` prints the
+// resolved form — so test expectations have to resolve too.
+func resolvedRoot(t *testing.T, dir string) string {
+	t.Helper()
+	real, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return real
+}
+
+func getDiff(t *testing.T, srv *Server, id, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	target := "/api/sessions/" + id + "/diff"
+	if query != "" {
+		target += "?" + query
+	}
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	return w
+}
+
+func decodeDiff(t *testing.T, w *httptest.ResponseRecorder) diffResponse {
+	t.Helper()
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp diffResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	return resp
+}
+
+func fileByPath(t *testing.T, repo diffRepo, path string) diffFile {
+	t.Helper()
+	for _, f := range repo.Files {
+		if f.Path == path {
+			return f
+		}
+	}
+	t.Fatalf("file %q not in %v", path, repoPaths(repo))
+	return diffFile{}
+}
+
+func repoPaths(repo diffRepo) []string {
+	var out []string
+	for _, f := range repo.Files {
+		out = append(out, f.Path)
+	}
+	return out
+}
+
+// TestSessionDiffMixedChanges: staged, unstaged and untracked changes in one
+// repository come back as a single merged view against HEAD, with the staged
+// flag carried alongside.
+func TestSessionDiffMixedChanges(t *testing.T) {
+	isolatedHome(t)
+	repo := filepath.Join(t.TempDir(), "app")
+	gitRepo(t, repo)
+	writeFile(t, repo, "staged.txt", "one\n")
+	writeFile(t, repo, "dirty.txt", "one\n")
+	writeFile(t, repo, "gone.txt", "one\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-qm", "init")
+
+	writeFile(t, repo, "staged.txt", "one\ntwo\n")
+	git(t, repo, "add", "staged.txt")
+	writeFile(t, repo, "dirty.txt", "one\nthree\n")
+	git(t, repo, "rm", "-q", "gone.txt")
+	writeFile(t, repo, "fresh.txt", "brand new\nsecond line\n")
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	id := diffSession(t, repo)
+
+	resp := decodeDiff(t, getDiff(t, srv, id, ""))
+	if len(resp.Repos) != 1 {
+		t.Fatalf("repos = %d, want 1: %+v", len(resp.Repos), resp.Repos)
+	}
+	r := resp.Repos[0]
+	if r.Root != resolvedRoot(t, repo) || r.Name != "app" || r.Branch != "main" {
+		t.Errorf("repo = %+v", r)
+	}
+	if len(r.Files) != 4 {
+		t.Fatalf("files = %v, want 4", repoPaths(r))
+	}
+
+	staged := fileByPath(t, r, "staged.txt")
+	if staged.Status != "M" || !staged.Staged || staged.Adds != 1 || staged.Patch == nil {
+		t.Errorf("staged.txt = %+v", staged)
+	}
+
+	dirty := fileByPath(t, r, "dirty.txt")
+	if dirty.Status != "M" || dirty.Staged {
+		t.Errorf("dirty.txt = %+v", dirty)
+	}
+
+	gone := fileByPath(t, r, "gone.txt")
+	if gone.Status != "D" || gone.Dels != 1 {
+		t.Errorf("gone.txt = %+v", gone)
+	}
+
+	// Untracked: synthesised as a new-file patch without touching the index.
+	fresh := fileByPath(t, r, "fresh.txt")
+	if fresh.Status != "?" || fresh.Staged || fresh.Adds != 2 || fresh.Patch == nil {
+		t.Fatalf("fresh.txt = %+v", fresh)
+	}
+	if fresh.Patch.OldPath != "/dev/null" || fresh.Patch.NewPath != "fresh.txt" {
+		t.Errorf("fresh patch paths = %+v", fresh.Patch)
+	}
+	if got := fresh.Patch.Hunks[0].Lines[0].Content; got != "brand new" {
+		t.Errorf("fresh first line = %q", got)
+	}
+	// The read-only promise: the untracked file must still be untracked.
+	if out := git(t, repo, "status", "--porcelain", "fresh.txt"); !strings.HasPrefix(out, "??") {
+		t.Errorf("index was modified: status = %q", out)
+	}
+}
+
+// TestSessionDiffRename: a rename keeps both sides so the UI can show the move.
+func TestSessionDiffRename(t *testing.T) {
+	isolatedHome(t)
+	repo := filepath.Join(t.TempDir(), "app")
+	gitRepo(t, repo)
+	writeFile(t, repo, "old.txt", "hello\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-qm", "init")
+	git(t, repo, "mv", "old.txt", "new.txt")
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	resp := decodeDiff(t, getDiff(t, srv, diffSession(t, repo), ""))
+
+	f := fileByPath(t, resp.Repos[0], "new.txt")
+	if f.Status != "R" || f.OldPath != "old.txt" {
+		t.Errorf("rename = %+v", f)
+	}
+	// A pure rename has no content delta, and hunks must still marshal as an
+	// array — `"hunks": null` would make every client null-check the field.
+	if !strings.Contains(getDiff(t, srv, diffSession(t, repo), "").Body.String(), `"hunks":[]`) {
+		t.Error("a hunk-less patch should serialise hunks as [], not null")
+	}
+}
+
+// TestSessionDiffMultiRepo: a project's mounted source dirs are reviewed
+// alongside the session's own directory, and non-repositories drop out.
+func TestSessionDiffMultiRepo(t *testing.T) {
+	isolatedHome(t)
+	base := t.TempDir()
+
+	own := filepath.Join(base, "own")
+	gitRepo(t, own)
+	writeFile(t, own, "a.txt", "a\n")
+
+	mounted := filepath.Join(base, "mounted")
+	gitRepo(t, mounted)
+	writeFile(t, mounted, "b.txt", "b\n")
+
+	plain := filepath.Join(base, "plain") // not a repository
+	if err := os.MkdirAll(plain, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	id := diffSession(t, own)
+	// EnsureProjectForDir mounts the directory as a source dir and generates
+	// the project's own workspace, which is not a repository either.
+	for _, dir := range []string{mounted, plain} {
+		if err := EnsureProjectForDir(dir, id); err != nil {
+			t.Fatalf("EnsureProjectForDir(%s): %v", dir, err)
+		}
+	}
+
+	resp := decodeDiff(t, getDiff(t, srv, id, ""))
+	roots := map[string]bool{}
+	for _, r := range resp.Repos {
+		roots[r.Root] = true
+	}
+	if !roots[resolvedRoot(t, own)] || !roots[resolvedRoot(t, mounted)] {
+		t.Fatalf("roots = %v, want both %s and %s", roots, own, mounted)
+	}
+	if roots[resolvedRoot(t, plain)] {
+		t.Errorf("non-repository %s was returned", plain)
+	}
+}
+
+// TestSessionDiffNoRepo: a session whose directory is not a repository gets an
+// empty list, not an error — the panel tells the user there is nothing to
+// review.
+func TestSessionDiffNoRepo(t *testing.T) {
+	isolatedHome(t)
+	plain := t.TempDir()
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	resp := decodeDiff(t, getDiff(t, srv, diffSession(t, plain), ""))
+	if len(resp.Repos) != 0 {
+		t.Errorf("repos = %+v, want empty", resp.Repos)
+	}
+}
+
+// TestSessionDiffClean: a repository with no uncommitted changes is left out
+// entirely, so the panel shows no group header for it.
+func TestSessionDiffClean(t *testing.T) {
+	isolatedHome(t)
+	repo := filepath.Join(t.TempDir(), "app")
+	gitRepo(t, repo)
+	writeFile(t, repo, "a.txt", "a\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-qm", "init")
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	resp := decodeDiff(t, getDiff(t, srv, diffSession(t, repo), ""))
+	if len(resp.Repos) != 0 {
+		t.Errorf("repos = %+v, want empty for a clean tree", resp.Repos)
+	}
+}
+
+// TestSessionDiffWorktree: a linked worktree carries .git as a file rather than
+// a directory, and must still resolve and diff.
+func TestSessionDiffWorktree(t *testing.T) {
+	isolatedHome(t)
+	base := t.TempDir()
+	main := filepath.Join(base, "main")
+	gitRepo(t, main)
+	writeFile(t, main, "a.txt", "a\n")
+	git(t, main, "add", "-A")
+	git(t, main, "commit", "-qm", "init")
+
+	wt := filepath.Join(base, "wt")
+	git(t, main, "worktree", "add", "-q", "-b", "side", wt)
+	if fi, err := os.Stat(filepath.Join(wt, ".git")); err != nil || fi.IsDir() {
+		t.Fatalf(".git in a linked worktree should be a file: %v", err)
+	}
+	writeFile(t, wt, "a.txt", "a\nb\n")
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	resp := decodeDiff(t, getDiff(t, srv, diffSession(t, wt), ""))
+	if len(resp.Repos) != 1 || resp.Repos[0].Root != resolvedRoot(t, wt) {
+		t.Fatalf("repos = %+v, want root %s", resp.Repos, wt)
+	}
+	if resp.Repos[0].Branch != "side" {
+		t.Errorf("branch = %q, want side", resp.Repos[0].Branch)
+	}
+	if f := fileByPath(t, resp.Repos[0], "a.txt"); f.Adds != 1 {
+		t.Errorf("a.txt = %+v", f)
+	}
+}
+
+// TestSessionDiffNoCommits: with no HEAD to diff against, the empty tree stands
+// in so staged content and later edits still show as one merged new-file view.
+func TestSessionDiffNoCommits(t *testing.T) {
+	isolatedHome(t)
+	repo := filepath.Join(t.TempDir(), "fresh")
+	gitRepo(t, repo)
+	writeFile(t, repo, "staged.txt", "one\n")
+	git(t, repo, "add", "staged.txt")
+	writeFile(t, repo, "staged.txt", "one\ntwo\n") // edited after staging
+	writeFile(t, repo, "loose.txt", "loose\n")
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	resp := decodeDiff(t, getDiff(t, srv, diffSession(t, repo), ""))
+	if len(resp.Repos) != 1 {
+		t.Fatalf("repos = %+v", resp.Repos)
+	}
+	r := resp.Repos[0]
+	if r.Branch != "main" {
+		t.Errorf("branch = %q, want main (no commits yet)", r.Branch)
+	}
+
+	staged := fileByPath(t, r, "staged.txt")
+	if staged.Status != "A" || !staged.Staged {
+		t.Errorf("staged.txt = %+v", staged)
+	}
+	// Merged view: both the staged line and the one added afterwards.
+	if staged.Adds != 2 {
+		t.Errorf("staged.txt adds = %d, want 2 (staged + unstaged merged)", staged.Adds)
+	}
+	if f := fileByPath(t, r, "loose.txt"); f.Status != "?" || f.Adds != 1 {
+		t.Errorf("loose.txt = %+v", f)
+	}
+}
+
+// TestSessionDiffTruncation: both caps fire — one huge file is clipped, and the
+// files past the response budget keep their metadata and lose their patch.
+func TestSessionDiffTruncation(t *testing.T) {
+	isolatedHome(t)
+	repo := filepath.Join(t.TempDir(), "big")
+	gitRepo(t, repo)
+	git(t, repo, "commit", "-q", "--allow-empty", "-m", "init")
+
+	// Eleven untracked files of 2500 lines each: each one is clipped to 2000,
+	// and the 20000-line response budget runs out inside the eleventh.
+	var b strings.Builder
+	for i := 0; i < 2500; i++ {
+		fmt.Fprintf(&b, "line %d\n", i)
+	}
+	for i := 0; i < 11; i++ {
+		writeFile(t, repo, fmt.Sprintf("f%02d.txt", i), b.String())
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	resp := decodeDiff(t, getDiff(t, srv, diffSession(t, repo), ""))
+	r := resp.Repos[0]
+	if len(r.Files) != 11 {
+		t.Fatalf("files = %d, want 11", len(r.Files))
+	}
+
+	first := r.Files[0]
+	if !first.Truncated || first.Patch == nil {
+		t.Fatalf("first file = %+v, want truncated with a patch", first)
+	}
+	if got := countPatchLines(first.Patch); got != diffFileMaxLines {
+		t.Errorf("first file rendered %d lines, want %d", got, diffFileMaxLines)
+	}
+	if first.TotalLines != 2500 {
+		t.Errorf("first file total_lines = %d, want 2500", first.TotalLines)
+	}
+
+	last := r.Files[10]
+	if !last.Omitted || last.Patch != nil {
+		t.Errorf("last file = %+v, want omitted with no patch", last)
+	}
+	if resp.TruncatedFiles != 10 || resp.OmittedFiles != 1 {
+		t.Errorf("counts = %d truncated / %d omitted, want 10/1", resp.TruncatedFiles, resp.OmittedFiles)
+	}
+}
+
+// TestSessionDiffBinaryUntracked: an untracked file with a NUL byte is flagged
+// rather than rendered as control characters.
+func TestSessionDiffBinaryUntracked(t *testing.T) {
+	isolatedHome(t)
+	repo := filepath.Join(t.TempDir(), "app")
+	gitRepo(t, repo)
+	git(t, repo, "commit", "-q", "--allow-empty", "-m", "init")
+	if err := os.WriteFile(filepath.Join(repo, "blob.bin"), []byte{'a', 0x00, 'b'}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	resp := decodeDiff(t, getDiff(t, srv, diffSession(t, repo), ""))
+	f := fileByPath(t, resp.Repos[0], "blob.bin")
+	if !f.Binary || f.Patch != nil {
+		t.Errorf("blob.bin = %+v, want binary with no patch", f)
+	}
+}
+
+// TestSessionDiffUntrackedDirExpanded: an untracked directory must arrive as
+// individual files — a bare `?? dir/` entry has no content to render.
+func TestSessionDiffUntrackedDirExpanded(t *testing.T) {
+	isolatedHome(t)
+	repo := filepath.Join(t.TempDir(), "app")
+	gitRepo(t, repo)
+	git(t, repo, "commit", "-q", "--allow-empty", "-m", "init")
+	writeFile(t, repo, "pkg/one.go", "package pkg\n")
+	writeFile(t, repo, "pkg/two.go", "package pkg\n")
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	resp := decodeDiff(t, getDiff(t, srv, diffSession(t, repo), ""))
+	r := resp.Repos[0]
+	if len(r.Files) != 2 {
+		t.Fatalf("files = %v, want the two files, not the directory", repoPaths(r))
+	}
+	for _, f := range r.Files {
+		if f.Patch == nil {
+			t.Errorf("%s has no patch", f.Path)
+		}
+	}
+}
+
+// TestSessionDiffSummary: summary mode returns counts only, with no patch
+// content, and skips clean repositories.
+func TestSessionDiffSummary(t *testing.T) {
+	isolatedHome(t)
+	repo := filepath.Join(t.TempDir(), "app")
+	gitRepo(t, repo)
+	writeFile(t, repo, "a.txt", "a\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-qm", "init")
+	writeFile(t, repo, "a.txt", "a\nb\n")
+	writeFile(t, repo, "new.txt", "n\n")
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	w := getDiff(t, srv, diffSession(t, repo), "summary=1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", w.Code, w.Body.String())
+	}
+
+	var resp diffSummaryResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Repos) != 1 || len(resp.Repos[0].Files) != 2 {
+		t.Fatalf("summary = %+v", resp.Repos)
+	}
+	// Patch content must be absent from the wire, not merely null.
+	if strings.Contains(w.Body.String(), "\"patch\"") || strings.Contains(w.Body.String(), "\"hunks\"") {
+		t.Errorf("summary body carries patch data: %s", w.Body.String())
+	}
+}
+
+// TestSessionDiffSessionNotFound: an unknown session id is a 404 before any
+// git runs.
+func TestSessionDiffSessionNotFound(t *testing.T) {
+	isolatedHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	w := getDiff(t, srv, "no-such-session", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func getFileDiff(t *testing.T, srv *Server, id, repo, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	q := url.Values{"repo": {repo}, "path": {path}}.Encode()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+id+"/diff/file?"+q, nil)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	return w
+}
+
+// TestSessionFileDiff: the single-file endpoint serves the whole file even when
+// the aggregate response clipped it, and refuses anything outside the session's
+// repositories or outside git's own list of changed files.
+func TestSessionFileDiff(t *testing.T) {
+	isolatedHome(t)
+	base := t.TempDir()
+	repo := filepath.Join(base, "app")
+	gitRepo(t, repo)
+	writeFile(t, repo, "tracked.txt", "seed\n")
+	writeFile(t, repo, "untouched.txt", "same\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-qm", "init")
+
+	var b strings.Builder
+	for i := 0; i < 2500; i++ {
+		fmt.Fprintf(&b, "line %d\n", i)
+	}
+	writeFile(t, repo, "tracked.txt", b.String())
+	writeFile(t, repo, "fresh.txt", "new file\n")
+
+	// A repository the session has nothing to do with.
+	outside := filepath.Join(base, "outside")
+	gitRepo(t, outside)
+	writeFile(t, outside, "secret.txt", "secret\n")
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	id := diffSession(t, repo)
+
+	// The aggregate response clips it…
+	agg := fileByPath(t, decodeDiff(t, getDiff(t, srv, id, "")).Repos[0], "tracked.txt")
+	if !agg.Truncated {
+		t.Fatalf("expected the aggregate response to truncate tracked.txt: %+v", agg)
+	}
+
+	// …and the single-file endpoint does not.
+	w := getFileDiff(t, srv, id, resolvedRoot(t, repo), "tracked.txt")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", w.Code, w.Body.String())
+	}
+	var got struct{ File diffFile }
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.File.Truncated || got.File.Patch == nil {
+		t.Fatalf("file = %+v, want the complete patch", got.File)
+	}
+	if lines := countPatchLines(got.File.Patch); lines <= diffFileMaxLines {
+		t.Errorf("rendered %d lines, want more than the %d cap", lines, diffFileMaxLines)
+	}
+
+	// Untracked files work here too, still without staging them.
+	if w := getFileDiff(t, srv, id, resolvedRoot(t, repo), "fresh.txt"); w.Code != http.StatusOK {
+		t.Errorf("untracked file diff: status = %d; body=%s", w.Code, w.Body.String())
+	}
+
+	// A repository outside the session's scope is refused even though it is a
+	// perfectly valid repository with changes in it.
+	if w := getFileDiff(t, srv, id, resolvedRoot(t, outside), "secret.txt"); w.Code != http.StatusForbidden {
+		t.Errorf("outside repo: status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+
+	// An unchanged file in an allowed repository is not readable through here.
+	if w := getFileDiff(t, srv, id, resolvedRoot(t, repo), "untouched.txt"); w.Code != http.StatusNotFound {
+		t.Errorf("unchanged file: status = %d, want 404", w.Code)
+	}
+
+	// Traversal out of the repository fails the same way: git status never
+	// reports such a path.
+	if w := getFileDiff(t, srv, id, resolvedRoot(t, repo), "../outside/secret.txt"); w.Code != http.StatusNotFound {
+		t.Errorf("traversal: status = %d, want 404", w.Code)
+	}
+}
+
+// TestUntrackedSymlinkEscape: an untracked symlink pointing out of the
+// repository must not be read through it.
+func TestUntrackedSymlinkEscape(t *testing.T) {
+	base := t.TempDir()
+	repo := filepath.Join(base, "app")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(base, "secret.txt")
+	if err := os.WriteFile(secret, []byte("top secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(repo, "link.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	if _, _, _, err := synthUntrackedPatch(repo, "link.txt"); err == nil {
+		t.Error("symlink out of the repository was read")
+	}
+	// Plain traversal, same answer.
+	if _, _, _, err := synthUntrackedPatch(repo, "../secret.txt"); err == nil {
+		t.Error("traversal out of the repository was read")
+	}
+}
+
+// TestUntrackedReadCap: a file larger than the read cap comes back truncated
+// rather than whole.
+func TestUntrackedReadCap(t *testing.T) {
+	repo := t.TempDir()
+	big := strings.Repeat("0123456789abcdef", (untrackedMaxBytes/16)+64)
+	if err := os.WriteFile(filepath.Join(repo, "big.txt"), []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	patch, binary, truncated, err := synthUntrackedPatch(repo, "big.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binary || !truncated || patch == nil {
+		t.Fatalf("binary=%v truncated=%v patch=%v, want a truncated text patch", binary, truncated, patch)
+	}
+}

--- a/internal/server/diff_parse.go
+++ b/internal/server/diff_parse.go
@@ -1,0 +1,248 @@
+package server
+
+import (
+	"strings"
+)
+
+// Unified-diff parsing for the sidebar Git Diff panel
+// (dev-docs/git-diff-panel-design.md). Pure text → structure, no IO, so the
+// interesting cases (renames, binary markers, truncation) are table-testable.
+//
+// Truncation lives here rather than in the frontend because it has to happen at
+// the data source: a 200k-line diff must never cross the wire in the first
+// place.
+
+const (
+	// diffFileMaxLines caps one file's rendered hunk lines. Beyond this the
+	// panel is unreadable anyway; the single-file endpoint serves the rest on
+	// demand.
+	diffFileMaxLines = 2000
+	// diffResponseMaxLines caps the whole aggregate response. Files past the
+	// budget keep their metadata and drop their patch.
+	diffResponseMaxLines = 20000
+)
+
+// diffLine is one rendered line of a hunk. Kind is "context", "add" or "del".
+type diffLine struct {
+	Kind    string `json:"kind"`
+	Content string `json:"content"`
+}
+
+// diffHunk is one @@ block.
+type diffHunk struct {
+	Header string     `json:"header"`
+	Lines  []diffLine `json:"lines"`
+}
+
+// diffPatch is a file's content change. Paths are repo-relative as git prints
+// them, with /dev/null kept verbatim for added and deleted files.
+type diffPatch struct {
+	OldPath string     `json:"old_path"`
+	NewPath string     `json:"new_path"`
+	Hunks   []diffHunk `json:"hunks"`
+}
+
+// newDiffPatch builds a patch whose Hunks always marshals as an array. A pure
+// rename or a mode-only change legitimately has none, and `"hunks": null` would
+// reach the client as something it has to null-check on every render.
+func newDiffPatch(oldPath, newPath string, hunks []diffHunk) *diffPatch {
+	if hunks == nil {
+		hunks = []diffHunk{}
+	}
+	return &diffPatch{OldPath: oldPath, NewPath: newPath, Hunks: hunks}
+}
+
+// diffFile is one changed file in the panel's file list.
+type diffFile struct {
+	Path string `json:"path"`
+	// OldPath is only set for renames and copies.
+	OldPath string `json:"old_path,omitempty"`
+	Status  string `json:"status"`
+	Staged  bool   `json:"staged"`
+	Adds    int    `json:"adds"`
+	Dels    int    `json:"dels"`
+	Binary  bool   `json:"binary"`
+	// Truncated means Patch holds a prefix of the change; TotalLines reports
+	// the full size so the UI can say how much is missing.
+	Truncated bool `json:"truncated"`
+	// Omitted means the aggregate line budget ran out before this file, so no
+	// patch was rendered at all.
+	Omitted    bool       `json:"omitted"`
+	TotalLines int        `json:"total_lines"`
+	Patch      *diffPatch `json:"patch"`
+}
+
+// diffRepo groups one repository's changes.
+type diffRepo struct {
+	Root   string     `json:"root"`
+	Name   string     `json:"name"`
+	Branch string     `json:"branch"`
+	Commit string     `json:"commit,omitempty"`
+	Files  []diffFile `json:"files"`
+	// Error degrades a single repository without failing the response: the
+	// other repositories still render.
+	Error string `json:"error,omitempty"`
+}
+
+// diffResponse is the aggregate endpoint's body.
+type diffResponse struct {
+	Repos          []diffRepo `json:"repos"`
+	TruncatedFiles int        `json:"truncated_files"`
+	OmittedFiles   int        `json:"omitted_files"`
+}
+
+// diffFileSummary is a file list entry in summary mode, where the badge only
+// needs counts and no git diff is run at all.
+type diffFileSummary struct {
+	Path   string `json:"path"`
+	Status string `json:"status"`
+	Staged bool   `json:"staged"`
+}
+
+// diffRepoSummary is a repository in summary mode.
+type diffRepoSummary struct {
+	Root  string            `json:"root"`
+	Name  string            `json:"name"`
+	Files []diffFileSummary `json:"files"`
+	Error string            `json:"error,omitempty"`
+}
+
+// diffSummaryResponse is the ?summary=1 body.
+type diffSummaryResponse struct {
+	Repos []diffRepoSummary `json:"repos"`
+}
+
+// filePatch is a parsed patch before it is matched against a git status entry.
+type filePatch struct {
+	oldPath    string
+	newPath    string
+	binary     bool
+	hunks      []diffHunk
+	adds       int
+	dels       int
+	totalLines int
+}
+
+// parseUnifiedDiff splits `git diff` output into one filePatch per file.
+//
+// Paths come from the ---/+++ lines when present because those carry exactly
+// one path each and so stay unambiguous for filenames containing spaces; the
+// `diff --git a/x b/y` header is only consulted for binary files and pure
+// mode/rename changes, which have no ---/+++ pair.
+func parseUnifiedDiff(out string) []*filePatch {
+	var patches []*filePatch
+	var cur *filePatch
+	var hunk *diffHunk
+
+	flushHunk := func() {
+		if cur != nil && hunk != nil {
+			cur.hunks = append(cur.hunks, *hunk)
+			hunk = nil
+		}
+	}
+	flushFile := func() {
+		flushHunk()
+		if cur != nil {
+			patches = append(patches, cur)
+			cur = nil
+		}
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			flushFile()
+			old, new_ := splitDiffGitHeader(strings.TrimPrefix(line, "diff --git "))
+			cur = &filePatch{oldPath: old, newPath: new_}
+		case cur == nil:
+			// Preamble or trailing junk; nothing to attach it to.
+		case strings.HasPrefix(line, "--- ") && hunk == nil:
+			cur.oldPath = stripDiffPathPrefix(strings.TrimPrefix(line, "--- "))
+		case strings.HasPrefix(line, "+++ ") && hunk == nil:
+			cur.newPath = stripDiffPathPrefix(strings.TrimPrefix(line, "+++ "))
+		case strings.HasPrefix(line, "@@"):
+			flushHunk()
+			hunk = &diffHunk{Header: line}
+		case strings.HasPrefix(line, "Binary files ") || strings.HasPrefix(line, "GIT binary patch"):
+			cur.binary = true
+		case hunk == nil:
+			// Extended header line (index, mode, similarity, rename from/to).
+		case strings.HasPrefix(line, "+"):
+			hunk.Lines = append(hunk.Lines, diffLine{Kind: "add", Content: line[1:]})
+			cur.adds++
+			cur.totalLines++
+		case strings.HasPrefix(line, "-"):
+			hunk.Lines = append(hunk.Lines, diffLine{Kind: "del", Content: line[1:]})
+			cur.dels++
+			cur.totalLines++
+		case strings.HasPrefix(line, " "):
+			hunk.Lines = append(hunk.Lines, diffLine{Kind: "context", Content: line[1:]})
+			cur.totalLines++
+		case strings.HasPrefix(line, `\`):
+			// "\ No newline at end of file" — an annotation on the previous
+			// line, carried as context so nothing is silently dropped.
+			hunk.Lines = append(hunk.Lines, diffLine{Kind: "context", Content: line})
+			cur.totalLines++
+		case line == "":
+			// git's trailing newline after the last hunk.
+		default:
+			// Unknown line inside a hunk: end the hunk rather than guess.
+			flushHunk()
+		}
+	}
+	flushFile()
+	return patches
+}
+
+// splitDiffGitHeader pulls the two paths out of a `a/x b/y` header. Filenames
+// containing " b/" make this ambiguous, which is why it is only the fallback.
+func splitDiffGitHeader(rest string) (string, string) {
+	if i := strings.Index(rest, " b/"); i >= 0 {
+		return stripDiffPathPrefix(rest[:i]), stripDiffPathPrefix(rest[i+1:])
+	}
+	if a, b, ok := strings.Cut(rest, " "); ok {
+		return stripDiffPathPrefix(a), stripDiffPathPrefix(b)
+	}
+	return stripDiffPathPrefix(rest), stripDiffPathPrefix(rest)
+}
+
+// stripDiffPathPrefix removes git's a/ or b/ prefix and the trailing tab it
+// appends when a filename needs it. /dev/null is passed through.
+func stripDiffPathPrefix(p string) string {
+	p = strings.TrimSuffix(p, "\t")
+	if i := strings.IndexByte(p, '\t'); i >= 0 {
+		p = p[:i]
+	}
+	if p == "/dev/null" {
+		return p
+	}
+	if strings.HasPrefix(p, "a/") || strings.HasPrefix(p, "b/") {
+		return p[2:]
+	}
+	return p
+}
+
+// truncatePatch cuts hunks so at most max lines are rendered. It reports
+// whether anything was dropped and how many lines were kept.
+func truncatePatch(p *diffPatch, max int) (truncated bool, kept int) {
+	if p == nil {
+		return false, 0
+	}
+	for i := range p.Hunks {
+		lines := p.Hunks[i].Lines
+		if kept+len(lines) <= max {
+			kept += len(lines)
+			continue
+		}
+		room := max - kept
+		if room > 0 {
+			p.Hunks[i].Lines = lines[:room]
+			kept += room
+			p.Hunks = p.Hunks[:i+1]
+		} else {
+			p.Hunks = p.Hunks[:i]
+		}
+		return true, kept
+	}
+	return false, kept
+}

--- a/internal/server/diff_parse_test.go
+++ b/internal/server/diff_parse_test.go
@@ -1,0 +1,209 @@
+package server
+
+import "testing"
+
+func TestParseUnifiedDiff(t *testing.T) {
+	out := `diff --git a/web/src/lib/stores.ts b/web/src/lib/stores.ts
+index 1111111..2222222 100644
+--- a/web/src/lib/stores.ts
++++ b/web/src/lib/stores.ts
+@@ -88,6 +88,8 @@ export const artifactSel = writable(0)
+ context one
+-removed line
++added line
++added two
+ context two
+diff --git a/old name.txt b/new name.txt
+similarity index 90%
+rename from old name.txt
+rename to new name.txt
+--- a/old name.txt
++++ b/new name.txt
+@@ -1 +1 @@
+-one
++two
+diff --git a/logo.png b/logo.png
+index 3333333..4444444 100644
+Binary files a/logo.png and b/logo.png differ
+diff --git a/gone.txt b/gone.txt
+deleted file mode 100644
+index 5555555..0000000
+--- a/gone.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-bye
+-now
+`
+	patches := parseUnifiedDiff(out)
+	if len(patches) != 4 {
+		t.Fatalf("patches = %d, want 4", len(patches))
+	}
+
+	// Modification: counts and hunk contents.
+	p := patches[0]
+	if p.newPath != "web/src/lib/stores.ts" || p.oldPath != "web/src/lib/stores.ts" {
+		t.Errorf("paths = %q / %q", p.oldPath, p.newPath)
+	}
+	if p.adds != 2 || p.dels != 1 || p.totalLines != 5 {
+		t.Errorf("adds/dels/total = %d/%d/%d, want 2/1/5", p.adds, p.dels, p.totalLines)
+	}
+	if len(p.hunks) != 1 || p.hunks[0].Header != "@@ -88,6 +88,8 @@ export const artifactSel = writable(0)" {
+		t.Fatalf("hunks = %+v", p.hunks)
+	}
+	want := []diffLine{
+		{Kind: "context", Content: "context one"},
+		{Kind: "del", Content: "removed line"},
+		{Kind: "add", Content: "added line"},
+		{Kind: "add", Content: "added two"},
+		{Kind: "context", Content: "context two"},
+	}
+	for i, w := range want {
+		if got := p.hunks[0].Lines[i]; got != w {
+			t.Errorf("line %d = %+v, want %+v", i, got, w)
+		}
+	}
+
+	// Rename with spaces in both names: the ---/+++ pair keeps each side whole,
+	// which the `diff --git a/x b/y` header could not.
+	if patches[1].oldPath != "old name.txt" || patches[1].newPath != "new name.txt" {
+		t.Errorf("rename paths = %q / %q", patches[1].oldPath, patches[1].newPath)
+	}
+
+	// Binary: flagged, no hunks.
+	if !patches[2].binary || len(patches[2].hunks) != 0 {
+		t.Errorf("binary patch = %+v", patches[2])
+	}
+	if patches[2].newPath != "logo.png" {
+		t.Errorf("binary path = %q", patches[2].newPath)
+	}
+
+	// Deletion: /dev/null on the new side is kept verbatim.
+	if patches[3].newPath != "/dev/null" || patches[3].dels != 2 {
+		t.Errorf("deletion = %+v", patches[3])
+	}
+}
+
+func TestParseUnifiedDiffNoNewline(t *testing.T) {
+	out := `diff --git a/a.txt b/a.txt
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-one
+\ No newline at end of file
++two
+\ No newline at end of file
+`
+	patches := parseUnifiedDiff(out)
+	if len(patches) != 1 {
+		t.Fatalf("patches = %d, want 1", len(patches))
+	}
+	// The annotation rides along as context so nothing is silently dropped, but
+	// it must not be counted as an addition or a deletion.
+	if patches[0].adds != 1 || patches[0].dels != 1 {
+		t.Errorf("adds/dels = %d/%d, want 1/1", patches[0].adds, patches[0].dels)
+	}
+	if got := len(patches[0].hunks[0].Lines); got != 4 {
+		t.Errorf("lines = %d, want 4", got)
+	}
+}
+
+func TestParseUnifiedDiffEmpty(t *testing.T) {
+	if got := parseUnifiedDiff(""); len(got) != 0 {
+		t.Errorf("patches = %d, want 0", len(got))
+	}
+}
+
+func TestTruncatePatch(t *testing.T) {
+	mk := func(sizes ...int) *diffPatch {
+		p := &diffPatch{}
+		for _, n := range sizes {
+			h := diffHunk{Header: "@@"}
+			for i := 0; i < n; i++ {
+				h.Lines = append(h.Lines, diffLine{Kind: "add", Content: "x"})
+			}
+			p.Hunks = append(p.Hunks, h)
+		}
+		return p
+	}
+
+	// Under the cap: untouched.
+	p := mk(3, 4)
+	if cut, kept := truncatePatch(p, 10); cut || kept != 7 || len(p.Hunks) != 2 {
+		t.Errorf("under cap: cut=%v kept=%d hunks=%d", cut, kept, len(p.Hunks))
+	}
+
+	// Cap lands mid-hunk: that hunk is clipped and later ones dropped.
+	p = mk(3, 4, 5)
+	cut, kept := truncatePatch(p, 5)
+	if !cut || kept != 5 {
+		t.Errorf("mid-hunk: cut=%v kept=%d, want true/5", cut, kept)
+	}
+	if len(p.Hunks) != 2 || len(p.Hunks[1].Lines) != 2 {
+		t.Errorf("mid-hunk hunks = %d, second len = %d", len(p.Hunks), len(p.Hunks[1].Lines))
+	}
+
+	// Cap lands exactly on a hunk boundary: no clipped hunk is kept.
+	p = mk(3, 4)
+	if cut, kept := truncatePatch(p, 3); !cut || kept != 3 || len(p.Hunks) != 1 {
+		t.Errorf("boundary: cut=%v kept=%d hunks=%d", cut, kept, len(p.Hunks))
+	}
+
+	// Zero cap: everything goes.
+	p = mk(3)
+	if cut, kept := truncatePatch(p, 0); !cut || kept != 0 || len(p.Hunks) != 0 {
+		t.Errorf("zero cap: cut=%v kept=%d hunks=%d", cut, kept, len(p.Hunks))
+	}
+
+	if cut, kept := truncatePatch(nil, 10); cut || kept != 0 {
+		t.Errorf("nil patch: cut=%v kept=%d", cut, kept)
+	}
+}
+
+func TestParseStatusZ(t *testing.T) {
+	// Renames span two fields, new path first — the reverse of the human
+	// format. Untracked and unmerged records ride alongside.
+	out := "M  mod.ts\x00 M unstaged.ts\x00R  new.txt\x00old.txt\x00?? fresh.txt\x00UU conflict.go\x00 D gone.txt\x00"
+	entries := parseStatusZ(out)
+	if len(entries) != 6 {
+		t.Fatalf("entries = %d, want 6\n%+v", len(entries), entries)
+	}
+
+	cases := []struct {
+		path, orig, status string
+		staged, untracked  bool
+	}{
+		{path: "mod.ts", status: "M", staged: true},
+		{path: "unstaged.ts", status: "M"},
+		{path: "new.txt", orig: "old.txt", status: "R", staged: true},
+		{path: "fresh.txt", status: "?", untracked: true},
+		{path: "conflict.go", status: "M", staged: true},
+		{path: "gone.txt", status: "D"},
+	}
+	for i, c := range cases {
+		e := entries[i]
+		if e.path != c.path || e.origPath != c.orig {
+			t.Errorf("entry %d path = %q / %q, want %q / %q", i, e.path, e.origPath, c.path, c.orig)
+		}
+		if e.status() != c.status {
+			t.Errorf("entry %d status = %q, want %q", i, e.status(), c.status)
+		}
+		if e.staged() != c.staged {
+			t.Errorf("entry %d staged = %v, want %v", i, e.staged(), c.staged)
+		}
+		if e.untracked() != c.untracked {
+			t.Errorf("entry %d untracked = %v, want %v", i, e.untracked(), c.untracked)
+		}
+	}
+}
+
+func TestStatusEntryWorktreeDeletionWins(t *testing.T) {
+	// Modified in the index, then deleted in the worktree: the net effect
+	// against HEAD is a deletion, so that is what the panel shows.
+	e := statusEntry{x: 'M', y: 'D', path: "x.txt"}
+	if e.status() != "D" {
+		t.Errorf("status = %q, want D", e.status())
+	}
+	if !e.staged() {
+		t.Error("staged = false, want true")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -813,6 +813,8 @@ func (s *Server) registerRoutes() {
 	s.api("GET /api/sessions/{id}/messages", s.handleGetSessionMessages)
 	s.api("GET /api/sessions/{id}/confirmation", s.handleGetSessionConfirmation)
 	s.api("GET /api/sessions/{id}/artifacts", s.handleGetArtifact)
+	s.api("GET /api/sessions/{id}/diff", s.handleGetSessionDiff)
+	s.api("GET /api/sessions/{id}/diff/file", s.handleGetSessionFileDiff)
 	s.api("DELETE /api/sessions/{id}", s.handleDeleteSession)
 	s.api("PATCH /api/sessions/{id}", s.handleUpdateSession)
 	s.api("PATCH /api/sessions/{id}/model", s.handleUpdateSessionModel)


### PR DESCRIPTION
Implements the server half of `dev-docs/git-diff-panel-design.md`. Two new read-only endpoints:

```
GET /api/sessions/{id}/diff[?summary=1]
GET /api/sessions/{id}/diff/file?repo=&path=
```

No frontend calls them yet, so this can land on its own with zero user-visible change.

## What it answers

"What has the agent changed in here that isn't committed" — `git status` + `git diff HEAD` across the session's own working directory plus its project's workspace and mounted source dirs, untracked files included.

## Decisions worth knowing about

**The aggregate endpoint takes a session id and nothing else.** The repository set is resolved server-side, the same model `handleNativeOpenFolder` uses: a caller-controlled path here would be an arbitrary-file-read hole. The single-file endpoint does take a `repo` and `path`, and checks both against a freshly resolved root set *and* a live `git status`, so an unchanged file elsewhere in an allowed repository is a 404.

**`git diff HEAD`, staged and unstaged merged, with a separate `staged` flag.** The question a review answers is what the tree will look like, not which half is in the index. A repository with no commits diffs against the empty tree instead, so the merged view survives there too — the design said `git diff --cached` for that case, but that would drop edits made after staging.

**Untracked files are read, not staged.** `git add -N` would work but writes the user's index, and an agent session must never do that. They are synthesised into new-file patches: 1 MB read cap, NUL byte in the first 8 KB means binary, path confined to the repository root by prefix check both before and after `EvalSymlinks`.

**Two truncation layers**, at the data source rather than the client: 2000 lines per file, 20000 for the whole response. Files past the budget keep their metadata and drop their patch; the single-file endpoint serves the rest on demand and applies no per-file cap.

**A repository whose git commands fail keeps its slot** with an `error` field rather than failing the whole response.

No new dependencies — the unified-diff and porcelain parsing is ~200 lines of pure Go.

## Testing

`go test -race ./internal/server/` — real `git init` repositories in `t.TempDir()`, because mocking git would only test our idea of its output, and porcelain/rename/no-commit behaviour is exactly what surprises you. Covers mixed staged/unstaged/untracked, renames, multi-repo aggregation, non-repositories, linked worktrees (`.git` as a file), a repository with no commits, both truncation layers, untracked binaries, untracked directory expansion, summary mode, and the confinement rejections (out-of-scope repo → 403, unchanged path → 404, traversal → 404, symlink escape refused).

Also exercised by hand against a real serve instance with a repository holding every case at once, confirming `git status --porcelain` was byte-identical before and after — the index really is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
