### PR TITLE
web: keep the composer draft when leaving the chat view

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { get } from 'svelte/store'
-  import { onMount, untrack, tick } from 'svelte'
+  import { onDestroy, onMount, untrack, tick } from 'svelte'
   import {
     running, activeSessionId, chatStreaming, sessions, sessionGroups,
     chatContextUsage, chatWorkingDir, chatPermMode, chatReasoningEffort, chatShowReasoning, showToast, chatGoal, chatModel,
@@ -13,24 +13,13 @@
   import { t } from '../../lib/i18n'
   import { submitIntent } from '../../lib/composerKeys'
   import { composeSlashCommand } from '../../lib/slashCompose'
+  import { parkDraft, takeDraft, patchParkedAttachments, type Attachment } from '../../lib/composerDrafts'
   import FolderPickerModal from '../overlays/FolderPickerModal.svelte'
   import ProjectModal from '../overlays/ProjectModal.svelte'
   import type { McpServerDetail, McpTool, SessionGroup } from '../../lib/types'
   import { getMcpServer } from '../../lib/api'
 
   let { onSend }: { onSend?: (text: string, files?: any[], queued?: boolean) => void } = $props()
-
-  // A staged attachment. Images carry inline as a base64 data URL (the model
-  // gets an image block); every other type is uploaded to the server and
-  // referenced by `path` (an /api/uploads/<name> URL) so the agent opens it
-  // with read_file/terminal — mirroring how it works against the CLI's
-  // filesystem. Exactly one of data_url / path is set once ready. `uploading`
-  // marks a placeholder whose upload is still in flight; `id` keys that
-  // placeholder so its async result lands on the right entry (see addAttachment).
-  // local_path is a real local path (native dialog on desktop, or the in-app
-  // file picker on localhost web) — the agent reads it in place, no upload
-  // (mirrors the folder picker). Set instead of data_url/path when same-machine.
-  type Attachment = { id?: string; name: string; mime_type?: string; data_url?: string; path?: string; local_path?: string; uploading?: boolean }
 
   // Reject oversized attachments client-side with a clear message rather than
   // letting them fail late. Images keep a conservative cap: they are canvas-
@@ -41,19 +30,17 @@
   const MAX_IMAGE_BYTES = 32 * 1024 * 1024
   const MAX_FILE_BYTES = 512 * 1024 * 1024
 
-  let text = $state('')
-  // Per-session composer draft: keyed by session id so switching sessions
-  // doesn't carry a half-typed message (or its staged attachments) into — or
-  // send them to — the wrong conversation. Plain objects, not $state —
-  // nothing renders them directly, they are only read/written from the
-  // session-switch effect below.
-  let draftsBySession: Record<string, string> = {}
-  let attachmentsBySession: Record<string, Attachment[]> = {}
-  let draftSid = ''
+  // Mounting claims the draft parked for this session — a trip through another
+  // view and back picks the box up exactly where it was left. The
+  // session-switch effect below owns it from there.
+  const initialSid = get(activeSessionId) ?? ''
+  const initialDraft = takeDraft(initialSid)
+  let text = $state(initialDraft.text)
+  let draftSid = initialSid
   let textareaEl = $state<HTMLTextAreaElement | null>(null)
   let fileInputEl = $state<HTMLInputElement | null>(null)
   let skillMenuEl = $state<HTMLDivElement | null>(null)
-  let attachments = $state<Attachment[]>([])
+  let attachments = $state<Attachment[]>(initialDraft.attachments)
   let dragOver = $state(false)
 
   // Called by ChatView when the user clicks "edit" on a prior message — loads
@@ -150,20 +137,28 @@
   // These helpers land the result on the session that STARTED the read, not
   // whatever session is active when it finishes — otherwise switching sessions
   // (or sending) mid-upload leaks the file into the wrong conversation.
+  // `destroyed` splits the same way for time rather than session: once the
+  // composer is gone its `attachments` is a dead end, so the result has to go
+  // to the parked draft — the placeholder is already sitting in there waiting
+  // for it (see patchParkedAttachments).
   let uploadSeq = 0
+  let destroyed = false
+  function live(originSid: string): boolean {
+    return !destroyed && originSid === sid
+  }
   function attachTo(originSid: string, att: Attachment) {
-    if (originSid === sid) attachments = [...attachments, att]
-    else attachmentsBySession[originSid] = [...(attachmentsBySession[originSid] ?? []), att]
+    if (live(originSid)) attachments = [...attachments, att]
+    else patchParkedAttachments(originSid, list => [...list, att])
   }
   function patchAttachment(originSid: string, id: string, patch: Partial<Attachment>) {
     const apply = (list: Attachment[]) => list.map(a => a.id === id ? { ...a, ...patch } : a)
-    if (originSid === sid) attachments = apply(attachments)
-    else if (attachmentsBySession[originSid]) attachmentsBySession[originSid] = apply(attachmentsBySession[originSid])
+    if (live(originSid)) attachments = apply(attachments)
+    else patchParkedAttachments(originSid, apply)
   }
   function dropAttachment(originSid: string, id: string) {
     const drop = (list: Attachment[]) => list.filter(a => a.id !== id)
-    if (originSid === sid) attachments = drop(attachments)
-    else if (attachmentsBySession[originSid]) attachmentsBySession[originSid] = drop(attachmentsBySession[originSid])
+    if (live(originSid)) attachments = drop(attachments)
+    else patchParkedAttachments(originSid, drop)
   }
 
   // Images ride inline as base64 data URLs inside the WebSocket chat message,
@@ -598,18 +593,26 @@
     const nextSid = sid
     if (nextSid === draftSid) return
     untrack(() => {
-      if (draftSid) {
-        draftsBySession[draftSid] = text
-        attachmentsBySession[draftSid] = attachments
-      }
-      text = draftsBySession[nextSid] ?? ''
-      attachments = attachmentsBySession[nextSid] ?? []
+      if (draftSid) parkDraft(draftSid, text, attachments)
+      const draft = takeDraft(nextSid)
+      text = draft.text
+      attachments = draft.attachments
       draftSid = nextSid
       historyIndex = null
       // The menu describes the departing session's text. Keyboard switches
       // (⌘K) never fire the outside-click that would otherwise close it.
       hideSlashMenu()
     })
+  })
+
+  // Leaving the chat view destroys the composer. Park what's in the box under
+  // the session it belongs to (including the empty-string key of a not-yet-
+  // created chat) so coming back restores it instead of starting blank. Park
+  // before flipping `destroyed`: an upload resolving after this point patches
+  // the entry left here.
+  onDestroy(() => {
+    parkDraft(draftSid, text, attachments)
+    destroyed = true
   })
 
   let isStreaming = $derived($chatStreaming[sid] ?? false)

--- a/web/src/lib/composerDrafts.test.ts
+++ b/web/src/lib/composerDrafts.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { parkDraft, takeDraft, patchParkedAttachments, type Attachment } from './composerDrafts'
+
+const file = (id: string, over: Partial<Attachment> = {}): Attachment =>
+  ({ id, name: `${id}.pdf`, ...over })
+
+describe('composerDrafts', () => {
+  it('hands a parked draft back to whoever takes it', () => {
+    parkDraft('s1', 'half a sentence', [file('a')])
+    const d = takeDraft('s1')
+    expect(d.text).toBe('half a sentence')
+    expect(d.attachments.map(a => a.id)).toEqual(['a'])
+  })
+
+  it('keeps sessions apart', () => {
+    parkDraft('s1', 'for one', [])
+    parkDraft('s2', 'for two', [])
+    expect(takeDraft('s2').text).toBe('for two')
+    expect(takeDraft('s1').text).toBe('for one')
+  })
+
+  it('reads a session that parked nothing as an empty draft', () => {
+    const d = takeDraft('never-seen')
+    expect(d.text).toBe('')
+    expect(d.attachments).toEqual([])
+  })
+
+  // The composer takes ownership on mount; leaving a copy behind would let a
+  // message that was typed in a not-yet-created chat ('') and then sent come
+  // back in the next new chat.
+  it('removes the draft it hands out', () => {
+    parkDraft('', 'sent already', [file('a')])
+    takeDraft('')
+    expect(takeDraft('')).toEqual({ text: '', attachments: [] })
+  })
+
+  it('stores nothing for an empty box, and clears what was there', () => {
+    parkDraft('s1', 'typed', [file('a')])
+    parkDraft('s1', '', [])
+    expect(takeDraft('s1')).toEqual({ text: '', attachments: [] })
+  })
+
+  it('keeps a draft that is attachments only', () => {
+    parkDraft('s1', '', [file('a')])
+    expect(takeDraft('s1').attachments.map(a => a.id)).toEqual(['a'])
+  })
+
+  describe('patchParkedAttachments', () => {
+    // An upload that resolves after the composer is unmounted: the placeholder
+    // must clear, or the chip comes back with no remove button and send()
+    // refuses to send past it.
+    it('lands a late upload result on the parked draft', () => {
+      parkDraft('s1', 'note', [file('a', { uploading: true })])
+      patchParkedAttachments('s1', list =>
+        list.map(a => a.id === 'a' ? { ...a, path: '/api/uploads/a.pdf', uploading: false } : a))
+      const d = takeDraft('s1')
+      expect(d.text).toBe('note')
+      expect(d.attachments[0]).toMatchObject({ path: '/api/uploads/a.pdf', uploading: false })
+    })
+
+    it('lands a late failure by dropping the placeholder', () => {
+      parkDraft('s1', 'note', [file('a', { uploading: true }), file('b')])
+      patchParkedAttachments('s1', list => list.filter(a => a.id !== 'a'))
+      expect(takeDraft('s1').attachments.map(a => a.id)).toEqual(['b'])
+    })
+
+    it('drops the entry when the patch empties it', () => {
+      parkDraft('s1', '', [file('a', { uploading: true })])
+      patchParkedAttachments('s1', list => list.filter(a => a.id !== 'a'))
+      expect(takeDraft('s1')).toEqual({ text: '', attachments: [] })
+    })
+
+    it('ignores a session with nothing parked', () => {
+      expect(() => patchParkedAttachments('gone', list => [...list, file('a')])).not.toThrow()
+      expect(takeDraft('gone').attachments).toEqual([])
+    })
+  })
+})

--- a/web/src/lib/composerDrafts.ts
+++ b/web/src/lib/composerDrafts.ts
@@ -1,0 +1,51 @@
+// Where a half-typed message waits while the composer isn't on screen.
+// App.svelte renders exactly one view at a time, so opening Light Apps (or
+// Skills, Tasks, …) unmounts the chat view and the composer with it — the
+// draft has to live somewhere the unmount can't take with it. The same shelf
+// carries drafts across session switches, which is why entries are keyed by
+// session id; '' is the new chat whose session doesn't exist yet.
+
+// A staged attachment. Images carry inline as a base64 data URL (the model
+// gets an image block); every other type is uploaded to the server and
+// referenced by `path` (an /api/uploads/<name> URL) so the agent opens it
+// with read_file/terminal — mirroring how it works against the CLI's
+// filesystem. Exactly one of data_url / path is set once ready. `uploading`
+// marks a placeholder whose upload is still in flight; `id` keys that
+// placeholder so its async result lands on the right entry (see addAttachment).
+// local_path is a real local path (native dialog on desktop, or the in-app
+// file picker on localhost web) — the agent reads it in place, no upload
+// (mirrors the folder picker). Set instead of data_url/path when same-machine.
+export type Attachment = { id?: string; name: string; mime_type?: string; data_url?: string; path?: string; local_path?: string; uploading?: boolean }
+
+export type Draft = { text: string; attachments: Attachment[] }
+
+const parked = new Map<string, Draft>()
+
+// An empty box is nothing to hold on to: dropping the entry instead of storing
+// a blank one keeps the shelf from growing a row per session ever visited, and
+// keeps staged images (base64 data URLs, up to 32 MB each) from outliving the
+// draft that staged them.
+export function parkDraft(sid: string, text: string, attachments: Attachment[]): void {
+  if (text === '' && attachments.length === 0) parked.delete(sid)
+  else parked.set(sid, { text, attachments })
+}
+
+// Read-and-remove: whoever takes a draft owns it from then on. A copy left
+// behind would resurface later — a message typed in a not-yet-created chat and
+// then sent would reappear in the NEXT new chat, attachments and all.
+export function takeDraft(sid: string): Draft {
+  const d = parked.get(sid)
+  parked.delete(sid)
+  return d ?? { text: '', attachments: [] }
+}
+
+// An attachment read/upload that resolves after the composer is gone still has
+// to land on its own session's parked draft. Without this the placeholder it
+// staged stays `uploading` forever — a chip with no remove button (it only
+// grows one once the upload clears) that send() refuses to send past, i.e. an
+// input box wedged until the page reloads.
+export function patchParkedAttachments(sid: string, fn: (list: Attachment[]) => Attachment[]): void {
+  const d = parked.get(sid)
+  if (!d) return
+  parkDraft(sid, d.text, fn(d.attachments))
+}


### PR DESCRIPTION
A message typed into the chat composer was lost the moment the user opened Light Apps (or Skills, Tasks, MCP, …) and came back.

## Cause

`App.svelte` renders exactly one view at a time — `{#if $view === 'chat'}` — so leaving the chat view unmounts `ChatView` and its `Composer`. The live `text` and the per-session draft maps were all component state, so they died with it and the remount started blank.

## Fix

The shelf moves out of the component into `web/src/lib/composerDrafts.ts` (matching how `composerKeys.ts` / `slashCompose.ts` were pulled out of Composer). The composer parks its box on unmount and claims it again on mount; the existing session-switch effect uses the same shelf, so drafts still never follow the user into the wrong conversation.

Two details the shelf has to get right, both caught in review:

- **Take, don't copy.** Whoever takes a draft owns it. A copy left behind would let a message typed in a not-yet-created chat (the `''` key) and then *sent* come back in the next new chat, attachments and all.
- **A late upload has to patch the parked draft.** An upload resolving while the composer is unmounted used to write into the dead component. Its placeholder would then stay `uploading` forever — a chip with no remove button (it only grows one once the upload clears) that `send()` refuses to send past, i.e. an input box wedged until the page reloads. Now the result lands on the parked entry.

An empty box parks nothing, so staged images (base64 data URLs, up to 32 MB each) don't outlive the draft that staged them.

## Verification

`web/src/lib/composerDrafts.test.ts` — 10 cases: round trip, session isolation, take-removes-the-entry, empty box stores nothing, and a late upload success/failure landing on the parked draft.

Walkthrough in an isolated worktree (vite dev + a stub API, no real `octo serve` touched), driven over CDP:

| Step | Before | After |
|---|---|---|
| Type a draft, open Light Apps, come back | empty | draft intact |
| Round trip through Tasks as well | empty | draft intact |
| Come back, add more text, round trip again | empty | both intact |
| Drop a file, leave while the upload is held open, let it finish unmounted, come back | — | text intact, chip resolved, remove button back, send unblocked |

`svelte-check` 0 errors; `vitest` 603 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)