### PR TITLE
web: keep the artifacts panel off the blank chat landing

### DIFF
--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -28,7 +28,7 @@
   // The button follows the view: it is only here when the current page has
   // something for the panel to show, so it can never reopen the last chat's
   // artifacts beside an unrelated page.
-  const panelTarget = $derived(panelForView($view, $lightappOpen))
+  const panelTarget = $derived(panelForView($view, $lightappOpen, $activeSessionId))
   function openPanel() {
     if (panelTarget) panelContent.set(panelTarget)
   }

--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -72,7 +72,7 @@
     { id: 'files', icon: 'ant-design:folder-open-outlined', label: () => $t('nav.file_recall'), shortcut: '', run: () => openDataSettings('trash') },
     { id: 'memory', icon: 'ant-design:user-outlined', label: () => $t('nav.memory'), shortcut: '', run: () => openDataSettings('memory') },
     { id: 'lightapps', icon: 'ant-design:appstore-outlined', label: () => $t('nav.light_apps'), shortcut: '', run: () => goTo('lightapps') },
-    { id: 'artifacts', icon: 'ant-design:file-text-outlined', label: () => $t('artifacts.toggle'), shortcut: '', run: () => togglePanel(), available: () => !!panelForView($view, $lightappOpen) },
+    { id: 'artifacts', icon: 'ant-design:file-text-outlined', label: () => $t('artifacts.toggle'), shortcut: '', run: () => togglePanel(), available: () => !!panelForView($view, $lightappOpen, $activeSessionId) },
     { id: 'settings', icon: 'ant-design:setting-outlined', label: () => $t('nav.settings'), shortcut: '', run: () => { close(); settingsModalOpen.set(true) } },
   ]
 

--- a/web/src/lib/panelForView.test.ts
+++ b/web/src/lib/panelForView.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { get } from 'svelte/store'
-import { lightappOpen, panelContent, panelForView, savePanelMode, togglePanel, view } from './stores'
+import { activeSessionId, lightappOpen, panelContent, panelForView, savePanelMode, togglePanel, view } from './stores'
 
 // jsdom exposes no localStorage under Node 26 (see unread.test.ts), and the
 // panel-mode helpers persist through it.
@@ -15,25 +15,32 @@ vi.stubGlobal('localStorage', {
 beforeEach(() => {
   localStorage.clear()
   view.set('chat')
+  activeSessionId.set('s1')
   lightappOpen.set([])
   panelContent.set(null)
 })
 
 describe('panelForView', () => {
   it('gives the chat view its remembered mode', () => {
-    expect(panelForView('chat', [])).toBe('session')
+    expect(panelForView('chat', [], 's1')).toBe('session')
     savePanelMode('diff')
-    expect(panelForView('chat', [])).toBe('diff')
+    expect(panelForView('chat', [], 's1')).toBe('diff')
+  })
+
+  it('offers nothing on the blank chat landing, which has no session to read', () => {
+    expect(panelForView('chat', [], null)).toBe(null)
+    savePanelMode('diff')
+    expect(panelForView('chat', [], null)).toBe(null)
   })
 
   it('gives the Light Apps view its own mode, but only with a tab open', () => {
-    expect(panelForView('lightapps', [])).toBe(null)
-    expect(panelForView('lightapps', ['clock'])).toBe('lightapps')
+    expect(panelForView('lightapps', [], null)).toBe(null)
+    expect(panelForView('lightapps', ['clock'], null)).toBe('lightapps')
   })
 
   it('offers nothing to views that own no panel content', () => {
     for (const v of ['tasks', 'skills', 'agents', 'workflows', 'browser', 'mcp', 'channels']) {
-      expect(panelForView(v, ['clock'])).toBe(null)
+      expect(panelForView(v, ['clock'], 's1')).toBe(null)
     }
   })
 })
@@ -43,6 +50,12 @@ describe('togglePanel', () => {
     savePanelMode('diff')
     togglePanel()
     expect(get(panelContent)).toBe('diff')
+  })
+
+  it('leaves the blank chat landing alone', () => {
+    activeSessionId.set(null)
+    togglePanel()
+    expect(get(panelContent)).toBe(null)
   })
 
   it('never parks the last session artifacts beside another view', () => {

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -143,17 +143,19 @@ export function savePanelMode(mode: PanelMode): void {
 // when that view has nothing for it. 'session' and 'diff' are the active
 // chat's own output, so they belong to the chat view alone — opened from
 // anywhere else they park the previous session's artifacts beside a page that
-// has nothing to do with them. Light Apps answers for its own view, and only
-// once a tab is open in it: an empty strip is not worth a column.
-export function panelForView(v: string, openApps: string[]): PanelContent | null {
-  if (v === 'chat') return readPanelMode()
+// has nothing to do with them. The blank chat landing counts as 'anywhere
+// else': there is no session yet, so neither mode has anything to read.
+// Light Apps answers for its own view, and only once a tab is open in it: an
+// empty strip is not worth a column.
+export function panelForView(v: string, openApps: string[], sessionId: string | null): PanelContent | null {
+  if (v === 'chat') return sessionId ? readPanelMode() : null
   if (v === 'lightapps') return openApps.length > 0 ? 'lightapps' : null
   return null
 }
 
 /** Open the panel in whatever the current view offers, or close it if open. */
 export function togglePanel(): void {
-  panelContent.update(v => v ? null : panelForView(get(view), get(lightappOpen)))
+  panelContent.update(v => v ? null : panelForView(get(view), get(lightappOpen), get(activeSessionId)))
 }
 
 // Artifacts panel taking over the whole content area except the sidebar, so a

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -483,6 +483,12 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
       // does not leave the chat view showing "Session is bound to another entry."
       bindRequiredFor = null
       turnError = null
+      // The landing is not a session, so it inherits none of one's artifacts.
+      // Leaving them would keep the panel open over a blank chat, still
+      // showing whichever session the user just left — the same stale-panel
+      // problem switching between two sessions already resets away. The empty
+      // marker matches no in-flight fetch, so nothing lands here afterwards.
+      resetArtifacts('')
       return
     }
 


### PR DESCRIPTION
Follow-up to #2303, which scoped the panel button to the current *view* — but the blank chat landing is a chat view with no session yet, so it slipped through. Two halves of the same leak:

**The button was offered with nothing to show.** `panelForView` asked only which view was showing, so on the landing it still handed back `session` / `diff` — two modes whose content is the active session's, when there is no active session. It now takes the session id and answers `null` without one; the command palette's "artifacts" action inherits that for free.

**The panel was left standing.** `ChatView`'s lifecycle effect returned early for a null session *without* calling `resetArtifacts`, so pressing "new session" with the panel open left it over the blank chat still showing the session the user had just left — the exact stale-panel complaint that started this. Switching between two sessions already resets that way; the landing now does too. The empty session marker matches no in-flight fetch, so nothing lands there afterwards.

## Verification

`npx vitest run` — 47 files / 634 tests pass (`panelForView.test.ts` gains landing cases). `svelte-check` clean.

Walked the real UI (vite dev + CDP):

| step | header button | panel |
|---|---|---|
| boot on the landing | **absent** | closed |
| open a session from the sidebar | present | closed |
| press the button | gone (it's in the panel now) | 制品 |
| press "new session" → landing | **absent** | **closed** |

Command palette, searching 制品 — with a positive control so the negative means something:

- on the landing → `未找到 "制品" 的匹配项`
- with a session open → `操作 / 制品`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
