### PR TITLE
web: keep session-list timestamps moving on their own

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -7,7 +7,7 @@
   import { confirmDialog } from '../../lib/confirm'
   import { splitSections, swapWithinSection, parseSectionFold, type SectionFold } from '../../lib/sidebarSections'
   import { SIDEBAR_MIN, SIDEBAR_MAX, CENTER_MIN, readSidebarWidth, saveSidebarWidth } from '../../lib/sidebarWidth'
-  import { ago } from '../../lib/relTime'
+  import { ago, clockTick } from '../../lib/relTime'
   import { isUnread, sessionSeenAt, sessionTouchedAt } from '../../lib/unread'
   import { ws } from '../../lib/ws'
   import VersionBadge from './VersionBadge.svelte'
@@ -903,7 +903,7 @@
             <span class="unread-dot on-rest" title={$t('sidebar.unread')}></span>
           {:else}
             <span class="session-time on-rest" style="color:var(--text-quaternary);">
-              {ago((s as any).updated_at, $t)}
+              {ago((s as any).updated_at, $t, $clockTick)}
             </span>
           {/if}
           {#if !$selMode}

--- a/web/src/components/overlays/SettingsModal.svelte
+++ b/web/src/components/overlays/SettingsModal.svelte
@@ -13,7 +13,7 @@
   import { notificationsEnabled, setNotificationsEnabled } from '../../lib/notifications'
   import { openUrl } from '../../lib/externalLinks'
   import { confirmDialog } from '../../lib/confirm'
-  import { ago } from '../../lib/relTime'
+  import { ago, clockTick } from '../../lib/relTime'
   import * as api from '../../lib/api'
 
   const LICENSE_URL = 'https://github.com/open-octo/octo-agent/blob/main/LICENSE.txt'
@@ -677,7 +677,7 @@
                             <input type="checkbox" checked={!!archiveSel[s.id]} onchange={() => toggleArchiveSel(s.id)} />
                             <div class="archived-info">
                               <span class="archived-name">{nameOf(s)}</span>
-                              <span class="archived-meta mono">{s.id} · {ago((s as any).updated_at, $t)}</span>
+                              <span class="archived-meta mono">{s.id} · {ago((s as any).updated_at, $t, $clockTick)}</span>
                             </div>
                             <div class="archived-actions">
                               <button class="btns danger" onclick={() => deleteArchivedSession(s.id)}>{$t('common.delete')}</button>

--- a/web/src/lib/relTime.test.ts
+++ b/web/src/lib/relTime.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { ago, clockTick } from './relTime'
+
+// The real i18n table is irrelevant here — echo the key with its {n} filled so
+// a wrong bucket reads as a wrong assertion rather than a translated string.
+const tf = (k: string) => k
+const tfn = (k: string) => `${k}:{n}`
+
+const T0 = Date.parse('2026-08-21T12:00:00Z')
+const iso = (msBefore: number) => new Date(T0 - msBefore).toISOString()
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('ago', () => {
+  it('buckets by the `now` it is given', () => {
+    expect(ago(iso(30_000), tf, T0)).toBe('time.just_now')
+    expect(ago(iso(5 * 60_000), tfn, T0)).toBe('time.min_ago:5')
+    expect(ago(iso(4 * 3600_000), tfn, T0)).toBe('time.hr_ago:4')
+    expect(ago(iso(50 * 3600_000), tfn, T0)).toBe('time.day_ago:2')
+  })
+
+  it('defaults `now` to the current clock', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+    expect(ago(iso(2 * 3600_000), tfn)).toBe('time.hr_ago:2')
+  })
+
+  it('returns nothing for a missing or unparseable stamp', () => {
+    expect(ago('', tf, T0)).toBe('')
+    expect(ago('not a date', tf, T0)).toBe('')
+  })
+
+  // The whole point of the tick: the same row, re-rendered later, moves buckets.
+  it('advances the bucket as `now` moves', () => {
+    const stamp = iso(0)
+    expect(ago(stamp, tf, T0)).toBe('time.just_now')
+    expect(ago(stamp, tfn, T0 + 90 * 60_000)).toBe('time.hr_ago:1')
+  })
+})
+
+describe('clockTick', () => {
+  it('re-stamps on an interval while subscribed, and stops after', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+
+    const seen: number[] = []
+    const stop = clockTick.subscribe(v => seen.push(v))
+    // The store's declared initial value is stamped at module load — before
+    // the fake clock exists — so only the re-stamp on subscribe is fixed.
+    expect(seen.at(-1)).toBe(T0)
+
+    vi.advanceTimersByTime(30_000)
+    expect(seen.at(-1)).toBe(T0 + 30_000)
+    vi.advanceTimersByTime(30_000)
+    expect(seen.at(-1)).toBe(T0 + 60_000)
+
+    stop()
+    const count = seen.length
+    vi.advanceTimersByTime(120_000)
+    expect(seen).toHaveLength(count)
+  })
+
+  it('re-stamps when a hidden tab comes back, without waiting out the tick', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+
+    const seen: number[] = []
+    const stop = clockTick.subscribe(v => seen.push(v))
+
+    // Stand in for the throttling a background tab gets: time moved on, no
+    // interval fired.
+    vi.setSystemTime(T0 + 10 * 60_000)
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(seen.at(-1)).toBe(T0 + 10 * 60_000)
+
+    stop()
+    // The listener goes with the subscription — a later event must not fire it.
+    const count = seen.length
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(seen).toHaveLength(count)
+  })
+})

--- a/web/src/lib/relTime.ts
+++ b/web/src/lib/relTime.ts
@@ -6,9 +6,37 @@
 // the timestamps — config-driven setLocale lands after the first session_list,
 // which would otherwise leave every row in the boot locale.
 
-export function ago(iso: string, tf: (k: string) => string): string {
+import { readable } from 'svelte/store'
+
+const TICK_MS = 30_000
+
+// Every one of these strings goes stale on its own: a sidebar left open all
+// afternoon keeps rendering whatever the last list fetch produced, so a row
+// that really is four hours old still reads "just now". `$clockTick` is the
+// missing input — subscribing to it alongside `$t` is what re-runs `ago` as
+// time passes. The interval lives inside the store's start function, so it
+// only runs while something is actually rendering a timestamp.
+export const clockTick = readable(Date.now(), set => {
+  const bump = () => set(Date.now())
+  // The initial value above is stamped at module load. Re-stamp on subscribe so
+  // a list mounted much later — or remounted after the last subscriber left and
+  // stopped the interval — starts from now rather than from page-load time.
+  bump()
+  const id = setInterval(bump, TICK_MS)
+  // A hidden tab's timers are throttled to a minute or worse, so the string on
+  // screen when a tab is restored can be well behind. Re-stamp on the way back
+  // in rather than making the user wait out the next tick.
+  const onVisibility = () => { if (!document.hidden) bump() }
+  document.addEventListener('visibilitychange', onVisibility)
+  return () => {
+    clearInterval(id)
+    document.removeEventListener('visibilitychange', onVisibility)
+  }
+})
+
+export function ago(iso: string, tf: (k: string) => string, now: number = Date.now()): string {
   if (!iso) return ''
-  const ms = Date.now() - new Date(iso).getTime()
+  const ms = now - new Date(iso).getTime()
   if (Number.isNaN(ms)) return ''
   const m = Math.floor(ms / 60000)
   if (m < 1) return tf('time.just_now')

--- a/web/src/mobile/SessionCard.svelte
+++ b/web/src/mobile/SessionCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { FeedItem, FeedKind } from './feedGroups'
   import { t } from '../lib/i18n'
-  import { ago } from '../lib/relTime'
+  import { ago, clockTick } from '../lib/relTime'
 
   let { item, onOpen }: { item: FeedItem; onOpen: (id: string, kind: FeedKind) => void } = $props()
 
@@ -34,7 +34,7 @@
       <span class="mono">{s.model || s.model_id || ''}</span>
     {/if}
     <span class="dot">·</span>
-    <span>{ago(s.updated_at, $t)}</span>
+    <span>{ago(s.updated_at, $t, $clockTick)}</span>
   </div>
 </button>
 


### PR DESCRIPTION
`ago()` read `Date.now()` at render time, and nothing ever re-rendered it. The session list only arrives from `GET /api/sessions` — the initial load and explicit refetches — and none of the WS deltas touch `updated_at`, so a sidebar left open kept showing whatever bucket the last fetch produced. A row stayed frozen at "刚刚" no matter how long the tab sat there.

Adds `clockTick`, a readable store that re-stamps every 30s, and threads it into `ago()` as an explicit `now` argument. Subscribing to it at the three call sites — sidebar rows, archived sessions in Settings, the mobile feed card — is what makes the text re-evaluate. `ago()` stays a pure function, so its buckets stay testable without touching the clock.

Two details the bare interval doesn't cover:

- **Restored tabs.** A background tab's timers are throttled to a minute or worse, so a tab coming back can be showing a badly stale string. A `visibilitychange` listener re-stamps on the way in instead of making the user wait out the next tick.
- **Late mounts.** The store's declared initial value is stamped at module load. The start function re-stamps on subscribe, so a list mounted much later — or remounted after the last subscriber left and stopped the interval — begins from now rather than page-load time.

Both the interval and the listener live in the store's start function, so they only run while a timestamp is actually on screen.

## Test

`vitest run` — 527 passed, including a new `src/lib/relTime.test.ts` covering the buckets under an injected `now`, the 30s tick, teardown on unsubscribe, and the visibility re-stamp. `svelte-check` — 0 errors.

Walked it through a headless Chrome against a stub `/api/sessions` (one session with a frozen `updated_at` 55s in the past, one 4h old), sampling the rendered sidebar text every 35s with no interaction at all:

```
13:15:01  ["1 分钟前", "4 小时前"]
13:15:36  ["2 分钟前", "4 小时前"]
13:16:11  ["2 分钟前", "4 小时前"]
13:16:46  ["3 分钟前", "4 小时前"]
13:17:21  ["3 分钟前", "4 小时前"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
