### PR TITLE
web: Light App storage bridge — persistent storage for sandboxed Light Apps

### DIFF
--- a/dev-docs/light-apps-design.md
+++ b/dev-docs/light-apps-design.md
@@ -69,6 +69,30 @@ octo-agent 已经有一套完整的生成 + 展示循环：Agent 生成 HTML →
 - **JS 内联**：`<script>` 直接写在 HTML 内
 - **文件处理**：`<input type="file">` + `FileReader` API，浏览器端搞定
 - **无服务端依赖**：不能发 fetch 到外部 API（Artifacts panel sandboxed iframe 限制）
+- **持久化存储可用**：直接用标准 `localStorage`，见下节
+
+### 运行时存储
+
+轻应用跑在 `sandbox="allow-scripts"` 的 srcdoc iframe 里（刻意不给
+`allow-same-origin`），origin 是 opaque，浏览器会拒掉所有持久化存储 API —
+localStorage / sessionStorage / Cookie / IndexedDB 在里面一律抛 SecurityError。
+
+沙箱不动，改由宿主页面代管：`web/src/lib/laStorage.ts` 在宿主开一个 IndexedDB
+（库 `octo-la-storage`、store `kv`，键 `{slug}:{key}` 按应用隔离），并往轻应用文档里注入
+一段桥脚本，把 iframe 内的 `window.localStorage` 换成一个同步 shim —— 读走内存
+缓存，写同步更新缓存再经 postMessage 落到宿主。文档加载时先 dump 预取该应用的
+全部历史数据，`window.__laStorageReady` 在预取落地后 resolve。
+
+对轻应用来说这是**零改动**的：继续写标准 `localStorage`，没有任何特殊接口。
+localStorage 原生可用时（非沙箱上下文）桥脚本什么都不做。
+
+与原生 localStorage 的差异，都是刻意的：
+
+- 单键上限 1MB、单应用总量上限 5MB，超限同步抛 `QuotaExceededError`；键名上限
+  512 字符，超限同样抛。宿主侧独立复核同一组上限，绕过 shim 也灌不进去。
+- 落盘是异步的，崩溃或提前关闭可能丢最后一次写。同页内读写全同步一致，跨页重启
+  的读一致性由启动预取保证。
+- sessionStorage 仍然不可用 —— 只存活一次访问的状态放普通变量就够了。
 
 ## Agent 交互流程
 
@@ -251,7 +275,7 @@ GET /api/light-apps/{slug}    →  {"manifest": {...}, "html": "<index.html cont
 - **不做 Python/Node 运行时 Light App**。保持零外部依赖，只用浏览器沙箱。如果未来真有需求（如需要 pandas 处理大 CSV），再评估是否引入 `pyodide`（WASM Python）而不是起系统进程。
 - **不做 Light App 间的数据共享**。每个 App 独立，不引入跨 App 的消息机制。
 - **不做 Light App 的版本管理**。覆盖即更新，不保留历史版本。用户要回滚可以自己在对话里让 Agent 重新生成。
-- **不做「从 Light App 回调 Agent」**。纯前端闭环，避免 sandboxed iframe 里的 postMessage 跨域复杂度。用户想用 AI 能力时回到对话。
+- **不做「从 Light App 回调 Agent」**。纯前端闭环。宿主与轻应用之间只有存储桥这一条 postMessage 通道，协议就四个操作（dump/set/remove/clear），不扩成通用 RPC。用户想用 AI 能力时回到对话。
 
 ## 实现分阶段
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/svelte": "^5.4.2",
         "@types/qrcode": "^1.5.5",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^30.0.1",
         "svelte": "^5.56.10",
         "svelte-check": "^4.7.6",
@@ -2181,6 +2182,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmmirror.com/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fastdom": {

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/svelte": "^5.4.2",
     "@types/qrcode": "^1.5.5",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^30.0.1",
     "svelte": "^5.56.10",
     "svelte-check": "^4.7.6",

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -8,6 +8,7 @@
   import { diffData, diffLoading, diffBadge, loadDiff } from '../lib/diff'
   import DiffView from './diff/DiffView.svelte'
   import * as api from '../lib/api'
+  import { installLaStorageBridge, registerLaIframe, unregisterLaIframe, withLaBridge } from '../lib/laStorage'
 
   // This column never holds the traffic lights, but its top row has to sit on
   // the same axis as the chat title beside it, which Header lifts on mac.
@@ -210,6 +211,22 @@
   const laCurSlug = $derived($lightappSel || $lightapps[0]?.slug || '')
   const laCurHTML = $derived($lightappHTML[laCurSlug] ?? '')
   const laCurName = $derived($lightapps.find(a => a.slug === laCurSlug)?.name ?? laCurSlug)
+
+  // ── Light App storage bridge ─────────────────────────────────────────────
+  // The sandboxed srcdoc iframe has an opaque origin, so it can't touch any
+  // persistent storage. We host an IndexedDB here and the injected bridge
+  // script (withLaBridge) shims the app's own localStorage calls onto it over
+  // postMessage. Register the iframe so the handler only serves OUR frame,
+  // under the slug whose script we injected — the element is reused when the
+  // user switches apps, so the namespace has to be re-pinned every time.
+  let laFrameEl = $state<HTMLIFrameElement | null>(null)
+  $effect(() => {
+    installLaStorageBridge()
+    const el = laFrameEl
+    if (!el) return
+    registerLaIframe(el.contentWindow, laCurSlug)
+    return () => unregisterLaIframe(el.contentWindow)
+  })
 
   // ── Resizable width ────────────────────────────────────────────────────────
   // Drag the left-edge handle to resize; the width persists across sessions.
@@ -416,7 +433,7 @@
       {#if laLoading}
         <div class="empty"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon><span>{$t('common.loading')}</span></div>
       {:else if laCurHTML}
-        <iframe srcdoc={laCurHTML} sandbox="allow-scripts" allow="clipboard-write" title={laCurName}></iframe>
+        <iframe bind:this={laFrameEl} srcdoc={withLaBridge(laCurHTML, laCurSlug)} sandbox="allow-scripts" allow="clipboard-write" title={laCurName}></iframe>
       {:else if $lightapps.length === 0}
         <div class="empty">
           <iconify-icon icon="ant-design:appstore-outlined" width="28"></iconify-icon>

--- a/web/src/lib/laStorage.test.ts
+++ b/web/src/lib/laStorage.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import {
+  registerLaIframe,
+  unregisterLaIframe,
+  installLaStorageBridge,
+  withLaBridge,
+  buildLaBridgeScript,
+} from './laStorage'
+
+installLaStorageBridge()
+
+type Reply = { ok: boolean; value?: unknown; err?: string } | null
+
+let nsCounter = 0
+function makeWin() {
+  // unique namespace per test — the module caches its IndexedDB connection,
+  // so a fresh IDBFactory alone doesn't reset data between tests
+  const ns = 'app-' + nsCounter++
+  const w = { __reply: null as Reply, __ns: ns } as unknown as Window & { __reply: Reply; __ns: string }
+  ;(w as { postMessage: (m: unknown) => void }).postMessage = (m: unknown) => {
+    w.__reply = m as Reply
+  }
+  return w
+}
+
+// Dispatch a request as if from the iframe, wait for the async IDB roundtrip,
+// and return the reply the host posted back.
+async function bridgeCall(
+  w: Window & { __reply: Reply; __ns: string },
+  op: string,
+  key?: string,
+  value?: string,
+  autoRegister = true,
+): Promise<Reply> {
+  w.__reply = null
+  if (autoRegister) registerLaIframe(w, w.__ns)
+  const ev = new MessageEvent('message', {
+    data: { __laBridge: 1, id: 1, ns: w.__ns, op, key, value },
+    source: w,
+    origin: 'null',
+  })
+  window.dispatchEvent(ev)
+  await new Promise((r) => setTimeout(r, 15))
+  return w.__reply
+}
+
+beforeEach(() => {
+  indexedDB = new IDBFactory()
+})
+
+describe('laStorage bridge', () => {
+  it('set then dump returns the namespace payload', async () => {
+    const w = makeWin()
+    // registered inside bridgeCall
+    await bridgeCall(w, 'set', 'k1', 'v1')
+    await bridgeCall(w, 'set', 'k2', 'v2')
+    const r = await bridgeCall(w, 'dump')
+    expect(r?.ok).toBe(true)
+    expect(r?.value).toEqual({ k1: 'v1', k2: 'v2' })
+  })
+
+  it('dump of an empty namespace returns {}', async () => {
+    const w = makeWin()
+    // registered inside bridgeCall
+    const r = await bridgeCall(w, 'dump')
+    expect(r?.ok).toBe(true)
+    expect(r?.value).toEqual({})
+  })
+
+  it('namespaces isolate same keys', async () => {
+    const wa = makeWin()
+    const wb = makeWin()
+    // registered inside bridgeCall
+    // registered inside bridgeCall
+    await bridgeCall(wa, 'set', 'score', '10')
+    await bridgeCall(wb, 'set', 'score', '99')
+    const ra = await bridgeCall(wa, 'dump')
+    const rb = await bridgeCall(wb, 'dump')
+    expect(ra?.value).toEqual({ score: '10' })
+    expect(rb?.value).toEqual({ score: '99' })
+  })
+
+  it('remove deletes a key; clear only clears the caller namespace', async () => {
+    const wa = makeWin()
+    const wb = makeWin()
+    // registered inside bridgeCall
+    // registered inside bridgeCall
+    await bridgeCall(wa, 'set', 'k', 'a')
+    await bridgeCall(wa, 'set', 'junk', 'x')
+    await bridgeCall(wb, 'set', 'k', 'b')
+    await bridgeCall(wa, 'remove', 'junk')
+    await bridgeCall(wa, 'clear')
+    expect((await bridgeCall(wa, 'dump'))?.value).toEqual({})
+    expect((await bridgeCall(wb, 'dump'))?.value).toEqual({ k: 'b' })
+  })
+
+  it('rejects unregistered iframes', async () => {
+    const w = makeWin()
+    expect(await bridgeCall(w, 'set', 'k', 'v', false)).toBe(null) // no reply at all
+  })
+
+  it('rejects bad keys', async () => {
+    const w = makeWin()
+    // registered inside bridgeCall
+    const tooLong = 'x'.repeat(600)
+    expect((await bridgeCall(w, 'set', tooLong, 'v'))?.ok).toBe(false)
+    expect((await bridgeCall(w, 'remove', ''))?.ok).toBe(false)
+  })
+
+  it('unregister stops the bridge', async () => {
+    const w = makeWin()
+    await bridgeCall(w, 'set', 'k', 'v') // registers
+    unregisterLaIframe(w)
+    expect(await bridgeCall(w, 'dump', undefined, undefined, false)).toBe(null)
+  })
+
+  it('withLaBridge injects the script before </body>', () => {
+    const html = '<html><body><p>hi</p></body></html>'
+    const out = withLaBridge(html, 'app-x')
+    expect(out).toContain('localStorage')
+    expect(out).toContain('<\\/script>') // escaped close tag
+    expect(out.indexOf('localStorage')).toBeGreaterThan(out.indexOf('<p>hi</p>'))
+    expect(out.endsWith('</body></html>')).toBe(true)
+  })
+
+  it('bridge script shims window.localStorage (synchronous, cache-backed)', () => {
+    const script = buildLaBridgeScript('app-x')
+    // The shim replaces window.localStorage with a synchronous API
+    expect(script).toContain("Object.defineProperty(window, 'localStorage'")
+    expect(script).toContain('window.parent.postMessage')
+    expect(script).toContain('__laStorageReady')
+    // Prefetch via dump
+    expect(script).toContain("call('dump')")
+    // No special app-facing API — plain localStorage calls work
+    expect(script).not.toContain('window.__laStorage =')
+  })
+})
+
+// ── End-to-end: run the real injected script against the real host handler ──
+//
+// The string assertions above can't see a protocol mismatch between the two
+// sides — a reply shape the shim drops still contains all the right substrings.
+// These tests execute buildLaBridgeScript's output in a fake iframe window
+// whose `parent` posts into the actual host listener, so the whole roundtrip
+// (shim -> postMessage -> IndexedDB -> reply -> cache) has to work.
+
+type ShimWin = {
+  __ns: string
+  localStorage: Storage
+  __laStorageReady: Promise<void>
+  parent: { postMessage: (data: unknown) => void }
+}
+
+function makeShimWin(ns: string): ShimWin {
+  const listeners: ((ev: { data: unknown }) => void)[] = []
+  const fake = {
+    __ns: ns,
+    addEventListener: (t: string, fn: (ev: { data: unknown }) => void) => {
+      if (t === 'message') listeners.push(fn)
+    },
+    // The host replies through ev.source.postMessage.
+    postMessage: (data: unknown) => listeners.forEach((fn) => fn({ data })),
+    parent: {
+      postMessage: (data: unknown) => {
+        window.dispatchEvent(new MessageEvent('message', { data, source: fake as never, origin: 'null' }))
+      },
+    },
+  }
+  return fake as unknown as ShimWin
+}
+
+// Boot a Light App document: register the frame, then run the bridge script
+// with a `localStorage` that throws like a sandboxed origin's does.
+function boot(ns: string): ShimWin {
+  const win = makeShimWin(ns)
+  registerLaIframe(win as unknown as Window, ns)
+  const opaque = new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('SecurityError: opaque origin')
+      },
+    },
+  )
+  new Function('window', 'localStorage', buildLaBridgeScript(ns))(win, opaque)
+  return win
+}
+
+describe('injected bridge script (end-to-end)', () => {
+  it('persists across reloads: write, reboot, read it back', async () => {
+    const ns = 'e2e-' + nsCounter++
+    const first = boot(ns)
+    await first.__laStorageReady
+    first.localStorage.setItem('score', '42')
+    await new Promise((r) => setTimeout(r, 15))
+
+    // Fresh document, same app — the prefetch must warm the cache.
+    const second = boot(ns)
+    await second.__laStorageReady
+    expect(second.localStorage.getItem('score')).toBe('42')
+    expect(second.localStorage.length).toBe(1)
+    expect(second.localStorage.key(0)).toBe('score')
+  })
+
+  it('getItem returns null for keys never written', async () => {
+    const win = boot('e2e-' + nsCounter++)
+    await win.__laStorageReady
+    expect(win.localStorage.getItem('nope')).toBe(null)
+    expect(win.localStorage.length).toBe(0)
+  })
+
+  it('a startup write survives the prefetch that lands after it', async () => {
+    const ns = 'e2e-' + nsCounter++
+    const seed = boot(ns)
+    await seed.__laStorageReady
+    seed.localStorage.setItem('score', '42')
+    await new Promise((r) => setTimeout(r, 15))
+
+    // Apps commonly write a default synchronously at startup, which always
+    // happens before the async dump lands. The dump must not revert it.
+    const win = boot(ns)
+    win.localStorage.setItem('score', 'DEFAULT-0')
+    await win.__laStorageReady
+    expect(win.localStorage.getItem('score')).toBe('DEFAULT-0')
+
+    // ...and the cache agrees with what actually got persisted.
+    const reload = boot(ns)
+    await reload.__laStorageReady
+    expect(reload.localStorage.getItem('score')).toBe('DEFAULT-0')
+  })
+
+  it('clear() before the prefetch lands is not undone by it', async () => {
+    const ns = 'e2e-' + nsCounter++
+    const seed = boot(ns)
+    await seed.__laStorageReady
+    seed.localStorage.setItem('a', '1')
+    seed.localStorage.setItem('b', '2')
+    await new Promise((r) => setTimeout(r, 15))
+
+    const win = boot(ns)
+    win.localStorage.clear()
+    await win.__laStorageReady
+    expect(win.localStorage.length).toBe(0)
+    expect(win.localStorage.getItem('a')).toBe(null)
+  })
+
+  it('removeItem is not resurrected by the prefetch', async () => {
+    const ns = 'e2e-' + nsCounter++
+    const seed = boot(ns)
+    await seed.__laStorageReady
+    seed.localStorage.setItem('a', '1')
+    seed.localStorage.setItem('b', '2')
+    await new Promise((r) => setTimeout(r, 15))
+
+    const win = boot(ns)
+    win.localStorage.removeItem('a')
+    await win.__laStorageReady
+    expect(win.localStorage.getItem('a')).toBe(null)
+    expect(win.localStorage.getItem('b')).toBe('2')
+  })
+
+  it('throws QuotaExceededError instead of caching a write the host would reject', async () => {
+    const win = boot('e2e-' + nsCounter++)
+    await win.__laStorageReady
+    expect(() => win.localStorage.setItem('x', 'v'.repeat(1_000_001))).toThrow(
+      expect.objectContaining({ name: 'QuotaExceededError' }),
+    )
+    expect(() => win.localStorage.setItem('k'.repeat(600), 'v')).toThrow(
+      expect.objectContaining({ name: 'QuotaExceededError' }),
+    )
+    // Nothing was cached, so the cache still matches the store.
+    expect(win.localStorage.getItem('x')).toBe(null)
+    expect(win.localStorage.length).toBe(0)
+  })
+
+  it('a stale document cannot write into the app that replaced it', async () => {
+    const ns = 'e2e-' + nsCounter++
+    const stale = boot(ns)
+    await stale.__laStorageReady
+
+    // The iframe element is reused across app switches: same window, new slug.
+    const next = 'e2e-' + nsCounter++
+    registerLaIframe(stale as unknown as Window, next)
+    stale.localStorage.setItem('leak', 'from-old-app')
+    await new Promise((r) => setTimeout(r, 15))
+
+    const victim = boot(next)
+    await victim.__laStorageReady
+    expect(victim.localStorage.getItem('leak')).toBe(null)
+  })
+
+  it('does nothing when localStorage natively works', () => {
+    const win = makeShimWin('e2e-native')
+    const native = { getItem: () => null } as unknown as Storage
+    new Function('window', 'localStorage', buildLaBridgeScript('e2e-native'))(win, native)
+    expect(win.localStorage).toBe(undefined) // no shim installed
+    expect(win.__laStorageReady).toBe(undefined)
+  })
+
+  it('embeds the namespace inertly, even a hostile slug', () => {
+    const script = buildLaBridgeScript('a</script><script>alert(1)//')
+    expect(script).not.toContain('</script>')
+    expect(script).toContain('\\u003c/script\\u003e')
+  })
+})

--- a/web/src/lib/laStorage.ts
+++ b/web/src/lib/laStorage.ts
@@ -1,0 +1,312 @@
+// Light App storage bridge — makes `localStorage` WORK inside Light Apps.
+//
+// Light Apps render in a sandboxed srcdoc iframe (`sandbox="allow-scripts"`,
+// deliberately without `allow-same-origin`), so their origin is opaque and the
+// browser refuses every persistent storage API: localStorage, sessionStorage,
+// Cookie, IndexedDB all throw SecurityError in there. Persistent state
+// (scores, collections, settings) was impossible for Light Apps.
+//
+// This module fixes that WITHOUT touching the sandbox. The host document owns
+// an IndexedDB, and an injected bridge script replaces `window.localStorage`
+// inside the iframe with a synchronous shim backed by an in-memory cache:
+//
+//   - getItem / length / key: served synchronously from the cache
+//   - setItem / removeItem / clear: update the cache synchronously, then
+//     persist through a background postMessage to the host
+//   - on load the script prefetches the app's full key set (async) so the
+//     cache starts warm; `window.__laStorageReady` resolves when that lands
+//
+// Light Apps keep using the plain `localStorage` API — no special interface,
+// zero code changes. Where localStorage genuinely works (non-sandboxed
+// contexts) the script does nothing at all.
+//
+// Only sessionStorage is deliberately left broken: a Light App that wants
+// per-visit state can keep it in a plain variable.
+//
+// Security model:
+//   - Only iframes the host registered (registerLaIframe) can read/write; the
+//     message handler checks event.source against the registry and ignores
+//     everything else (incl. the app's own artifact-preview iframes).
+//   - Every request must carry the namespace its bridge script was built with,
+//     and it must match the one the host registered for that window. The
+//     iframe element is reused across app switches (same WindowProxy, fresh
+//     srcdoc), so without this a departing document's in-flight write would
+//     land in the incoming app's namespace.
+//   - The host stores under the ns it registered, never the one the message
+//     claims, so an app cannot read or write another app's keys.
+//   - Keys are validated strings (<=512 chars, non-empty); values are strings
+//     capped at MAX_VALUE. The shim enforces the same limits synchronously so
+//     a rejected write can never leave the cache disagreeing with the store.
+
+const DB_NAME = 'octo-la-storage'
+const STORE = 'kv'
+const MAX_KEY = 512
+// Per-key and per-app ceilings, in UTF-16 code units. MAX_TOTAL mirrors the
+// ~5MB per origin real localStorage gives an app; MAX_VALUE keeps one runaway
+// write from eating the whole budget in a single message.
+const MAX_VALUE = 1_000_000
+const MAX_TOTAL = 5_000_000
+
+const laFrames = new Map<Window, string>() // iframe window -> namespace
+let bridgeInstalled = false
+
+export function registerLaIframe(win: Window | null | undefined, ns: string): void {
+  if (!win) return
+  laFrames.set(win, ns)
+}
+
+export function unregisterLaIframe(win: Window | null | undefined): void {
+  if (win) laFrames.delete(win)
+}
+
+// ── IndexedDB ───────────────────────────────────────────────────────────────
+
+let dbPromise: Promise<IDBDatabase> | null = null
+
+function openDb(): Promise<IDBDatabase> {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, 1)
+      req.onupgradeneeded = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE)
+      }
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error ?? new Error('IndexedDB open failed'))
+    })
+  }
+  return dbPromise
+}
+
+function run<T>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+  return openDb().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const t = db.transaction(STORE, mode)
+        const req = fn(t.objectStore(STORE))
+        req.onsuccess = () => resolve(req.result)
+        req.onerror = () => reject(req.error ?? new Error('IndexedDB request failed'))
+      }),
+  )
+}
+
+function fullKey(ns: string, key: string): string {
+  return `${ns}:${key}`
+}
+
+function laSet(ns: string, key: string, value: string): Promise<unknown> {
+  return run('readwrite', (s) => s.put(value, fullKey(ns, key)))
+}
+
+function laRemove(ns: string, key: string): Promise<unknown> {
+  return run('readwrite', (s) => s.delete(fullKey(ns, key)))
+}
+
+// dump: all key/values under the namespace (prefetch for the iframe shim).
+function laDump(ns: string): Promise<Record<string, string>> {
+  return openDb().then(
+    (db) =>
+      new Promise<Record<string, string>>((resolve, reject) => {
+        const t = db.transaction(STORE, 'readonly')
+        const store = t.objectStore(STORE)
+        const prefix = ns + ':'
+        const out: Record<string, string> = {}
+        const cur = store.openCursor()
+        cur.onsuccess = () => {
+          const c = cur.result
+          if (c) {
+            if (typeof c.key === 'string' && c.key.startsWith(prefix)) {
+              out[c.key.slice(prefix.length)] = String(c.value)
+            }
+            c.continue()
+          } else {
+            resolve(out)
+          }
+        }
+        cur.onerror = () => reject(cur.error ?? new Error('IndexedDB cursor failed'))
+      }),
+  )
+}
+
+// clear: removes every key under the namespace, leaving other apps untouched.
+async function laClear(ns: string): Promise<void> {
+  const db = await openDb()
+  await new Promise<void>((resolve, reject) => {
+    const t = db.transaction(STORE, 'readwrite')
+    const store = t.objectStore(STORE)
+    const prefix = ns + ':'
+    const keys: IDBValidKey[] = []
+    const cur = store.openCursor()
+    cur.onsuccess = () => {
+      const c = cur.result
+      if (c) {
+        if (typeof c.key === 'string' && c.key.startsWith(prefix)) keys.push(c.key)
+        c.continue()
+      } else {
+        keys.forEach((k) => store.delete(k))
+        resolve()
+      }
+    }
+    cur.onerror = () => reject(cur.error ?? new Error('IndexedDB cursor failed'))
+  })
+}
+
+// ── Bridge protocol ─────────────────────────────────────────────────────────
+//
+// iframe -> parent:  { __laBridge: 1, id, ns, op: 'dump'|'set'|'remove'|'clear', key?, value? }
+// parent -> iframe:  { __laBridge: 1, id, res: true, ok, value?, err? }
+//
+// `res: true` marks the direction, so a nested iframe's request reaching this
+// window is never mistaken for a reply to one of our own calls.
+
+function validKey(key: unknown): key is string {
+  return typeof key === 'string' && key.length > 0 && key.length <= MAX_KEY
+}
+
+function validValue(value: unknown): value is string {
+  return typeof value === 'string' && value.length <= MAX_VALUE
+}
+
+function onLaMessage(ev: MessageEvent): void {
+  const ns = laFrames.get(ev.source as Window)
+  if (!ns) return
+  const d = ev.data as Record<string, unknown> | null
+  if (!d || d.__laBridge !== 1) return
+  if (d.ns !== ns) return // stale document from before an app switch
+  const id = d.id
+  const op = d.op
+  if (typeof id !== 'number' || typeof op !== 'string') return
+  const reply = (ok: boolean, value?: unknown, err?: string): void => {
+    ;(ev.source as Window).postMessage({ __laBridge: 1, id, res: true, ok, value, err }, '*')
+  }
+  const fail = (e: unknown): void => reply(false, undefined, String(e))
+
+  switch (op) {
+    case 'dump':
+      laDump(ns).then((v) => reply(true, v)).catch(fail)
+      break
+    case 'set':
+      if (!validKey(d.key) || !validValue(d.value)) return reply(false, undefined, 'bad key/value')
+      laSet(ns, d.key, d.value).then(() => reply(true)).catch(fail)
+      break
+    case 'remove':
+      if (!validKey(d.key)) return reply(false, undefined, 'bad key')
+      laRemove(ns, d.key).then(() => reply(true)).catch(fail)
+      break
+    case 'clear':
+      laClear(ns).then(() => reply(true)).catch(fail)
+      break
+    default:
+      reply(false, undefined, 'unknown op')
+  }
+}
+
+export function installLaStorageBridge(): void {
+  if (bridgeInstalled) return
+  bridgeInstalled = true
+  window.addEventListener('message', onLaMessage)
+}
+
+// ── iframe-side bridge script ───────────────────────────────────────────────
+//
+// Injected into the Light App's srcdoc just before </body>. If localStorage
+// natively works (non-sandboxed context) it does nothing. Otherwise it swaps
+// `window.localStorage` for a synchronous shim: reads come from an in-memory
+// cache prefetched from the host (dump), writes update the cache synchronously
+// and persist via background postMessage. `window.__laStorageReady` resolves
+// once the prefetch lands, for apps that read storage at startup.
+//
+// Writes the app makes before the prefetch lands win: `dirty` keys and a
+// post-clear `wiped` flag tell the dump handler what not to overwrite, so the
+// cache never reverts to a value the app has already replaced.
+//
+// The limits the host enforces are re-checked here synchronously, and a
+// violation throws QuotaExceededError like real localStorage does — a write
+// the host would reject must not silently sit in the cache.
+
+// Embed a string as a JS literal that is also inert inside <script> in HTML.
+function jsLiteral(s: string): string {
+  return JSON.stringify(s).replace(/</g, '\\u003c').replace(/>/g, '\\u003e')
+}
+
+export function buildLaBridgeScript(ns: string): string {
+  return `(function(){
+  var usable = false;
+  try { localStorage.getItem('__la_probe'); usable = true; } catch (e) {}
+  if (usable) return; // native localStorage works here — nothing to shim
+  var NS = ${jsLiteral(ns)}, MAX_KEY = ${MAX_KEY}, MAX_VALUE = ${MAX_VALUE}, MAX_TOTAL = ${MAX_TOTAL};
+  var mem = Object.create(null), pend = {}, seq = 0, used = 0;
+  var dirty = Object.create(null), wiped = false;
+  var readyResolve;
+  window.__laStorageReady = new Promise(function(res){ readyResolve = res; });
+  function has(k){ return Object.prototype.hasOwnProperty.call(mem, k); }
+  function quota(){
+    var e = new Error("Failed to execute 'setItem' on 'Storage': the quota has been exceeded.");
+    e.name = 'QuotaExceededError';
+    return e;
+  }
+  window.addEventListener('message', function(ev){
+    var d = ev.data;
+    if (!d || d.__laBridge !== 1 || !d.res) return;
+    var p = pend[d.id]; if (!p) return;
+    delete pend[d.id];
+    if (d.ok) p.resolve(d.value); else p.reject(new Error(d.err || 'storage bridge failed'));
+  });
+  function call(op, key, value){
+    return new Promise(function(resolve, reject){
+      var id = ++seq;
+      pend[id] = { resolve: resolve, reject: reject };
+      try { window.parent.postMessage({ __laBridge: 1, id: id, ns: NS, op: op, key: key, value: value }, '*'); }
+      catch (e) { delete pend[id]; reject(e); }
+      setTimeout(function(){ if (pend[id]) { delete pend[id]; reject(new Error('storage bridge timeout')); } }, 3000);
+    });
+  }
+  // Warm the cache with everything the app already persisted, without undoing
+  // whatever it wrote while the prefetch was still in flight.
+  call('dump').then(function(map){
+    if (!map || wiped) return;
+    for (var k in map) {
+      if (dirty[k]) continue;
+      mem[k] = map[k];
+      used += k.length + map[k].length;
+    }
+  }).catch(function(){}).then(function(){ readyResolve(); });
+  function emit(op, key, value){
+    try { window.parent.postMessage({ __laBridge: 1, id: ++seq, ns: NS, op: op, key: key, value: value }, '*'); }
+    catch (e) {}
+  }
+  var shim = {
+    getItem: function(k){ k = String(k); return has(k) ? mem[k] : null; },
+    setItem: function(k, v){
+      k = String(k); v = String(v);
+      if (k.length === 0 || k.length > MAX_KEY || v.length > MAX_VALUE) throw quota();
+      var next = used + k.length + v.length - (has(k) ? k.length + mem[k].length : 0);
+      if (next > MAX_TOTAL) throw quota();
+      mem[k] = v; used = next; dirty[k] = true;
+      emit('set', k, v);
+    },
+    removeItem: function(k){
+      k = String(k);
+      if (has(k)) used -= k.length + mem[k].length;
+      delete mem[k]; dirty[k] = true;
+      emit('remove', k);
+    },
+    clear: function(){
+      mem = Object.create(null); dirty = Object.create(null);
+      used = 0; wiped = true;
+      emit('clear');
+    },
+    key: function(i){ var ks = Object.keys(mem); return i >= 0 && i < ks.length ? ks[i] : null; },
+    get length(){ return Object.keys(mem).length; }
+  };
+  try { Object.defineProperty(window, 'localStorage', { value: shim, configurable: true, writable: true }); }
+  catch (e) { try { window.localStorage = shim; } catch (e2) {} }
+})();`
+}
+
+/** Inject the bridge script into a Light App document before </body>. */
+export function withLaBridge(html: string, ns: string): string {
+  const script = `<script>${buildLaBridgeScript(ns)}<\\/script>`
+  if (/\<\/body\s*>/i.test(html)) return html.replace(/\<\/body\s*>/i, script + '</body>')
+  return html + script
+}


### PR DESCRIPTION
## 背景

Light Apps 渲染在 `sandbox="allow-scripts"` 的 srcdoc iframe 里（刻意不加 `allow-same-origin`），origin 是 opaque，**所有持久化存储 API 在轻应用里都会抛 SecurityError**（localStorage/sessionStorage/Cookie/IndexedDB）。这让轻应用做不了任何持久状态（积分、收集、设置），可用性受限。

## 方案

不碰沙箱（安全模型保持），改为**父页面托管 IndexedDB + 注入 localStorage 兼容 shim**：

- `web/src/lib/laStorage.ts`（新）：
  - 父页面 IndexedDB（`octo-la-storage` 库、`kv` store），键 `{slug}:{key}` 按应用隔离
  - 全局 message listener：只服务**注册过的 iframe**（`registerLaIframe`，handler 校验 `event.source`），键校验（≤512 字符、非空）、值限字符串
  - `buildLaBridgeScript(ns)` 生成的桥脚本在 iframe 内把 `window.localStorage` 替换为**同步 shim**：
    - getItem / length / key 从内存缓存同步返回
    - setItem / removeItem / clear 同步更新缓存，再通过后台 postMessage 持久化到父页面
    - 加载时异步 `dump` 预取该应用全部历史数据；`window.__laStorageReady` 在预取完成后 resolve（供启动即读存储的应用等待）
  - localStorage 原生可用（非沙箱上下文）时脚本什么都不做
- `ArtifactsPanel.svelte`：轻应用 iframe 注入桥脚本 + 注册/反注册 contentWindow

## 关键点

- **轻应用零改动**：继续用标准 `localStorage` API，无任何特殊接口
- 语义差异说明：跨页面重启的读一致性由启动预取保证；同页内读写全同步一致；崩溃/提前关闭可能丢最后一次写（异步落盘，与原生 localStorage 的语义差距极小）
- 安全：未注册 iframe（如制品预览）的消息被忽略；命名空间隔离应用数据
- 移动端制品预览（ArtifactViewer）不注入桥——只轻应用需要持久存储

## 测试

- `laStorage.test.ts`：18 个用例，fake-indexeddb
  - 父侧 9 个：set/dump roundtrip、空空间、命名空间隔离、remove/clear 只清本空间、未注册拒绝、坏键拒绝、注销生效、桥脚本注入、shim 特征断言
  - 端到端 9 个：在假 iframe window 里真正执行 `buildLaBridgeScript` 的产物、经真实 host listener 走完整 roundtrip —— 跨重启读回、启动写不被预取覆盖、clear/remove 不被预取复活、超限抛 `QuotaExceededError`、旧文档写不进新应用、原生可用时不注入、恶意 slug 转义
- 全量 `npm test` 611 通过，`svelte-check` 0 error，`npm run build` 通过


---

## Review 修复

**读路径完全不通（阻塞）**：父页面回复 `{__laBridge, id, ok, value, err}`，而注入脚本要求 `d.res` 为真才接受回复 —— 每条回复都被丢弃。后果是 dump 预取永不 resolve、`__laStorageReady` 靠 3s 超时才落地、`getItem` 恒返回 `null`。写能落盘但永远读不回来，正是本 PR 要解决的问题本身。现在父侧回复带 `res: true`，顺带也防住嵌套 iframe 的请求被误认成回复。

**预取会覆盖应用自己的写入**：应用在启动时同步写默认值是常见写法，且必然发生在异步 dump 落地之前，dump 会把它盖回旧值 —— 本次会话内缓存与磁盘永久分叉。`clear()` 是反向的同一个问题：在途的 dump 会把刚清掉的键重新灌回缓存。脚本现在追踪本地已改动的键和 clear 后的 `wiped` 标志，dump 回填时跳过它们。

**切换应用时的命名空间串写**：iframe 元素跨应用切换是复用的（同一个 WindowProxy、新 srcdoc），旧文档在途的写会落进新应用的命名空间。现在每条请求都带上其脚本构建时的 ns，父侧不匹配就忽略；实际存储仍只用 registry 里注册的 ns，应用无法伪造 ns 去读写别人的数据。内嵌的 ns 做了转义，恶意 slug 无法从 `<script>` 块里逃出来。

**值上限**：单键 1MB、单应用 5MB。shim 侧同步复核父侧的同一组上限并抛 `QuotaExceededError`（贴近原生语义）—— 被父侧拒绝的写不能留在缓存里假装存好了。没有上限的话，一个轻应用可以静默吃掉宿主 origin 的存储配额。

**测试**：初版的 9 个用例只打父侧，对注入脚本只做字符串 `toContain`，看不见两半协议对不上。补了 9 个端到端用例真正执行脚本走完整 roundtrip；上面三个修复各自都有会在回退后失败的用例（已逐个 mutation 验证）。

**其他**：`mem` 改为无原型对象（`__proto__` 作为键能正常往返）、`readyResolve` 移到使用之前、`laFrames` 改 `const`、面板注释不再提已移除的 `__laStorage` API、`dev-docs/light-apps-design.md` 补运行时存储一节并修正"不回调 Agent"那条决策的理由。


