### PR TITLE
web: grey out the export button with no session

### DIFF
--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -2505,7 +2505,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
         <iconify-icon icon="ant-design:compress-outlined" width="13"></iconify-icon>
         <span class="btn-label">{$t('chat.compact')}</span>
       </button>
-      <button class="hdr-btn" title={$t('chat.export')} onclick={enterExportMode}>
+      <button class="hdr-btn" title={$t('chat.export')} disabled={!id} onclick={enterExportMode}>
         <iconify-icon icon="ant-design:export-outlined" width="13"></iconify-icon>
         <span class="btn-label">{$t('chat.export')}</span>
       </button>


### PR DESCRIPTION
On the landing page ("新建会话") there is no active session, so `enterExportMode` returned early — the export button looked live but clicking it did nothing. The compact button next to it was already gated on `!id`; the export button now matches.

Export stays enabled while streaming (unlike compact, which is disabled mid-turn) since it does not touch the running turn.

One line in `web/src/views/ChatView.svelte`. `svelte-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)