### PR TITLE
chore: drop the unreachable WS session_list path

### DIFF
--- a/internal/server/model_binding_endpoint_test.go
+++ b/internal/server/model_binding_endpoint_test.go
@@ -136,26 +136,3 @@ func TestHandleListSessions_SurfacesModelID(t *testing.T) {
 	}
 	t.Fatalf("session %s not in list", sess.ID)
 }
-
-// The WS brief list feeds the sidebar's first hydration (session_list on
-// connect) and must carry the same binding identity as the HTTP list.
-func TestListSessionsBrief_SurfacesModelID(t *testing.T) {
-	sameModelTwoEndpointsConfig(t)
-
-	sess := agent.NewSession("kimi-k2.6", "")
-	sess.ModelConfig = "ep-proxy::kimi-k2.6"
-	if err := sess.Save(); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-
-	for _, info := range srv.listSessionsBrief() {
-		if info.ID == sess.ID {
-			if info.ModelID != "ep-proxy::kimi-k2.6" {
-				t.Fatalf("brief model_id = %q, want the composite id ep-proxy::kimi-k2.6", info.ModelID)
-			}
-			return
-		}
-	}
-	t.Fatalf("session %s not in brief list", sess.ID)
-}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2232,7 +2232,7 @@ func TestHandleGetSessionMessages_ThinkingBeforeTools(t *testing.T) {
 // event is allowed to end a tool-call group on this value instead of the
 // reactive session-list state, which can still be empty (defaulting to true)
 // on a page load that lands straight on this session via URL hash — before
-// api.listSessions()/the WS session_list broadcast has resolved.
+// api.listSessions() has resolved.
 func TestHandleGetSessionMessages_ShowReasoningField(t *testing.T) {
 	setTestHome(t)
 	off := false

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -121,10 +122,10 @@ func TestDoAgentTurn_GeneratesSessionTitle(t *testing.T) {
 	}
 }
 
-// TestListSessionsBrief_ReflectsGeneratedTitle guards the REST fallback path
-// used by the web UI when the live session_renamed broadcast is missed. The
-// sidebar should be able to refresh from listSessions and see the new title.
-func TestListSessionsBrief_ReflectsGeneratedTitle(t *testing.T) {
+// TestSessionList_ReflectsGeneratedTitle guards the list path the web UI
+// refetches when the live session_renamed broadcast is missed. The sidebar
+// should be able to refresh from GET /api/sessions and see the new title.
+func TestSessionList_ReflectsGeneratedTitle(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
@@ -155,13 +156,6 @@ func TestListSessionsBrief_ReflectsGeneratedTitle(t *testing.T) {
 	// is still running). List responses must already surface it — the web
 	// sidebar refetches on session_renamed, and without the overlay that
 	// refetch would regress the just-renamed session to the placeholder.
-	if brief := srv.listSessionsBrief(); len(brief) != 1 || brief[0].Name != "early title" {
-		n := ""
-		if len(brief) == 1 {
-			n = brief[0].Name
-		}
-		t.Errorf("mid-turn listSessionsBrief Name = %q (n=%d), want %q — pending-title overlay missing", n, len(brief), "early title")
-	}
 	if item := srv.toSessionItem(sess, "web", ""); item.Name != "early title" || item.Title != "early title" {
 		t.Errorf("mid-turn toSessionItem = (%q, %q), want (%q, %q)", item.Name, item.Title, "early title", "early title")
 	}
@@ -169,14 +163,26 @@ func TestListSessionsBrief_ReflectsGeneratedTitle(t *testing.T) {
 	close(sender.release)
 	<-turnDone
 
-	// listSessionsBrief is what the frontend REST fallback calls. It must
-	// report the generated title, not the placeholder.
-	brief := srv.listSessionsBrief()
-	if len(brief) != 1 {
-		t.Fatalf("listSessionsBrief returned %d sessions, want 1", len(brief))
+	// GET /api/sessions is what the sidebar refetches. It must report the
+	// generated title, not the placeholder.
+	w := doJSON(t, srv, http.MethodGet, "/api/sessions", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/sessions = %d: %s", w.Code, w.Body.String())
 	}
-	if brief[0].Name != "early title" {
-		t.Errorf("Name = %q, want %q", brief[0].Name, "early title")
+	var resp struct {
+		Sessions []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Sessions) != 1 {
+		t.Fatalf("list returned %d sessions, want 1", len(resp.Sessions))
+	}
+	if resp.Sessions[0].Name != "early title" {
+		t.Errorf("Name = %q, want %q", resp.Sessions[0].Name, "early title")
 	}
 }
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -95,47 +95,6 @@ func (ls *sessionLiveState) flushDeltas(sessionID string) {
 
 // ─── WS handler methods on Server ──────────────────────────────────────────
 
-// listSessionsBrief returns a brief session list for the initial WS handshake.
-func (s *Server) listSessionsBrief() []wsSessionInfo {
-	sessions, err := agent.ListSessions(50)
-	if err != nil {
-		return nil
-	}
-	out := make([]wsSessionInfo, 0, len(sessions))
-	for _, sess := range sessions {
-		source := sess.Source
-		if source == "" {
-			source = "manual"
-		}
-		name := sess.DisplayTitle()
-		// Same pending-title overlay as toSessionItem: a title broadcast
-		// mid-turn isn't on disk yet, and this list feeds the sidebar.
-		if pt := s.peekPendingTitle(sess.ID); pt != "" && agent.IsAutoNamePlaceholder(sess.Title) {
-			name = pt
-		}
-		_, pm, re, sr, ctxUsage := s.sessionStatusFields(sess)
-		out = append(out, wsSessionInfo{
-			ID:                  sess.ID,
-			Name:                name,
-			Status:              s.sessionStatus(sess.ID),
-			CreatedAt:           sess.CreatedAt.UnixMilli(),
-			Source:              source,
-			AgentProfile:        sess.EffectiveAgentID(),
-			Model:               sess.Model,
-			ModelID:             sess.ModelConfig,
-			TotalTurns:          sess.TurnCount(),
-			WorkingDir:          s.sessionCwd(sess),
-			PermissionMode:      pm,
-			ReasoningEffort:     re,
-			ShowReasoning:       sr,
-			ContextUsage:        ctxUsage,
-			PendingQuestion:     s.hasPendingQuestion(sess.ID),
-			PendingConfirmation: s.hasPendingConfirmation(sess.ID),
-		})
-	}
-	return out
-}
-
 // hasPendingQuestion reports whether a session has an outstanding
 // ask_user_question awaiting an answer, so a freshly-loaded session list
 // (initial connect / page refresh) shows the sidebar badge immediately

--- a/internal/server/ws_hub.go
+++ b/internal/server/ws_hub.go
@@ -264,14 +264,6 @@ func (c *wsConn) readPump() {
 // dispatch routes an inbound WS message to the appropriate handler.
 func (c *wsConn) dispatch(msgType string, raw []byte) {
 	switch msgType {
-	case "list_sessions":
-		sessions := c.hub.s.listSessionsBrief()
-		b, _ := json.Marshal(wsEventSessionList{
-			Type:     "session_list",
-			Sessions: sessions,
-		})
-		c.send <- b
-
 	case "subscribe":
 		var msg wsMsgSubscribe
 		if err := json.Unmarshal(raw, &msg); err != nil {
@@ -383,7 +375,6 @@ func (c *wsConn) dispatch(msgType string, raw []byte) {
 // by embedding a hub field via interface.
 
 type wsHubOwner interface {
-	listSessionsBrief() []wsSessionInfo
 	handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage)
 	handleWSInterrupt(sessionID string)
 	handleWSRetry(conn *wsConn, sessionID string)

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -102,31 +102,6 @@ type wsOutEvent struct {
 	Type string `json:"type"`
 }
 
-// wsEventSessionList carries the full session list sent on connect + refresh.
-type wsEventSessionList struct {
-	Type     string          `json:"type"`
-	Sessions []wsSessionInfo `json:"sessions"`
-}
-
-type wsSessionInfo struct {
-	ID                  string `json:"id"`
-	Name                string `json:"name"`
-	Status              string `json:"status,omitempty"` // "idle" | "running"
-	CreatedAt           int64  `json:"created_at"`       // unix ms
-	Source              string `json:"source,omitempty"` // "manual" | "cron" | "channel" | "setup"
-	AgentProfile        string `json:"agent_profile,omitempty"`
-	Model               string `json:"model,omitempty"`
-	ModelID             string `json:"model_id,omitempty"`
-	TotalTurns          int    `json:"total_turns,omitempty"`
-	WorkingDir          string `json:"working_dir,omitempty"`
-	PermissionMode      string `json:"permission_mode,omitempty"`
-	ReasoningEffort     string `json:"reasoning_effort,omitempty"`
-	ShowReasoning       *bool  `json:"show_reasoning,omitempty"`
-	ContextUsage        int    `json:"context_usage,omitempty"`
-	PendingQuestion     bool   `json:"pending_question,omitempty"`
-	PendingConfirmation bool   `json:"pending_confirmation,omitempty"`
-}
-
 type wsEventHistoryUserMessage struct {
 	Type      string   `json:"type"`
 	Content   string   `json:"content"`

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -196,22 +196,6 @@
       if (cfg.permission_mode) globalPermissionMode.set(cfg.permission_mode)
     }).catch(() => { /* non-critical */ })
 
-    ws.on('session_list', (ev: any) => {
-      const list = ev.sessions ?? []
-      sessions.set(list)
-      chatShowReasoning.update(m => {
-        const next = { ...m }
-        for (const s of list) {
-          if (typeof s.show_reasoning === 'boolean') next[s.id] = s.show_reasoning
-        }
-        return next
-      })
-      if (!autoSelectDone) {
-        autoSelectDone = true
-        if (!get(activeSessionId) && list.length > 0) activeSessionId.set(list[0].id)
-      }
-    })
-
     ws.on('session_update', (ev: any) => {
       // permission_mode is per-session (each session has its own, only
       // inheriting the global default at creation) — a mode change only
@@ -346,7 +330,8 @@
       }
     })
 
-    // REST fallback (WS session_list may be delayed)
+    // The sidebar's only source of session rows — nothing pushes the list
+    // over the WS, only per-session deltas (session_update / session_activity).
     api.listSessions().then((data: any) => {
       const list = data.sessions ?? []
       if (list.length > 0) {
@@ -363,7 +348,7 @@
           if (!get(activeSessionId)) activeSessionId.set(list[0].id)
         }
       }
-    }).catch(() => { /* non-critical: WS session_list will arrive shortly */ })
+    }).catch(() => { /* non-critical: an empty sidebar, not a broken page */ })
 
     // Restore the view/session from the URL now — synchronously, before the
     // WS/REST auto-select above resolves (both guard on activeSessionId being

--- a/web/src/lib/relTime.ts
+++ b/web/src/lib/relTime.ts
@@ -3,8 +3,8 @@
 // 40 seconds ago, only that it was minutes rather than days.
 //
 // Takes the reactive `$t` rather than importing `tr`, so a locale flip re-renders
-// the timestamps — config-driven setLocale lands after the first session_list,
-// which would otherwise leave every row in the boot locale.
+// the timestamps — config-driven setLocale lands after the first session list
+// arrives, which would otherwise leave every row in the boot locale.
 
 export function ago(iso: string, tf: (k: string) => string): string {
   if (!iso) return ''

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -16,7 +16,7 @@ export interface Session {
   model: string
   model_id: string
   // "running" while a turn is in flight (see server sessionStatus) — seeded by
-  // session_list, kept live via session_update (subscribed tabs) and the
+  // GET /api/sessions, kept live via session_update (subscribed tabs) and the
   // global session_activity turn_started/turn_ended pair (all tabs).
   status: 'idle' | 'running' | string
   source: string
@@ -30,7 +30,7 @@ export interface Session {
   show_reasoning?: boolean
   context_usage: number
   // Set when this session has an outstanding ask_user_question awaiting an
-  // answer — seeded by the initial session_list, kept live via the global
+  // answer — seeded by the initial GET /api/sessions, kept live via the global
   // session_activity broadcast (App.svelte), independent of whether this
   // tab is currently subscribed to the session.
   pending_question?: boolean
@@ -214,28 +214,7 @@ export interface ToolSearchSettings {
   threshold_pct: number
 }
 
-// WsSessionInfo matches the Go server WebSocket session info struct
-export interface WsSessionInfo {
-  id: string
-  name: string
-  status: string
-  created_at: string
-  model: string
-  total_turns: number
-  working_dir: string
-  permission_mode: 'interactive' | 'auto' | 'strict'
-  reasoning_effort: 'off' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | string
-  show_reasoning?: boolean
-  context_usage: number
-  pending_question?: boolean
-}
-
 // WebSocket event interfaces
-export interface WsEventSessionList {
-  type: 'session_list'
-  sessions: WsSessionInfo[]
-}
-
 export interface WsEventOutput {
   type: 'output'
   content: string
@@ -407,7 +386,6 @@ export interface WsEventSessionActivity {
 
 // Discriminated union of all WebSocket event types
 export type WsEvent =
-  | WsEventSessionList
   | WsEventOutput
   | WsEventHistoryUserMessage
   | WsEventAssistantMessage

--- a/web/src/lib/unread.ts
+++ b/web/src/lib/unread.ts
@@ -139,7 +139,7 @@ export function reconcileSeen(list: Session[]) {
   })
 }
 
-// The session list is replaced wholesale by several paths (the WS session_list,
-// the REST fallback, every post-broadcast refetch). Subscribing here means each
-// of them baselines and prunes without having to remember to.
+// The session list is replaced wholesale by several paths (the initial fetch,
+// every post-broadcast refetch). Subscribing here means each of them baselines
+// and prunes without having to remember to.
 sessions.subscribe(list => reconcileSeen(list))

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -380,7 +380,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       // historyShowReasoning comes from this fetch's own response (not the
       // reactive `showReasoning` derived from $sessions) because on a
       // page-load landing directly on a session via URL hash, loadHistory's
-      // REST call races api.listSessions()/the WS session_list broadcast —
+      // REST call races api.listSessions() —
       // $sessions can still be empty when this loop runs, which would make
       // `showReasoning` fall back to its default (true) regardless of the
       // session's real setting.


### PR DESCRIPTION
No client sends `list_sessions`. The web ws client (`web/src/lib/ws.ts`, shared with mobile and the desktop shell) has no method for it, and a repo-wide grep for the string turns up exactly one hit: the server's own `case` arm. So `session_list` was never emitted, the handler in `App.svelte` never ran, and `listSessionsBrief` only ever ran from tests.

The sidebar's real source is `GET /api/sessions` plus the per-session deltas (`session_update`, `session_activity`). The REST branch in `App.svelte` already did everything the dead handler did — set the list, seed `chatShowReasoning`, auto-select the first row — so removing the handler changes no behaviour.

Removed:

- server: the `list_sessions` case arm, `listSessionsBrief`, `wsEventSessionList`, `wsSessionInfo`, and the `wsHubOwner` interface method
- frontend: the `ws.on('session_list')` handler, `WsSessionInfo`, `WsEventSessionList`, and the union member

Comments that described the list as arriving over the WS — or REST as a "fallback" to it — now describe what actually happens.

Two tests covered the brief list. `TestListSessionsBrief_SurfacesModelID` was a duplicate of the adjacent `TestHandleListSessions_SurfacesModelID` and goes away with the code it tested. The pending-title test keeps both of its assertions, re-pointed at `toSessionItem` and `GET /api/sessions`, so the mid-turn overlay stays covered.

## Test

- `go test ./internal/server/` — ok
- `svelte-check` — 0 errors
- `vitest run` — 521 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
