### PR TITLE
web: put all three titlebar rows on the traffic lights' axis

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -497,7 +497,7 @@
 }
 /* The same axis lift Header and Sidebar apply on mac — see Header.native-lift
    for why the height has to be pinned for the padding to move anything. */
-.topbar.native-lift { box-sizing: border-box; max-height: 44px; padding-bottom: 8px; }
+.topbar.native-lift { box-sizing: border-box; max-height: 44px; padding-bottom: 4px; }
 .file-name { min-width: 0; font-size: 12px; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* The mode label ("制品"/"Artifacts") names the panel, not a file: keep it
    unshrinkable and muted so the artifact name beside it stays primary. */

--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -153,9 +153,11 @@ header.native-inset { padding-left: 82px; }
    it. Padding-bottom alone only moves the axis while min-height still decides the
    row height; .chat-header-slot is taller than the 36px that would leave, so the
    row grew to 52px instead and the axis never moved. Pinning the height makes the
-   padding actually shorten the content box. */
+   padding actually shorten the content box.
+   The lights' centre sits 20px below the window's top edge, so 4px of padding is
+   the whole lift: (44 - 4) / 2 lands the row's axis exactly there. */
 header.native-lift {
-  box-sizing: border-box; max-height: 44px; padding-bottom: 8px;
+  box-sizing: border-box; max-height: 44px; padding-bottom: 4px;
 }
 /* The row is a window drag handle; every control opts back out so it stays
    clickable, leaving the blank stretches to drag the window. */

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -1118,7 +1118,7 @@
    padding has to shorten the content box, not grow the row. */
 .side-header.native-inset {
   box-sizing: border-box; max-height: 44px;
-  padding-left: 82px; padding-bottom: 8px;
+  padding-left: 82px; padding-bottom: 4px;
 }
 .side-header .icon-btn { --wails-draggable: no-drag; }
 .side-header :global(.logo) { color: var(--blue-6); flex: 0 0 auto; }


### PR DESCRIPTION
Mac's traffic lights centre 20px below the window's top edge. The lifted titlebar rows put their content on 18px — measured off the reported screenshot, where the row's icons sit exactly 2px above the lights' centre.

`padding-bottom: 8px` on the pinned 44px row was 2px too much lift; `4px` puts the axis on 20px, where the lights are.

All three columns carry the same lift under the same condition (`nativeShell && isMac`, 44px pinned), so all three move together:

- `Header.svelte` — main column
- `Sidebar.svelte` — `.side-header.native-inset` (folds the lift in with the horizontal inset)
- `ArtifactsPanel.svelte` — `.topbar.native-lift`

Mac desktop shell only; nothing applies elsewhere.

`svelte-check` 0 errors, `vitest` 580 passed. The alignment itself needs a Wails build to eyeball, since the lights are drawn by the OS, not the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)