### PR TITLE
chore: bump version to 1.16.3

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.2"
+var Version = "1.16.3"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release. Everything since v1.16.2 is web-side.

**Projects: reach the folders a project actually works on**

- #2256 — remove the project output-folder marker. It was a UI switch backed by one sentence of prompt, and it lost to the env context's own "the workspace is for anything not asked to land elsewhere" line, so it only ever bit once the user had already named the destination. Sessions frozen with the old instruction re-compose on their next turn and drop it. `output_dir` in an existing registry falls away unread on its next write; no migration.
- #2257 — the sidebar's "Open folder" now lists every place a project has: its workspace plus each mounted folder. Previously it could only reach the (usually empty) workspace.
- #2258 — the composer's attach picker gets the same jumps, and the desktop OS dialog stops overriding the panel's memory of where you last were.
- #2259 — follow-ups found reviewing the above: the row menu could be pushed off the left edge of the window by a long folder name, and `dirLeaf` had been written twice.

**Also in**

- #2255 — the new-chat model chip names the default model.
- #2254 — project settings leads the project menu.
- #2253 — the artifacts panel topbar hides its text on small screens.
- #2252 — docs: proxy setup via `HTTPS_PROXY` and `serve.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
