### PR TITLE
fix(web): hide artifacts panel topbar text on small screens

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -503,6 +503,15 @@
    unshrinkable and muted so the artifact name beside it stays primary. */
 .file-name.mode-label { flex: 0 0 auto; color: var(--text-tertiary); }
 .file-meta { font-size: 11px; color: var(--text-tertiary); flex: 0 0 auto; }
+/* Small screens (a phone browser gets the desktop layout squeezed into a few
+   hundred px): the topbar's text — mode label, file/repo name, type badge,
+   branch, file count — crowds the icon controls past each other. The mode
+   switcher's icon still names the mode and tooltips carry the rest, so the
+   text is what gives. Same breakpoint as ChatView's narrow-screen rules. */
+@media (max-width: 620px) {
+  .topbar .file-name,
+  .topbar .file-meta { display: none; }
+}
 .mono { font-family: var(--font-mono); }
 .icon-btn {
   width: 28px; height: 28px; flex: 0 0 28px; border: none; background: transparent;


### PR DESCRIPTION
## Problem

On a phone browser the desktop layout is squeezed into a few hundred px (`width=device-width` is set, and `mobileShell` only covers the Capacitor app). The artifacts panel topbar's text — the 制品/Git Diff mode label, file/repo name, type badge, branch, file count — crowds the icon controls until they overlap.

## Change

Below 620px, `.topbar .file-name` and `.topbar .file-meta` are hidden:

- The mode switcher's icon still names the current mode (制品 vs Diff), and the dropdown keeps the full labels.
- The 预览/代码 segmented control, refresh, expand and close buttons are untouched.
- Desktop (>620px) is unchanged.

The 620px breakpoint matches ChatView's existing narrow-screen rules. This intentionally relaxes the "mode label shows in every state" rule from #2250 for small screens only, where the switcher icon takes over that job.

## Verification

- `npm run build` ✓
- `npm test` — 575 passed ✓
- Not yet eyeballed on a real phone; worth a quick look after merge.
