### PR TITLE
web: collapse the background-process tray into a text trigger, fix its clock

### DIFF
--- a/web/src/components/chat/BackgroundProcesses.svelte
+++ b/web/src/components/chat/BackgroundProcesses.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   import { t } from '../../lib/i18n'
 
-  // Real background tasks come from the background_task_update WS event.
-  // Each task: { handle_id, command, elapsed } (elapsed in seconds).
-  let { tasks = [] }: { tasks?: any[] } = $props()
+  // Real background tasks come from the background_tasks_update WS event.
+  // Each task: { handle_id, command, startedAt } — ChatView anchors the
+  // server's one-shot `elapsed` to a local timestamp, since the server only
+  // re-broadcasts on tool calls and process exits.
+  let { tasks = [], now = 0 }: { tasks?: any[]; now?: number } = $props()
 
   let open = $state(false)
   let rootEl: HTMLElement | undefined = $state()
 
-  function fmtElapsed(sec: number): string {
+  function fmtElapsed(startedAt: number): string {
+    const sec = now > 0 && startedAt > 0 ? (now - startedAt) / 1000 : 0
     if (!sec || sec < 0) return '0s'
     if (sec < 60) return `${Math.floor(sec)}s`
     const m = Math.floor(sec / 60)
@@ -42,7 +45,7 @@
             <div class="proc-info">
               <span class="proc-cmd mono">{p.command}</span>
             </div>
-            <span class="proc-time">{$t('bgtask.running_elapsed').replace('{elapsed}', fmtElapsed(p.elapsed))}</span>
+            <span class="proc-time">{$t('bgtask.running_elapsed').replace('{elapsed}', fmtElapsed(p.startedAt))}</span>
           </div>
           {/each}
         </div>

--- a/web/src/components/chat/BackgroundProcesses.svelte
+++ b/web/src/components/chat/BackgroundProcesses.svelte
@@ -23,6 +23,11 @@
   // rootEl wraps only the trigger and the popover — not the empty width of the
   // row — so clicking anywhere else, that blank space included, closes it. The
   // trigger being inside means its own click never counts as "outside".
+  //
+  // Listened for during capture: the composer's menu chips stopPropagation on
+  // their own clicks (that's how their menus survive the composer's own
+  // window-level close), and a bubble-phase listener would never see those —
+  // leaving this popover open underneath a freshly opened menu.
   function onDocClick(e: MouseEvent) {
     if (open && rootEl && !rootEl.contains(e.target as Node)) open = false
   }
@@ -33,7 +38,7 @@
   }
 </script>
 
-<svelte:window onclick={onDocClick} onkeydown={onKeydown} />
+<svelte:window onclickcapture={onDocClick} onkeydown={onKeydown} />
 
 <div class="bg-line">
   <div class="bg-line-inner">

--- a/web/src/components/chat/BackgroundProcesses.svelte
+++ b/web/src/components/chat/BackgroundProcesses.svelte
@@ -5,6 +5,9 @@
   // Each task: { handle_id, command, elapsed } (elapsed in seconds).
   let { tasks = [] }: { tasks?: any[] } = $props()
 
+  let open = $state(false)
+  let rootEl: HTMLElement | undefined = $state()
+
   function fmtElapsed(sec: number): string {
     if (!sec || sec < 0) return '0s'
     if (sec < 60) return `${Math.floor(sec)}s`
@@ -12,47 +15,64 @@
     const s = Math.floor(sec % 60)
     return `${m}m ${s.toString().padStart(2, '0')}s`
   }
+
+  // The trigger lives inside rootEl, so its own click never closes the popover.
+  function onDocClick(e: MouseEvent) {
+    if (open && rootEl && !rootEl.contains(e.target as Node)) open = false
+  }
+  function onKeydown(e: KeyboardEvent) {
+    if (open && e.key === 'Escape') open = false
+  }
 </script>
 
-<div class="bg-tray">
-  <div style="max-width:800px;margin:0 auto;padding:4px 24px;">
-    <details>
-      <summary class="tray-summary">
+<svelte:window onclick={onDocClick} onkeydown={onKeydown} />
+
+<div class="bg-line" bind:this={rootEl}>
+  <div class="bg-line-inner">
+    <div class="bg-anchor">
+      <button class="bg-trigger" class:open aria-expanded={open} onclick={() => (open = !open)}>
         <span class="dot"></span>
         <span class="lbl">{$t(tasks.length === 1 ? 'bgtask.n_process' : 'bgtask.n_processes').replace('{n}', String(tasks.length))}</span>
-        <span style="margin-left:auto"></span>
-        <iconify-icon class="chev" icon="lucide:chevron-up" width="14" style="color:var(--text-tertiary)"></iconify-icon>
-      </summary>
-      <div class="proc-list">
-        {#each tasks as p (p.handle_id)}
-        <div class="proc-row">
-          <span class="proc-dot"></span>
-          <div class="proc-info">
-            <span class="proc-cmd mono">{p.command}</span>
+      </button>
+      {#if open}
+        <div class="bg-pop">
+          {#each tasks as p (p.handle_id)}
+          <div class="proc-row">
+            <span class="proc-dot"></span>
+            <div class="proc-info">
+              <span class="proc-cmd mono">{p.command}</span>
+            </div>
+            <span class="proc-time">{$t('bgtask.running_elapsed').replace('{elapsed}', fmtElapsed(p.elapsed))}</span>
           </div>
-          <span class="proc-time">{$t('bgtask.running_elapsed').replace('{elapsed}', fmtElapsed(p.elapsed))}</span>
+          {/each}
         </div>
-        {/each}
-      </div>
-    </details>
+      {/if}
+    </div>
   </div>
 </div>
 
 <style>
-.bg-tray { flex: 0 0 auto; background: var(--bg-container); border-top: 1px solid var(--border-secondary); }
-.tray-summary {
-  list-style: none; display: flex; align-items: center; gap: 8px;
-  padding: 7px 4px; cursor: pointer; user-select: none; color: var(--text-secondary);
-  font-size: 13px;
+.bg-line { flex: 0 0 auto; }
+.bg-line-inner { max-width: 800px; margin: 0 auto; padding: 2px 24px; }
+.bg-anchor { position: relative; display: inline-block; }
+.bg-trigger {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 4px 0; border: none; background: transparent;
+  font-family: inherit; font-size: 13px; color: var(--text-secondary);
+  cursor: pointer;
 }
-.tray-summary:hover { color: var(--blue-6); }
-.chev { transition: transform 0.15s ease; }
-details[open] .chev { transform: rotate(180deg); }
+.bg-trigger:hover, .bg-trigger.open { color: var(--blue-6); }
 .dot {
   width: 7px; height: 7px; border-radius: 9999px; background: var(--success);
   animation: octo-dot 1.4s infinite; flex: 0 0 auto;
 }
-.proc-list { display: flex; flex-direction: column; gap: 6px; padding: 4px 0 8px; }
+.bg-pop {
+  position: absolute; bottom: calc(100% + 6px); left: 0; z-index: 50;
+  min-width: 260px; max-width: 420px; max-height: 280px; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 6px;
+  background: var(--bg-container); border: 1px solid var(--border-secondary); border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(15,23,42,0.14); padding: 6px;
+}
 .proc-row {
   display: flex; align-items: center; gap: 10px;
   padding: 8px 12px; border: 1px solid var(--border-table); border-radius: 8px; background: var(--bg-table-header);

--- a/web/src/components/chat/BackgroundProcesses.svelte
+++ b/web/src/components/chat/BackgroundProcesses.svelte
@@ -9,6 +9,7 @@
 
   let open = $state(false)
   let rootEl: HTMLElement | undefined = $state()
+  let triggerEl: HTMLButtonElement | undefined = $state()
 
   function fmtElapsed(startedAt: number): string {
     const sec = now > 0 && startedAt > 0 ? (now - startedAt) / 1000 : 0
@@ -19,26 +20,38 @@
     return `${m}m ${s.toString().padStart(2, '0')}s`
   }
 
-  // The trigger lives inside rootEl, so its own click never closes the popover.
+  // rootEl wraps only the trigger and the popover — not the empty width of the
+  // row — so clicking anywhere else, that blank space included, closes it. The
+  // trigger being inside means its own click never counts as "outside".
   function onDocClick(e: MouseEvent) {
     if (open && rootEl && !rootEl.contains(e.target as Node)) open = false
   }
   function onKeydown(e: KeyboardEvent) {
-    if (open && e.key === 'Escape') open = false
+    if (!open || e.key !== 'Escape') return
+    open = false
+    triggerEl?.focus()
   }
 </script>
 
 <svelte:window onclick={onDocClick} onkeydown={onKeydown} />
 
-<div class="bg-line" bind:this={rootEl}>
+<div class="bg-line">
   <div class="bg-line-inner">
-    <div class="bg-anchor">
-      <button class="bg-trigger" class:open aria-expanded={open} onclick={() => (open = !open)}>
+    <div class="bg-anchor" bind:this={rootEl}>
+      <button
+        class="bg-trigger"
+        class:open
+        bind:this={triggerEl}
+        aria-expanded={open}
+        aria-haspopup="true"
+        aria-controls={open ? 'bg-proc-list' : undefined}
+        onclick={() => (open = !open)}
+      >
         <span class="dot"></span>
         <span class="lbl">{$t(tasks.length === 1 ? 'bgtask.n_process' : 'bgtask.n_processes').replace('{n}', String(tasks.length))}</span>
       </button>
       {#if open}
-        <div class="bg-pop">
+        <div class="bg-pop" id="bg-proc-list">
           {#each tasks as p (p.handle_id)}
           <div class="proc-row">
             <span class="proc-dot"></span>
@@ -56,7 +69,7 @@
 
 <style>
 .bg-line { flex: 0 0 auto; }
-.bg-line-inner { max-width: 800px; margin: 0 auto; padding: 2px 24px; }
+.bg-line-inner { max-width: var(--chat-content-max-width, 1080px); width: 100%; margin: 0 auto; padding: 2px 24px; }
 .bg-anchor { position: relative; display: inline-block; }
 .bg-trigger {
   display: inline-flex; align-items: center; gap: 8px;

--- a/web/src/lib/bgTaskAnchor.test.ts
+++ b/web/src/lib/bgTaskAnchor.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { anchorBgTasks, BG_ANCHOR_TOLERANCE_MS } from './bgTaskAnchor'
+
+const T0 = Date.parse('2026-08-26T10:00:00Z')
+
+function task(id: string, elapsed?: any) {
+  return { handle_id: id, command: `cmd ${id}`, elapsed }
+}
+
+describe('anchorBgTasks', () => {
+  it('anchors a new task to now minus the server elapsed', () => {
+    const [t] = anchorBgTasks([], [task('bg_1', 67)], T0)
+    expect(t.startedAt).toBe(T0 - 67_000)
+    expect(t.command).toBe('cmd bg_1')
+  })
+
+  it('keeps the anchor of a task already on screen', () => {
+    const first = anchorBgTasks([], [task('bg_1', 67)], T0)
+    // A later broadcast: elapsed advanced, and truncation lost a fraction.
+    const second = anchorBgTasks(first, [task('bg_1', 70)], T0 + 3_600)
+    expect(second[0].startedAt).toBe(first[0].startedAt)
+  })
+
+  it('re-anchors when the server disagrees beyond the tolerance', () => {
+    const first = anchorBgTasks([], [task('bg_1', 9_000)], T0)
+    // Same handle id, but a freshly started process (server ids restart at 1).
+    const second = anchorBgTasks(first, [task('bg_1', 2)], T0 + 1_000)
+    expect(second[0].startedAt).toBe(T0 + 1_000 - 2_000)
+  })
+
+  it('treats a drift inside the tolerance as the same process', () => {
+    const first = anchorBgTasks([], [task('bg_1', 30)], T0)
+    const second = anchorBgTasks(first, [task('bg_1', 30)], T0 + BG_ANCHOR_TOLERANCE_MS)
+    expect(second[0].startedAt).toBe(first[0].startedAt)
+  })
+
+  it('falls back to now for missing, non-numeric or negative elapsed', () => {
+    const tasks = anchorBgTasks([], [task('a'), task('b', null), task('c', 'x'), task('d', -5)], T0)
+    for (const t of tasks) expect(t.startedAt).toBe(T0)
+  })
+
+  it('re-anchors a task that disappeared and came back', () => {
+    const first = anchorBgTasks([], [task('bg_1', 300)], T0)
+    const gone = anchorBgTasks(first, [], T0 + 1_000)
+    expect(gone).toEqual([])
+    const back = anchorBgTasks(gone, [task('bg_1', 1)], T0 + 2_000)
+    expect(back[0].startedAt).toBe(T0 + 1_000)
+  })
+
+  it('handles an empty or missing incoming list', () => {
+    expect(anchorBgTasks([], [], T0)).toEqual([])
+    expect(anchorBgTasks(undefined as any, undefined as any, T0)).toEqual([])
+  })
+})

--- a/web/src/lib/bgTaskAnchor.ts
+++ b/web/src/lib/bgTaskAnchor.ts
@@ -1,0 +1,38 @@
+// Background-process elapsed time, anchored locally.
+//
+// The server stamps `elapsed` when it broadcasts background_tasks_update, and
+// it only broadcasts on tool calls and process exits — so between them the
+// number sits frozen and under-reports a process that outlives its turn.
+// Anchoring each task to a local start timestamp lets the UI derive elapsed
+// from its own one-second tick instead.
+
+/** How far the server's elapsed may drift from a kept anchor before re-anchoring. */
+export const BG_ANCHOR_TOLERANCE_MS = 2000
+
+export interface BgTask {
+  handle_id?: string
+  command?: string
+  elapsed?: number
+  /** Local wall-clock ms the process is treated as having started at. */
+  startedAt?: number
+  [k: string]: any
+}
+
+/**
+ * Stamps `startedAt` on each incoming task.
+ *
+ * A task already on screen keeps its original anchor, so re-broadcasts (whose
+ * `elapsed` is truncated to whole seconds and arrives after some network
+ * delay) can't make a running clock jump. The anchor is only recomputed when
+ * the server disagrees by more than the tolerance — which is what a reused
+ * handle id looks like after the server restarts and its ids fall back to 1.
+ */
+export function anchorBgTasks(prev: BgTask[], incoming: BgTask[], at: number): BgTask[] {
+  return (incoming ?? []).map(t => {
+    const elapsed = Math.max(0, Number(t.elapsed) || 0)
+    const anchored = at - elapsed * 1000
+    const seen = (prev ?? []).find(p => p.handle_id === t.handle_id)
+    const keep = seen?.startedAt !== undefined && Math.abs(seen.startedAt - anchored) <= BG_ANCHOR_TOLERANCE_MS
+    return { ...t, startedAt: keep ? seen!.startedAt! : anchored }
+  })
+}

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1193,7 +1193,22 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
     cleanups.push(ws.on('background_tasks_update', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
-      chatBgTasks.update(b => ({ ...b, [sid]: (ev as any).tasks ?? [] }))
+      // The server stamps `elapsed` when it broadcasts, and it only broadcasts
+      // on tool calls and process exits — so the number sits frozen between
+      // them, under-reporting a process that outlives the turn. Anchor each
+      // task to a local start timestamp instead and let the UI tick off `now`.
+      // A task already on screen keeps its original anchor, so re-broadcasts
+      // can't make its clock jump.
+      const at = Date.now()
+      chatBgTasks.update(b => {
+        const prev = b[sid] ?? []
+        const tasks = ((ev as any).tasks ?? []).map((t: any) => {
+          const seen = prev.find((p: any) => p.handle_id === t.handle_id)
+          const elapsed = Math.max(0, Number(t.elapsed) || 0)
+          return { ...t, startedAt: seen?.startedAt ?? at - elapsed * 1000 }
+        })
+        return { ...b, [sid]: tasks }
+      })
     }))
 
     cleanups.push(ws.on('request_confirmation', (ev) => {
@@ -3128,7 +3143,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
       <!-- Background processes tray -->
       {#if bgTasks && bgTasks.length > 0}
-        <BackgroundProcesses tasks={bgTasks} />
+        <BackgroundProcesses tasks={bgTasks} {now} />
       {/if}
 
       <!-- Question banner (aligned with composer) -->

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -75,6 +75,7 @@
   import { inlineSlashCommand } from '../lib/inlineSlash'
   import { exportModeStore, selectedMessagesStore } from '../lib/exportStore'
   import { filenameStem } from '../lib/filename'
+  import { anchorBgTasks } from '../lib/bgTaskAnchor'
   import DOMPurify from 'dompurify'
   import ToolGroup from '../components/chat/ToolGroup.svelte'
   import SubAgentsCard from '../components/chat/SubAgentsCard.svelte'
@@ -1193,22 +1194,8 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
     cleanups.push(ws.on('background_tasks_update', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
-      // The server stamps `elapsed` when it broadcasts, and it only broadcasts
-      // on tool calls and process exits — so the number sits frozen between
-      // them, under-reporting a process that outlives the turn. Anchor each
-      // task to a local start timestamp instead and let the UI tick off `now`.
-      // A task already on screen keeps its original anchor, so re-broadcasts
-      // can't make its clock jump.
       const at = Date.now()
-      chatBgTasks.update(b => {
-        const prev = b[sid] ?? []
-        const tasks = ((ev as any).tasks ?? []).map((t: any) => {
-          const seen = prev.find((p: any) => p.handle_id === t.handle_id)
-          const elapsed = Math.max(0, Number(t.elapsed) || 0)
-          return { ...t, startedAt: seen?.startedAt ?? at - elapsed * 1000 }
-        })
-        return { ...b, [sid]: tasks }
-      })
+      chatBgTasks.update(b => ({ ...b, [sid]: anchorBgTasks(b[sid] ?? [], (ev as any).tasks ?? [], at) }))
     }))
 
     cleanups.push(ws.on('request_confirmation', (ev) => {
@@ -3141,7 +3128,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
         </div>
       {/if}
 
-      <!-- Background processes tray -->
+      <!-- Background processes: a text trigger opening a popover list -->
       {#if bgTasks && bgTasks.length > 0}
         <BackgroundProcesses tasks={bgTasks} {now} />
       {/if}


### PR DESCRIPTION
## What

Two things about the background-process tray above the composer.

**1. The bar becomes a text trigger.** It drew a full-width bar — border, background, chevron — for what is usually a single line of information, competing with the composer for attention even when nothing needed acting on. Now it is a plain clickable line (status dot + "N background processes") that opens the process list in a popover; the rows themselves are unchanged.

**2. The elapsed time was wrong.** The server stamps `elapsed` at broadcast time and only broadcasts on tool calls and process exits, so the number sat frozen in between: a process that outlives its turn reported however long it had been running when the turn's last tool call happened, not how long it has actually been running.

## Details

- Popover reuses the composer menu primitives: anchored above the trigger, hairline border, shadow, `max-height: 280px` with scroll. Closes via the trigger, a click outside, or Escape.
- Open state is a `$state` boolean rather than `<details>` — binding interactive DOM state to a derived value has swallowed toggles in this codebase before.
- Supersedes the chevron introduced in #2288: there is no chevron left to flip.
- Elapsed is now anchored locally (`now - elapsed` when the event arrives) and derived from the session's existing one-second `now` tick, the same way `WorkflowsCard` does it. Tasks already on screen keep their original anchor across re-broadcasts, so a refresh cannot make a running clock jump. No server change.

## Verification

- `svelte-check`: 0 errors, 0 warnings.
- Isolated walkthrough (temporary mount page + vite dev + headless CDP, temp files removed): collapsed by default (`pop=false, rows=0`), click renders both rows (`pop=true, rows=2`), outside click collapses again. With the clock harness, the two rows read `1m 09s / 7s` → `1m 11s / 9s` → `1m 13s / 11s` → `1m 15s / 13s` across successive samples — the counters advance in real time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)