### PR TITLE
web: name the default model in the new-chat model chip

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -617,10 +617,15 @@
   // Session meta chips — pull live values from per-session stores, fall back
   // to the session record, then to sensible defaults.
   // No session yet → show the pending pick (composite "<endpoint>::<model>"
-  // id; display just the model half) that ensureActiveSession will apply.
+  // id; display just the model half) that ensureActiveSession will apply, or,
+  // absent a pick, the configured default — which is the model the session
+  // ensureActiveSession creates will actually run on, so the blank new-chat
+  // view names it instead of showing a dash.
+  let defaultModelName = $state('')
   let modelName = $derived(
     $chatModel[sid] || currentSession?.model || currentSession?.model_id
-    || ($pendingModel ? $pendingModel.split('::').pop() : '') || '—',
+    || ($pendingModel ? $pendingModel.split('::').pop() : '')
+    || defaultModelName || '—',
   )
   // A pending pick belongs to the blank new-chat view only. Once a session is
   // active (auto-created — which consumed it — or picked/created any other
@@ -819,6 +824,9 @@
       // carry a bare model name, which no menu row's composite id can ever
       // equal. Treat that as identity-unknown so name matching still applies.
       defaultModelId = ep.default?.includes('::') ? ep.default : ''
+      // Display name, unlike defaultModelId: a bare-model default is unusable
+      // as an identity but still names the model the chip should show.
+      defaultModelName = ep.default?.split('::').pop() ?? ''
     } catch { /* keep the previous list */ }
   }
 


### PR DESCRIPTION
## What

On the landing page (new chat, no session yet) the model chip showed `—`. It now shows the configured default model's name.

Before / after (same config, `default = kimi-coding-plan::k3-256k`):

| | chip |
|---|---|
| before | `—` |
| after | `k3-256k` |

## Why

With no session and no pending pick, every link in the chip's fallback chain resolved empty, so it fell through to the dash. But a new chat is not model-less: the session the first message creates runs on the configured default entry — which `refreshModels()` already fetches for menu highlighting. The chip now names it.

`defaultModelName` is kept separate from the existing `defaultModelId`: a bare-model default (possible in a hand-written config) is unusable as an identity for row matching, but still names a model worth displaying.

## Verification

- `npx svelte-check` — 0 errors.
- Landing page rendered against a local `octo serve` (vite dev + headless Chrome, `?shell=octo-desktop#new`): chip reads `k3-256k`, matching `GET /api/config/endpoints` → `default: "kimi-coding-plan::k3-256k"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)