### PR TITLE
web: clamp artifacts panel width to fit on open and resize

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -460,6 +460,27 @@
       createNewSession()
     }
   }
+
+  // The center column's floor is CENTER_MIN, but only up to whatever room the
+  // sidebar actually leaves — a plain constant would force overflow on a
+  // screen narrower than sidebar-width + CENTER_MIN (a phone browser, or a
+  // desktop window between the 'full'-sidebar breakpoint and CENTER_MIN's own
+  // width). Sidebar's <aside> is `.content`'s first child regardless of its
+  // mode (full/rail/hidden), so measuring it live covers all three without
+  // duplicating their width constants here.
+  let contentEl = $state<HTMLElement | null>(null)
+  let mainMinWidth = $state(CENTER_MIN)
+  $effect(() => {
+    function recompute() {
+      const sideEl = contentEl?.firstElementChild as HTMLElement | null
+      const sideW = sideEl?.getBoundingClientRect().width ?? 0
+      const rowW = contentEl?.getBoundingClientRect().width ?? window.innerWidth
+      mainMinWidth = Math.max(0, Math.min(CENTER_MIN, rowW - sideW))
+    }
+    recompute()
+    window.addEventListener('resize', recompute)
+    return () => window.removeEventListener('resize', recompute)
+  })
 </script>
 
 <svelte:window onkeydown={onGlobalKeydown} />
@@ -474,12 +495,12 @@
 <MobileApp />
 {:else}
 <div class="app">
-  <div class="content">
+  <div class="content" bind:this={contentEl}>
     <Sidebar />
     <!-- Yield the width only while the panel is actually there to take it:
          an expanded flag left over from a closed panel would hide the main
          column with nothing rendered beside it, i.e. a blank page. -->
-    <main class="main" class:yielded={$panelExpanded && !!$panelContent} style="min-width:{$panelContent ? 0 : CENTER_MIN}px">
+    <main class="main" class:yielded={$panelExpanded && !!$panelContent} style="min-width:{$panelContent ? 0 : mainMinWidth}px">
       <Header />
       {#if $view === 'chat'}
         <ChatView />
@@ -536,16 +557,19 @@
   display: flex;
   min-height: 0;
 }
-/* min-width comes from the inline style rather than a fixed value here, and
-   is only CENTER_MIN while the panel is closed: with the panel open, its own
-   resize clamp (ArtifactsPanel.svelte) already keeps this column at
-   CENTER_MIN whenever there's room, and — in the rare case there isn't
-   room for both minimums — shrinks itself to PANEL_MIN rather than this
-   column giving up its floor, which would just push the panel off-screen
-   instead. A hard floor here would fight that trade-off. With the panel
-   closed this is the only flexible column, so the plain floor applies:
-   without it, shrinking the OS window itself had nothing stopping this
-   column from being crushed to nothing. */
+/* min-width comes from the inline style (mainMinWidth) rather than a fixed
+   value here, and only applies while the panel is closed: with the panel
+   open, its own resize clamp (ArtifactsPanel.svelte) already keeps this
+   column at CENTER_MIN whenever there's room, and — in the rare case there
+   isn't room for both minimums — shrinks itself to PANEL_MIN rather than
+   this column giving up its floor, which would just push the panel
+   off-screen instead. A hard floor here would fight that trade-off.
+   With the panel closed this is the only flexible column, so a floor
+   applies — but capped at whatever the sidebar actually leaves (see
+   mainMinWidth above), not a blind CENTER_MIN: on a screen narrower than
+   sidebar + CENTER_MIN (a phone browser, mainly), a plain constant would
+   force the same overflow this was meant to prevent, just from the other
+   side. */
 .main {
   flex: 1;
   display: flex;

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -479,7 +479,7 @@
     <!-- Yield the width only while the panel is actually there to take it:
          an expanded flag left over from a closed panel would hide the main
          column with nothing rendered beside it, i.e. a blank page. -->
-    <main class="main" class:yielded={$panelExpanded && !!$panelContent} style="min-width:{CENTER_MIN}px">
+    <main class="main" class:yielded={$panelExpanded && !!$panelContent} style="min-width:{$panelContent ? 0 : CENTER_MIN}px">
       <Header />
       {#if $view === 'chat'}
         <ChatView />
@@ -536,12 +536,16 @@
   display: flex;
   min-height: 0;
 }
-/* min-width comes from the inline style (CENTER_MIN) rather than a fixed
-   value here: the sidebar's and artifacts panel's own resize grips already
-   stop short of squeezing this column past it, but only while dragging —
-   without this, shrinking the OS window itself (or the panel's fixed pixel
-   width outliving a narrower window) had nothing stopping the column from
-   being crushed to nothing. */
+/* min-width comes from the inline style rather than a fixed value here, and
+   is only CENTER_MIN while the panel is closed: with the panel open, its own
+   resize clamp (ArtifactsPanel.svelte) already keeps this column at
+   CENTER_MIN whenever there's room, and — in the rare case there isn't
+   room for both minimums — shrinks itself to PANEL_MIN rather than this
+   column giving up its floor, which would just push the panel off-screen
+   instead. A hard floor here would fight that trade-off. With the panel
+   closed this is the only flexible column, so the plain floor applies:
+   without it, shrinking the OS window itself had nothing stopping this
+   column from being crushed to nothing. */
 .main {
   flex: 1;
   display: flex;

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -225,6 +225,27 @@
     return Number.isFinite(v) && v >= PANEL_MIN ? v : 420
   }
 
+  // The same bound startResize enforces mid-drag, applied on mount and on
+  // every window resize too — otherwise a saved width from a wider window (or
+  // one that fit before the OS window itself got dragged smaller) can outgrow
+  // the room actually available. flex:0 0 auto below means this column never
+  // shrinks on its own to make way; left unclamped, the excess just overflows
+  // past the window edge instead of appearing anywhere.
+  $effect(() => {
+    function clamp() {
+      const row = panelEl?.parentElement
+      const side = panelEl?.previousElementSibling as HTMLElement | null
+      if (!row || !side) return
+      const rowW = row.getBoundingClientRect().width
+      const sideW = side.getBoundingClientRect().width
+      const maxW = Math.max(PANEL_MIN, rowW - sideW - CENTER_MIN)
+      if (panelWidth > maxW) panelWidth = maxW
+    }
+    clamp()
+    window.addEventListener('resize', clamp)
+    return () => window.removeEventListener('resize', clamp)
+  })
+
   // Take over the content area, leaving the sidebar in place: the main column
   // yields its width (App.svelte hides it) and this panel grows into it. No
   // pixel maths — flex fills whatever is left, so it stays right through a


### PR DESCRIPTION
## Summary
- Root cause of "点击右侧面板按钮，看不到面板": the panel's width was only ever bounded during an active drag of its own resize handle. Opening it (or resizing the OS window while already open) left it at whatever was last saved. At a small window — including the new native minimum from #2276 — that saved width can be wider than the room actually left after the sidebar and `CENTER_MIN` (#2274/#2275), and since the panel is `flex: 0 0 auto` (never auto-shrinks), the excess just overflowed past the window edge instead of appearing anywhere. The panel technically opened, just entirely off-screen.
- Fix: the same `PANEL_MIN`/`CENTER_MIN` bound `startResize` already computes now also runs on mount and on window resize, so the panel always renders within the visible row.
- `App.svelte`'s `CENTER_MIN` floor on the center column now only applies while the panel is closed — with it open, the panel's own clamp already protects `CENTER_MIN` whenever there's room, and deliberately drops itself to `PANEL_MIN` instead of forcing the center column below its floor in the rare case there isn't room for both (matches the original drag-handler design intent, which a blanket CSS floor on `.main` was fighting).
- Second commit: `CENTER_MIN` as a blind constant has the same overflow problem even with the panel closed, on any screen narrower than sidebar-width + `CENTER_MIN` — e.g. a phone browser opening the plain web UI (not the native mobile shell, which renders a separate `MobileApp` and is unaffected), or a desktop window sized between the 'full'-sidebar breakpoint (860px) and `CENTER_MIN`'s own width (640px). The center column's floor is now capped at whatever the sidebar's actual rendered width leaves, measured live and recomputed on window resize — never a blind constant that can exceed the available screen.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [ ] Manually verify: shrink the desktop window to its native minimum, open the artifacts panel, confirm it's visible (not off-screen) and the composer toolbar still doesn't wrap
- [ ] Manually verify: open the served web UI in a phone browser (not `?mobile=1`) and confirm no horizontal overflow