### PR TITLE
fix(web): close image lightbox when clicking the image

### DIFF
--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -3122,7 +3122,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
     <button class="lightbox-close" aria-label={$t('chat.image_close')} onclick={() => { lightboxSrc = null }}>
       <iconify-icon icon="ant-design:close-outlined" width="18"></iconify-icon>
     </button>
-    <img src={lightboxSrc} alt="" class="lightbox-image" onclick={(e) => e.stopPropagation()} />
+    <img src={lightboxSrc} alt="" class="lightbox-image" onclick={() => { lightboxSrc = null }} />
   </div>
 {/if}
 


### PR DESCRIPTION
## 问题

Web 端会话里，图片点击放大后，再点图片本身不会缩小——只能在空白处点击缩小。

## 根因

`web/src/views/ChatView.svelte` 的图片 lightbox：

- 遮罩层 `.lightbox-overlay` 的 `onclick` 负责关闭（`lightboxSrc = null`）
- 图片 `<img class="lightbox-image">` 写的是 `onclick={(e) => e.stopPropagation()}`
- 但图片的 `cursor` 样式却是 `zoom-out`，意图显然是"点图片 = 缩小关闭"

`stopPropagation()` 拦住了图片点击事件，永远到不了遮罩层的关闭 handler，所以点图片没反应；只有点图片以外的空白遮罩区域才会关闭。

## 改动

让图片点击直接关闭 lightbox，与 `zoom-out` 光标语义一致：

```svelte
<img src={lightboxSrc} alt="" class="lightbox-image" onclick={() => { lightboxSrc = null }} />
```

## 验证

- `npm run build` 通过（1.82s）
