### PR TITLE
web: fix sidebar and artifacts panel resize lock-ups

### DIFF
--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -225,6 +225,33 @@
     return Number.isFinite(v) && v >= PANEL_MIN ? v : 420
   }
 
+  // The sidebar's width isn't queried directly — main (this panel's previous
+  // sibling) sits between it and the panel. rowW - currentPanelW - main's
+  // rendered width isolates it instead: main's width already reflects
+  // "whatever's left after the sidebar and the panel", so subtracting both
+  // out algebraically cancels back to just the sidebar, independent of
+  // currentPanelW's actual value (the term appears on both sides). Reading
+  // previousElementSibling's width directly as "the sidebar" — an earlier
+  // version of this function did — is wrong: that element IS main, so it
+  // silently measured main's width as the sidebar's, inflating the room the
+  // math thought main already had and starving the ceiling it computed for
+  // the panel.
+  function maxPanelWidth(rowW: number, currentPanelW: number): number {
+    const main = panelEl?.previousElementSibling as HTMLElement | null
+    const mainW = main?.getBoundingClientRect().width ?? 0
+    const sideW = rowW - currentPanelW - mainW
+    const centerProtectingCeiling = rowW - sideW - CENTER_MIN
+    // Below PANEL_MIN, protecting CENTER_MIN is impossible regardless of the
+    // panel's width — the window itself is too narrow, not something this
+    // drag can fix. Falling through to Math.max(PANEL_MIN, ...) would floor
+    // the ceiling at PANEL_MIN, freezing the handle at that single point
+    // instead of just giving up on the trade-off (main already degrades
+    // gracefully below CENTER_MIN when there's no room to spare — see
+    // App.svelte's mainMinWidth).
+    if (centerProtectingCeiling < PANEL_MIN) return Math.max(PANEL_MIN, rowW - sideW)
+    return centerProtectingCeiling
+  }
+
   // The same bound startResize enforces mid-drag, applied on mount and on
   // every window resize too — otherwise a saved width from a wider window (or
   // one that fit before the OS window itself got dragged smaller) can outgrow
@@ -234,11 +261,9 @@
   $effect(() => {
     function clamp() {
       const row = panelEl?.parentElement
-      const side = panelEl?.previousElementSibling as HTMLElement | null
-      if (!row || !side) return
+      if (!row || !panelEl) return
       const rowW = row.getBoundingClientRect().width
-      const sideW = side.getBoundingClientRect().width
-      const maxW = Math.max(PANEL_MIN, rowW - sideW - CENTER_MIN)
+      const maxW = maxPanelWidth(rowW, panelWidth)
       if (panelWidth > maxW) panelWidth = maxW
     }
     clamp()
@@ -267,11 +292,8 @@
     const handle = e.currentTarget as HTMLElement
     const startX = e.clientX
     const startW = panelEl!.getBoundingClientRect().width
-    // Everything left of the panel (sidebar + center) must keep CENTER_MIN for
-    // the center column; the sidebar's share is whatever it currently occupies.
     const rowW = row.getBoundingClientRect().width
-    const sideW = rowW - startW - (panelEl!.previousElementSibling as HTMLElement)?.getBoundingClientRect().width
-    const maxW = Math.max(PANEL_MIN, rowW - sideW - CENTER_MIN)
+    const maxW = maxPanelWidth(rowW, startW)
     let raf = 0
     let pointerX = startX
     const apply = () => {

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -286,7 +286,17 @@
     const rowW = row.getBoundingClientRect().width
     // Whatever sits beyond the center column — the artifacts panel, or nothing.
     const beyondCenter = rowW - startW - main.getBoundingClientRect().width
-    return Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, rowW - beyondCenter - CENTER_MIN))
+    const centerProtectingCeiling = rowW - beyondCenter - CENTER_MIN
+    // Below this, protecting CENTER_MIN is impossible even at SIDEBAR_MIN — the
+    // window itself is just too narrow, not something dragging the sidebar can
+    // fix. Falling through to Math.max(SIDEBAR_MIN, centerProtectingCeiling)
+    // would floor the CEILING at SIDEBAR_MIN, collapsing the whole draggable
+    // range to that single point (the drag would visibly do nothing). Fall
+    // back to the sidebar's own normal range instead — the trade-off elsewhere
+    // (main dropping below CENTER_MIN) already accepts this window size can't
+    // have both.
+    if (centerProtectingCeiling < SIDEBAR_MIN) return SIDEBAR_MAX
+    return Math.min(SIDEBAR_MAX, centerProtectingCeiling)
   }
 
   function startResize(e: MouseEvent) {


### PR DESCRIPTION
## Summary

Two related, but distinct, drag-lock bugs — both reported as "拖动不起作用" (turned out to be about the artifacts panel specifically, not the left sidebar).

**1. Sidebar (`Sidebar.svelte`)** — raising `CENTER_MIN` to 640 (#2275) broke sidebar resizing on any window between 860px (the `'full'`-sidebar breakpoint) and ~960px (`SIDEBAR_MIN + CENTER_MIN`) — a very common desktop window width range. `maxDraggableWidth`'s `Math.max(SIDEBAR_MIN, ...)` floors the drag ceiling at `SIDEBAR_MIN` whenever protecting `CENTER_MIN` isn't achievable, collapsing the whole `[SIDEBAR_MIN, maxW]` draggable range to a single point. Before the `CENTER_MIN` raise this was unreachable (`320 + 460 < 860` always held). Fixed by falling back to the sidebar's own normal ceiling (`SIDEBAR_MAX`) instead of freezing at `SIDEBAR_MIN`.

**2. Artifacts panel (`ArtifactsPanel.svelte`)** — this is the one actually being reported. Two bugs stacked:
   - The mount/resize clamp effect (added in #2278) read `panelEl.previousElementSibling`'s width directly as "the sidebar's width" — that element is actually `main`, not the sidebar. This measured main's width instead, producing a ceiling that depended on the panel's *own current width* rather than the sidebar's real, independent width. On most window sizes this collapsed to `PANEL_MIN` regardless of how much room actually existed — and because the effect reads `panelWidth` to derive that (wrong) value, it re-ran on every width change the drag itself made, snapping the panel back down *mid-drag*. This is almost certainly what "拖不动" was — the handle would follow the cursor for a frame and then get yanked back.
   - Same shape as the sidebar bug above: when protecting `CENTER_MIN` isn't achievable even at `PANEL_MIN`, the ceiling floored at `PANEL_MIN`, freezing the handle. Fixed the same way — give up on the trade-off (main already degrades gracefully below `CENTER_MIN` when there's no room to spare, per App.svelte's `mainMinWidth`) rather than locking the control.
   - Both call sites (`startResize` and the clamp effect) now share one `maxPanelWidth` helper so they can't drift apart again.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [ ] Manually verify: open the artifacts panel and drag its resize handle across a range of window widths (including ~900px) — should move smoothly with no snap-back
- [ ] Manually verify: size the desktop window to ~900px wide and confirm the sidebar's own resize handle also moves it