### PR TITLE
web: show mode label in artifacts panel empty-state topbar

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -376,6 +376,7 @@
     {#if !cur}
       <div class="topbar" class:native-lift={liftForTrafficLights}>
         {@render modeSwitcher()}
+        <span class="file-name">{$t('panel.mode_artifacts')}</span>
         <span style="flex:1"></span>
         {@render topbarControls()}
       </div>


### PR DESCRIPTION
## What

The session (artifacts) mode topbar showed only the mode-switcher icon when no artifact was selected, while Git Diff mode always names itself next to the icon. Add the mode label ("Artifacts" / 制品) beside the icon in the empty state so the panel identifies itself consistently.

## How

One line in `ArtifactsPanel.svelte`: reuse the existing `panel.mode_artifacts` i18n string and `file-name` style in the empty-state topbar, mirroring how diff mode renders its label.

## Verification

`npm run build` passes.