### PR TITLE
web: raise sidebar min-width to match the artifacts panel's

### DIFF
--- a/web/src/lib/sidebarWidth.test.ts
+++ b/web/src/lib/sidebarWidth.test.ts
@@ -45,8 +45,8 @@ describe('parseSidebarWidth', () => {
 
 describe('readSidebarWidth', () => {
   it('reads a persisted width', () => {
-    stubStorage({ 'octo.sidebarWidth': '312' })
-    expect(readSidebarWidth()).toBe(312)
+    stubStorage({ 'octo.sidebarWidth': '340' })
+    expect(readSidebarWidth()).toBe(340)
   })
 
   it('defaults when nothing is stored', () => {

--- a/web/src/lib/sidebarWidth.ts
+++ b/web/src/lib/sidebarWidth.ts
@@ -2,7 +2,13 @@
 // Sidebar.svelte so the parsing rules can be tested directly (same reason
 // sidebarSections.ts sits here).
 
-export const SIDEBAR_MIN = 200
+// Matches the artifacts panel's own PANEL_MIN (ArtifactsPanel.svelte) — the
+// two resizable columns share one minimum so neither reads as more
+// squeezable than the other. 200 used to clip the top-bar search button in
+// the desktop shell, where .side-header's fixed-width children (toolbar
+// buttons, logo, brand name, traffic-light padding) already add up to more
+// than 200px before the flexible spacer even collapses.
+export const SIDEBAR_MIN = 320
 export const SIDEBAR_MAX = 480
 export const SIDEBAR_DEFAULT = 256
 


### PR DESCRIPTION
## Summary
- Dragging the left sidebar to its minimum width (200px) clipped the top-bar search button in the desktop shell: `.side-header`'s fixed-width children (traffic-light padding, toggle button, logo, brand name, search button) already add up to ~228px before the flexible spacer even collapses.
- Raised `SIDEBAR_MIN` (`web/src/lib/sidebarWidth.ts`) from 200 to 320, matching the artifacts panel's own `PANEL_MIN` (`ArtifactsPanel.svelte`) — the two resizable columns now share one minimum instead of the sidebar reading as more squeezable than the panel.
- Updated a `sidebarWidth.test.ts` case whose stored-width fixture (312) fell between the old and new minimum.

## Test plan
- [x] `npx svelte-check` — 760 files, 0 errors
- [x] `npx vitest run` — 42 files / 586 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)