### PR TITLE
web: restore last-visited page on cold start instead of most-recent session

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { view, sessions, sessionGroups, pinnedSessions, collapsedSessions, activeSessionId, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, globalReasoningEffort, nativeShell, mobileShell, panelContent, panelExpanded, cmdkOpen, settingsModalOpen, createNewSession, clearPendingSessionOpts, isDesktopShell } from './lib/stores'
+  import { view, sessions, sessionGroups, pinnedSessions, collapsedSessions, activeSessionId, onboardPhase, openAgentSession, chatShowReasoning, globalPermissionMode, globalReasoningEffort, nativeShell, mobileShell, panelContent, panelExpanded, cmdkOpen, settingsModalOpen, createNewSession, clearPendingSessionOpts, isDesktopShell, readLastRoute, writeLastRoute } from './lib/stores'
   import MobileApp from './mobile/MobileApp.svelte'
   import { ws, wsState } from './lib/ws'
   import { notificationsEnabled } from './lib/notifications'
@@ -70,13 +70,13 @@
   // Reflect the current view (and active chat session) in the hash so a refresh
   // lands back where the user was instead of the default chat view.
   let routeReady = false
-  // The "open the most recent session" fallback below fires at most once, on
-  // the first session list of the boot — and not at all when the URL already
-  // names the chat target. After that the active session belongs to the user:
-  // a later list (another tab creating a session, a WS reconnect) must not
-  // yank them off the new-session landing page, nor out of the empty state a
-  // delete leaves behind. Read synchronously at module init, before any list
-  // can arrive.
+  // The "restore where the user left off" fallback below fires at most once,
+  // on the first session list of the boot — and not at all when the URL
+  // already names the chat target. After that the active session belongs to
+  // the user: a later list (another tab creating a session, a WS reconnect)
+  // must not yank them off the new-session landing page, nor out of the empty
+  // state a delete leaves behind. Read synchronously at module init, before
+  // any list can arrive.
   let autoSelectDone = typeof location !== 'undefined' && hashPicksChatTarget(location.hash)
   const VALID_VIEWS = ['chat', 'agents', 'skills', 'workflows', 'browser', 'tasks', 'mcp', 'channels', 'lightapps']
 
@@ -183,12 +183,16 @@
   })
 
   // Write the current view/session to the hash on navigation (once the initial
-  // hash has been restored, and only while the main UI is showing).
+  // hash has been restored, and only while the main UI is showing). Also
+  // remember it in localStorage — the hash itself doesn't survive the tab or
+  // window closing, but a later cold start's fallback (below) reads this to
+  // put the user back where they left off.
   $effect(() => {
     const v = $view, sid = $activeSessionId, phase = $onboardPhase
     if (!routeReady || phase === 'unknown' || phase === 'key_setup') return
     const hash = normalizeHash(v, sid)
     if (location.hash !== hash) location.hash = hash
+    writeLastRoute(v, sid)
   })
 
   function bootMain() {
@@ -361,7 +365,21 @@
         })
         if (!autoSelectDone) {
           autoSelectDone = true
-          if (!get(activeSessionId)) activeSessionId.set(list[0].id)
+          if (!get(activeSessionId)) {
+            // Restore the page the user was last on, not "whichever session
+            // is most recently touched" — that ranking can change from
+            // background activity the user never looked at. If the
+            // remembered session was deleted since, or nothing was ever
+            // remembered, stay on the landing page (view/activeSessionId
+            // already default there) rather than guessing a replacement.
+            const last = readLastRoute()
+            if (last?.sid && list.some((s: any) => s.id === last.sid)) {
+              if (VALID_VIEWS.includes(last.view) && get(view) !== last.view) view.set(last.view)
+              activeSessionId.set(last.sid)
+            } else if (last?.view && last.view !== 'chat' && VALID_VIEWS.includes(last.view) && get(view) === 'chat') {
+              view.set(last.view)
+            }
+          }
         }
       }
     }).catch(() => { /* non-critical: an empty sidebar, not a broken page */ })

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -154,6 +154,33 @@ export const lightappHTML = writable<Record<string, string>>({})
 // Sessions
 export const sessions = writable<Session[]>([])
 export const activeSessionId = writable<string | null>(null)
+
+// Last view/session on screen before the tab or window closed, so a cold
+// start (no hash naming a target) can put the user back where they left off
+// instead of guessing "whichever session was most recently touched" —
+// another tab or a background reply can update that ranking without the
+// user ever having looked at it. Session existence is re-checked against the
+// session list on boot (App.svelte) since the remembered id may since have
+// been deleted; when it's gone this is worth nothing and the landing page
+// opens instead.
+export interface LastRoute { view: string; sid: string | null }
+const LAST_ROUTE_KEY = 'octo.lastRoute'
+
+export function readLastRoute(): LastRoute | null {
+  try {
+    const raw = localStorage.getItem(LAST_ROUTE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (typeof parsed?.view !== 'string') return null
+    return { view: parsed.view, sid: typeof parsed.sid === 'string' ? parsed.sid : null }
+  } catch {
+    return null
+  }
+}
+
+export function writeLastRoute(view: string, sid: string | null): void {
+  try { localStorage.setItem(LAST_ROUTE_KEY, JSON.stringify({ view, sid })) } catch { /* private mode: this visit only */ }
+}
 // Web-UI sidebar groups. Membership lives here (server registry), not on the
 // session; the sidebar clusters the session list by these.
 export const sessionGroups = writable<SessionGroup[]>([])


### PR DESCRIPTION
## Summary
- On a fresh boot with no session named in the URL hash, the app used to fall back to whichever session had the most recently modified file — which can drift from what the user actually had open if another tab or a background reply touches a different session.
- Persist the current view/session to `localStorage` on every navigation (`octo.lastRoute`), and on cold start restore that instead: reopen the remembered session if it still exists, restore the remembered non-chat view if the session is gone, and otherwise land on the new-session page rather than guessing a replacement.

## Test plan
- [x] `svelte-check` passes with 0 errors
- [ ] Manually verify: open a session, close the tab/window, reopen — lands back on that session
- [ ] Manually verify: delete the last-open session from another tab, then reopen — lands on the new-session landing page instead of an arbitrary session