### PR TITLE
web: dismiss the version popover on a click anywhere outside it

### DIFF
--- a/web/src/components/layout/VersionBadge.svelte
+++ b/web/src/components/layout/VersionBadge.svelte
@@ -150,11 +150,27 @@
     if (locked) return
     open = false
   }
+
+  // Dismiss on any click outside the badge or its popover. A fixed full-bleed
+  // scrim can't do this job here: the <aside>'s backdrop-filter makes it the
+  // containing block for position:fixed, so the scrim only ever covered the
+  // sidebar and a click anywhere else left the popover open. Same approach the
+  // sidebar's other popovers use (dismissPicker in Sidebar.svelte), except this
+  // listens on the capture phase: sidebar rows stopPropagation on click, so a
+  // bubbling listener would miss a click on a kebab and leave two popovers open
+  // at once. Capture runs before the badge's own onclick, which still sits
+  // inside wrapEl, so clicking the badge closes rather than reopening.
+  let wrapEl = $state<HTMLElement | null>(null)
+  function dismiss(e: MouseEvent) {
+    if (!open || locked) return
+    if (wrapEl && !wrapEl.contains(e.target as Node)) open = false
+  }
 </script>
 
-<div class="vb-wrap">
+<svelte:window onclickcapture={dismiss} />
+
+<div class="vb-wrap" bind:this={wrapEl}>
   {#if open}
-    <button class="vb-scrim" onclick={close} aria-label="close" tabindex="-1"></button>
     <div class="vb-pop" role="dialog" aria-modal="false">
       {#if phase === 'restart_failed'}
         <p class="vb-title warn">⚠ {$t('upgrade.restart.timeout.title')}</p>
@@ -250,7 +266,6 @@
 @keyframes vb-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
 @keyframes vb-bounce { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-2px); } }
 
-.vb-scrim { position: fixed; inset: 0; z-index: 60; background: none; border: none; cursor: default; }
 .vb-pop {
   position: absolute; bottom: calc(100% + 8px); right: 0; z-index: 61;
   width: 232px; padding: 14px;

--- a/web/src/components/layout/VersionBadge.test.ts
+++ b/web/src/components/layout/VersionBadge.test.ts
@@ -1,0 +1,127 @@
+// Dismissal coverage for the version badge popover. Possible because
+// vitest.config.ts sets resolve.conditions: ['browser'] — see
+// src/lib/genui/components.test.ts.
+//
+// The popover used to rely on a fixed full-bleed scrim, which the sidebar's
+// backdrop-filter silently confined to the sidebar itself, so a click anywhere
+// else left it open. These tests pin the window-level dismissal that replaced
+// it — including the two clicks that must NOT close it.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount, unmount, flushSync } from 'svelte'
+import VersionBadge from './VersionBadge.svelte'
+import * as api from '../../lib/api'
+import { ws } from '../../lib/ws'
+
+let target: HTMLElement
+let app: Record<string, unknown> | null = null
+let wsHandlers: Record<string, (ev: unknown) => void>
+
+function versionPayload(over: Record<string, unknown> = {}) {
+  return {
+    current: '1.16.7',
+    latest: '1.16.7',
+    needs_update: false,
+    cli_command: 'octo',
+    upgrade_mode: 'cli',
+    local: true,
+    native: false,
+    self_update: false,
+    ...over,
+  }
+}
+
+async function render(over: Record<string, unknown> = {}) {
+  vi.spyOn(api, 'getVersion').mockResolvedValue(versionPayload(over) as never)
+  app = mount(VersionBadge, { target }) as Record<string, unknown>
+  // Let onMount's checkVersion() settle so the badge actually renders.
+  await new Promise((r) => setTimeout(r, 0))
+  flushSync()
+  return target.querySelector('.vb-badge') as HTMLElement
+}
+
+const pop = () => target.querySelector('.vb-pop')
+
+beforeEach(() => {
+  wsHandlers = {}
+  vi.spyOn(ws, 'on').mockImplementation(((type: string, fn: (ev: unknown) => void) => {
+    wsHandlers[type] = fn
+    return () => {}
+  }) as never)
+  target = document.createElement('div')
+  document.body.appendChild(target)
+})
+
+afterEach(() => {
+  if (app) unmount(app)
+  app = null
+  target.remove()
+  vi.restoreAllMocks()
+})
+
+describe('VersionBadge popover dismissal', () => {
+  it('opens on the badge and closes on a click anywhere outside', async () => {
+    const badge = await render()
+    expect(badge).toBeTruthy()
+
+    badge.click()
+    flushSync()
+    expect(pop()).toBeTruthy()
+
+    // A click outside the sidebar entirely — the case the scrim never covered.
+    const elsewhere = document.createElement('div')
+    document.body.appendChild(elsewhere)
+    elsewhere.click()
+    flushSync()
+    expect(pop()).toBe(null)
+    elsewhere.remove()
+  })
+
+  it('stays open when the click lands inside the popover', async () => {
+    const badge = await render()
+    badge.click()
+    flushSync()
+
+    ;(pop() as HTMLElement).click()
+    flushSync()
+    expect(pop()).toBeTruthy()
+  })
+
+  it('clicking the badge again closes it rather than reopening', async () => {
+    const badge = await render()
+    badge.click()
+    flushSync()
+    expect(pop()).toBeTruthy()
+
+    // The capture-phase dismisser must not fire for a click on the badge, or
+    // toggle() would reopen what it just closed and the popover would stick.
+    badge.click()
+    flushSync()
+    expect(pop()).toBe(null)
+  })
+
+  it('cannot be dismissed mid-upgrade', async () => {
+    await render()
+    // An upgrade broadcast opens the popover and locks it: dismissing here
+    // would leave the install running with no surface.
+    wsHandlers['upgrade_log']?.({ line: 'downloading...' })
+    flushSync()
+    expect(pop()).toBeTruthy()
+
+    document.body.click()
+    flushSync()
+    expect(pop()).toBeTruthy()
+  })
+
+  it('is dismissable again once the upgrade needs a restart', async () => {
+    await render()
+    wsHandlers['upgrade_log']?.({ line: 'downloading...' })
+    flushSync()
+    wsHandlers['upgrade_complete']?.({ success: true })
+    flushSync()
+    expect(pop()).toBeTruthy()
+
+    document.body.click()
+    flushSync()
+    expect(pop()).toBe(null)
+  })
+})


### PR DESCRIPTION
## 问题

侧栏底部版本徽章的弹框（「已是最新版本 / 有新版本」），**点页面空白处不收起**。

## 根因

弹框本来有 scrim 兜外部点击：

```css
.vb-scrim { position: fixed; inset: 0; z-index: 60; ... }
```

但侧栏 `<aside>` 带 `backdrop-filter`（`Sidebar.svelte:609`），这让它成为 `position: fixed` 的 **containing block** —— scrim 于是只覆盖侧栏，而不是整个视口。真实浏览器实测：

| | 尺寸 |
|---|---|
| scrim 实际渲染 | **255 × 813**（= 侧栏宽度） |
| viewport | **1400 × 813** |

点主聊天区（x=1050）命中的是 `rich-answer`，不是 scrim，弹框保持打开。只有恰好点在侧栏内才会收起。

这个 containing block 陷阱侧栏自己早就知道并绕过了 —— row menu / more-popover 都为此 portal 到了 `<body>`（`Sidebar.svelte:53-57` 的注释），只有这个 scrim 漏了。

## 改法

删掉 scrim，改成 window 级监听 + 排除徽章容器，跟侧栏其他弹层已有的 `dismissPicker` 一致。

两个细节：

- **走 capture 阶段**：侧栏 row 的 onclick 会 `stopPropagation()`（`Sidebar.svelte:800/957`），冒泡监听收不到点 kebab 的事件，会出现两个弹层同时开着。capture 仍早于徽章自己的 onclick，所以点徽章还是「关闭」而不是「关了又开」。
- **locked 阶段不受影响**：`upgrading` / `reconnecting` 仍然不可关闭，安装中的流程不会失去唯一界面。

## 验证

- 组件测试 5 个（`VersionBadge.test.ts`）：外部点击关闭、弹框内点击不关、连点徽章不卡住、升级中外部点击忽略、needs_restart 后可关。回退修复会挂掉其中 2 个。
- 真实浏览器（headless Chrome + CDP）双向验证：
  - 还原 scrim 方案 → 点主区域**不收起**，复现 bug
  - 当前改法 → 点主区域收起、点侧栏空白收起、点弹框内保持、弹框定位不变（`{x:12, y:658, 232×115}`，完整在视口内）
- `npm test` 621 通过、`svelte-check` 0 error、`npm run build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)