### PR TITLE
agent: let mid-turn compaction see what a turn appended

### DIFF
--- a/dev-docs/compaction-redesign.md
+++ b/dev-docs/compaction-redesign.md
@@ -77,7 +77,7 @@ single-giant-turn case Part 1 alone can't fold.
   block content with a placeholder `[elided N bytes — <tool> result; re-run to
   view]`. IDs are preserved so tool_use/tool_result pairing stays valid. No model
   call.
-- Wire into `maybeCompact` / between-batch path: when over trigger, run
+- Wire into `maybeCompact` / mid-turn path: when over trigger, run
   reclamation **first**; recompute tokens; if now under `trigger − margin`, skip
   the LLM summarize entirely. Otherwise fall through to Part 1's summarize.
 - Cache: rewriting old blocks invalidates the prompt-cache prefix from the first

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1086,6 +1086,17 @@ func (a *Agent) runLoop(
 		// error tool_results prevents Anthropic HTTP 400 errors.
 		a.ensureToolPairing()
 
+		// Pre-send checkpoint. Everything appended since the last provider call
+		// converges here — the previous batch's tool results, a steer message
+		// injected above, a background-completion notice — so this is where
+		// mid-turn growth becomes visible. The steer path in particular reaches
+		// this line without passing through a tool batch, so a check hung off
+		// the batch alone never saw it. Skipped on the first round: the
+		// between-turns check ran moments ago, just above the loop.
+		if i > 0 && a.shouldCompactMidTurn() {
+			_ = a.maybeCompact(ctx, handler)
+		}
+
 		// Images a text-only model can't read become text before they go on
 		// the wire. No-op when no describer is wired or the model has vision.
 		msgs := a.History.Snapshot()
@@ -1239,6 +1250,15 @@ func (a *Agent) runLoop(
 		}
 
 		if reply.StopReason == "tool_use" {
+			// Pre-dispatch checkpoint. accrueUsage above just learned what the
+			// prompt really cost, and this batch may run for many minutes —
+			// leaving the next checkpoint (the pre-send one, a full batch away)
+			// to park the context over the threshold for that whole stretch.
+			// History still ends on a tool_result or a plain user turn here, the
+			// same safe boundary.
+			if a.shouldCompactMidTurn() {
+				_ = a.maybeCompact(ctx, handler)
+			}
 			a.History.Append(NewToolUseMessage(reply.Blocks))
 			// A tool call ends the current stretch of assistant speech (every
 			// UI starts a new block after it), so a carried pre-reminder answer
@@ -1298,13 +1318,6 @@ func (a *Agent) runLoop(
 			a.applyPostToolUse(ctx, reply.Blocks, resultBlocks)
 
 			a.History.Append(NewToolResultMessage(resultBlocks))
-
-			// Turn-in compaction check: after a tool batch, history may have
-			// grown significantly. If the estimated size is near the window,
-			// compact before the next LLM call to avoid a 400.
-			if a.shouldCompactBetweenBatches() {
-				_ = a.maybeCompact(ctx, handler)
-			}
 			continue
 		}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1091,8 +1091,17 @@ func (a *Agent) runLoop(
 		// injected above, a background-completion notice — so this is where
 		// mid-turn growth becomes visible. The steer path in particular reaches
 		// this line without passing through a tool batch, so a check hung off
-		// the batch alone never saw it. Skipped on the first round: the
-		// between-turns check ran moments ago, just above the loop.
+		// the batch alone never saw it. A summarization failure is non-fatal for
+		// the same reason it is above the loop: proceed with the full history and
+		// let the provider's own limit be the backstop.
+		//
+		// Round 0 is left to the between-turns check above the loop, which — like
+		// this one — cannot see what appendUserInput and a round-0 Inbox drain
+		// add after it. Closing that gap by checking here instead would compact
+		// after baseHistoryLen was taken, and a first-round send failure would
+		// then set inputRolledBack while TruncateTo silently no-ops on the now
+		// shorter history: the composer gets a message that is still in the
+		// transcript. That is a rollback-semantics change, not a checkpoint one.
 		if i > 0 && a.shouldCompactMidTurn() {
 			_ = a.maybeCompact(ctx, handler)
 		}

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -274,8 +274,8 @@ func (a *Agent) compactTriggerTokens() int {
 	}
 }
 
-// historyTokens returns the best available token count for the given messages:
-// the larger of what the provider counted and what the estimate sees.
+// historyTokens returns the best available token count for msgs: the larger of
+// what the provider counted and what the estimate sees.
 //
 // Neither number is sufficient alone. The provider's count is exact but measures
 // the prompt we last SENT — it knows nothing of what has been appended since: a
@@ -285,11 +285,21 @@ func (a *Agent) compactTriggerTokens() int {
 // provider count outright (what this did) let mid-turn growth hide behind a
 // stale number until the next provider call re-measured it — a turn could append
 // 100k of tool output and still look like whatever the last prompt cost.
+//
+// The estimate side must count what the reported side counts, or the comparison
+// is between two different things: the reported figure is the WHOLE prompt, and
+// the system prompt plus tool schemas ride every call for 10k+ tokens. Leaving
+// them out would mean mid-turn growth had to exceed that overhead before it
+// could ever win the max — which is most of the blind spot, still blind. Same
+// arithmetic as ContextUsage's estimate fallback.
+//
+// msgs must be the full history; every caller passes a complete snapshot.
 func (a *Agent) historyTokens(msgs []Message) int {
 	a.usageMu.Lock()
 	reported := a.lastInputTokens
+	overhead := a.toolDefTokens
 	a.usageMu.Unlock()
-	if est := estimateMessages(msgs); est > reported {
+	if est := estimateMessages(msgs) + estimateText(a.System) + overhead; est > reported {
 		return est
 	}
 	return reported

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -274,19 +274,25 @@ func (a *Agent) compactTriggerTokens() int {
 	}
 }
 
-// historyTokens returns the best available token count for the given messages.
-// When the provider has reported a real input token count (lastInputTokens > 0),
-// it returns that value; otherwise it falls back to the heuristic estimate.
-// The real count is more accurate because it reflects exactly how the provider's
-// tokenizer counted the prompt, including any format overhead the estimate misses.
+// historyTokens returns the best available token count for the given messages:
+// the larger of what the provider counted and what the estimate sees.
+//
+// Neither number is sufficient alone. The provider's count is exact but measures
+// the prompt we last SENT — it knows nothing of what has been appended since: a
+// whole tool batch's results, a steer message, an injected background notice.
+// The estimate covers history as it stands now but runs low, since CJK text and
+// JSON tool input both under-count against a real tokenizer. Preferring the
+// provider count outright (what this did) let mid-turn growth hide behind a
+// stale number until the next provider call re-measured it — a turn could append
+// 100k of tool output and still look like whatever the last prompt cost.
 func (a *Agent) historyTokens(msgs []Message) int {
 	a.usageMu.Lock()
-	real := a.lastInputTokens
+	reported := a.lastInputTokens
 	a.usageMu.Unlock()
-	if real > 0 {
-		return real
+	if est := estimateMessages(msgs); est > reported {
+		return est
 	}
-	return estimateMessages(msgs)
+	return reported
 }
 
 // summarizeMaxTokens caps the summary length. A summary is meant to be a
@@ -713,14 +719,16 @@ func hasToolResult(m Message) bool {
 	return false
 }
 
-// shouldCompactBetweenBatches reports whether compaction should run after a
-// tool batch, before the next LLM call. This catches history growth within a
-// turn that lastInputTokens (from the previous provider call) doesn't reflect.
+// shouldCompactMidTurn reports whether compaction should run at one of the
+// turn's interior boundaries: before a provider call (where the previous
+// batch's results and any injected steer have landed) or before dispatching a
+// tool batch (where the reply just told us what the prompt really cost). Both
+// are points where history ends on a complete message.
 //
 // It uses the one and only compaction trigger (compactTriggerTokens) — the same
 // point between-turns compaction fires — so a single threshold governs the whole
 // session and context can't quietly climb past it mid-turn and sit there.
-func (a *Agent) shouldCompactBetweenBatches() bool {
+func (a *Agent) shouldCompactMidTurn() bool {
 	trigger := a.compactTriggerTokens()
 	if trigger <= 0 {
 		return false

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -202,7 +202,7 @@ func TestCompactTriggerTokens(t *testing.T) {
 // Between-batches (mid-turn) compaction uses the one and only compaction
 // trigger — the same point between-turns fires — so a single threshold governs
 // the whole session and honors CompactAutoFraction.
-func TestShouldCompactBetweenBatches_UsesSingleTrigger(t *testing.T) {
+func TestShouldCompactMidTurn_UsesSingleTrigger(t *testing.T) {
 	a := New(&summarizeFake{}, "unknown-model-xyz") // unknown model → default window
 
 	trigger := a.compactTriggerTokens() // auto: 75% of the default window
@@ -613,13 +613,10 @@ func TestRun_CompactsBetweenTurns(t *testing.T) {
 type dispatchObservingExecutor struct {
 	a         *Agent
 	headAtRun string
-	lenAtRun  int
 }
 
 func (e *dispatchObservingExecutor) Execute(_ context.Context, _ string, _ map[string]any) (ToolResult, error) {
-	snap := e.a.History.Snapshot()
-	e.lenAtRun = len(snap)
-	if len(snap) > 0 {
+	if snap := e.a.History.Snapshot(); len(snap) > 0 {
 		e.headAtRun = snap[0].Content
 	}
 	return ToolResult{Text: "ok"}, nil
@@ -641,9 +638,14 @@ func (f *usageReportingFake) SendMessages(_ context.Context, _, _ string, _ []Me
 }
 
 func (f *usageReportingFake) SendMessagesWithTools(_ context.Context, _, _ string, _ []Message, _ int, _ []ToolDefinition) (Reply, error) {
-	r := f.loopReplies[f.loopCalls]
 	f.loopCalls++
-	return r, nil
+	if f.loopCalls > len(f.loopReplies) {
+		// An extra round means the loop did something the test didn't script.
+		// Ending the turn surfaces that as a failed assertion rather than an
+		// index panic in a stack trace nobody can read.
+		return Reply{Content: "unscripted round", StopReason: "end_turn"}, nil
+	}
+	return f.loopReplies[f.loopCalls-1], nil
 }
 
 // TestRun_CompactsBeforeDispatchingToolBatch pins the pre-dispatch checkpoint.
@@ -790,6 +792,108 @@ func TestHistoryTokens_TakesLargerOfReportedAndEstimate(t *testing.T) {
 	a.usageMu.Unlock()
 	if got := a.historyTokens(msgs); got != est*2 {
 		t.Errorf("with a report above the estimate, historyTokens = %d, want %d", got, est*2)
+	}
+}
+
+// toolOutputFake runs one tool round and records every prompt it is sent, so a
+// test can check what the round AFTER the batch was given.
+type toolOutputFake struct {
+	prompts        [][]Message
+	summarizeCalls int
+	loopCalls      int
+}
+
+func (f *toolOutputFake) SendMessages(_ context.Context, _, _ string, _ []Message, _ int) (Reply, error) {
+	f.summarizeCalls++
+	return Reply{Content: "earlier work summary"}, nil
+}
+
+func (f *toolOutputFake) SendMessagesWithTools(_ context.Context, _, _ string, msgs []Message, _ int, _ []ToolDefinition) (Reply, error) {
+	f.loopCalls++
+	f.prompts = append(f.prompts, msgs)
+	if f.loopCalls == 1 {
+		// A small reported prompt: the crossing has to be found in the tool
+		// result appended after this reply, not in what this prompt cost.
+		return Reply{
+			StopReason:  "tool_use",
+			Blocks:      []ContentBlock{NewToolUseBlock("t1", "terminal", map[string]any{"command": "true"})},
+			InputTokens: 100,
+		}, nil
+	}
+	return Reply{Content: "done", StopReason: "end_turn"}, nil
+}
+
+// bigOutputExecutor returns more output than the trigger allows.
+type bigOutputExecutor struct{ out string }
+
+func (e *bigOutputExecutor) Execute(_ context.Context, _ string, _ map[string]any) (ToolResult, error) {
+	return ToolResult{Text: e.out}, nil
+}
+
+// TestRun_CompactsAfterToolResultsPushPastTrigger covers the case a tool batch's
+// own output is what crosses the trigger. The batch's results land in history
+// after the reply that requested it, so neither the between-turns check nor the
+// pre-dispatch one can see them — only the checkpoint before the next provider
+// call.
+func TestRun_CompactsAfterToolResultsPushPastTrigger(t *testing.T) {
+	f := &toolOutputFake{}
+	a := New(f, "m")
+	a.CompactThreshold = 3000
+
+	longMsg := strings.Repeat("x ", 500) // ~250 tokens each
+	for i := 0; i < 4; i++ {
+		a.History.Append(NewUserMessage(longMsg))
+		a.History.Append(NewAssistantMessage(longMsg))
+	}
+	if est := estimateMessages(a.History.Snapshot()); est >= 3000 {
+		t.Fatalf("test setup: seeded history (%d) must start under the trigger", est)
+	}
+
+	exec := &bigOutputExecutor{out: strings.Repeat("build output line ", 900)}
+	if _, err := a.Run(context.Background(), "run it", []ToolDefinition{{Name: "terminal"}}, exec); err != nil {
+		t.Fatal(err)
+	}
+
+	if f.loopCalls != 2 {
+		t.Fatalf("expected two rounds (tool round, then the answer), got %d", f.loopCalls)
+	}
+	if f.summarizeCalls != 1 {
+		t.Fatalf("expected exactly one summarization, got %d", f.summarizeCalls)
+	}
+	second := f.prompts[1]
+	if len(second) == 0 || !strings.Contains(second[0].Content, "earlier work summary") {
+		t.Errorf("the round after the batch should be sent a compacted history; head = %q",
+			truncateForMsg(second[0].Content))
+	}
+	// The tool_use/tool_result pair must have survived compaction intact —
+	// splitting it is an immediate provider 400.
+	assertToolPairing(t, second)
+}
+
+// assertToolPairing fails when any tool_use in msgs lacks a matching
+// tool_result, or vice versa.
+func assertToolPairing(t *testing.T, msgs []Message) {
+	t.Helper()
+	uses, results := map[string]bool{}, map[string]bool{}
+	for _, m := range msgs {
+		for _, b := range m.Blocks {
+			switch b.Type {
+			case "tool_use":
+				uses[b.ID] = true
+			case "tool_result":
+				results[b.ToolUseID] = true
+			}
+		}
+	}
+	for id := range uses {
+		if !results[id] {
+			t.Errorf("tool_use %q has no tool_result", id)
+		}
+	}
+	for id := range results {
+		if !uses[id] {
+			t.Errorf("tool_result for %q has no tool_use", id)
+		}
 	}
 }
 

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -210,20 +210,20 @@ func TestShouldCompactBetweenBatches_UsesSingleTrigger(t *testing.T) {
 	a.usageMu.Lock()
 	a.lastInputTokens = trigger - 1
 	a.usageMu.Unlock()
-	if a.shouldCompactBetweenBatches() {
+	if a.shouldCompactMidTurn() {
 		t.Errorf("should not compact between batches below the trigger (%d)", trigger)
 	}
 	// Just over: it fires, at the very same threshold between-turns uses.
 	a.usageMu.Lock()
 	a.lastInputTokens = trigger + 1
 	a.usageMu.Unlock()
-	if !a.shouldCompactBetweenBatches() {
+	if !a.shouldCompactMidTurn() {
 		t.Errorf("should compact between batches above the trigger (%d)", trigger)
 	}
 
 	// Disabling compaction entirely (CompactThreshold < 0) disables it here too.
 	a.CompactThreshold = -1
-	if a.shouldCompactBetweenBatches() {
+	if a.shouldCompactMidTurn() {
 		t.Error("should not compact between batches when compaction is disabled")
 	}
 }
@@ -604,6 +604,192 @@ func TestRun_CompactsBetweenTurns(t *testing.T) {
 	snap := a.History.Snapshot()
 	if !strings.Contains(snap[0].Content, "earlier work summary") {
 		t.Errorf("compaction summary should lead the history, got %+v", snap[0])
+	}
+}
+
+// dispatchObservingExecutor records what the history looked like at the moment
+// a tool ran, so a test can tell whether compaction happened before the batch
+// was dispatched or only after its results landed.
+type dispatchObservingExecutor struct {
+	a         *Agent
+	headAtRun string
+	lenAtRun  int
+}
+
+func (e *dispatchObservingExecutor) Execute(_ context.Context, _ string, _ map[string]any) (ToolResult, error) {
+	snap := e.a.History.Snapshot()
+	e.lenAtRun = len(snap)
+	if len(snap) > 0 {
+		e.headAtRun = snap[0].Content
+	}
+	return ToolResult{Text: "ok"}, nil
+}
+
+// usageReportingFake drives one tool_use round whose reply reports a prompt far
+// over the trigger — the shape of a turn that crosses the threshold mid-flight,
+// where the between-turns check has already run and passed.
+type usageReportingFake struct {
+	summary        string
+	loopReplies    []Reply
+	loopCalls      int
+	summarizeCalls int
+}
+
+func (f *usageReportingFake) SendMessages(_ context.Context, _, _ string, _ []Message, _ int) (Reply, error) {
+	f.summarizeCalls++
+	return Reply{Content: f.summary}, nil
+}
+
+func (f *usageReportingFake) SendMessagesWithTools(_ context.Context, _, _ string, _ []Message, _ int, _ []ToolDefinition) (Reply, error) {
+	r := f.loopReplies[f.loopCalls]
+	f.loopCalls++
+	return r, nil
+}
+
+// TestRun_CompactsBeforeDispatchingToolBatch pins the pre-dispatch checkpoint.
+// A batch can run for many minutes; if compaction only ran after the results
+// landed, the context would sit over the threshold for that entire stretch.
+func TestRun_CompactsBeforeDispatchingToolBatch(t *testing.T) {
+	f := &usageReportingFake{
+		summary: "earlier work summary",
+		loopReplies: []Reply{
+			// Round 1 asks for a tool AND reports a prompt over the trigger.
+			{
+				StopReason:  "tool_use",
+				Blocks:      []ContentBlock{NewToolUseBlock("t1", "terminal", map[string]any{"command": "true"})},
+				InputTokens: 5000,
+			},
+			{Content: "done", StopReason: "end_turn"},
+		},
+	}
+	a := New(f, "m")
+	a.CompactThreshold = 3000
+
+	// Prior history stays UNDER the trigger by estimate, so the between-turns
+	// check at turn start passes and only the reported usage can trip it.
+	longMsg := strings.Repeat("x ", 500) // ~250 tokens each
+	for i := 0; i < 4; i++ {
+		a.History.Append(NewUserMessage(longMsg))
+		a.History.Append(NewAssistantMessage(longMsg))
+	}
+	if est := estimateMessages(a.History.Snapshot()); est >= 3000 {
+		t.Fatalf("test setup: seeded history (%d) must start under the trigger", est)
+	}
+
+	exec := &dispatchObservingExecutor{a: a}
+	if _, err := a.Run(context.Background(), "next request", []ToolDefinition{{Name: "terminal"}}, exec); err != nil {
+		t.Fatal(err)
+	}
+
+	if f.summarizeCalls != 1 {
+		t.Fatalf("expected exactly one summarization, got %d", f.summarizeCalls)
+	}
+	if !strings.Contains(exec.headAtRun, "earlier work summary") {
+		t.Errorf("compaction must run BEFORE the batch is dispatched; history head at dispatch = %q",
+			truncateForMsg(exec.headAtRun))
+	}
+}
+
+func truncateForMsg(s string) string {
+	if len(s) > 80 {
+		return s[:80] + "…"
+	}
+	return s
+}
+
+// steerInjectingFake drops a large message on the Inbox during the first round,
+// the way a background-completion notice arrives mid-turn, and records the size
+// of every prompt it is sent.
+type steerInjectingFake struct {
+	a              *Agent
+	steer          string
+	prompts        [][]Message
+	summarizeCalls int
+	loopCalls      int
+}
+
+func (f *steerInjectingFake) SendMessages(_ context.Context, _, _ string, _ []Message, _ int) (Reply, error) {
+	f.summarizeCalls++
+	return Reply{Content: "earlier work summary"}, nil
+}
+
+func (f *steerInjectingFake) SendMessagesWithTools(_ context.Context, _, _ string, msgs []Message, _ int, _ []ToolDefinition) (Reply, error) {
+	f.loopCalls++
+	f.prompts = append(f.prompts, msgs)
+	if f.loopCalls == 1 {
+		f.a.Inbox.Enqueue(f.steer)
+		// InputTokens stays small: the crossing must be found in what was
+		// appended after this reply, not in what this prompt cost.
+		return Reply{Content: "working on it", StopReason: "end_turn", InputTokens: 100}, nil
+	}
+	return Reply{Content: "done", StopReason: "end_turn"}, nil
+}
+
+// TestRun_CompactsAfterSteerInjection covers the path that reaches a provider
+// call without passing through a tool batch: a steer message (a background
+// notice, a mid-turn user message) injected into history mid-turn. A checkpoint
+// hung off tool batches alone never sees it.
+func TestRun_CompactsAfterSteerInjection(t *testing.T) {
+	f := &steerInjectingFake{
+		// One notice big enough to cross the trigger on its own — the shape a
+		// chatty background process produces.
+		steer: strings.Repeat("training log line ", 900),
+	}
+	a := New(f, "m")
+	f.a = a
+	a.CompactThreshold = 3000
+
+	longMsg := strings.Repeat("x ", 500) // ~250 tokens each
+	for i := 0; i < 4; i++ {
+		a.History.Append(NewUserMessage(longMsg))
+		a.History.Append(NewAssistantMessage(longMsg))
+	}
+	if est := estimateMessages(a.History.Snapshot()); est >= 3000 {
+		t.Fatalf("test setup: seeded history (%d) must start under the trigger", est)
+	}
+
+	if _, err := a.Run(context.Background(), "run it", []ToolDefinition{{Name: "terminal"}}, &fakeExecutor{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if f.loopCalls != 2 {
+		t.Fatalf("expected two rounds (the steer keeps the turn going), got %d", f.loopCalls)
+	}
+	if f.summarizeCalls != 1 {
+		t.Fatalf("expected exactly one summarization, got %d", f.summarizeCalls)
+	}
+	second := f.prompts[1]
+	if len(second) == 0 || !strings.Contains(second[0].Content, "earlier work summary") {
+		t.Errorf("the round after the steer should be sent a compacted history; head = %q",
+			truncateForMsg(second[0].Content))
+	}
+}
+
+// TestHistoryTokens_TakesLargerOfReportedAndEstimate pins the fix for the
+// blind spot behind all of this: the provider's count measures the prompt last
+// SENT, so on its own it cannot see a tool batch's results or an injected
+// notice appended after it, and mid-turn growth stayed invisible until the next
+// provider call re-measured it.
+func TestHistoryTokens_TakesLargerOfReportedAndEstimate(t *testing.T) {
+	a := New(&compactingFake{}, "m")
+	msgs := []Message{NewUserMessage(strings.Repeat("x ", 4000))} // ~2000 tokens
+	est := estimateMessages(msgs)
+
+	// Stale small report (what the last prompt cost) — the estimate must win.
+	a.usageMu.Lock()
+	a.lastInputTokens = 50
+	a.usageMu.Unlock()
+	if got := a.historyTokens(msgs); got != est {
+		t.Errorf("with a stale report, historyTokens = %d, want the estimate %d", got, est)
+	}
+
+	// Report above the estimate (a cached prefix the estimate under-counts) —
+	// the report must win, since the estimate runs low.
+	a.usageMu.Lock()
+	a.lastInputTokens = est * 2
+	a.usageMu.Unlock()
+	if got := a.historyTokens(msgs); got != est*2 {
+		t.Errorf("with a report above the estimate, historyTokens = %d, want %d", got, est*2)
 	}
 }
 


### PR DESCRIPTION
## The symptom

A session sat at 87% of its context window and did not compact, for the length of a 22-minute turn. Following on from #2289, which came out of the same investigation.

## Why the checkpoint was blind

`historyTokens` returned the provider's reported count verbatim whenever it was set:

```go
if real > 0 {
    return real
}
return estimateMessages(msgs)
```

That number measures **the prompt we last sent**. It knows nothing about what was appended after it — a whole tool batch's results, a steer message, an injected background notice. So a turn could append 100k of tool output and still measure whatever the previous prompt happened to cost, until the next provider call re-measured it. The checkpoint ran on every batch and kept answering "we're fine".

In the session that prompted this: a `write_file` of 12 KB landed in history, and the post-batch check was still reading the *previous* call's number.

Now it takes the larger of the two views. The report is exact but stale; the estimate is current but runs low (CJK text and JSON tool input both under-count against a real tokenizer). Either one alone lets a crossing hide.

**Both sides must count the same things.** The reported figure is the whole prompt, system prompt and tool schemas included, and those routinely add 10k+ tokens. An estimate over the transcript alone would have to exceed that overhead before it could ever win the max — most of the blind spot, still blind. So the estimate side adds `estimateText(a.System) + toolDefTokens`, the arithmetic `ContextUsage`'s estimate fallback (`agent.go:2354`) already uses. Every `historyTokens` caller passes a complete history snapshot, so the overhead applies uniformly; `summarizeOn`'s overflow loop deliberately calls `estimateMessages` directly and is unaffected.

## Where the checkpoints go

- **Pre-send** — top of the loop, once `ensureToolPairing` has run and before `History.Snapshot()` is taken for `describeImages` (which writes back through snapshot indices, so compacting after the snapshot would be a bug). Replaces the post-batch check: same "before the next provider call" boundary, but it also covers **the steer path**, which reaches a provider call without passing through a tool batch and so was never checked at all.
- **Pre-dispatch** — after a reply asks for tools, before the `tool_use` message is appended. `accrueUsage` has just learned what the prompt really cost, and the batch about to run may take many minutes. Leaving it to the pre-send checkpoint a full batch away parks the context over the threshold for that entire stretch — which is exactly what the 22-minute turn did.

`shouldCompactBetweenBatches` → `shouldCompactMidTurn`, since it no longer serves only batch boundaries.

### Why the pre-send check skips round 0

`baseHistoryLen` is taken before the loop. Compacting before the first provider call would shorten history underneath it, and a first-round send failure would then set `inputRolledBack` while `TruncateTo` silently no-ops — handing the composer a message that is still in the transcript, the exact bug `TestInputRolledBack_CompactionThenMidTurnErrorIsNotRollback` exists to prevent.

There is a real gap here: `appendUserInput` (including hook-injected context) and a round-0 `Inbox.Drain()` both land *after* the between-turns check. That gap predates this change — the old between-turns call sat before `baseHistoryLen` and `appendUserInput` too — and closing it means changing rollback semantics, not adding a checkpoint. Left for its own change, with the reasoning recorded at the call site.

## Both halves are load-bearing

Verified by disabling each in turn against `TestRun_CompactsAfterSteerInjection`:

| | summarizations |
|---|---|
| both | 1 |
| checkpoint, no token fix | 0 |
| token fix, no checkpoint | 0 |

## Tests

- `TestRun_CompactsAfterSteerInjection` — a large notice arrives on the Inbox mid-turn; the next round must be sent a compacted history. Covers the path with no tool batch in it.
- `TestRun_CompactsBeforeDispatchingToolBatch` — a reply that both asks for tools and reports an over-trigger prompt must compact *before* dispatch. An executor records the history head at dispatch time to pin the ordering. Disabling the checkpoint makes it fail while still summarizing once, which is the point: the old behaviour was not "never compacts", it was "compacts a batch too late".
- `TestRun_CompactsAfterToolResultsPushPastTrigger` — the scenario the removed post-batch check used to own: the batch's own output crosses the trigger and the following round must be sent a compacted history. Also asserts `tool_use`/`tool_result` pairing survived the rebuild.
- `TestHistoryTokens_TakesLargerOfReportedAndEstimate` — pins both directions.

Two real regressions surfaced on the way, both from the first round double-compacting; the `i > 0` guard is what fixes them, and they are why it's there:

- `TestRun_CompactsBetweenTurns` — summarized twice
- `TestInputRolledBack_CompactionThenMidTurnErrorIsNotRollback` — the extra summarize consumed a reply and desynced the fake sender's script

```
gofmt -l .          clean
go vet ./...        clean
go test -race ./... exit 0, 51 packages ok
```

## Known gaps, deliberately not in this change

- `estimateMessage` counts both `Message.Content` and the text blocks in `Message.Blocks`, double-counting prose on replies that carry thinking blocks. A real bug, and more relevant now that the estimate can be the deciding number, but fixing it moves every test that depends on estimate values.
- `ContextUsage` still returns the reported count outright when set, so the UI gauge lags mid-turn growth the same way the trigger used to. It is called at render-tick rate, so the estimate path stays a cold fallback there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)