### PR TITLE
web: fix permission-mode menu overflowing page edge

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -1693,6 +1693,7 @@ textarea {
 }
 .menu-item.manage { flex-direction: row; align-items: center; gap: 6px; }
 .menu-item.manage .mi-name { color: var(--blue-6); }
+.perm-menu { left: auto; right: 0; min-width: 140px; }
 .perm-menu .menu-item { flex-direction: row; align-items: center; gap: 8px; }
 .perm-dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; background: var(--text-quaternary); }
 .perm-dot[data-mode="auto"] { background: var(--success); }


### PR DESCRIPTION
## Summary
- The permission-mode dropdown in the composer footer is the rightmost picker, but it reused the generic `.menu` rule (`left: 0`), so it opened toward the right and spilled off the page edge.
- Anchor `.perm-menu` to the button's right edge (`right: 0`) instead, and shrink `min-width` from the generic 200px down to 140px since its items are just a dot + a short label.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `make build` + manual verification via local `octo serve` — dropdown now stays within the viewport and no longer has excess trailing whitespace