### PR TITLE
fix(web): stop tool-arg click from toggling the tool card when selecting/copying

### DIFF
--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -462,7 +462,7 @@
                 <span class="tool-title mono">{tool.name}</span>
               {/if}
               {#if argText}
-                <span class="tool-arg mono" title={argText}>{argText}</span>
+                <span class="tool-arg mono" title={argText} onclick={(e) => e.stopPropagation()}>{argText}</span>
               {/if}
             </div>
             {#if meta && !fErr && !tErr}<div class="tool-submeta">{meta}</div>{/if}


### PR DESCRIPTION
## Summary

The tool card is a native `<details>/<summary>`, so the whole header bar is the click-to-toggle trigger. The args row (`.tool-arg`) is `user-select: text` so users can select and copy long tool args, but selecting them (drag-select or double-click) fires a `click` on the span that bubbles up to `<summary>` and toggles the card open/closed while copying.

## Change

Stop `click` propagation on the `.tool-arg` span so select/copy never toggles the card:

```svelte
<span class="tool-arg mono" title={argText} onclick={(e) => e.stopPropagation()}>{argText}</span>
```

Text selection/copy still works (selection only needs the `mousedown` to propagate; `stopPropagation()` on `click` doesn't break it), but the card no longer expands/collapses from that interaction. Clicks on the icon, title text, chevron, empty bar, and the promote button behave exactly as before.

## Verification

- `npm run build` passes
- vitest: 40 files / 574 tests green
