### PR TITLE
web: add a dropdown caret to the panel mode switcher

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -277,6 +277,10 @@
       onclick={() => modeMenu = !modeMenu}
     >
       <iconify-icon icon={curModeIcon} width="14"></iconify-icon>
+      <!-- Always-on caret: without it the trigger reads as a static mode
+           indicator, and the dropdown is only discoverable by hovering for
+           the tooltip. -->
+      <iconify-icon class="caret" icon="ant-design:down-outlined" width="8"></iconify-icon>
       {#if badgeCount > 0 && curMode !== 'diff'}<span class="dot"></span>{/if}
     </button>
     {#if modeMenu}
@@ -509,9 +513,13 @@
 .icon-btn.on:hover:not(:disabled) { color: var(--text); }
 /* ── Panel mode switcher ─────────────────────────────────────────────── */
 .mode-wrap { position: relative; flex: 0 0 auto; display: flex; }
-.mode-trigger { position: relative; }
+/* Wider than a plain .icon-btn (which pins 28px square): the trigger carries
+   the mode icon plus a dropdown caret, so it sizes to its content. */
+.mode-trigger { position: relative; width: auto; flex: 0 0 auto; padding: 0 7px; gap: 3px; }
+.mode-trigger .caret { transition: transform 0.15s ease; }
+.mode-trigger.on .caret { transform: rotate(180deg); }
 /* Same "there is something here" dot the sidebar's unread marker uses, sized
-   for a 28px control rather than a list row. */
+   for a compact control rather than a list row. */
 .mode-trigger .dot {
   position: absolute; top: 4px; right: 4px; width: 6px; height: 6px;
   border-radius: 50%; background: var(--blue-6);


### PR DESCRIPTION
## Why

The panel's mode trigger was a bare icon button showing the current mode's icon. Until hover revealed the "切换面板" tooltip, nothing signalled that clicking it opens a menu to switch between 制品 and Git Diff — it read as a static mode indicator.

## What

- Add an always-visible `▾` caret beside the mode icon; it rotates 180° while the menu is open
- The trigger now sizes to its content instead of the fixed 28px icon-button square
- No change to the menu itself or to any other topbar control

## Verify

- `npm run build` + `npx vitest run` (575 tests) pass
- Headless walkthrough (Chrome for Testing, zh-CN, fresh `octo serve` on :8899): caret visible in artifacts and diff modes; click opens the menu with 制品 / Git Diff entries; caret rotates while open; switching to diff mode still works
- Screenshots checked: trigger reads `📄▾ MEMORY.md Markdown` (artifacts) and `🌿▾ Git Diff` (diff)

Independent of #2250 (mode label) — the two touch different parts of the file and merge cleanly either way.
