### PR TITLE
tools: cap the spilled-output preview in bytes, not just lines

### DIFF
--- a/internal/tools/spill.go
+++ b/internal/tools/spill.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 )
 
 // TerminalSpillBytes is the size past which terminal output is written to a
@@ -22,6 +23,13 @@ const (
 	spillHeadLines = 50
 	spillTailLines = 50
 )
+
+// spillPreviewMaxBytes bounds the inline preview in bytes, on top of the line
+// bounds above. Lines alone can't bound it: a progress bar rewritten with \r
+// arrives as one multi-hundred-KB line, so fifty "lines" can still be a
+// quarter of a megabyte. ~8 KB (~2k tokens) leaves the preview useful while
+// keeping a single notice from dominating the context window.
+const spillPreviewMaxBytes = 8 * 1024
 
 // spillMaxAge is how long a spill file lives before a later spill sweeps it.
 // Files from a clean shutdown are removed immediately (CleanSpillFiles); this
@@ -58,39 +66,84 @@ func isSweepable(name string) bool {
 }
 
 // MaybeSpillOutput returns body unchanged when it is small enough to give the
-// LLM directly. When body exceeds TerminalSpillBytes — and has more lines than
-// the preview would show — it writes the full body to a temp file and returns
-// a head+tail preview plus the file path and a one-line read hint, so the
-// agent decides how to read the rest (read_file with offset/limit, or grep)
-// instead of having the whole blob flood its context.
+// LLM directly. When body exceeds TerminalSpillBytes it writes the full body to
+// a temp file and returns a bounded preview plus the file path and a one-line
+// read hint, so the agent decides how to read the rest (read_file with
+// offset/limit, or grep) instead of having the whole blob flood its context.
+//
+// The preview is bounded twice: by lines (head+tail) and by bytes
+// (spillPreviewMaxBytes). Both are needed — output can be enormous in few lines
+// as easily as in many, and one caller (the background-completion notice) has
+// no tool_result backstop behind it, so whatever this returns is what reaches
+// history.
 //
 // id names the source (e.g. a background process id) and is woven into the
-// temp filename. On any write failure it degrades to returning body unchanged:
-// losing context is worse than a missing file.
+// temp filename. A write failure still returns a capped preview: a missing file
+// is survivable, an unbounded body is not.
 func MaybeSpillOutput(id, body string) string {
 	if len(body) <= TerminalSpillBytes {
-		return body
-	}
-	lines := strings.Split(body, "\n")
-	if len(lines) <= spillHeadLines+spillTailLines {
-		// A few very long lines — a line-based preview would hide nothing,
-		// so a temp file buys us no context savings. Return as-is (bounded
-		// by the 1 MiB per-line scanner cap upstream).
 		return body
 	}
 
 	path, err := writeSpillFile(id, body)
 	if err != nil {
-		return body
+		return capSpillSegment(body, spillPreviewMaxBytes)
 	}
 
-	head := strings.Join(lines[:spillHeadLines], "\n")
-	tail := strings.Join(lines[len(lines)-spillTailLines:], "\n")
+	lines := strings.Split(body, "\n")
+	head, tail := body, ""
+	if len(lines) > spillHeadLines+spillTailLines {
+		head = strings.Join(lines[:spillHeadLines], "\n")
+		tail = strings.Join(lines[len(lines)-spillTailLines:], "\n")
+	}
+	if tail == "" {
+		head = capSpillSegment(head, spillPreviewMaxBytes)
+	} else {
+		half := spillPreviewMaxBytes / 2
+		head, tail = capSpillSegment(head, half), capSpillSegment(tail, half)
+	}
+
 	marker := fmt.Sprintf(
-		"[output too long: %d lines / %s written to\n %s\n showing first %d + last %d lines. read_file (offset/limit) or grep that path for the rest.]",
-		len(lines), formatBytes(int64(len(body))), path, spillHeadLines, spillTailLines,
+		"[output too long: %d lines / %s written to\n %s\n showing at most %s of it. read_file (offset/limit) or grep that path for the rest.]",
+		len(lines), formatBytes(int64(len(body))), path, formatBytes(spillPreviewMaxBytes),
 	)
+	if tail == "" {
+		return head + "\n\n" + marker
+	}
 	return head + "\n\n" + marker + "\n\n" + tail
+}
+
+// capSpillSegment bounds one end of the preview to max bytes, keeping both
+// sides of the segment so a trailing error or exit code survives, and saying
+// how much it dropped. Cuts are trimmed to rune boundaries: the result rides
+// the JSON wire format, which requires valid UTF-8.
+func capSpillSegment(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	marker := fmt.Sprintf("\n… [%s elided to fit context] …\n", formatBytes(int64(len(s)-max)))
+	budget := max - len(marker)
+	if budget < 0 {
+		budget = 0
+	}
+	head := budget / 2
+	return trimPartialRuneTail(s[:head]) + marker + trimPartialRuneHead(s[len(s)-(budget-head):])
+}
+
+// trimPartialRuneTail drops a trailing partial rune left by a byte slice.
+func trimPartialRuneTail(s string) string {
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// trimPartialRuneHead drops a leading partial rune left by a byte slice.
+func trimPartialRuneHead(s string) string {
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[1:]
+	}
+	return s
 }
 
 // writeSpillFile persists body under ~/.octo/tmp and returns the absolute path.

--- a/internal/tools/spill_test.go
+++ b/internal/tools/spill_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 // spillHome points ~/.octo at a temp dir so spill files don't touch the real
@@ -69,13 +70,77 @@ func TestMaybeSpillOutput_LargeSpillsToFile(t *testing.T) {
 	}
 }
 
-func TestMaybeSpillOutput_FewLongLinesPassThrough(t *testing.T) {
+func TestMaybeSpillOutput_FewLongLinesAreCapped(t *testing.T) {
 	spillHome(t)
-	// Over the byte threshold but only a handful of (very long) lines — a
-	// line-based preview would hide nothing, so we return as-is.
-	body := strings.Repeat("x", TerminalSpillBytes+100) + "\n" + strings.Repeat("y", 100)
-	if got := MaybeSpillOutput("bg_7", body); got != body {
-		t.Errorf("few long lines should pass through unchanged")
+	// Over the byte threshold in only a handful of (very long) lines — the
+	// shape a \r-rewritten progress bar arrives in. The line bounds can't touch
+	// it, so the byte cap has to: this used to pass through whole, and one such
+	// notice took ~250 KB of the context window.
+	body := strings.Repeat("x", 300*1024) + "\n" + strings.Repeat("y", 100)
+
+	out := MaybeSpillOutput("bg_7", body)
+
+	if len(out) > spillPreviewMaxBytes+512 {
+		t.Errorf("preview should be capped near %d bytes, got %d", spillPreviewMaxBytes, len(out))
+	}
+	if !strings.Contains(out, "elided to fit context") {
+		t.Errorf("expected an elision marker, got:\n%s", out[:min(len(out), 300)])
+	}
+	// The full body is still recoverable from the file the preview names.
+	data, err := os.ReadFile(extractSpillPath(t, out))
+	if err != nil {
+		t.Fatalf("spill file unreadable: %v", err)
+	}
+	if string(data) != body {
+		t.Errorf("spill file should hold the full body (%d vs %d bytes)", len(data), len(body))
+	}
+}
+
+func TestMaybeSpillOutput_LongLinesInsideLinePreviewAreCapped(t *testing.T) {
+	spillHome(t)
+	// Enough lines to trigger the head+tail split, but with enormous lines
+	// inside the kept head — the case that let a spilled background notice
+	// still reach history at 316 KB.
+	var b strings.Builder
+	for i := 0; i < spillHeadLines+spillTailLines+10; i++ {
+		b.WriteString(strings.Repeat("z", 4*1024))
+		b.WriteByte('\n')
+	}
+	body := b.String()
+
+	out := MaybeSpillOutput("bg_8", body)
+
+	if len(out) > spillPreviewMaxBytes+512 {
+		t.Errorf("preview should stay near %d bytes, got %d", spillPreviewMaxBytes, len(out))
+	}
+	if !strings.Contains(out, "output too long") {
+		t.Errorf("expected spill marker, got:\n%s", out[:min(len(out), 300)])
+	}
+}
+
+func TestCapSpillSegment_KeepsValidUTF8(t *testing.T) {
+	// Cutting mid-rune would put invalid UTF-8 on the JSON wire. CJK makes
+	// every cut land inside a 3-byte rune unless the trims do their job.
+	body := strings.Repeat("云识别测试", 4096)
+	got := capSpillSegment(body, 1024)
+	if !utf8.ValidString(got) {
+		t.Errorf("capped segment must be valid UTF-8")
+	}
+	if len(got) > 1024 {
+		t.Errorf("capped segment = %d bytes, want <= 1024", len(got))
+	}
+	if !strings.HasPrefix(got, "云") {
+		t.Errorf("head should survive, got %q", got[:12])
+	}
+	if !strings.HasSuffix(got, "试") {
+		t.Errorf("tail should survive, got %q", got[len(got)-12:])
+	}
+}
+
+func TestCapSpillSegment_ShortInputUntouched(t *testing.T) {
+	body := "exit status 1\n"
+	if got := capSpillSegment(body, 1024); got != body {
+		t.Errorf("segment within budget should be returned unchanged, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## The symptom

A session sat at 87% context and did not auto-compact. Digging into its history: **one message was 316 KB** — a `[BACKGROUND COMPLETED]` notice for a TensorFlow training run, 1365 lines, 43% of the model's context window in a single message. The spill marker was present, so `MaybeSpillOutput` had run and written the file. The preview it returned was still 316 KB.

## Why

`MaybeSpillOutput` bounded the preview only by **line count**, and had two ways to return an unbounded body:

1. `len(lines) <= spillHeadLines+spillTailLines` → `return body` verbatim, on the reasoning that "a line-based preview would hide nothing"
2. even when it did spill, `head 50 + tail 50` lines had no byte ceiling

Terminal output does not respect line counts. A progress bar rewritten with `\r` arrives as **one** multi-hundred-KB line, so fifty "lines" can be a quarter of a megabyte — which is exactly what a Keras training log produces.

What makes this path different from the rest is that **it has no backstop behind it**. The background-completion notice reaches history through `Inbox`/steer, not as a `tool_result`, so `microCompact`'s 40 KB ceiling never sees it. Whatever `MaybeSpillOutput` returns is what enters the context window, verbatim. The synchronous `terminal` callers are covered by `microCompact`; this one never was.

## The fix

A byte bound on top of the line bounds, all inside `spill.go`:

- `spillPreviewMaxBytes = 8 KB` (~2k tokens) caps the inline preview
- `capSpillSegment` trims each end middle-out, so a trailing error or exit code survives, and reports how much it dropped. Cuts are trimmed to rune boundaries — the result rides the JSON wire format, which requires valid UTF-8
- the few-long-lines passthrough is gone: with bytes bounded, a preview of a huge single line is now worth showing
- a spill-file write failure caps the body too, instead of returning it whole. A missing file is survivable; an unbounded body is not

`bgnotify.go` is unchanged — it calls `MaybeSpillOutput` and inherits the cap.

## Tests

`TestMaybeSpillOutput_FewLongLinesPassThrough` asserted the very passthrough that caused this, so it is rewritten to assert the cap. Three new cases: a 300 KB single line is capped and still fully recoverable from the spill file; huge lines *inside* the kept head are capped (the 316 KB shape); CJK text survives capping as valid UTF-8 with both ends intact.

```
gofmt -l .        clean
go vet ./...      clean
go test -race ./internal/tools/ ./internal/agent/   ok
```

## Not in scope

`FormatSubAgentNote` and `FormatWorkflowNote` write `ev.Result` with no ceiling either — same shape. Their payloads are model output / workflow return values, bounded by `max_tokens` rather than by a chatty subprocess, and neither has been observed causing this. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)