### PR TITLE
web: cap the question banner instead of letting options push the transcript away

### DIFF
--- a/web/src/components/overlays/QuestionModal.svelte
+++ b/web/src/components/overlays/QuestionModal.svelte
@@ -38,6 +38,7 @@
   let drafts = $state<AskDraft[]>([])
   let focusedLabel = $state('')
   let inputEl = $state<HTMLInputElement | null>(null)
+  let rowListEl = $state<HTMLDivElement | null>(null)
   let expanded = $state(false)
   let lastQuestionId = $state<string | null>(null)
 
@@ -66,6 +67,15 @@
     qIdx = i
     focusedLabel = questions[i]?.options?.[0]?.label ?? ''
   }
+
+  // The banner caps the option list and scrolls it. A new tab — or a whole new
+  // question, which reuses the same DOM node — must start at the top rather
+  // than inherit the previous list's scroll offset.
+  $effect(() => {
+    qIdx
+    current?.questionId
+    rowListEl?.scrollTo({ top: 0 })
+  })
 
   function pick(label: string) {
     if (!question) return
@@ -162,12 +172,13 @@
 
 {#snippet rows()}
   <div class="rows" class:with-preview={preview}>
-    <div class="row-list">
+    <div class="row-list" bind:this={rowListEl}>
       {#each question?.options ?? [] as o, i}
         <button
           class="row"
           class:selected={draft.choices.includes(o.label)}
           class:focused={preview && focusedLabel === o.label}
+          title={o.description || o.label}
           onclick={() => (preview ? (focusedLabel = o.label) : pick(o.label))}
           ondblclick={() => pick(o.label)}
         >
@@ -473,6 +484,23 @@
   }
   .banner-expand:hover { background: var(--hover-neutral); color: var(--blue-6); }
   .banner-actions { display: flex; align-items: center; gap: 8px; justify-content: flex-end; }
+
+  /* The banner shares the chat column with the transcript, so its option list
+     is capped and scrolls instead of pushing the messages off-screen. Rows are
+     tightened and descriptions clamped to one line; the full text stays
+     reachable through the row's title. The expanded modal keeps the roomy
+     layout — it already owns the whole viewport. */
+  .banner-inner .row-list {
+    max-height: calc(30vh / var(--font-zoom));
+    overflow-y: auto;
+    gap: 4px;
+  }
+  .banner-inner .row { padding: 6px 10px; }
+  .banner-inner .row-desc {
+    display: -webkit-box; -webkit-line-clamp: 1; line-clamp: 1;
+    -webkit-box-orient: vertical; overflow: hidden;
+  }
+  .banner-inner .preview-body { max-height: calc(26vh / var(--font-zoom)); }
 
   /* ─── Full modal (expanded) ──────────────────────────────────── */
   .backdrop {


### PR DESCRIPTION
## Problem

The `ask_user_question` banner renders in the chat column above the composer, in flow (`flex: 0 0 auto`), and grows with the option list. There is no ceiling on it.

Measured in a 900px-tall window, 960px chat column:

| Case | Banner | Transcript left |
|---|---|---|
| 4 options with descriptions | 422px | 273px |
| 8 options with descriptions | 667px | **28px** |

At eight options the transcript is effectively gone — the output the question is asking about is no longer on screen.

## Change

Banner-scoped only; the expanded modal (⤢) is untouched, since it already owns the whole viewport.

- Cap `.row-list` at `30vh` and scroll inside it.
- Clamp `.row-desc` to one line; the full text stays reachable through a new `title` on the row.
- Tighten row padding `8px 10px` → `6px 10px` and the list gap `6px` → `4px`.
- Reset the list's scroll offset when the tab or the question changes — the list node is reused, so a new question otherwise inherits the previous offset (measured: 26px of residual scroll).

| Case | Banner before | Banner after | Transcript after |
|---|---|---|---|
| 4 options with descriptions | 422px | **372px** | 410px |
| 8 options with descriptions | 667px | **372px** | 410px |

## Verification

Driven through CDP against a harness that mounts `QuestionModal` in a chat-column layout, at 1440×900 and 1000×760:

- Height is capped: 4 and 8 options both measure 372px, and the list scrolls.
- Clamp works: a 3-line description (52px natural) renders at 17px with an ellipsis; the row's `title` carries the full text.
- Scroll reset: `scrollTop` goes 279 → 0 on question change.
- Expanded modal unaffected: `padding: 8px 10px`, `max-height: none`, `line-clamp: none`, description renders all 4 lines.

`svelte-check` reports 0 errors; `vitest run` passes 593 tests across 43 files.