### PR TITLE
web: fix landing-page permission mode, reasoning menu, show-reasoning toggle

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -5,7 +5,8 @@
     running, activeSessionId, chatStreaming, sessions, sessionGroups,
     chatContextUsage, chatWorkingDir, chatPermMode, chatReasoningEffort, chatShowReasoning, showToast, chatGoal, chatModel,
     globalPermissionMode, globalReasoningEffort, nativeShell, localAccess, activeAgent, pendingModel, view, settingsModalOpen,
-    pendingAgent, pendingWorkingDir, pendingGroupId, pendingReasoningEffort, normalizeDir, dirLeaf, projectsClaimingDir,
+    pendingAgent, pendingWorkingDir, pendingGroupId, pendingReasoningEffort, pendingPermissionMode, pendingShowReasoning,
+    normalizeDir, dirLeaf, projectsClaimingDir,
   } from '../../lib/stores'
   import { ws } from '../../lib/ws'
   import * as api from '../../lib/api'
@@ -699,9 +700,14 @@
   // could name. A project with no mounts keeps the workspace, which is then
   // genuinely the only place its work happens.
   let attachStartDir = $derived(attachShortcuts.length > 0 ? '' : workingDir)
-  let permMode = $derived($chatPermMode[sid] || currentSession?.permission_mode || $globalPermissionMode)
-  // Effective show-reasoning for this session: live store > session record > default true.
-  let showReasoning = $derived($chatShowReasoning[sid] ?? currentSession?.show_reasoning ?? true)
+  // On the landing page (no sid) the fallback is whatever was picked there
+  // (pendingPermissionMode, consumed by ChatView.ensureActiveSession at
+  // session creation — mirrors pendingReasoningEffort), else the configured
+  // global default.
+  let permMode = $derived($chatPermMode[sid] || currentSession?.permission_mode || (sid ? '' : $pendingPermissionMode) || $globalPermissionMode)
+  // Effective show-reasoning for this session: live store > session record >
+  // (landing page only) pendingShowReasoning > default true.
+  let showReasoning = $derived($chatShowReasoning[sid] ?? currentSession?.show_reasoning ?? (sid ? true : ($pendingShowReasoning ?? true)))
   let ctxUsage = $derived(Number($chatContextUsage[sid] ?? currentSession?.context_usage ?? 0))
   // Session goal chip: usage while active, status label otherwise. null/absent
   // hides the chip entirely.
@@ -892,6 +898,7 @@
   }
 
   async function pickReasoning(level: string) {
+    reasonMenu = false
     // No active session yet (landing page): just park the pick, exactly like
     // pickModel does with pendingModel. Nothing is sent to the server until
     // ChatView.ensureActiveSession actually creates a session — this menu is
@@ -917,8 +924,14 @@
   }
 
   async function toggleShowReasoning() {
-    if (!sid || reasoning === 'off') return
+    if (reasoning === 'off') return
     const next = !showReasoning
+    if (!sid) {
+      // Landing page: park the flip, exactly like pickReasoning does with
+      // pendingReasoningEffort — nothing to PATCH until a session exists.
+      pendingShowReasoning.set(next)
+      return
+    }
     try {
       await api.updateSessionShowReasoning(sid, next)
       chatShowReasoning.update(r => ({ ...r, [sid]: next }))
@@ -936,7 +949,14 @@
   }
   async function pickPermMode(next: string) {
     permMenu = false
-    if (!sid || next === permMode) return
+    if (next === permMode) return
+    if (!sid) {
+      // Landing page: park the pick, exactly like pickReasoning does with
+      // pendingReasoningEffort — consumed once ChatView.ensureActiveSession
+      // actually creates a session.
+      pendingPermissionMode.set(next)
+      return
+    }
     try {
       await api.updateSessionPermissionMode(sid, next)
       chatPermMode.update(m => ({ ...m, [sid]: next }))

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -37,6 +37,18 @@ export const pendingGroupId = writable<string>('')
 // a session is actually created, since every keystroke on the landing page
 // is reversible right up to that point.
 export const pendingReasoningEffort = writable<string>('')
+// Permission mode picked on the landing page before any session exists. ''
+// means "no override" (the Composer falls back to globalPermissionMode for
+// display). Consumed once by the same ensureActiveSession flow that consumes
+// pendingModel — without this, picking a mode on the blank new-chat view was
+// a silent no-op, same failure shape as pendingModel's #2066.
+export const pendingPermissionMode = writable<string>('')
+// Show-reasoning toggle flipped on the landing page before any session
+// exists. null means "no override" (falls back to true, same as the
+// Composer's post-session default). Same failure shape as the two stores
+// above: without this, toggleShowReasoning's `!sid` guard made the switch a
+// silent no-op until a session existed.
+export const pendingShowReasoning = writable<boolean | null>(null)
 export const sidebar = writable('full')
 export const cmdkOpen = writable(false)
 // Drives the MCP import-JSON modal. Adding a single server and editing an
@@ -359,6 +371,8 @@ export function clearPendingSessionOpts() {
   pendingWorkingDir.set('')
   pendingModel.set('')
   pendingReasoningEffort.set('')
+  pendingPermissionMode.set('')
+  pendingShowReasoning.set(null)
 }
 
 // Plain "new session" entry point shared by the sidebar button and the

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -10,6 +10,8 @@
     pendingWorkingDir,
     pendingGroupId,
     pendingReasoningEffort,
+    pendingPermissionMode,
+    pendingShowReasoning,
     globalReasoningEffort,
     resolveProjectForDir,
     prependSession,
@@ -2242,6 +2244,10 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       pendingWorkingDir.set('')
       const reasoningPick = get(pendingReasoningEffort)
       pendingReasoningEffort.set('')
+      const permPick = get(pendingPermissionMode)
+      pendingPermissionMode.set('')
+      const showReasoningPick = get(pendingShowReasoning)
+      pendingShowReasoning.set(null)
       const newSess = created.session ?? created
       prependSession(newSess)
       // The server filed it under the group; mirror that locally so the
@@ -2269,6 +2275,28 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
           }
         } catch (e: any) {
           showToast(e.message ?? 'Failed to apply reasoning effort', 'error')
+        }
+      }
+      // Same story as reasoning effort above: permission mode and the
+      // show-reasoning toggle have no create-time field either, so a
+      // landing-page pick only takes effect as a follow-up PATCH once the
+      // session is real.
+      if (permPick) {
+        try {
+          await api.updateSessionPermissionMode(newSess.id, permPick)
+          chatPermMode.update(m => ({ ...m, [newSess.id]: permPick }))
+        } catch (e: any) {
+          showToast(e.message ?? 'Failed to apply permission mode', 'error')
+        }
+      }
+      // Reasoning effort 'off' already forced show_reasoning off locally
+      // above; skip so a stale pending toggle doesn't fight that.
+      if (showReasoningPick !== null && reasoningPick !== 'off') {
+        try {
+          await api.updateSessionShowReasoning(newSess.id, showReasoningPick)
+          chatShowReasoning.update(r => ({ ...r, [newSess.id]: showReasoningPick }))
+        } catch (e: any) {
+          showToast(e.message ?? 'Failed to apply reasoning visibility', 'error')
         }
       }
       return { id: newSess.id, created: true }


### PR DESCRIPTION
## Summary
- Fix the permission-mode picker being a silent no-op on the landing page (no active session yet) — same failure shape #2066 fixed for the model picker. Adds `pendingPermissionMode`, consumed by `ensureActiveSession` once the session is created.
- Fix the show-reasoning toggle having the same `!sid` no-op bug on the landing page. Adds `pendingShowReasoning`, consumed the same way.
- Fix `pickReasoning` never closing the reasoning dropdown after picking a level (missing `reasonMenu = false`, present in every sibling picker).

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run src/lib/lazySessionCreate.test.ts` — 11 passed
- [ ] Manual: on the landing page (no session), pick a permission mode / reasoning level / toggle show-reasoning, then send a message — confirm the picks land on the newly created session

🤖 Generated with [Claude Code](https://claude.com/claude-code)