### PR TITLE
scheduler: enforce a 1-hour minimum cron interval

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -92,6 +92,29 @@ var exprParser = cron.NewParser(
 	cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
 )
 
+// minCronInterval is the shortest gap allowed between two consecutive fires.
+// The seconds field lets an expression fire sub-minute, which turns a single
+// scheduled task into a runaway loop of agent sessions — so Add/Update reject
+// anything finer than this floor up front.
+const minCronInterval = time.Hour
+
+// enforceMinInterval rejects an expression whose next two fires are closer
+// together than minCronInterval. Sampled from "now" rather than derived from
+// the expression's fields, so it needs no special-casing for @every or the
+// other descriptors on top of fixed-field expressions — the realistic abuse
+// case (a uniform */N seconds-or-minutes field, or @every) is always caught.
+// It only samples one gap, so a deliberately clustered expression (e.g. two
+// seconds-field values a second apart, once a day) could in theory dodge it;
+// that shape has no legitimate use case and isn't worth guarding against.
+func enforceMinInterval(expr string, sched cron.Schedule) error {
+	t1 := sched.Next(time.Now())
+	t2 := sched.Next(t1)
+	if gap := t2.Sub(t1); gap < minCronInterval {
+		return fmt.Errorf("cron expression %q fires every %s, minimum allowed interval is %s", expr, gap, minCronInterval)
+	}
+	return nil
+}
+
 // Scheduler manages cron-based task execution.
 type Scheduler struct {
 	dir    string
@@ -140,8 +163,12 @@ func (s *Scheduler) Stop() {
 // written back into task so the caller can report them (e.g. in the create
 // API response).
 func (s *Scheduler) Add(task *Task) error {
-	if _, err := exprParser.Parse(task.Cron); err != nil {
+	sched, err := exprParser.Parse(task.Cron)
+	if err != nil {
 		return fmt.Errorf("invalid cron expression %q: %w", task.Cron, err)
+	}
+	if err := enforceMinInterval(task.Cron, sched); err != nil {
+		return err
 	}
 	if task.ID == "" {
 		task.ID = fmt.Sprintf("task_%d", time.Now().UnixMilli())
@@ -165,9 +192,25 @@ func (s *Scheduler) Add(task *Task) error {
 // Update modifies an existing task and reschedules its live cron entry so the
 // change (new expression, enable/disable) takes effect immediately, not at the
 // next process restart.
+//
+// The cron expression is only re-validated when it's actually changing. A
+// task whose Cron predates minCronInterval (e.g. loaded from a hand-written
+// file — see loadAll) must otherwise stay editable, since re-validating an
+// unchanged expression on every unrelated field edit (rename, disable, ...)
+// would make such a task un-patchable except by deleting and recreating it.
 func (s *Scheduler) Update(task Task) error {
-	if _, err := exprParser.Parse(task.Cron); err != nil {
-		return fmt.Errorf("invalid cron expression %q: %w", task.Cron, err)
+	prev, err := s.Get(task.ID)
+	if err != nil {
+		return err
+	}
+	if task.Cron != prev.Cron {
+		sched, err := exprParser.Parse(task.Cron)
+		if err != nil {
+			return fmt.Errorf("invalid cron expression %q: %w", task.Cron, err)
+		}
+		if err := enforceMinInterval(task.Cron, sched); err != nil {
+			return err
+		}
 	}
 	s.mu.Lock()
 	existing, ok := s.tasks[task.ID]
@@ -283,12 +326,20 @@ func (s *Scheduler) SetSessionGroup(id, groupID string) error {
 // ─── Private methods ─────────────────────────────────────────────────────
 
 // schedule registers a cron entry for the task and records its EntryID so a
-// later Update/Delete can remove it. The expression is pre-validated by the
-// callers, so a parse failure here is a programming error worth logging.
+// later Update/Delete can remove it. Add/Update pre-validate the expression
+// (syntax and minCronInterval), so a rejection here only happens for a task
+// loaded straight off disk by loadAll — e.g. hand-written while octo serve
+// wasn't running — and is handled the same way as a syntax error: logged and
+// left unscheduled rather than failing the whole load.
 func (s *Scheduler) schedule(id, expr string) {
 	eid, err := s.cron.AddFunc(expr, s.wrap(id))
 	if err != nil {
 		log.Printf("[scheduler] cron add %q: %v", id, err)
+		return
+	}
+	if err := enforceMinInterval(expr, s.cron.Entry(eid).Schedule); err != nil {
+		log.Printf("[scheduler] task %q not scheduled: %v", id, err)
+		s.cron.Remove(eid)
 		return
 	}
 	s.mu.Lock()

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -102,6 +102,120 @@ func TestAddRejectsInvalidCron(t *testing.T) {
 	}
 }
 
+func TestAddRejectsSubHourlyCron(t *testing.T) {
+	for _, expr := range []string{"0 */5 * * * *", "0,30 * * * * *", "@every 10m"} {
+		s, _ := newTestScheduler(t)
+		err := s.Add(&Task{ID: "t1", Name: "n", Cron: expr, Prompt: "p", Enabled: true})
+		if err == nil || !strings.Contains(err.Error(), "minimum allowed interval") {
+			t.Fatalf("Add(%q): got %v, want minimum-interval error", expr, err)
+		}
+		if got := len(s.tasks); got != 0 {
+			t.Fatalf("Add(%q): tasks stored = %d, want 0", expr, got)
+		}
+	}
+}
+
+func TestAddAcceptsExactlyOneHourInterval(t *testing.T) {
+	s, _ := newTestScheduler(t)
+	if err := s.Add(&Task{ID: "t1", Name: "n", Cron: "0 0 * * * *", Prompt: "p", Enabled: true}); err != nil {
+		t.Fatalf("Add with hourly cron: %v", err)
+	}
+	if got := s.entryCount(); got != 1 {
+		t.Fatalf("tracked entries = %d, want 1", got)
+	}
+}
+
+func TestUpdateRejectsNewSubHourlyCron(t *testing.T) {
+	s, _ := newTestScheduler(t)
+	task := Task{ID: "t1", Name: "n", Cron: "0 0 9 * * *", Prompt: "p", Enabled: true}
+	if err := s.Add(&task); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	task.Cron = "0 */5 * * * *"
+	if err := s.Update(task); err == nil || !strings.Contains(err.Error(), "minimum allowed interval") {
+		t.Fatalf("Update with sub-hourly cron: got %v, want minimum-interval error", err)
+	}
+	// The original schedule must survive a rejected update.
+	got, _ := s.Get("t1")
+	if got.Cron != "0 0 9 * * *" {
+		t.Fatalf("stored cron = %q, want original expression", got.Cron)
+	}
+}
+
+// TestUpdateAllowsEditingLegacySubHourlyTask covers a task whose cron predates
+// minCronInterval — the only way to get one into the store, since Add now
+// rejects it, is loading it straight off disk (see loadAll). Update must
+// still accept edits that leave Cron untouched (e.g. disabling it), or such a
+// task becomes stuck: un-runnable by the new floor and un-patchable to fix.
+func TestUpdateAllowsEditingLegacySubHourlyTask(t *testing.T) {
+	dir := t.TempDir()
+	legacy := Task{ID: "t1", Name: "n", Cron: "0 */5 * * * *", Prompt: "p", Enabled: true}
+	b, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "t1.json"), b, 0600); err != nil {
+		t.Fatalf("write legacy task file: %v", err)
+	}
+
+	r := &recordRunner{}
+	s, err := New(dir, r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got, err := s.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Cron != legacy.Cron {
+		t.Fatalf("loaded cron = %q, want %q", got.Cron, legacy.Cron)
+	}
+
+	got.Enabled = false
+	if err := s.Update(*got); err != nil {
+		t.Fatalf("Update (disable, cron unchanged): %v", err)
+	}
+	disabled, err := s.Get("t1")
+	if err != nil {
+		t.Fatalf("Get after disable: %v", err)
+	}
+	if disabled.Enabled {
+		t.Fatal("task still enabled after Update")
+	}
+}
+
+// TestLoadAllSkipsSubHourlyLegacyTask: a task file written directly to disk
+// (bypassing Add's validation, e.g. hand-written while octo serve wasn't
+// running) with a sub-hourly cron loads without error but never gets a live
+// cron entry — mirroring how a syntactically invalid cron is already handled
+// at load time.
+func TestLoadAllSkipsSubHourlyLegacyTask(t *testing.T) {
+	dir := t.TempDir()
+	legacy := Task{ID: "t1", Name: "n", Cron: "0 */5 * * * *", Prompt: "p", Enabled: true}
+	b, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "t1.json"), b, 0600); err != nil {
+		t.Fatalf("write legacy task file: %v", err)
+	}
+
+	r := &recordRunner{}
+	s, err := New(dir, r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := len(s.List()); got != 1 {
+		t.Fatalf("loaded tasks = %d, want 1", got)
+	}
+	if got := len(s.cron.Entries()); got != 0 {
+		t.Fatalf("cron entries = %d, want 0 (sub-hourly legacy task must stay unscheduled)", got)
+	}
+	if got := s.NextRun("t1"); !got.IsZero() {
+		t.Fatalf("NextRun = %v, want zero time for an unscheduled task", got)
+	}
+}
+
 func TestNextRun(t *testing.T) {
 	s, _ := newTestScheduler(t)
 	// cron.Entry.Next is computed by the running scheduler loop, not at

--- a/internal/server/tasks_handlers_test.go
+++ b/internal/server/tasks_handlers_test.go
@@ -332,7 +332,7 @@ func TestTaskToResponse_NextRunIsTheSchedulerInstant(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	srv.initScheduler()
 
-	task := scheduler.Task{Name: "next-run", Cron: "0 */5 * * * *", Prompt: "p", Enabled: true}
+	task := scheduler.Task{Name: "next-run", Cron: "0 0 * * * *", Prompt: "p", Enabled: true}
 	if err := srv.scheduler.Add(&task); err != nil {
 		t.Fatalf("Add: %v", err)
 	}

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -47,12 +47,18 @@ seconds minutes hours day-of-month month day-of-week
 | Want | Expression |
 |------|------------|
 | Every day at 09:00 | `0 0 9 * * *` |
-| Every 30 minutes | `0 */30 * * * *` |
+| Every hour | `0 0 * * * *` |
 | Weekdays at 18:30 | `0 30 18 * * 1-5` |
 | 1st of each month at 08:00 | `0 0 8 1 * *` |
 
 Descriptors also work: `@hourly`, `@daily`, `@weekly`, `@every 90m`. Times are
 in the server's local timezone.
+
+**Minimum interval is 1 hour.** The scheduler rejects any expression whose
+consecutive fires are closer together than that (e.g. `0 */30 * * * *` or
+`@every 10m`) — the seconds/minutes fields exist for picking a precise time of
+day, not for sub-hourly polling. If the user wants faster iteration, use
+`/loop` in a live session instead of a cron task.
 
 ## Workflow
 
@@ -127,9 +133,11 @@ Write `~/.octo/tasks/<id>.json` with `write_file` (`id` format
 ```
 
 The file is picked up the next time `octo serve` starts. A hand-written file
-with a bad cron expression fails silently at load (logged to stderr only) —
-double-check the 6-field format. **File edits to an already-running server are
-ignored until restart** — when the server is up, always go through the API.
+with a bad cron expression — invalid syntax, or faster than the 1-hour floor —
+fails silently at load (logged to stderr only, task stays listed but never
+fires): double-check the 6-field format and the interval. **File edits to an
+already-running server are ignored until restart** — when the server is up,
+always go through the API.
 
 ## Caveats — mention when relevant
 


### PR DESCRIPTION
## Summary
- The scheduler's cron grammar includes a seconds field, which let a task be scheduled to fire every few seconds — a runaway loop of agent sessions. `Scheduler.Add`/`Update` now reject any expression whose next two computed fires are less than 1 hour apart.
- `schedule()` enforces the same floor for tasks loaded straight off disk at startup, since the documented direct-file-write fallback (server not running) bypasses `Add`/`Update`'s validation — a violating legacy task is logged and left unscheduled, mirroring how a syntactically invalid cron is already handled.
- `Update` only re-checks the floor when `Cron` is actually changing, so a legacy sub-hourly task (loaded from before this change) stays editable — e.g. can still be disabled — instead of becoming permanently stuck once any PATCH re-validates its unchanged expression.
- Updated the `cron-task-creator` skill doc so the LLM-facing guidance reflects the new floor and stops suggesting a now-rejected "every 30 minutes" example.

## Test plan
- [x] `go test ./internal/scheduler/... ./internal/server/...` — new tests cover: rejecting sub-hourly cron on `Add` (fixed-field and `@every`), accepting the exact 1-hour boundary, rejecting a sub-hourly change on `Update`, allowing a legacy sub-hourly task to still be edited (cron unchanged), and a legacy sub-hourly task loading without a live cron entry.
- [x] `go test ./...` (full repo) — no failures
- [x] `make fmt-check`, `make vet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)