### PR TITLE
web: keep the sidebar row menu on screen, and share dirLeaf

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -5,7 +5,7 @@
     running, activeSessionId, chatStreaming, sessions, sessionGroups,
     chatContextUsage, chatWorkingDir, chatPermMode, chatReasoningEffort, chatShowReasoning, showToast, chatGoal, chatModel,
     globalPermissionMode, nativeShell, localAccess, activeAgent, pendingModel, view, settingsModalOpen,
-    pendingAgent, pendingWorkingDir, pendingGroupId, normalizeDir, projectsClaimingDir,
+    pendingAgent, pendingWorkingDir, pendingGroupId, normalizeDir, dirLeaf, projectsClaimingDir,
   } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
@@ -1039,14 +1039,6 @@
   function dirTail(p: string): string {
     const cut = p.lastIndexOf('/')
     return cut < 0 ? p : p.slice(cut)
-  }
-
-  // Last path segment, for naming a folder on an attach shortcut. Unlike
-  // dirTail this drops the separator and tolerates a trailing one — the chip
-  // is a name, and the full path rides along as its tooltip.
-  function dirLeaf(p: string): string {
-    const norm = p.replace(/\\/g, '/').replace(/\/+$/, '')
-    return norm.slice(norm.lastIndexOf('/') + 1) || norm
   }
 
   // queued=true parks the message as its own follow-up turn instead of steering

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte'
   import { get } from 'svelte/store'
-  import { view, sidebar, sessions, sessionGroups, pinnedSessions, collapsedSessions, editGroupId, editGroupDraft, activeSessionId, selMode, sel, menuFor, editId, editDraft, showToast, mcpServers, createNewSession, createSessionInGroup, clearPendingSessionOpts, settingsModalOpen, cmdkOpen, nativeShell } from '../../lib/stores'
+  import { view, sidebar, sessions, sessionGroups, pinnedSessions, collapsedSessions, editGroupId, editGroupDraft, activeSessionId, selMode, sel, menuFor, editId, editDraft, showToast, mcpServers, createNewSession, createSessionInGroup, clearPendingSessionOpts, settingsModalOpen, cmdkOpen, nativeShell, dirLeaf } from '../../lib/stores'
   import * as api from '../../lib/api'
   import { t, tr } from '../../lib/i18n'
   import { confirmDialog } from '../../lib/confirm'
@@ -248,14 +248,6 @@
     } catch (e: any) {
       showToast(e?.message || tr('sidebar.open_folder_failed'), 'error')
     }
-  }
-
-  // Last path segment, for naming a mounted folder in the menu. The full path
-  // is the row's title attribute, which is where two same-named folders from
-  // different parents get told apart.
-  function dirLabel(path: string): string {
-    const norm = path.replace(/\\/g, '/').replace(/\/+$/, '')
-    return norm.slice(norm.lastIndexOf('/') + 1) || norm
   }
 
   $effect(() => {
@@ -799,7 +791,7 @@
             <iconify-icon icon="ant-design:plus-outlined" width="13"></iconify-icon>
           </span>
           {#if projectMenuFor === g.id}
-          <div class="row-menu" use:rowMenuPortal={rowMenuPos.anchorTop} style="top:{rowMenuPos.top}px;right:{rowMenuPos.right}px" onclick={(e) => e.stopPropagation()}>
+          <div class="row-menu" use:rowMenuPortal={rowMenuPos.anchorTop} style="top:{rowMenuPos.top}px;right:{rowMenuPos.right}px;--menu-right:{rowMenuPos.right}px" onclick={(e) => e.stopPropagation()}>
             <!-- Settings leads, on its own above the rule: it is what this menu
                  is opened for most, and it used to sit behind an entry that only
                  exists on desktop. -->
@@ -823,7 +815,7 @@
             {#each g.source_dirs ?? [] as sd (sd)}
             <div class="row-menu-item sub" title={sd} onclick={(e) => { e.stopPropagation(); projectMenuFor = ''; openFolder({ groupId: g.id, sourceDir: sd }) }}>
               <iconify-icon icon="ant-design:folder-outlined" width="13"></iconify-icon>
-              <span class="menu-text">{dirLabel(sd)}</span>
+              <span class="menu-text">{dirLeaf(sd)}</span>
             </div>
             {/each}
             <!-- The label opens the group; this closes it. Without it the last
@@ -964,7 +956,7 @@
               <iconify-icon icon={pinned ? 'ant-design:pushpin-filled' : 'ant-design:pushpin-outlined'} width="13"></iconify-icon>
             </span>
             {#if menuOpen}
-            <div class="row-menu" use:rowMenuPortal={rowMenuPos.anchorTop} style="top:{rowMenuPos.top}px;right:{rowMenuPos.right}px" onclick={(e) => e.stopPropagation()}>
+            <div class="row-menu" use:rowMenuPortal={rowMenuPos.anchorTop} style="top:{rowMenuPos.top}px;right:{rowMenuPos.right}px;--menu-right:{rowMenuPos.right}px" onclick={(e) => e.stopPropagation()}>
               {#if !pinned}
               <!-- First entry: acting on many sessions starts from one of them,
                    which is also why this one is pre-selected. Not offered on a
@@ -1249,7 +1241,16 @@
 .nav-row.menu-open .on-rest { display: none; }
 .row-menu {
   position: fixed; z-index: 30;
-  min-width: 132px; padding: 4px;
+  /* The menu is anchored by its RIGHT edge just inside the sidebar, so anything
+     that widens it grows LEFTWARD — off the screen, taking every row's icon and
+     first characters with it. A mounted folder's name is caller data and can be
+     arbitrarily long, so the width needs a ceiling. --menu-right is the very
+     offset the inline style positions by, which makes the second term exactly
+     the room that exists to the left of the anchor; rowMenuPortal already does
+     the vertical counterpart of this clamp. The ceiling is also what lets
+     .menu-text below ellipsize at all — a flex item only shrinks once its
+     container is bounded. */
+  min-width: 132px; max-width: min(280px, calc(100vw - var(--menu-right, 8px) - 8px)); padding: 4px;
   background: var(--bg-container); border: 1px solid var(--border-secondary);
   border-radius: 8px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);
 }
@@ -1267,8 +1268,8 @@
   user-select: none;
 }
 .row-menu-item.sub { padding-left: 18px; }
-/* A deep mount can out-measure the menu; the title attribute carries the full
-   path, so the row itself may ellipsize rather than widen the menu. */
+/* Trims a long folder name to the menu's ceiling (set on .row-menu). The full
+   path is on the row's title attribute, so nothing is lost by cutting here. */
 .menu-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* Sits where the footer does, so entering batch mode does not shift the list
    above it — the rows must stay under the cursor that is selecting them. */

--- a/web/src/lib/dirLeaf.test.ts
+++ b/web/src/lib/dirLeaf.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { dirLeaf } from './stores'
+
+// dirLeaf names a directory where a full path will not fit. It replaced three
+// near-identical private copies (two of which were added a commit apart), so
+// the edge cases they each had to get right independently are pinned here.
+describe('dirLeaf', () => {
+  it('takes the last segment', () => {
+    expect(dirLeaf('/Users/roy/Projects/klook-ceg')).toBe('klook-ceg')
+  })
+
+  it('ignores a trailing separator', () => {
+    // The registry stores what the picker returned, and both the OS dialog and
+    // a hand-typed path can carry one.
+    expect(dirLeaf('/Users/roy/Projects/klook-ceg/')).toBe('klook-ceg')
+    expect(dirLeaf('/Users/roy/Projects/klook-ceg///')).toBe('klook-ceg')
+  })
+
+  it('handles Windows separators', () => {
+    expect(dirLeaf('C:\\Users\\roy\\klook-ceg')).toBe('klook-ceg')
+    expect(dirLeaf('C:\\Users\\roy\\klook-ceg\\')).toBe('klook-ceg')
+  })
+
+  it('passes a bare name through', () => {
+    expect(dirLeaf('klook-ceg')).toBe('klook-ceg')
+  })
+
+  it('never returns empty for a root or an empty input', () => {
+    // An empty label would render a nameless, unclickable-looking row; falling
+    // back to the input keeps something on screen.
+    expect(dirLeaf('/')).toBe('/')
+    expect(dirLeaf('')).toBe('')
+  })
+})

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -359,6 +359,18 @@ export function normalizeDir(p: string): string {
   return p.replace(/[\\/]+$/, '')
 }
 
+// Last path segment — the name to show when a directory has to fit somewhere a
+// full path would not (a menu row, a chip). Always pair it with the full path
+// as a title: two mounts can share a leaf name and differ only in their parent.
+// Tolerates a trailing separator and Windows separators; a bare name passes
+// through. The last fallback is the filesystem root, which normalises to the
+// empty string and would otherwise render a nameless row — mounting "/" is
+// unusual but nothing rejects it.
+export function dirLeaf(p: string): string {
+  const norm = normalizeDir(p.replace(/\\/g, '/'))
+  return norm.slice(norm.lastIndexOf('/') + 1) || norm || p
+}
+
 // Resolve a working directory picked on the landing page to the project that
 // owns it, creating that project if none exists yet. Returns the group id to
 // file the new session under. Matching is by directory, not by name: two


### PR DESCRIPTION
Two follow-ups to #2257 / #2258, found while reviewing them.

## 1. The row menu could be pushed off the left of the window

`.row-menu` is positioned by its **right** edge just inside the sidebar, so anything that widens it grows *leftward*. #2257 put caller data in that menu — a mounted folder's name — and a long one walks it off the screen.

Measured, 1280px viewport, a 53-character folder name:

| | width | left edge |
|---|---|---|
| before | 371px | **-133** |
| after | 230px | 8 |

At -133 the icon and first characters of **every** row are cut off, "Delete project" included — not just the folder row.

The `.menu-text` ellipsis added alongside could not save it: an `overflow: hidden` flex item only shrinks once its container is bounded, and `.row-menu` had a `min-width` and no `max-width`. So the rule was dead code, and its comment claimed a behaviour that never happened — worse than no comment. Both fixed.

The ceiling is `min(280px, calc(100vw - var(--menu-right) - 8px))`. The second term reads `--menu-right`, set from the very same `rowMenuPos.right` the inline style positions by, so the clamp cannot drift from the anchor as the sidebar resizes. `rowMenuPortal` already does the vertical counterpart of this.

The attach picker from #2258 needed nothing: `.shortcut { max-width: 100% }` already supplied the bound, which is why its chips ellipsized correctly from the start (re-verified with a 95-character name — clipped, no spill).

## 2. `dirLeaf` existed twice, identically

Written in `Sidebar.svelte` (#2257) and again in `Composer.svelte` (#2258), one commit apart, byte for byte. It moves to `lib/stores.ts` beside `normalizeDir`.

Its new test caught a bug **both** copies shared: the filesystem root normalises to the empty string, so a project mounting `/` rendered a nameless row. Nothing rejects that mount, so `dirLeaf` now falls back to the original input.

`artifacts.ts` keeps its own `basename` — it deliberately does not trim a trailing separator, and folding it in would give it behaviour it does not want.

## Verification

Re-ran the #2257/#2258 walkthrough against a stub API in headless Chrome with a pathological folder name, measuring geometry rather than eyeballing it — numbers above. `svelte-check` 0 errors; `vitest` 580 passed (41 files, +5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
