### PR TITLE
web: flip the background-process chevron when the tray is open

### DIFF
--- a/web/src/components/chat/BackgroundProcesses.svelte
+++ b/web/src/components/chat/BackgroundProcesses.svelte
@@ -21,7 +21,7 @@
         <span class="dot"></span>
         <span class="lbl">{$t(tasks.length === 1 ? 'bgtask.n_process' : 'bgtask.n_processes').replace('{n}', String(tasks.length))}</span>
         <span style="margin-left:auto"></span>
-        <iconify-icon icon="lucide:chevron-up" width="14" style="color:var(--text-tertiary)"></iconify-icon>
+        <iconify-icon class="chev" icon="lucide:chevron-up" width="14" style="color:var(--text-tertiary)"></iconify-icon>
       </summary>
       <div class="proc-list">
         {#each tasks as p (p.handle_id)}
@@ -46,6 +46,8 @@
   font-size: 13px;
 }
 .tray-summary:hover { color: var(--blue-6); }
+.chev { transition: transform 0.15s ease; }
+details[open] .chev { transform: rotate(180deg); }
 .dot {
   width: 7px; height: 7px; border-radius: 9999px; background: var(--success);
   animation: octo-dot 1.4s infinite; flex: 0 0 auto;


### PR DESCRIPTION
## What

The background-process tray's chevron was a hardcoded `lucide:chevron-up`, so it looked identical collapsed and expanded — it never told you what clicking would do.

Now it points at the action: up while collapsed (click to open), rotated down once open (click to close). Done with a `details[open] .chev` rule rather than component state, so the arrow can't drift out of sync with `<details>`' own open state.

## Verification

`npx svelte-check` in `web/`: 0 errors, no new warnings (the two `line-clamp` ones are pre-existing on main and fixed separately in #2287).

🤖 Generated with [Claude Code](https://claude.com/claude-code)