### PR TITLE
web: raise CENTER_MIN so the composer toolbar stops wrapping

### DIFF
--- a/web/src/lib/sidebarWidth.ts
+++ b/web/src/lib/sidebarWidth.ts
@@ -14,8 +14,11 @@ export const SIDEBAR_DEFAULT = 256
 
 // The narrowest the conversation column may become. Both resizable columns
 // squeeze it, so the number lives in one place: the sidebar's grip and the
-// artifacts panel's grip each cap themselves against it.
-export const CENTER_MIN = 460
+// artifacts panel's grip each cap themselves against it, and App.svelte's
+// own min-width falls back on it too. 640, not some smaller round number —
+// below that the composer's bottom toolbar (model/reasoning/context chips)
+// runs out of room and wraps to a second line.
+export const CENTER_MIN = 640
 
 const SIDEBAR_WIDTH_KEY = 'octo.sidebarWidth'
 


### PR DESCRIPTION
## Summary
- `CENTER_MIN` (460) was too small in practice — dragging the sidebar or artifacts panel grip (or shrinking the window, after #2274) could squeeze the conversation column down to a point where the composer's bottom toolbar (model / reasoning / context chips) ran out of room and wrapped to a second line.
- Raise it to 640, the width below which the wrap reproduces, per user testing/screenshot.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run src/lib/sidebarWidth.test.ts` — 9 passed
- [ ] Manually verify: shrink the window/panel to the new minimum and confirm the composer toolbar stays on one line