### PR TITLE
chore: bump version to 1.16.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.1"
+var Version = "1.16.2"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over v1.16.1 — 18 commits.

Highlights:
- Rich sub-agent / workflow-agent output panels (#2231–#2239): structured per-agent events, persisted agent-run trails, live and transcript-review rendering in the web UI.
- `ask_user_question` parity with Claude Code (#2237, #2242).
- Read-only Git Diff review panel in the sidebar (#2229, #2235, #2236).
- Light Apps topbar switcher, side-panel opening, project picker layout (#2226–#2230).
- Session-list timestamps keep ticking on their own (#2241); dead WS `session_list` path dropped (#2240); CodeQL path-injection guard on the mount trust-grant read (#2225).

version.go only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)