### PR TITLE
release: bump version to 1.16.6

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.5"
+var Version = "1.16.6"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release. Since v1.16.5:

- #2287 — label only queued messages above the composer
- #2288 — flip the background-process chevron when the tray is open
- #2290 — let mid-turn compaction see what a turn appended
- #2289 — cap the spilled-output preview in bytes, not just lines
- #2291 — collapse the background-process tray into a text trigger, and fix its clock (supersedes #2288's chevron)
- #2292 — wait for the registry lock in the kernel, not on a timer (pending; the tag will be cut once it has landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)