### PR TITLE
desktop: enforce a native minimum window size

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -133,6 +133,19 @@ const (
 	defaultWindowHeight = 860
 )
 
+// Floor on the native window itself. Below this the CSS-level minimums inside
+// the webview (sidebarWidth.ts's CENTER_MIN, PANEL_MIN) can't do their job —
+// they only stop the resizable columns from squeezing the conversation
+// column, not the OS window from shrinking out from under all of them. 704 =
+// the rail-mode sidebar (64px, the width the sidebar collapses to below the
+// 860px breakpoint) plus CENTER_MIN (640px, see sidebarWidth.ts) with the
+// artifacts panel closed — the narrowest state the layout is ever meant to
+// reach.
+const (
+	minWindowWidth  = 704
+	minWindowHeight = 480
+)
+
 // desktopShellQuery marks the window's URL so the frontend can tell it is
 // running inside the desktop-shell webview rather than an external browser
 // pointed at the same hub. The hub reports native=true to every client (the
@@ -515,6 +528,8 @@ func (b *nativeBridge) showWindowAt(hash string) {
 			Title:      "Octo",
 			Width:      width,
 			Height:     height,
+			MinWidth:   minWindowWidth,
+			MinHeight:  minWindowHeight,
 			StartState: startState,
 			URL:        target,
 			// Mac keeps its native title bar (hidden, inset traffic lights)


### PR DESCRIPTION
## Summary
- The conversation column's CSS minimum (`CENTER_MIN`, #2274/#2275) only stops the sidebar/artifacts-panel resize grips from squeezing it — dragging the OS window's own edge smaller had nothing stopping it, so the window could still shrink arbitrarily small and the layout would just overflow instead.
- Set `MinWidth`/`MinHeight` on the Wails window: 704×480. 704 = rail-mode sidebar (64px, the width it collapses to below the 860px breakpoint) + `CENTER_MIN` (640px) with the panel closed — the narrowest state the layout is meant to reach.

## Test plan
- [x] `go build ./...` and `go vet ./...` in `cmd/octo-desktop` — clean
- [ ] Manually verify: try to drag the desktop window's edge below ~704×480 and confirm the OS refuses to shrink it further