### PR TITLE
web: scope the artifacts panel to the view that owns it

### DIFF
--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { sidebar, nativeShell, panelContent, view, chatHeaderSnippet, activeSessionId, readPanelMode } from '../../lib/stores'
+  import { sidebar, nativeShell, panelContent, view, chatHeaderSnippet, activeSessionId, lightappOpen, panelForView } from '../../lib/stores'
   import { diffBadge } from '../../lib/diff'
   import { t } from '../../lib/i18n'
   import { ws, wsState } from '../../lib/ws'
@@ -24,8 +24,13 @@
   // open/close toggle: choosing the mode is the panel's own job, from its
   // topbar. What this button does gain is a badge — with the panel closed,
   // nothing else can say the agent left changes to review.
+  //
+  // The button follows the view: it is only here when the current page has
+  // something for the panel to show, so it can never reopen the last chat's
+  // artifacts beside an unrelated page.
+  const panelTarget = $derived(panelForView($view, $lightappOpen))
   function openPanel() {
-    panelContent.set(readPanelMode())
+    if (panelTarget) panelContent.set(panelTarget)
   }
 
   const diffCount = $derived($diffBadge[$activeSessionId ?? ''] ?? 0)
@@ -85,10 +90,10 @@
     </button>
   {/if}
 
-  {#if !$panelContent}
+  {#if !$panelContent && panelTarget}
     <button class="icon-btn panel-btn" title={$t('header.toggle_right')} onclick={openPanel}>
       <iconify-icon icon="lucide:panel-right" width="16"></iconify-icon>
-      {#if diffCount > 0}<span class="dot"></span>{/if}
+      {#if diffCount > 0 && panelTarget !== 'lightapps'}<span class="dot"></span>{/if}
     </button>
   {/if}
 

--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cmdkOpen, view, sessions, activeSessionId, skills, openAgentSession, createNewSession, togglePanel, settingsModalOpen, openSettingsAt, isDesktopShell } from '../../lib/stores'
+  import { cmdkOpen, view, sessions, activeSessionId, skills, openAgentSession, createNewSession, togglePanel, panelForView, lightappOpen, settingsModalOpen, openSettingsAt, isDesktopShell } from '../../lib/stores'
   import { t } from '../../lib/i18n'
 
   let query = $state('')
@@ -49,8 +49,17 @@
     createNewSession()
   }
 
-  // Static actions (always available)
-  const actions = [
+  // Static actions. `available` narrows one to the views it makes sense on;
+  // omitted means always.
+  type PaletteAction = {
+    id: string
+    icon: string
+    label: () => string
+    shortcut: string
+    run: () => void
+    available?: () => boolean
+  }
+  const actions: PaletteAction[] = [
     { id: 'new', icon: 'ant-design:plus-outlined', label: () => $t('nav.new_session'), shortcut: isDesktopShell ? '⌘N' : '', run: () => newSession() },
     { id: 'agents', icon: 'ant-design:robot-outlined', label: () => $t('nav.agents'), shortcut: '', run: () => goTo('agents') },
     { id: 'skills', icon: 'ant-design:thunderbolt-outlined', label: () => $t('nav.skills'), shortcut: '', run: () => goTo('skills') },
@@ -63,7 +72,7 @@
     { id: 'files', icon: 'ant-design:folder-open-outlined', label: () => $t('nav.file_recall'), shortcut: '', run: () => openDataSettings('trash') },
     { id: 'memory', icon: 'ant-design:user-outlined', label: () => $t('nav.memory'), shortcut: '', run: () => openDataSettings('memory') },
     { id: 'lightapps', icon: 'ant-design:appstore-outlined', label: () => $t('nav.light_apps'), shortcut: '', run: () => goTo('lightapps') },
-    { id: 'artifacts', icon: 'ant-design:file-text-outlined', label: () => $t('artifacts.toggle'), shortcut: '', run: () => togglePanel() },
+    { id: 'artifacts', icon: 'ant-design:file-text-outlined', label: () => $t('artifacts.toggle'), shortcut: '', run: () => togglePanel(), available: () => !!panelForView($view, $lightappOpen) },
     { id: 'settings', icon: 'ant-design:setting-outlined', label: () => $t('nav.settings'), shortcut: '', run: () => { close(); settingsModalOpen.set(true) } },
   ]
 
@@ -79,7 +88,7 @@
   )
 
   let matchedActions = $derived(
-    actions.filter((a) => !q || a.label().toLowerCase().includes(q))
+    actions.filter((a) => (a.available?.() ?? true) && (!q || a.label().toLowerCase().includes(q)))
   )
 
   // Flat list for keyboard navigation

--- a/web/src/lib/panelForView.test.ts
+++ b/web/src/lib/panelForView.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { get } from 'svelte/store'
+import { lightappOpen, panelContent, panelForView, savePanelMode, togglePanel, view } from './stores'
+
+// jsdom exposes no localStorage under Node 26 (see unread.test.ts), and the
+// panel-mode helpers persist through it.
+const backing = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => (backing.has(k) ? backing.get(k)! : null),
+  setItem: (k: string, v: string) => { backing.set(k, String(v)) },
+  removeItem: (k: string) => { backing.delete(k) },
+  clear: () => backing.clear(),
+})
+
+beforeEach(() => {
+  localStorage.clear()
+  view.set('chat')
+  lightappOpen.set([])
+  panelContent.set(null)
+})
+
+describe('panelForView', () => {
+  it('gives the chat view its remembered mode', () => {
+    expect(panelForView('chat', [])).toBe('session')
+    savePanelMode('diff')
+    expect(panelForView('chat', [])).toBe('diff')
+  })
+
+  it('gives the Light Apps view its own mode, but only with a tab open', () => {
+    expect(panelForView('lightapps', [])).toBe(null)
+    expect(panelForView('lightapps', ['clock'])).toBe('lightapps')
+  })
+
+  it('offers nothing to views that own no panel content', () => {
+    for (const v of ['tasks', 'skills', 'agents', 'workflows', 'browser', 'mcp', 'channels']) {
+      expect(panelForView(v, ['clock'])).toBe(null)
+    }
+  })
+})
+
+describe('togglePanel', () => {
+  it('opens the chat view on its remembered mode', () => {
+    savePanelMode('diff')
+    togglePanel()
+    expect(get(panelContent)).toBe('diff')
+  })
+
+  it('never parks the last session artifacts beside another view', () => {
+    view.set('lightapps')
+    togglePanel()
+    expect(get(panelContent)).toBe(null)
+
+    lightappOpen.set(['clock'])
+    togglePanel()
+    expect(get(panelContent)).toBe('lightapps')
+  })
+
+  it('still closes an open panel from any view', () => {
+    panelContent.set('lightapps')
+    view.set('tasks')
+    togglePanel()
+    expect(get(panelContent)).toBe(null)
+  })
+})

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -117,7 +117,8 @@ export const artifactModalOpen = writable(false)
 
 // Artifacts panel sidebar mode. null = closed, 'session' = session artifacts,
 // 'lightapps' = Light Apps list + rendering, 'diff' = git diff review.
-export const panelContent = writable<'session' | 'lightapps' | 'diff' | null>(null)
+export type PanelContent = 'session' | 'lightapps' | 'diff'
+export const panelContent = writable<PanelContent | null>(null)
 
 // The two modes the panel's own switcher offers, and the one it comes back to.
 // Light Apps is not among them: it has its own entry point and is never a
@@ -138,9 +139,21 @@ export function savePanelMode(mode: PanelMode): void {
   try { localStorage.setItem(PANEL_MODE_KEY, mode) } catch { /* private mode: this visit only */ }
 }
 
-/** Open the panel in its remembered mode, or close it if it is already open. */
+// What the panel can show next to the view the user is actually on, or null
+// when that view has nothing for it. 'session' and 'diff' are the active
+// chat's own output, so they belong to the chat view alone — opened from
+// anywhere else they park the previous session's artifacts beside a page that
+// has nothing to do with them. Light Apps answers for its own view, and only
+// once a tab is open in it: an empty strip is not worth a column.
+export function panelForView(v: string, openApps: string[]): PanelContent | null {
+  if (v === 'chat') return readPanelMode()
+  if (v === 'lightapps') return openApps.length > 0 ? 'lightapps' : null
+  return null
+}
+
+/** Open the panel in whatever the current view offers, or close it if open. */
 export function togglePanel(): void {
-  panelContent.update(v => v ? null : readPanelMode())
+  panelContent.update(v => v ? null : panelForView(get(view), get(lightappOpen)))
 }
 
 // Artifacts panel taking over the whole content area except the sidebar, so a


### PR DESCRIPTION
The header's panel button was unconditional, so pressing it on the Light Apps page (or Tasks, Skills, …) reopened the last chat session's artifacts next to a page that has nothing to do with them. #2219 closed the panel on navigation, but left the way back in wide open.

Which panel a view can offer is now one function, `panelForView`:

- **chat** → its remembered mode (`session` / `diff`, the active chat's own output)
- **Light Apps** → its tab strip, and only once an app is open in it (an empty strip isn't worth a column)
- **every other view** → nothing

The header button and the command palette's "artifacts" action both read it, so neither can open a panel the current page has no content for — the button simply isn't rendered, and the palette entry isn't listed.

The diff badge rides on that button, so it's suppressed when the button stands for Light Apps: a dot meaning "the agent left changes to review" says nothing about an app tab.

## Verification

`npx vitest run` — 48 files / 638 tests pass, including the new `panelForView.test.ts`. `svelte-check` clean.

Walked the real UI (vite dev + CDP), probing the header button and the panel at each step:

| step | header button | panel |
|---|---|---|
| chat, panel closed | present | — |
| chat, button pressed | gone (it's in the panel now) | 制品 |
| navigate to Light Apps | **absent** | closed |
| open an app from its card | absent | 轻应用 · quicksort-visualizer |
| close the panel | present | closed |
| press the button again | gone | **轻应用 · quicksort-visualizer** (not the old session's artifacts) |
| navigate to Tasks | **absent** | closed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)