### PR TITLE
release: bump version to 1.16.5

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.4"
+var Version = "1.16.5"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Bump internal/version/version.go base version ahead of tagging v1.16.5.

## Test plan
- N/A (version bump only)