### PR TITLE
release: bump version to 1.16.7

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.6"
+var Version = "1.16.7"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release on top of 1.16.6.

Ships #2298 — Light Apps get working `localStorage` inside the sandboxed
srcdoc iframe, hosted by a parent-side IndexedDB and an injected shim, so
persistent state (scores, collections, settings) works without weakening
the sandbox.

Only `internal/version/version.go` changes here; the tag is cut after
#2298 lands so the release actually contains it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)