### PR TITLE
docs: document proxy setup via HTTPS_PROXY and serve.env

### DIFF
--- a/docs/src/content/docs/community/faq.md
+++ b/docs/src/content/docs/community/faq.md
@@ -42,6 +42,13 @@ Non-loopback binds require the access key on every request. Startup prints a rea
 the key embedded; see [Self-host octo serve](/docs/guides/self-host/) and the
 [security model](/docs/reference/security/).
 
+### I can't reach OpenAI / Anthropic
+
+If your network needs a proxy to reach these endpoints, set `HTTPS_PROXY` for octo: export it in
+your shell for terminal launches; for the desktop app and `octo serve`, put it in
+`~/.octo/serve.env` (GUI processes don't inherit the shell environment). See
+[Choose a provider · Reaching endpoints through a proxy](/docs/getting-started/choose-a-provider/#reaching-endpoints-through-a-proxy).
+
 ### Where do I report a bug or request a feature?
 
 [Open an issue](https://github.com/open-octo/octo-agent/issues) on GitHub. For a security

--- a/docs/src/content/docs/getting-started/choose-a-provider.mdx
+++ b/docs/src/content/docs/getting-started/choose-a-provider.mdx
@@ -60,6 +60,25 @@ octo config path   # print the file location
 but the env var is recommended.
 </Aside>
 
+## Reaching endpoints through a proxy
+
+If reaching OpenAI, Anthropic, or other endpoints requires a proxy, octo honors Go's standard proxy environment variables — `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` (both `http://` and `socks5://` addresses work, either case):
+
+```bash
+HTTPS_PROXY=http://127.0.0.1:7890 octo --provider openai "..."
+```
+
+A shell export is enough when you launch from a terminal. But **the desktop app and a background `octo serve` don't inherit your shell environment** — an export in `~/.zshrc` never reaches them. The uniform fix is `~/.octo/serve.env`, which every launch mode (CLI, desktop, `octo serve`) loads at startup:
+
+```bash
+cat >> ~/.octo/serve.env << 'EOF'
+HTTPS_PROXY=http://127.0.0.1:7890
+EOF
+chmod 600 ~/.octo/serve.env
+```
+
+Restart the app after editing. The proxy applies to all of the process's outbound traffic (model APIs, search, update checks); to route only some domains through it, use your proxy software's rules (Clash & co.) or exclude hosts with `NO_PROXY=api.moonshot.cn` — octo has no per-provider proxy setting.
+
 ## Extended reasoning
 
 Reasoning models can deliberate before answering. Two knobs control it, both available as CLI flags

--- a/docs/src/content/docs/guides/self-host.md
+++ b/docs/src/content/docs/guides/self-host.md
@@ -43,6 +43,9 @@ This is the same file the systemd/launchd packaging templates already point at v
 `EnvironmentFile=%h/.octo/serve.env` (`packaging/systemd/octo.service`). Now `octo serve`,
 the desktop app, and the TUI all resolve the same file — pick once, work everywhere.
 
+Proxy variables (`HTTPS_PROXY` and friends) go in this same file — see
+[Choose a provider · Reaching endpoints through a proxy](/docs/getting-started/choose-a-provider/#reaching-endpoints-through-a-proxy).
+
 ## Access control
 
 `127.0.0.1` is loopback and trusted implicitly — no key needed, and that's the default bind. The

--- a/docs/src/content/docs/zh/community/faq.md
+++ b/docs/src/content/docs/zh/community/faq.md
@@ -40,6 +40,12 @@ fail closed（拒绝运行），而不是假装限制了什么。那边靠交互
 非回环绑定要求每个请求都带访问密钥。启动时会打印一个带 key 的、可以直接打开的 URL；见
 [自托管 octo serve](/docs/zh/guides/self-host/)和[安全模型](/docs/zh/reference/security/)。
 
+### 连不上 OpenAI / Anthropic 怎么办？
+
+如果你的网络访问这些端点需要代理，给 octo 设 `HTTPS_PROXY`：终端启动时直接在 shell 里
+export；桌面版和 `octo serve` 要写进 `~/.octo/serve.env`（GUI 进程不继承 shell 环境）。
+详见[选择 Provider · 通过代理访问](/docs/zh/getting-started/choose-a-provider/#通过代理访问)。
+
 ### 在哪里报 bug 或者提功能需求？
 
 去 GitHub [提交 issue](https://github.com/open-octo/octo-agent/issues)。如果是安全漏洞，

--- a/docs/src/content/docs/zh/getting-started/choose-a-provider.mdx
+++ b/docs/src/content/docs/zh/getting-started/choose-a-provider.mdx
@@ -58,6 +58,25 @@ octo config path   # 打印配置文件路径
 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` 读取；向导可以把 key 存进文件（权限 `0600`），但更推荐用环境变量。
 </Aside>
 
+## 通过代理访问
+
+访问 OpenAI、Anthropic 等境外端点需要代理时，octo 沿用 Go 的标准代理环境变量——`HTTPS_PROXY`、`HTTP_PROXY`、`NO_PROXY`（支持 `http://` 和 `socks5://` 地址，大小写写法都认）：
+
+```bash
+HTTPS_PROXY=http://127.0.0.1:7890 octo --provider openai "..."
+```
+
+从终端启动时在 shell 里 export 就够了。但**桌面应用和后台运行的 `octo serve` 不会继承 shell 环境**——在 `~/.zshrc` 里 export 对它们无效。统一的办法是写进 `~/.octo/serve.env`，所有启动方式（CLI、桌面版、`octo serve`）都会在启动时加载它：
+
+```bash
+cat >> ~/.octo/serve.env << 'EOF'
+HTTPS_PROXY=http://127.0.0.1:7890
+EOF
+chmod 600 ~/.octo/serve.env
+```
+
+改完重启应用生效。代理对进程的所有出网流量生效（模型 API、搜索、更新检查等）；如果只想让部分域名走代理，请在代理软件（Clash 等）的分流规则里配置，或用 `NO_PROXY=api.moonshot.cn` 逐个排除——octo 不提供按 provider 分开的代理设置。
+
 ## 扩展推理
 
 推理模型可以在回答前先思考。两个开关控制这个行为，同时支持 CLI flag 和 `octo config` 默认值：

--- a/docs/src/content/docs/zh/guides/self-host.md
+++ b/docs/src/content/docs/zh/guides/self-host.md
@@ -35,6 +35,8 @@ octo 在启动时（早于任何工具或 channel 读取环境）加载它：
 
 这也是 systemd/launchd 打包模板里已经通过 `EnvironmentFile=%h/.octo/serve.env`（`packaging/systemd/octo.service`）指向的同一个文件。现在 `octo serve`、桌面版、TUI 都能解析同一份文件 ——配一次，到处生效。
 
+代理环境变量（`HTTPS_PROXY` 等）也走这同一个文件——用法见[选择 Provider · 通过代理访问](/docs/zh/getting-started/choose-a-provider/#通过代理访问)。
+
 ## 访问控制
 
 `127.0.0.1` 是回环地址，默认就被信任——不需要 key，这也是默认的绑定方式。一旦绑定得更宽


### PR DESCRIPTION
## Summary

octo already honors Go's standard proxy env vars (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY`, via `http.DefaultTransport`'s `ProxyFromEnvironment`) on every outbound request, and `internal/serveenv` already loads `~/.octo/serve.env` for GUI/headless launches. The mechanism is complete — what's missing is discoverability: `serve.env` was only documented in the self-hosting guide, which desktop users (the audience that most often needs a proxy) never read.

This is a docs-only change, documenting the existing mechanism where the connectivity question actually arises:

- **choose-a-provider** (zh + en): new "Reaching endpoints through a proxy" section — the env vars (`http://` and `socks5://` supported), why GUI-launched apps don't inherit shell exports, the `serve.env` fallback, and the restart requirement
- **self-host** (zh + en): cross-reference from the `serve.env` section
- **faq** (zh + en): "I can't reach OpenAI / Anthropic" entry

## Deliberately out of scope

Per-provider proxy config (a `proxy` field on `config.Endpoint`, a UI input) was considered and rejected: traffic splitting is the proxy software's job (Clash rules, `NO_PROXY`), not the agent's. The docs say this explicitly to head off repeat requests.

## Verification

`npm run build` in `docs/` passes (79 pages); anchor slugs (`#reaching-endpoints-through-a-proxy`, `#通过代理访问`) and all four cross-references verified in the built HTML.
