### PR TITLE
test(workflow): fix flaky anti-polling guard tests in startBlockedRun

### DIFF
--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -302,9 +302,14 @@ func TestWorkflowManager_RecordStatusRead(t *testing.T) {
 }
 
 // startBlockedRun starts a workflow whose single agent blocks until cancelled,
-// on an isolated manager, and waits for the launch progress line so
-// LastActivity is stable across subsequent status reads (a blocked agent emits
-// nothing further). Returns the ctx carrying the manager and the run id.
+// on an isolated manager, and waits for the run to become quiescent: the launch
+// progress line logged AND LastActivity not advancing for a short settle window.
+// A blocked agent emits nothing further, but the agent() call stamps a one-shot
+// agent_started structured event right after the launch line — returning on the
+// log line alone can hand the caller a LastActivity that is about to advance by
+// a few microseconds, which resets the anti-poll streak mid-loop and flakes
+// TestWorkflowStatus_AntiPollingGuard / _ListForm. Returns the ctx carrying the
+// manager and the run id.
 func startBlockedRun(t *testing.T, mgr *WorkflowManager) (context.Context, string) {
 	t.Helper()
 	SetSpawner(ctxBlockingSpawner{})
@@ -319,14 +324,18 @@ func startBlockedRun(t *testing.T, mgr *WorkflowManager) (context.Context, strin
 	if id == "" {
 		t.Fatalf("no run id in %q", res.Text)
 	}
+	// The settle window is the quiet period we demand after the last observed
+	// activity. It only needs to outlast the one-time agent_started stamp that
+	// follows the launch line, so a few tens of ms is plenty.
+	const quiesce = 50 * time.Millisecond
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
-		if snap, ok := mgr.Read(id); ok && len(snap.Logs) > 0 {
+		if snap, ok := mgr.Read(id); ok && len(snap.Logs) > 0 && time.Since(snap.LastActivity) > quiesce {
 			return ctx, id
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("workflow never logged its launch")
+	t.Fatal("workflow never reached quiescence")
 	return ctx, id
 }
 


### PR DESCRIPTION
## Summary

`TestWorkflowStatus_AntiPollingGuard` / `TestWorkflowStatus_AntiPollingGuard_ListForm` were flaky: read #3 intermittently failed to carry the STOP marker.

## Root cause

`startBlockedRun` returned as soon as the launch progress line was logged (`len(Logs) > 0`). But the `agent()` call stamps a one-shot `agent_started` structured event *right after* that line, bumping the run's `LastActivity` by a few microseconds. When that bump landed between status read #1 and read #2, `RecordStatusRead` (which resets the streak whenever it sees fresher activity) dropped the count back to 1, so read #3 reached only 2 — below the threshold of 3 — and no STOP marker appeared.

Reproduced at ~10–50% under `-race -count=50`: a spy showed `AgentEvents=0` at read #0 then `AgentEvents=1` (with an advanced `LastActivity`) at read #1 in the failing iterations.

## Fix

Make `startBlockedRun` wait for the run to be truly quiescent: log line present **and** `LastActivity` not advancing for a short settle window (50ms), which outlasts the one-time `agent_started` stamp.

Test-only change. The helper is used by exactly the two tests it fixes.

## Verification

- `go test -race -run TestWorkflowStatus_AntiPollingGuard -count=50 ./internal/tools/` — 50/50 pass (previously ~25/50 failed)
- `go test -race ./internal/tools/` — green
