### PR TITLE
Revert version bump to 1.16.5

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.5"
+var Version = "1.16.4"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- The 1.16.5 bump (#2269) was a misread — the ask was to re-cut the v1.16.4 tag onto the fixed commit, not ship a new version. Reverting the version string; the tag itself is being re-pointed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)