### PR TITLE
web: put project settings first in the project menu

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -792,17 +792,20 @@
           </span>
           {#if projectMenuFor === g.id}
           <div class="row-menu" use:rowMenuPortal={rowMenuPos.anchorTop} style="top:{rowMenuPos.top}px;right:{rowMenuPos.right}px" onclick={(e) => e.stopPropagation()}>
+            <!-- Settings leads, on its own above the rule: it is what this menu
+                 is opened for most, and it used to sit behind an entry that only
+                 exists on desktop. -->
+            <div class="row-menu-item" onclick={(e) => { e.stopPropagation(); projectMenuFor = ''; settingsGroup = g }}>
+              <iconify-icon icon="ant-design:setting-outlined" width="13"></iconify-icon>
+              <span>{$t('sidebar.project_settings')}</span>
+            </div>
+            <div class="row-menu-sep"></div>
             {#if $nativeShell && g.working_dir}
             <div class="row-menu-item" onclick={(e) => { e.stopPropagation(); projectMenuFor = ''; openFolder({ groupId: g.id }) }}>
               <iconify-icon icon="ant-design:folder-open-outlined" width="13"></iconify-icon>
               <span>{$t('sidebar.open_folder')}</span>
             </div>
-            <div class="row-menu-sep"></div>
             {/if}
-            <div class="row-menu-item" onclick={(e) => { e.stopPropagation(); projectMenuFor = ''; settingsGroup = g }}>
-              <iconify-icon icon="ant-design:setting-outlined" width="13"></iconify-icon>
-              <span>{$t('sidebar.project_settings')}</span>
-            </div>
             <div class="row-menu-item" onclick={(e) => { e.stopPropagation(); projectMenuFor = ''; editGroupId.set(g.id); editGroupDraft.set(g.name) }}>
               <iconify-icon icon="ant-design:edit-outlined" width="13"></iconify-icon>
               <span>{$t('sidebar.rename_group')}</span>


### PR DESCRIPTION
## What

In the sidebar's project row menu, **项目设置 / Project settings** now leads the list, followed by a separator, then everything else.

Before: `打开文件夹` (desktop-only) → separator → `项目设置` → `重命名项目` → 上移/下移 → separator → `删除项目`.

After: `项目设置` → separator → `打开文件夹` (desktop-only) → `重命名项目` → 上移/下移 → separator → `删除项目`.

## Why

Settings is what this menu gets opened for most often, yet it sat second — behind an entry that only renders in the desktop shell. In the browser the menu therefore opened with settings buried in an undivided list.

The new separator is unconditional, so the first item under the cursor is the same on web and desktop.

## Verification

`npx svelte-check` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)