### PR TITLE
web: show and let landing page pick the real default reasoning effort

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, sessions, sessionGroups, pinnedSessions, collapsedSessions, activeSessionId, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, nativeShell, mobileShell, panelContent, panelExpanded, cmdkOpen, settingsModalOpen, createNewSession, clearPendingSessionOpts, isDesktopShell } from './lib/stores'
+  import { view, sessions, sessionGroups, pinnedSessions, collapsedSessions, activeSessionId, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, globalReasoningEffort, nativeShell, mobileShell, panelContent, panelExpanded, cmdkOpen, settingsModalOpen, createNewSession, clearPendingSessionOpts, isDesktopShell } from './lib/stores'
   import MobileApp from './mobile/MobileApp.svelte'
   import { ws, wsState } from './lib/ws'
   import { notificationsEnabled } from './lib/notifications'
@@ -194,14 +194,17 @@
     ws.connect()
 
     // Restore the persisted UI language from server config so a refresh
-    // keeps the user's locale choice. Also seed globalPermissionMode from the
-    // default model entry, so the Composer's no-active-session fallback
-    // shows the real configured default instead of a hardcoded guess.
+    // keeps the user's locale choice. Also seed globalPermissionMode and
+    // globalReasoningEffort, so the Composer's no-active-session fallback
+    // shows the real configured defaults instead of a hardcoded guess.
     api.getConfig().then(cfg => {
       if (cfg.language) setLocale(cfg.language)
       // PR5: permission_mode is global (was per-default-entry before). The
       // Composer reads this to seed its no-active-session fallback.
       if (cfg.permission_mode) globalPermissionMode.set(cfg.permission_mode)
+      // reasoning_effort is likewise global; the server normalizes an unset
+      // value to the literal "off" in this response (see handleGetConfig).
+      if (cfg.reasoning_effort) globalReasoningEffort.set(cfg.reasoning_effort)
     }).catch(() => { /* non-critical */ })
 
     ws.on('session_update', (ev: any) => {

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -4,8 +4,8 @@
   import {
     running, activeSessionId, chatStreaming, sessions, sessionGroups,
     chatContextUsage, chatWorkingDir, chatPermMode, chatReasoningEffort, chatShowReasoning, showToast, chatGoal, chatModel,
-    globalPermissionMode, nativeShell, localAccess, activeAgent, pendingModel, view, settingsModalOpen,
-    pendingAgent, pendingWorkingDir, pendingGroupId, normalizeDir, dirLeaf, projectsClaimingDir,
+    globalPermissionMode, globalReasoningEffort, nativeShell, localAccess, activeAgent, pendingModel, view, settingsModalOpen,
+    pendingAgent, pendingWorkingDir, pendingGroupId, pendingReasoningEffort, normalizeDir, dirLeaf, projectsClaimingDir,
   } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
@@ -630,15 +630,19 @@
   // A pending pick belongs to the blank new-chat view only. Once a session is
   // active (auto-created — which consumed it — or picked/created any other
   // way), drop any leftover so it can't leak into a later blank view.
-  $effect(() => { if (sid) pendingModel.set('') })
+  $effect(() => { if (sid) { pendingModel.set(''); pendingReasoningEffort.set('') } })
   // "" (off) is a legitimate resolved value, not "no data yet" — only fall
-  // back to the bootstrap default when neither source has reported anything
-  // at all (?? only skips null/undefined, not ""). That default is 'off':
-  // an absent reasoning_effort in config means reasoning disabled, so
-  // claiming 'medium' before data arrives misreports the real state.
+  // back to a default (?? only skips null/undefined, not "") when neither
+  // source has reported anything at all. On the landing page (no sid) that
+  // default is whatever the user already picked there (pendingReasoningEffort,
+  // consumed by ChatView.ensureActiveSession at session creation — mirrors
+  // pendingModel), or else the configured global default; a loaded session
+  // always has real data by the time it's active, so the global default is
+  // the fallback there too.
   let reasoning = $derived.by(() => {
     const v = $chatReasoningEffort[sid] ?? currentSession?.reasoning_effort
-    return v === undefined ? 'off' : (v || 'off')
+    if (v !== undefined) return v || 'off'
+    return (sid ? '' : $pendingReasoningEffort) || $globalReasoningEffort || 'off'
   })
   // The project (a session group carrying a working dir) this session belongs
   // to, if any. A project's directory governs every session in it, so the dir
@@ -888,10 +892,19 @@
   }
 
   async function pickReasoning(level: string) {
-    if (!sid) return
+    // No active session yet (landing page): just park the pick, exactly like
+    // pickModel does with pendingModel. Nothing is sent to the server until
+    // ChatView.ensureActiveSession actually creates a session — this menu is
+    // freely reversible up to that point, so it must not write global state
+    // (or broadcast to every other session) on every click.
+    if (!sid) {
+      pendingReasoningEffort.set(level)
+      return
+    }
     try {
       await api.updateSessionReasoningEffort(sid, level)
       chatReasoningEffort.update(r => ({ ...r, [sid]: level }))
+      globalReasoningEffort.set(level)
       // Off has no trace to show — the server forces show_reasoning off too
       // (see handleUpdateSessionReasoningEffort); mirror it locally so the
       // toggle doesn't flash "on" until the session_update broadcast lands.

--- a/web/src/lib/lazySessionCreate.test.ts
+++ b/web/src/lib/lazySessionCreate.test.ts
@@ -29,6 +29,7 @@ import {
   pendingGroupId,
   pendingWorkingDir,
   pendingModel,
+  pendingReasoningEffort,
 } from './stores'
 
 const group = (id: string, working_dir?: string): SessionGroup =>
@@ -43,6 +44,7 @@ beforeEach(() => {
   pendingGroupId.set('')
   pendingWorkingDir.set('')
   pendingModel.set('')
+  pendingReasoningEffort.set('')
 })
 
 describe('createNewSession', () => {
@@ -69,12 +71,14 @@ describe('createNewSession', () => {
     createNewSession('expert-7')
     pendingWorkingDir.set('/work/app')
     pendingModel.set('ep::gpt')
+    pendingReasoningEffort.set('high')
 
     createNewSession()
     expect(get(pendingAgent)).toBe('')
     expect(get(pendingWorkingDir)).toBe('')
     expect(get(pendingModel)).toBe('')
     expect(get(pendingGroupId)).toBe('')
+    expect(get(pendingReasoningEffort)).toBe('')
   })
 })
 
@@ -143,6 +147,7 @@ describe('clearPendingSessionOpts', () => {
     pendingWorkingDir.set('/work/app')
     pendingAgent.set('expert-7')
     pendingModel.set('ep::gpt')
+    pendingReasoningEffort.set('high')
 
     clearPendingSessionOpts()
 
@@ -150,5 +155,6 @@ describe('clearPendingSessionOpts', () => {
     expect(get(pendingWorkingDir)).toBe('')
     expect(get(pendingAgent)).toBe('')
     expect(get(pendingModel)).toBe('')
+    expect(get(pendingReasoningEffort)).toBe('')
   })
 })

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -30,6 +30,13 @@ export const pendingWorkingDir = writable<string>('')
 // Set by the sidebar's per-group "+": the group the not-yet-created session
 // belongs to. An explicit group wins over pendingWorkingDir's inference.
 export const pendingGroupId = writable<string>('')
+// Reasoning effort picked on the landing page before any session exists.
+// '' means "no override" (the Composer falls back to globalReasoningEffort
+// for display). Consumed once by the same ensureActiveSession flow that
+// consumes pendingModel — picking it must not touch the global config until
+// a session is actually created, since every keystroke on the landing page
+// is reversible right up to that point.
+export const pendingReasoningEffort = writable<string>('')
 export const sidebar = writable('full')
 export const cmdkOpen = writable(false)
 // Drives the MCP import-JSON modal. Adding a single server and editing an
@@ -164,6 +171,10 @@ export const editGroupDraft = writable('')
 // fallback when no session is active (e.g. right after deleting one) —
 // 'ask' alone would ignore whatever the user actually configured.
 export const globalPermissionMode = writable<string>('ask')
+// The configured default reasoning effort (~/.octo/config.yml), seeded once
+// from GET /api/config on app start. Used as the Composer's landing-page
+// (no active session) fallback, mirroring globalPermissionMode above.
+export const globalReasoningEffort = writable<string>('off')
 // Sidebar session UI state
 export const selMode = writable(false)
 export const sel = writable<Record<string, boolean>>({})
@@ -320,6 +331,7 @@ export function clearPendingSessionOpts() {
   pendingGroupId.set('')
   pendingWorkingDir.set('')
   pendingModel.set('')
+  pendingReasoningEffort.set('')
 }
 
 // Plain "new session" entry point shared by the sidebar button and the

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -9,6 +9,8 @@
     pendingAgent,
     pendingWorkingDir,
     pendingGroupId,
+    pendingReasoningEffort,
+    globalReasoningEffort,
     resolveProjectForDir,
     prependSession,
     sessions,
@@ -2238,6 +2240,8 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       pendingAgent.set('')
       pendingGroupId.set('')
       pendingWorkingDir.set('')
+      const reasoningPick = get(pendingReasoningEffort)
+      pendingReasoningEffort.set('')
       const newSess = created.session ?? created
       prependSession(newSess)
       // The server filed it under the group; mirror that locally so the
@@ -2249,6 +2253,24 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
           : g))
       }
       activeSessionId.set(newSess.id)
+      // Reasoning effort has no create-time field of its own (it's a global
+      // setting every session inherits — see the PATCH endpoint's own PR5
+      // note), so a landing-page pick can only take effect as a follow-up
+      // call once the session is real. Best-effort: the session already
+      // exists at this point, so a failure here shouldn't undo it — just
+      // leave the global default in place and tell the user.
+      if (reasoningPick) {
+        try {
+          await api.updateSessionReasoningEffort(newSess.id, reasoningPick)
+          chatReasoningEffort.update(r => ({ ...r, [newSess.id]: reasoningPick }))
+          globalReasoningEffort.set(reasoningPick)
+          if (reasoningPick === 'off') {
+            chatShowReasoning.update(r => ({ ...r, [newSess.id]: false }))
+          }
+        } catch (e: any) {
+          showToast(e.message ?? 'Failed to apply reasoning effort', 'error')
+        }
+      }
       return { id: newSess.id, created: true }
     } catch (e: any) {
       showToast(e.message, 'error')


### PR DESCRIPTION
## Summary
- The landing page's reasoning-effort chip hard-coded "off" and silently ignored clicks (no session exists yet). It now seeds `globalReasoningEffort` from `GET /api/config` on boot (mirrors `globalPermissionMode`) so it shows the real configured default.
- Picking a level on the landing page now stages it in a new `pendingReasoningEffort` store (mirrors `pendingModel`/`pendingAgent`/`pendingWorkingDir`/`pendingGroupId`) instead of writing global config on every click.
- `ChatView.createSessionForFirstMessage` consumes the pending pick with a follow-up `PATCH /api/sessions/{id}/reasoning_effort` right after the session is created (reasoning effort has no create-time field of its own — it's a purely global setting).

## Test plan
- [x] `npx svelte-check` — 760 files, 0 errors
- [x] `npx vitest run` — full suite passes, including two updated assertions in `lazySessionCreate.test.ts` covering `pendingReasoningEffort` clearing
- [x] Independent code-review subagent pass (no critical/blocking findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)