### PR TITLE
web: give every titlebar row the native titlebar gestures

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { artifacts, panelContent, panelExpanded, artifactSel, artifactView, lightappSel, lightapps, lightappHTML, showToast, nativeShell, activeSessionId, savePanelMode, type PanelMode } from '../lib/stores'
+  import { titlebarDblClick } from '../lib/nativeWindow'
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact, imagePreviewError } from '../lib/artifact-actions'
   import { hydrateArtifact, lightAppSource, pathIsInside } from '../lib/artifacts'
@@ -317,7 +318,11 @@
   {/if}
   {#if $panelContent === 'lightapps'}
     <!-- ── Light Apps mode ───────────────────────────────────────────────── -->
-    <div class="topbar" class:native-lift={liftForTrafficLights}>
+    <!-- Every mode's topbar takes the double-click-to-zoom the other two columns
+         have. Unlike theirs it is not a window drag region — the controls packed
+         into it leave too little blank width to grab — but it is still the top
+         edge of the window, and that is where the gesture is expected. -->
+    <div class="topbar" class:native-lift={liftForTrafficLights} ondblclick={titlebarDblClick}>
       <div class="la-chips">
         <span class="footer-lbl">{$t('artifacts.light_apps')}</span>
         {#each $lightapps as a}
@@ -347,7 +352,7 @@
 
   {:else if $panelContent === 'diff'}
     <!-- ── Git Diff mode ──────────────────────────────────────────────────── -->
-    <div class="topbar" class:native-lift={liftForTrafficLights}>
+    <div class="topbar" class:native-lift={liftForTrafficLights} ondblclick={titlebarDblClick}>
       {@render modeSwitcher()}
       {#if diffSoleRepo}
         <span class="file-name mono">{diffSoleRepo.name}</span>
@@ -378,7 +383,7 @@
   {:else if $panelContent === 'session'}
     <!-- ── Session mode (existing behavior) ────────────────────────────────── -->
     {#if !cur}
-      <div class="topbar" class:native-lift={liftForTrafficLights}>
+      <div class="topbar" class:native-lift={liftForTrafficLights} ondblclick={titlebarDblClick}>
         {@render modeSwitcher()}
         <span class="file-name mode-label">{$t('panel.mode_artifacts')}</span>
         <span style="flex:1"></span>
@@ -389,7 +394,7 @@
         <span>{$t('artifacts.empty')}</span>
       </div>
     {:else}
-      <div class="topbar" class:native-lift={liftForTrafficLights}>
+      <div class="topbar" class:native-lift={liftForTrafficLights} ondblclick={titlebarDblClick}>
         {@render modeSwitcher()}
         <span class="file-name mode-label">{$t('panel.mode_artifacts')}</span>
         <span class="file-name mono">{cur.name}</span>

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -318,10 +318,9 @@
   {/if}
   {#if $panelContent === 'lightapps'}
     <!-- ── Light Apps mode ───────────────────────────────────────────────── -->
-    <!-- Every mode's topbar takes the double-click-to-zoom the other two columns
-         have. Unlike theirs it is not a window drag region — the controls packed
-         into it leave too little blank width to grab — but it is still the top
-         edge of the window, and that is where the gesture is expected. -->
+    <!-- Every mode's topbar is the window's top edge like the other two columns'
+         rows, so it drags the window (see .topbar's --wails-draggable) and takes
+         the double-click that zooms it. -->
     <div class="topbar" class:native-lift={liftForTrafficLights} ondblclick={titlebarDblClick}>
       <div class="la-chips">
         <span class="footer-lbl">{$t('artifacts.light_apps')}</span>
@@ -499,7 +498,15 @@
 .topbar {
   flex: 0 0 auto; min-height: 44px; padding: 0 8px 0 10px;
   display: flex; align-items: center; gap: 8px;
+  --wails-draggable: drag;
 }
+/* Every control in here opts back out, leaving the labels and the flex spacer
+   to drag the window. Matched by element rather than by class the way Header
+   and Sidebar do it: the controls are spread across four mode branches and two
+   snippets, and a class this rule missed would become a button that drags the
+   window instead of clicking. That includes the mode menu's full-bleed
+   backdrop, which is a button too. */
+.topbar button { --wails-draggable: no-drag; }
 /* The same axis lift Header and Sidebar apply on mac — see Header.native-lift
    for why the height has to be pinned for the padding to move anything. */
 .topbar.native-lift { box-sizing: border-box; max-height: 44px; padding-bottom: 8px; }

--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -4,7 +4,8 @@
   import { diffBadge } from '../../lib/diff'
   import { t } from '../../lib/i18n'
   import { ws, wsState } from '../../lib/ws'
-  import { nativeToggleMaximise, nativeMinimise, nativeClose, nativeWindowState } from '../../lib/api'
+  import { nativeMinimise, nativeClose } from '../../lib/api'
+  import { isMaximised, flipMaximise, refreshMaximised, titlebarDblClick } from '../../lib/nativeWindow'
 
   // The main column's own top row. There is no window-spanning title bar: each
   // of the three columns (Sidebar, this, ArtifactsPanel) starts at the very top
@@ -41,41 +42,12 @@
   // 4px apart.
   const liftForTrafficLights = $derived($nativeShell && isMac)
 
-  // Desktop only: double-clicking the draggable header zooms the window, the way
-  // a native title bar does. Wails' custom drag region doesn't wire this up, and
-  // the octo-served page can't call Wails directly, so it goes through the native
-  // bridge over HTTP. Ignore double-clicks that land on a control.
-  function onHeaderDblClick(e: MouseEvent) {
-    if (!$nativeShell) return
-    if ((e.target as HTMLElement).closest('button, a, input, select, textarea')) return
-    flipMaximise()
-  }
-
-  // Track maximise state so the icon flips between □ (maximise) and ❐ (restore).
-  // The frontend owns this state — there's no native title bar reading it. We
-  // sync from the OS on mount, on window focus (catches Aero Snap / keyboard
-  // maximize / taskbar restore the frontend can't otherwise observe), and after
-  // every toggle so the icon always reflects reality. A sequence counter
-  // prevents a stale focus response from overwriting a fresh toggle result.
-  let isMaximised = $state(false)
-  let stateSeq = 0
-  async function refreshMaximised() {
-    const seq = ++stateSeq
-    const m = await nativeWindowState()
-    if (seq === stateSeq) isMaximised = m
-  }
-  async function flipMaximise() {
-    const next = !isMaximised
-    try {
-      await nativeToggleMaximise()
-      isMaximised = next
-      ++stateSeq // stale focus refreshes that started before the toggle must not overwrite this
-    } catch {
-      // Toggle failed — fetch the real OS state to stay in sync rather than
-      // gambling that the old isMaximised is still accurate.
-      await refreshMaximised()
-    }
-  }
+  // The □/❐ icon reflects maximise state the frontend owns — there's no native
+  // title bar reading it. This row holds the only copy of that icon, so it is
+  // also where the OS gets polled for it: on mount and on window focus (which
+  // catches Aero Snap / keyboard maximize / taskbar restore the frontend can't
+  // otherwise observe). The toggle itself lives in lib/nativeWindow because the
+  // sidebar's titlebar flips it too.
 
   onMount(() => {
     if (!$nativeShell) return // web mode has no native bridge — skip entirely
@@ -86,7 +58,7 @@
   })
 </script>
 
-<header class:native-inset={insetForTrafficLights} class:native-lift={liftForTrafficLights} style="--wails-draggable:drag" ondblclick={onHeaderDblClick}>
+<header class:native-inset={insetForTrafficLights} class:native-lift={liftForTrafficLights} style="--wails-draggable:drag" ondblclick={titlebarDblClick}>
   {#if $sidebar === 'hidden'}
     <button class="icon-btn" title={$t('header.toggle_left')} aria-pressed={false} onclick={toggleSidebar}>
       <iconify-icon icon="lucide:panel-left" width="16"></iconify-icon>
@@ -123,8 +95,8 @@
   {#if $nativeShell && !isMac}
     <div class="window-controls">
       <button class="window-btn minimise" aria-label="Minimise" title="Minimise" onclick={() => nativeMinimise()}>−</button>
-      <button class="window-btn maximise" aria-label={isMaximised ? 'Restore' : 'Maximise'} title={isMaximised ? 'Restore' : 'Maximise'} onclick={flipMaximise}>
-        {isMaximised ? '❐' : '□'}
+      <button class="window-btn maximise" aria-label={$isMaximised ? 'Restore' : 'Maximise'} title={$isMaximised ? 'Restore' : 'Maximise'} onclick={flipMaximise}>
+        {$isMaximised ? '❐' : '□'}
       </button>
       <button class="window-btn close" aria-label="Close" title="Close" onclick={() => nativeClose()}>×</button>
     </div>

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -3,6 +3,7 @@
   import { get } from 'svelte/store'
   import { view, sidebar, sessions, sessionGroups, pinnedSessions, collapsedSessions, editGroupId, editGroupDraft, activeSessionId, selMode, sel, menuFor, editId, editDraft, showToast, mcpServers, createNewSession, createSessionInGroup, clearPendingSessionOpts, settingsModalOpen, cmdkOpen, nativeShell, dirLeaf } from '../../lib/stores'
   import * as api from '../../lib/api'
+  import { titlebarDblClick } from '../../lib/nativeWindow'
   import { t, tr } from '../../lib/i18n'
   import { confirmDialog } from '../../lib/confirm'
   import { splitSections, swapWithinSection, parseSectionFold, type SectionFold } from '../../lib/sidebarSections'
@@ -602,7 +603,9 @@
        it stays flush with the divider rather than straddling it. -->
   <div class="resize-grip" role="separator" aria-orientation="vertical" onmousedown={startResize}></div>
   <div class="full" style="width:{fullWidth}px">
-    <div class="side-header" class:native-inset={$nativeShell && isMac} style="--wails-draggable:drag">
+    <!-- Draggable like the main column's top row, and so it takes the same
+         double-click-to-zoom a native title bar would give it. -->
+    <div class="side-header" class:native-inset={$nativeShell && isMac} style="--wails-draggable:drag" ondblclick={titlebarDblClick}>
       <button class="icon-btn" title={$t('header.toggle_left')} aria-pressed={true} onclick={() => sidebar.set('hidden')}>
         <iconify-icon icon="lucide:panel-left" width="16"></iconify-icon>
       </button>

--- a/web/src/lib/nativeWindow.test.ts
+++ b/web/src/lib/nativeWindow.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { get } from 'svelte/store'
+
+const mocks = vi.hoisted(() => ({ toggle: vi.fn(), state: vi.fn() }))
+vi.mock('./stores', async () => {
+  const { writable } = await import('svelte/store')
+  return { nativeShell: writable(false) }
+})
+vi.mock('./api', () => ({
+  nativeToggleMaximise: mocks.toggle,
+  nativeWindowState: mocks.state,
+}))
+
+import { nativeShell } from './stores'
+import { isMaximised, flipMaximise, refreshMaximised, titlebarDblClick } from './nativeWindow'
+
+// A double-click carries no coordinates worth modelling — only what it landed
+// on, since the handler has to let controls inside a titlebar keep their clicks.
+function dblclickOn(html: string, selector: string) {
+  document.body.innerHTML = `<div class="bar">${html}</div>`
+  document.querySelector('.bar')!.addEventListener('dblclick', titlebarDblClick as EventListener)
+  document.querySelector(selector)!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+}
+
+describe('nativeWindow', () => {
+  beforeEach(() => {
+    mocks.toggle.mockReset().mockResolvedValue(undefined)
+    mocks.state.mockReset().mockResolvedValue(false)
+    nativeShell.set(false)
+    isMaximised.set(false)
+  })
+
+  it('ignores titlebar double-clicks outside the desktop shell', () => {
+    dblclickOn('<span class="brand">Octo</span>', '.brand')
+    expect(mocks.toggle).not.toHaveBeenCalled()
+  })
+
+  it('zooms on a double-click in the titlebar itself', async () => {
+    nativeShell.set(true)
+    dblclickOn('<span class="brand">Octo</span>', '.brand')
+    await vi.waitFor(() => expect(mocks.toggle).toHaveBeenCalledTimes(1))
+    expect(get(isMaximised)).toBe(true)
+  })
+
+  it('leaves double-clicks on a titlebar control alone', () => {
+    nativeShell.set(true)
+    dblclickOn('<button class="search">s</button>', '.search')
+    expect(mocks.toggle).not.toHaveBeenCalled()
+  })
+
+  // The icon lives in one header while both headers can flip the state, so the
+  // shared store — not a component-local copy — is what has to move.
+  it('flips the shared state on every toggle', async () => {
+    await flipMaximise()
+    expect(get(isMaximised)).toBe(true)
+    await flipMaximise()
+    expect(get(isMaximised)).toBe(false)
+  })
+
+  it('resyncs from the OS when a toggle fails', async () => {
+    mocks.toggle.mockRejectedValue(new Error('bridge down'))
+    mocks.state.mockResolvedValue(true)
+    await flipMaximise()
+    expect(get(isMaximised)).toBe(true) // the OS value, not the optimistic guess
+  })
+
+  // A focus refresh that started before a toggle must not land after it and
+  // report the pre-toggle state.
+  it('drops a stale refresh that a toggle overtook', async () => {
+    let releaseState: (v: boolean) => void = () => {}
+    mocks.state.mockReturnValue(new Promise<boolean>(r => { releaseState = r }))
+    const stale = refreshMaximised()
+    await flipMaximise()
+    expect(get(isMaximised)).toBe(true)
+    releaseState(false)
+    await stale
+    expect(get(isMaximised)).toBe(true)
+  })
+})

--- a/web/src/lib/nativeWindow.ts
+++ b/web/src/lib/nativeWindow.ts
@@ -1,0 +1,42 @@
+import { get, writable } from 'svelte/store'
+import { nativeShell } from './stores'
+import { nativeToggleMaximise, nativeWindowState } from './api'
+
+// Desktop shell only. Maximise state has to be shared rather than owned by one
+// component: the main header draws the □/❐ icon, but every draggable titlebar
+// region — that header and the sidebar's own — accepts the double-click that
+// flips it, so a toggle from either has to move the icon.
+export const isMaximised = writable(false)
+
+// Guards against a stale focus refresh landing after a fresh toggle and
+// overwriting its result.
+let stateSeq = 0
+
+export async function refreshMaximised(): Promise<void> {
+  const seq = ++stateSeq
+  const m = await nativeWindowState()
+  if (seq === stateSeq) isMaximised.set(m)
+}
+
+export async function flipMaximise(): Promise<void> {
+  const next = !get(isMaximised)
+  try {
+    await nativeToggleMaximise()
+    isMaximised.set(next)
+    ++stateSeq
+  } catch {
+    // Toggle failed — fetch the real OS state to stay in sync rather than
+    // gambling that the old value is still accurate.
+    await refreshMaximised()
+  }
+}
+
+// Double-clicking a draggable titlebar region zooms the window, the way a
+// native title bar does. Wails' custom drag region doesn't wire this up, and
+// the octo-served page can't call Wails directly, so it goes through the native
+// bridge over HTTP. Ignore double-clicks that land on a control.
+export function titlebarDblClick(e: MouseEvent): void {
+  if (!get(nativeShell)) return
+  if ((e.target as HTMLElement).closest('button, a, input, select, textarea')) return
+  void flipMaximise()
+}


### PR DESCRIPTION
All three columns start at the very top of the window — there is no window-spanning title bar — but only the main column's row behaved like one. Now all three drag the window and answer the double-click that zooms it.

| | drag window | double-click to zoom |
|---|---|---|
| main column (`Header.svelte`) | already | already |
| sidebar brand row (`Sidebar.svelte`) | already | **new** |
| artifacts panel topbar (`ArtifactsPanel.svelte`) | **new** | **new** |

The panel's controls opt back out of the drag region by element selector (`.topbar button`) rather than by class the way Header and Sidebar do it: they are spread across four mode branches and two snippets, and a class the rule missed would turn a button into a window drag. That includes the mode menu's full-bleed backdrop, which is a button too.

The maximise toggle moves out of `Header.svelte` into `lib/nativeWindow.ts`, because maximise state can't stay component-local once three rows can flip it: the □/❐ icon exists only in the main row (Windows/Linux), and a zoom triggered elsewhere has to move it. `Header` keeps the OS polling (mount + window focus) since it owns that icon.

Desktop shell only — `titlebarDblClick` returns early when `nativeShell` is false, and `framelessDrag` only installs its listeners there, so plain browser mode is untouched.

`web/src/lib/nativeWindow.test.ts` covers the guard (non-shell, clicks on titlebar controls), the shared flip, the resync-on-failure path, and the stale-refresh ordering.

Verified: `vitest` 586 passed, `svelte-check` 0 errors. Not exercised in a real Wails build — the new rows reuse the handler and the drag attribute the main header already ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)