### PR TITLE
lockfile: wait for the lock in the kernel, not on a timer

### DIFF
--- a/internal/lockfile/contention_test.go
+++ b/internal/lockfile/contention_test.go
@@ -13,63 +13,69 @@ import (
 // acquire that keeps losing the race is how the registry silently drops
 // another process's write — the failure this package exists to prevent.
 //
-// Every waiter here is behind a bounded queue: at most waiters*hold of work
-// stands between it and the lock, and its budget is 25x that. A queued wait
-// tracks the queue (measured: ~78ms against an 80ms queue, stable to the
-// millisecond). Retrying a non-blocking lock on a timer instead — no queue, so
-// each retry re-enters the race from scratch — stretched the same 80ms queue
-// to 528-664ms, and tightening the budget made waiters give up outright. The
-// ceiling below sits between the two.
-func TestAcquire_ContentionQueuesRatherThanStarves(t *testing.T) {
-	if h := Acquire(filepath.Join(t.TempDir(), "probe.json")); h == nil {
-		t.Skip("file locking unavailable here")
-	} else {
-		h.Release()
-	}
-
+// The shape: one waiter asks first and then blocks, a second caller hammers
+// the lock behind it, and the count of times the latecomer gets in ahead is
+// the measurement. Queued, it cannot get in at all — it asked later, so it
+// waits later. Retrying a non-blocking lock on a timer has no queue, so every
+// release is a fresh coin flip and the latecomer wins its share of them.
+//
+// Counting who gets in, rather than timing how long a wait took, is what keeps
+// this honest on a loaded CI machine: the verdict does not move when every
+// sleep in it runs long.
+func TestAcquire_ContentionQueuesRatherThanRacing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "registry.json")
-	const waiters = 8
-	const rounds = 10
-	const hold = 10 * time.Millisecond
-	const queue = waiters * hold // work standing between a waiter and the lock
-	const budget = 25 * queue    // generous: the point is that nobody gives up
-	const ceiling = 4 * queue    // a queued wait stays well inside this
-
-	var gaveUp atomic.Int64
-	var worst atomic.Int64
-	var wg sync.WaitGroup
-	for i := 0; i < waiters; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for r := 0; r < rounds; r++ {
-				start := time.Now()
-				h := acquire(path, budget)
-				waited := int64(time.Since(start))
-				for {
-					old := worst.Load()
-					if waited <= old || worst.CompareAndSwap(old, waited) {
-						break
-					}
-				}
-				if h == nil {
-					gaveUp.Add(1)
-					continue
-				}
-				time.Sleep(hold)
-				h.Release()
-			}
-		}()
+	held := Acquire(path)
+	if held == nil {
+		t.Skip("file locking unavailable here")
 	}
+
+	// The first waiter. It asks while the lock is held, so it is at the head of
+	// the queue before anyone else asks.
+	var firstIn atomic.Bool
+	asked := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(asked)
+		h := acquire(path, 10*time.Second)
+		firstIn.Store(true)
+		if h == nil {
+			return
+		}
+		h.Release()
+	}()
+	<-asked
+	time.Sleep(50 * time.Millisecond) // let it reach the wait
+
+	// The latecomer, asking over and over from behind.
+	var jumpedAhead atomic.Int64
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deadline := time.Now().Add(5 * time.Second)
+		for !firstIn.Load() && time.Now().Before(deadline) {
+			h := acquire(path, 50*time.Millisecond)
+			if h == nil {
+				continue
+			}
+			if !firstIn.Load() {
+				jumpedAhead.Add(1)
+			}
+			h.Release()
+		}
+	}()
+
+	held.Release()
 	wg.Wait()
 
-	acquires := waiters * rounds
-	t.Logf("worst wait %s over %d acquires behind a %s queue, %d gave up",
-		time.Duration(worst.Load()), acquires, queue, gaveUp.Load())
-	if n := gaveUp.Load(); n > 0 {
-		t.Errorf("%d of %d acquires gave up inside a %s budget — an unlocked write, and a lost update with it", n, acquires, budget)
+	if !firstIn.Load() {
+		t.Fatal("the first waiter never got the lock")
 	}
-	if w := time.Duration(worst.Load()); w > ceiling {
-		t.Errorf("worst wait %s exceeds %s for a %s queue — waiters are racing, not queueing", w, ceiling, queue)
+	// One is the benign race: the latecomer can slip in during the window
+	// between the release and the queued waiter being scheduled. Repeatedly is
+	// the bug — it means asking first bought nothing.
+	if n := jumpedAhead.Load(); n > 1 {
+		t.Errorf("the latecomer got the lock %d times ahead of the waiter that asked first — waiters are racing, not queueing", n)
 	}
 }

--- a/internal/lockfile/contention_test.go
+++ b/internal/lockfile/contention_test.go
@@ -1,0 +1,75 @@
+package lockfile
+
+import (
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Contention must queue, not race. This is what stops a lost update in
+// practice: a caller that waits out its budget proceeds unlocked, so an
+// acquire that keeps losing the race is how the registry silently drops
+// another process's write — the failure this package exists to prevent.
+//
+// Every waiter here is behind a bounded queue: at most waiters*hold of work
+// stands between it and the lock, and its budget is 25x that. A queued wait
+// tracks the queue (measured: ~78ms against an 80ms queue, stable to the
+// millisecond). Retrying a non-blocking lock on a timer instead — no queue, so
+// each retry re-enters the race from scratch — stretched the same 80ms queue
+// to 528-664ms, and tightening the budget made waiters give up outright. The
+// ceiling below sits between the two.
+func TestAcquire_ContentionQueuesRatherThanStarves(t *testing.T) {
+	if h := Acquire(filepath.Join(t.TempDir(), "probe.json")); h == nil {
+		t.Skip("file locking unavailable here")
+	} else {
+		h.Release()
+	}
+
+	path := filepath.Join(t.TempDir(), "registry.json")
+	const waiters = 8
+	const rounds = 10
+	const hold = 10 * time.Millisecond
+	const queue = waiters * hold // work standing between a waiter and the lock
+	const budget = 25 * queue    // generous: the point is that nobody gives up
+	const ceiling = 4 * queue    // a queued wait stays well inside this
+
+	var gaveUp atomic.Int64
+	var worst atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < waiters; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r := 0; r < rounds; r++ {
+				start := time.Now()
+				h := acquire(path, budget)
+				waited := int64(time.Since(start))
+				for {
+					old := worst.Load()
+					if waited <= old || worst.CompareAndSwap(old, waited) {
+						break
+					}
+				}
+				if h == nil {
+					gaveUp.Add(1)
+					continue
+				}
+				time.Sleep(hold)
+				h.Release()
+			}
+		}()
+	}
+	wg.Wait()
+
+	acquires := waiters * rounds
+	t.Logf("worst wait %s over %d acquires behind a %s queue, %d gave up",
+		time.Duration(worst.Load()), acquires, queue, gaveUp.Load())
+	if n := gaveUp.Load(); n > 0 {
+		t.Errorf("%d of %d acquires gave up inside a %s budget — an unlocked write, and a lost update with it", n, acquires, budget)
+	}
+	if w := time.Duration(worst.Load()); w > ceiling {
+		t.Errorf("worst wait %s exceeds %s for a %s queue — waiters are racing, not queueing", w, ceiling, queue)
+	}
+}

--- a/internal/lockfile/lock_unix.go
+++ b/internal/lockfile/lock_unix.go
@@ -9,19 +9,20 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// errLocked reports that someone else holds the lock — the one failure Acquire
-// retries rather than giving up on.
-var errLocked = errors.New("lockfile: held by another process")
-
-// tryLockFD attempts an exclusive advisory lock without blocking. A contended
-// lock comes back as EWOULDBLOCK (== EAGAIN on every platform Go supports),
-// which is reported as errLocked so the caller can retry until its deadline.
-func tryLockFD(f *os.File) error {
-	err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
-	if errors.Is(err, unix.EWOULDBLOCK) {
-		return errLocked
+// lockFD takes an exclusive advisory lock, waiting for any current holder. The
+// wait is in the kernel, which queues waiters — a non-blocking poll would let
+// one caller lose the race arbitrarily many times in a row.
+//
+// EINTR is retried rather than reported: Go's scheduler preempts with signals,
+// so an interrupted flock says nothing about the lock.
+func lockFD(f *os.File) error {
+	for {
+		err := unix.Flock(int(f.Fd()), unix.LOCK_EX)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		return err
 	}
-	return err
 }
 
 // unlockFD releases it. Closing the descriptor would release it too; doing it

--- a/internal/lockfile/lock_windows.go
+++ b/internal/lockfile/lock_windows.go
@@ -1,29 +1,23 @@
 package lockfile
 
 import (
-	"errors"
 	"os"
 
 	"golang.org/x/sys/windows"
 )
 
-// errLocked reports that someone else holds the lock — the one failure Acquire
-// retries rather than giving up on.
-var errLocked = errors.New("lockfile: held by another handle")
-
-// tryLockFD attempts an exclusive lock on the first byte without blocking.
-// LOCKFILE_FAIL_IMMEDIATELY makes a contended lock return
-// ERROR_LOCK_VIOLATION instead of waiting, which is reported as errLocked so
-// the caller can retry until its deadline. Windows locks are per-handle rather
-// than per-process, so the handle stays open for as long as the lock is held.
-func tryLockFD(f *os.File) error {
+// lockFD takes an exclusive lock on the first byte, waiting for any current
+// holder. Without LOCKFILE_FAIL_IMMEDIATELY the wait happens in the kernel,
+// which queues waiters — polling with the immediate-fail flag instead let one
+// caller lose the race arbitrarily many times in a row, and a caller that
+// eventually gives up writes unlocked.
+//
+// Windows locks are per-handle rather than per-process, so the handle stays
+// open for as long as the lock is held.
+func lockFD(f *os.File) error {
 	var ol windows.Overlapped
-	err := windows.LockFileEx(windows.Handle(f.Fd()),
-		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &ol)
-	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
-		return errLocked
-	}
-	return err
+	return windows.LockFileEx(windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &ol)
 }
 
 // unlockFD releases it. The byte range must match the one locked.

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -25,7 +25,6 @@
 package lockfile
 
 import (
-	"errors"
 	"log/slog"
 	"os"
 	"time"
@@ -41,11 +40,6 @@ type Handle struct {
 // than this means the holder is not making progress — stopped, or stuck on a
 // network filesystem — rather than merely busy.
 const Timeout = 5 * time.Second
-
-// pollInterval is how often a contended lock is retried. Short enough that the
-// common case (a holder mid-write) is indistinguishable from waiting on the
-// kernel, long enough not to spin.
-const pollInterval = 2 * time.Millisecond
 
 // Acquire takes an exclusive lock for path, creating the sibling lock file if
 // needed, and waits up to Timeout for it.
@@ -67,30 +61,48 @@ func Acquire(path string) *Handle {
 
 // acquire is Acquire with the wait made explicit, so the give-up path can be
 // tested without a test that waits Timeout.
+//
+// The wait for a holder happens in the kernel, on its own goroutine, with the
+// timeout enforced here. Waiting in the kernel is what makes contention fair:
+// it queues waiters, where retrying a non-blocking lock on a timer let one
+// caller lose the race arbitrarily many times in a row and give up — writing
+// unlocked — while its turn never came. Under eight waiters holding for 5ms
+// each, polling stretched a 40ms queue into a 390ms wait; queued, the wait
+// tracks the queue.
 func acquire(path string, timeout time.Duration) *Handle {
 	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
-		slog.Debug("lockfile: open failed, proceeding unlocked", "path", path, "err", err)
+		// Warn, not Debug: proceeding unlocked is how an update gets lost, and
+		// it is the kind of thing only visible in a log after the fact.
+		slog.Warn("lockfile: open failed, proceeding unlocked — a concurrent write may be lost", "path", path, "err", err)
 		return nil
 	}
-	deadline := time.Now().Add(timeout)
-	for {
-		err = tryLockFD(f)
-		if err == nil {
-			return &Handle{f: f}
-		}
-		if !errors.Is(err, errLocked) {
-			slog.Debug("lockfile: lock failed, proceeding unlocked", "path", path, "err", err)
+	locked := make(chan error, 1)
+	go func() { locked <- lockFD(f) }()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-locked:
+		if err != nil {
+			slog.Warn("lockfile: lock failed, proceeding unlocked — a concurrent write may be lost", "path", path, "err", err)
 			f.Close()
 			return nil
 		}
-		if time.Now().After(deadline) {
-			slog.Warn("lockfile: still held after waiting, proceeding unlocked — a concurrent write may be lost",
-				"path", path, "waited", timeout)
+		return &Handle{f: f}
+	case <-timer.C:
+		// The kernel may still grant the lock after this: the waiting
+		// goroutine owns the file from here, and hands it straight back so a
+		// lock nobody is using cannot outlive the caller that wanted it.
+		go func() {
+			if err := <-locked; err == nil {
+				unlockFD(f)
+			}
 			f.Close()
-			return nil
-		}
-		time.Sleep(pollInterval)
+		}()
+		slog.Warn("lockfile: still held after waiting, proceeding unlocked — a concurrent write may be lost",
+			"path", path, "waited", timeout)
+		return nil
 	}
 }
 

--- a/internal/server/ensure_project_crossproc_test.go
+++ b/internal/server/ensure_project_crossproc_test.go
@@ -117,6 +117,13 @@ func TestEnsureProject_CrossProcessLockKeepsEveryGroup(t *testing.T) {
 	if missing > 0 {
 		t.Errorf("%d of %d projects were lost to concurrent writes by other processes (e.g. %s)",
 			missing, children*writesPerChild, firstMissing)
+		// A lost write means some child proceeded without the file lock, and
+		// the only record of that is the warning it logged. Children that exit
+		// cleanly have their output discarded, which left past failures with no
+		// evidence of which step gave way.
+		for i, out := range outs {
+			t.Logf("child %d output:\n%s", i, out.String())
+		}
 	}
 }
 


### PR DESCRIPTION
## What

`TestEnsureProject_CrossProcessLockKeepsEveryGroup` fails intermittently on Windows CI — "1 of 100 projects were lost to concurrent writes by other processes". The cross-process lock is what should make that impossible. The reason it doesn't is how it waits.

`Acquire` retried a **non-blocking** lock every 2ms until its deadline. With no queue, every retry re-enters the race from scratch, so a waiter can lose arbitrarily many times in a row. Whoever runs out of budget proceeds **unlocked** — and an unlocked read-modify-write of the registry is exactly the lost update the lock exists to prevent.

Windows holds the lock far longer per write (temp file + rename, with a virus scanner in the way), so its 5s budget covers far fewer turns of the queue than it does on Linux, and every so often somebody's turn never comes.

## Evidence

Who gets the lock when a latecomer competes with a waiter that asked first, while the lock is held by someone else:

| Wait strategy | Times the latecomer got in ahead |
|---|---|
| Non-blocking retry every 2ms (before) | 9–13 |
| Queued in the kernel (after) | 0 |

Timing tells the same story — with 8 waiters each holding 10ms, so at most an 80ms queue in front of anyone, the worst wait went from 528–664ms (polling) to ~78ms (queued) on a quiet machine.

And the give-up path is the data loss: forcing `Timeout` to 1ms makes the cross-process test drop **57 of 100** writes, the same failure mode as CI's 1 of 100.

## Change

- Wait in the kernel — blocking `flock` / `LockFileEx` without `LOCKFILE_FAIL_IMMEDIATELY` — on its own goroutine, with the timeout still enforced by the caller. The kernel queues waiters, so asking first means getting in first instead of entering a fresh coin flip on every release. `EINTR` is retried on the unix side (Go preempts with signals).
- If the kernel grants the lock after the caller gave up, the waiting goroutine hands it straight back, so a lock nobody is using cannot outlive the caller that wanted it.
- Both "proceeding unlocked" paths go from `Debug` to `Warn`: that line is how an update gets lost, and it was invisible by default.
- The cross-process test now dumps child output when it fails — children that exit cleanly were the ones holding the evidence, which is why past failures left none.

The bounded wait is deliberately kept: callers hold an in-process mutex across `Acquire`, so an indefinite wait would let one stuck process elsewhere freeze this one's readers.

## Verification

- `internal/lockfile` with `-race`, including a new regression test for queueing. It asserts a **count** (how many times a latecomer gets in ahead), not a duration: an earlier version of it asserted a ceiling on the worst wait and failed on macos-latest at 344ms with nobody giving up — a loaded runner, not a racing lock. The count verdict does not move when the machine is slow, and it separates the two implementations cleanly (0 vs 9–13).
- `TestEnsureProject_CrossProcessLockKeepsEveryGroup` x5: pass.
- `internal/server`, `internal/config` with `-race`: pass. Full `go test ./...`: pass.
- `GOOS=windows go build ./...` + `go vet`: clean. The Windows lock path itself can only be exercised by CI's windows-latest job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)