### PR TITLE
Align sidebar project directory font size with session titles

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -1186,7 +1186,10 @@
 }
 .grp-name {
   flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  font-size: 12px; font-weight: 600; color: var(--text-secondary); cursor: pointer;
+  /* Matches .session-title's size so a project directory and the sessions filed
+     under it read on the same scale — the 600 weight and secondary color alone
+     keep the directory as the row's heading. */
+  font-size: 13px; font-weight: 600; color: var(--text-secondary); cursor: pointer;
 }
 .grp-name.muted { font-weight: 600; color: var(--text-quaternary); cursor: default; }
 /* Group-header actions in two frequency tiers. The high-frequency pair


### PR DESCRIPTION
## Summary

The font size of project directory rows in the sidebar (`.grp-name`) was 12px while session titles (`.session-title`) are 13px. Since directories and their sessions sit side by side in the same list, the 1px discrepancy plus the differing weight made the two row types look inconsistent.

This bumps `.grp-name` from 12px to 13px so a directory and the sessions filed under it read on the same scale. The directory still reads as the row's heading via its 600 weight and secondary color.

## Changes

- `web/src/components/layout/Sidebar.svelte`: `.grp-name` `font-size` 12px → 13px

Note: `.grp-name` also styles the "Pinned" label, which follows the same bump.

## Verification

- `npm run build` in `web/` passes.