### PR TITLE
fix: heal phantom unread dots on sessions the user already read

### DIFF
--- a/internal/server/turn_activity_test.go
+++ b/internal/server/turn_activity_test.go
@@ -178,7 +178,6 @@ func TestDoAgentTurn_WritesPrecedeComplete(t *testing.T) {
 		t.Fatalf("title adoption (event #%d) landed after complete (#%d): end-of-turn writes must precede the complete broadcast", renamedAt, completeAt)
 	}
 
-
 	// And the write itself must be on disk, not just broadcast.
 	p, err := sess.SavePath()
 	if err != nil {

--- a/internal/server/turn_activity_test.go
+++ b/internal/server/turn_activity_test.go
@@ -2,7 +2,11 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/scheduler"
@@ -92,5 +96,99 @@ func TestRunTask_BroadcastsRunningActivityPair(t *testing.T) {
 	})
 	if ended["session_id"] != sessionID {
 		t.Fatalf("turn_ended session_id = %v, want %v", ended["session_id"], sessionID)
+	}
+}
+
+// TestDoAgentTurn_WritesPrecedeComplete: `complete` tells the client the
+// turn's content is settled — it carries the reply's persisted message_index
+// — so every end-of-turn file write (title adoption, context-usage persist)
+// must land BEFORE it. The sidebar's unread watermark compares the session
+// file's mtime against the last moment the user could have read the reply; a
+// write after `complete` pushes the mtime past the turn's visible completion
+// and resurfaces as a phantom unread dot for anyone whose window closed (or
+// whose webview was suspended) before turn_ended arrived. The adoption's
+// session_renamed re-broadcast rides the same code path as the write, so its
+// order against complete is the observable proxy for "the write came first".
+//
+// The mid-turn title generation is pre-claimed away: its live session_renamed
+// broadcast precedes complete on every ordering and would make the assertion
+// vacuous.
+func TestDoAgentTurn_WritesPrecedeComplete(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.sender = stubSender{}
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]queuedTurn)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	if !agent.IsAutoNamePlaceholder(sess.Title) {
+		t.Fatalf("test needs the placeholder title, got %q", sess.Title)
+	}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Occupy the generation claim so doAgentTurn never spawns its own title
+	// goroutine, then hand the turn a pending title to adopt directly.
+	if !srv.claimTitleGeneration(sess.ID) {
+		t.Fatal("pre-claim: title generation unexpectedly already in flight")
+	}
+	srv.storePendingTitle(sess.ID, "Adopted Title")
+
+	// Subscribed to the session, so both the per-session `complete` and the
+	// global `session_renamed` land in this conn, in broadcast order.
+	sub := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.wsHub.register <- sub
+	srv.wsHub.subscribe(sub, sess.ID)
+
+	srv.doAgentTurn(sess, "question", nil, nil)
+	// Balance the pre-claim above: mustServer's cleanup waits (up to 10s) for
+	// titlePending to drain, and nothing else releases this claim.
+	srv.releaseTitleGeneration(sess.ID)
+
+	renamedAt, completeAt := -1, -1
+	deadline := time.After(5 * time.Second)
+	for i := 0; completeAt < 0; i++ {
+		select {
+		case raw := <-sub.send:
+			var ev map[string]any
+			if err := json.Unmarshal(raw, &ev); err != nil {
+				t.Fatalf("decode event: %v", err)
+			}
+			switch ev["type"] {
+			case "session_renamed":
+				if renamedAt < 0 {
+					renamedAt = i
+				}
+			case "complete":
+				completeAt = i
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the complete event")
+		}
+	}
+	if renamedAt < 0 {
+		t.Fatal("no session_renamed broadcast — the pending title was never adopted")
+	}
+	if renamedAt > completeAt {
+		t.Fatalf("title adoption (event #%d) landed after complete (#%d): end-of-turn writes must precede the complete broadcast", renamedAt, completeAt)
+	}
+
+
+	// And the write itself must be on disk, not just broadcast.
+	p, err := sess.SavePath()
+	if err != nil {
+		t.Fatalf("SavePath: %v", err)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if !strings.Contains(string(b), "Adopted Title") {
+		t.Fatal("adopted title missing from the persisted transcript")
 	}
 }

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1726,42 +1726,15 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		sw.sendRaw(b)
 	}
 
-	completeEvent := map[string]any{
-		"type":       "complete",
-		"session_id": sess.ID,
-		"iterations": a.TurnIterations(),
-	}
-	// Tells the browser the persisted index of the reply it just streamed, so
-	// the Branch action lights up on the live bubble too — omitted (not -1)
-	// when the turn didn't end on a branchable reply.
-	if idx := lastBranchableIndex(sess); idx >= 0 {
-		completeEvent["message_index"] = idx
-	}
-	if err == nil {
-		// a is freshly built per turn (buildAgent), so its usage counters start
-		// at zero — no before/after diff needed, unlike the CLI/IM persistent-
-		// Agent call sites. Omitted on error/interrupt, matching the CLI's
-		// summary line which only prints on a clean completion.
-		inTok, outTok := a.SessionTokens()
-		completeEvent["duration_ms"] = time.Since(turnCallStart).Milliseconds()
-		completeEvent["tokens"] = inTok + outTok
-		// Cache utilization for the turn's prompt side; omitted (not 0) when
-		// the backend reported no cache activity, so the UI hides the readout.
-		cr, cw := a.SessionCacheTokens()
-		if pct, ok := agent.CacheUtilizationPct(inTok, cr, cw); ok {
-			completeEvent["cache_pct"] = pct
-		}
-	}
-	s.wsHub.broadcast(sess.ID, completeEvent)
-	// completeEvent above only reaches tabs subscribed to this session; a tab
-	// looking at a different session needs this global companion to drive
-	// the "agent finished replying" desktop notification.
-	s.wsHub.broadcast("", wsEventSessionActivity{
-		Type:      "session_activity",
-		SessionID: sess.ID,
-		Kind:      "turn_complete",
-	})
-
+	// The turn's remaining file writes ALL land before the `complete` broadcast
+	// below. complete carries the reply's persisted message_index — it already
+	// claims the turn's content is settled on disk — and the sidebar's unread
+	// watermark compares the file's mtime against the last moment the user
+	// could have read the reply. Running these writes after complete pushed
+	// the mtime past the turn's visible completion, so a client whose window
+	// closed (or whose webview was suspended) between the reply rendering and
+	// the fire-and-forget turn_ended kept a stale watermark and showed a
+	// phantom unread dot on next open.
 	used, window := a.ContextUsage()
 	ctxPct := 0
 	if window > 0 {
@@ -1801,6 +1774,43 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			})
 		}
 	}
+
+	completeEvent := map[string]any{
+		"type":       "complete",
+		"session_id": sess.ID,
+		"iterations": a.TurnIterations(),
+	}
+	// Tells the browser the persisted index of the reply it just streamed, so
+	// the Branch action lights up on the live bubble too — omitted (not -1)
+	// when the turn didn't end on a branchable reply.
+	if idx := lastBranchableIndex(sess); idx >= 0 {
+		completeEvent["message_index"] = idx
+	}
+	if err == nil {
+		// a is freshly built per turn (buildAgent), so its usage counters start
+		// at zero — no before/after diff needed, unlike the CLI/IM persistent-
+		// Agent call sites. Omitted on error/interrupt, matching the CLI's
+		// summary line which only prints on a clean completion.
+		inTok, outTok := a.SessionTokens()
+		completeEvent["duration_ms"] = time.Since(turnCallStart).Milliseconds()
+		completeEvent["tokens"] = inTok + outTok
+		// Cache utilization for the turn's prompt side; omitted (not 0) when
+		// the backend reported no cache activity, so the UI hides the readout.
+		cr, cw := a.SessionCacheTokens()
+		if pct, ok := agent.CacheUtilizationPct(inTok, cr, cw); ok {
+			completeEvent["cache_pct"] = pct
+		}
+	}
+	s.wsHub.broadcast(sess.ID, completeEvent)
+	// completeEvent above only reaches tabs subscribed to this session; a tab
+	// looking at a different session needs this global companion to drive
+	// the "agent finished replying" desktop notification.
+	s.wsHub.broadcast("", wsEventSessionActivity{
+		Type:      "session_activity",
+		SessionID: sess.ID,
+		Kind:      "turn_complete",
+	})
+
 	_, pm, re, _, _ := s.sessionStatusFields(sess)
 	s.wsHub.broadcast(sess.ID, map[string]any{
 		"type":             "session_update",

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -37,7 +37,7 @@
   import ArtifactsPanel from './components/ArtifactsPanel.svelte'
   import FeedbackModal from './components/overlays/FeedbackModal.svelte'
   import Toast from './components/overlays/Toast.svelte'
-  import { touchSession, markSessionSeen, sessionTouchedAt } from './lib/unread'
+  import { touchSession, markSessionSeen, markActiveSessionSeenOnLeave, sessionTouchedAt } from './lib/unread'
 
   // The session on screen is read by definition — this is the only place the
   // sidebar's unread dot gets cleared. It re-marks on every list change and
@@ -53,6 +53,14 @@
     if ($view !== 'chat' || !sid) return
     markSessionSeen(sid)
   })
+
+  // The effect above only runs on store changes, and a turn's end-of-turn file
+  // writes produce none the client can see — the fire-and-forget turn_ended is
+  // the sole re-mark, and a window closed (or a webview suspended) before it
+  // arrives leaves the seen mark behind the file's mtime: a phantom unread dot
+  // on next open for a session the user finished reading. Stamp the on-screen
+  // session seen as the page goes away.
+  onMount(() => markActiveSessionSeenOnLeave(() => get(view) === 'chat' ? get(activeSessionId) : null))
 
   // Switching chats must never leave the previous session's diff on screen: the
   // panel is per-session, and a stale patch list reads as this session's work.
@@ -291,6 +299,14 @@
       refreshSessionsFromServer()
       api.listSessionGroups().then(org => sessionGroups.set(org.groups)).catch(() => { /* non-critical */ })
     })
+
+    // Synthesized by the WS manager on every reconnect (ws.ts): the socket
+    // has no backlog, so session_activity events broadcast while this tab was
+    // disconnected are gone for good, and with them the turn_ended that would
+    // have refreshed a row's unread state. Refetching the list lands the
+    // server's real updated_at, and the unread effect re-marks the session on
+    // screen — healing both missed dots and phantom ones.
+    ws.on('session_list_reload', refreshSessionsFromServer)
 
     // The group registry changed — in this tab or another (a group edit, a
     // membership move, a pin, a project's working directory or notes). The

--- a/web/src/lib/unread.test.ts
+++ b/web/src/lib/unread.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { get } from 'svelte/store'
 import { sessions } from './stores'
-import { isUnread, markSessionSeen, touchSession, reconcileSeen, sessionSeenAt, sessionTouchedAt } from './unread'
+import { isUnread, markSessionSeen, markActiveSessionSeenOnLeave, touchSession, reconcileSeen, sessionSeenAt, sessionTouchedAt } from './unread'
 
 // jsdom under Node 26 exposes no localStorage (the built-in one needs
 // --localstorage-file, and jsdom's own doesn't get installed over it), so the
@@ -123,6 +123,47 @@ describe('markSessionSeen', () => {
     sessionSeenAt.set({ a: far })
     markSessionSeen('a')
     expect(get(sessionSeenAt).a).toBe(far)
+  })
+})
+
+describe('markActiveSessionSeenOnLeave', () => {
+  function setVisibility(state: string) {
+    Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state })
+  }
+
+  it('marks the on-screen session seen when the window closes (pagehide)', () => {
+    sessionSeenAt.set({ a: T0 })
+    const off = markActiveSessionSeenOnLeave(() => 'a')
+    window.dispatchEvent(new Event('pagehide'))
+    expect(get(sessionSeenAt).a).toBeGreaterThan(T0)
+    off()
+  })
+
+  it('marks on visibilitychange to hidden, not on a return to visible', () => {
+    sessionSeenAt.set({ a: T0 })
+    const off = markActiveSessionSeenOnLeave(() => 'a')
+    setVisibility('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(get(sessionSeenAt).a).toBe(T0)
+    setVisibility('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(get(sessionSeenAt).a).toBeGreaterThan(T0)
+    off()
+    setVisibility('visible')
+  })
+
+  it('does nothing when no session transcript is on screen', () => {
+    const off = markActiveSessionSeenOnLeave(() => null)
+    window.dispatchEvent(new Event('pagehide'))
+    expect(get(sessionSeenAt)).toEqual({})
+    off()
+  })
+
+  it('stops marking after unsubscribe', () => {
+    const off = markActiveSessionSeenOnLeave(() => 'a')
+    off()
+    window.dispatchEvent(new Event('pagehide'))
+    expect(get(sessionSeenAt)).toEqual({})
   })
 })
 

--- a/web/src/lib/unread.ts
+++ b/web/src/lib/unread.ts
@@ -101,6 +101,40 @@ export function touchSession(id: string) {
 }
 
 /**
+ * Mark the on-screen session seen when the page goes away — window/tab close
+ * (pagehide) or minimize/OS-suspension of the webview (visibilitychange →
+ * hidden).
+ *
+ * A turn's end-of-turn file writes (context-usage persist, title adoption)
+ * land AFTER the reply is fully rendered, and the only event that re-marks
+ * the session afterwards is the fire-and-forget turn_ended broadcast: a
+ * window gone before that broadcast arrives — or a webview the OS suspended
+ * mid-turn — keeps a seen mark older than the file's new mtime, and the next
+ * open shows an unread dot on a session the user finished reading. Stamping
+ * on the way out closes that gap for the session on screen, the only one the
+ * user could have read through.
+ *
+ * `activeId` returns the session whose transcript is on screen, or null when
+ * chat isn't the visible view — the same contract as the marking effect in
+ * App.svelte. Returns an unsubscribe.
+ */
+export function markActiveSessionSeenOnLeave(activeId: () => string | null): () => void {
+  const mark = () => {
+    const sid = activeId()
+    if (sid) markSessionSeen(sid)
+  }
+  const onVisibility = () => {
+    if (document.visibilityState === 'hidden') mark()
+  }
+  window.addEventListener('pagehide', mark)
+  document.addEventListener('visibilitychange', onVisibility)
+  return () => {
+    window.removeEventListener('pagehide', mark)
+    document.removeEventListener('visibilitychange', onVisibility)
+  }
+}
+
+/**
  * Baseline newly-seen sessions and forget vanished ones.
  *
  * Baselining is what keeps a first visit (or a new browser) from opening onto

--- a/web/src/lib/ws.test.ts
+++ b/web/src/lib/ws.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { WsManager } from './ws'
+
+// A controllable WebSocket stand-in. The manager only ever constructs it,
+// assigns the four handlers, and calls send/close, so the fake is a property
+// bag plus a send log. open()/drop() drive the lifecycle from the test.
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  static CONNECTING = 0
+  static OPEN = 1
+  readyState = FakeWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onclose: ((ev: unknown) => void) | null = null
+  onerror: (() => void) | null = null
+  onmessage: ((ev: unknown) => void) | null = null
+  sent: string[] = []
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+  send(msg: string) {
+    this.sent.push(msg)
+  }
+  close() {
+    this.readyState = 3
+  }
+  open() {
+    this.readyState = FakeWebSocket.OPEN
+    this.onopen?.()
+  }
+  // A dropped connection the manager hasn't noticed yet: readyState moved,
+  // no close event fired (the reconnect timer path is tested implicitly by
+  // the manager calling connect() itself — here the test drives it).
+  drop() {
+    this.readyState = 3
+  }
+}
+
+vi.stubGlobal('WebSocket', FakeWebSocket)
+
+function lastSocket() {
+  return FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances = []
+})
+
+describe('WsManager reconnect resync', () => {
+  it('does not refetch the session list on the very first connect', () => {
+    const mgr = new WsManager()
+    const reloads: string[] = []
+    mgr.on('session_list_reload', () => reloads.push('reload'))
+    mgr.connect()
+    lastSocket().open()
+    expect(reloads).toEqual([])
+  })
+
+  it('refetches the session list on a reconnect — turn_ended broadcasts missed while down are unrecoverable otherwise', () => {
+    const mgr = new WsManager()
+    const reloads: string[] = []
+    mgr.on('session_list_reload', () => reloads.push('reload'))
+    mgr.connect()
+    lastSocket().open()
+    lastSocket().drop()
+    mgr.connect()
+    lastSocket().open()
+    expect(reloads).toEqual(['reload'])
+  })
+
+  it('still resyncs subscribed session histories alongside the list reload', () => {
+    const mgr = new WsManager()
+    const historyReloads: unknown[] = []
+    const listReloads: unknown[] = []
+    mgr.on('history_reload', ev => historyReloads.push(ev))
+    mgr.on('session_list_reload', ev => listReloads.push(ev))
+    mgr.subscribe('s1')
+    mgr.connect()
+    lastSocket().open()
+    lastSocket().drop()
+    mgr.connect()
+    lastSocket().open()
+    expect(historyReloads).toEqual([{ type: 'history_reload', session_id: 's1' }])
+    expect(listReloads).toEqual([{ type: 'session_list_reload' }])
+  })
+})

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -69,6 +69,13 @@ export class WsManager {
         for (const sessionId of this.subscriptions) {
           this.dispatch({ type: "history_reload", session_id: sessionId });
         }
+        // The sidebar is a hole too: session_activity events are
+        // fire-and-forget, so a turn_ended broadcast during the disconnect
+        // never arrived. Its session's updated_at moved on the server while
+        // this tab's copy — and its unread-dot watermark — stayed stale:
+        // the row either misses a dot it should have, or keeps a phantom one
+        // the user already read through. Refetch the list so both reconcile.
+        this.dispatch({ type: "session_list_reload" });
       }
     };
 


### PR DESCRIPTION
## Problem

The sidebar's unread dot compares the session file's mtime (`updated_at`) against a client-side seen watermark in localStorage. The only event that advances the watermark past a turn's end-of-turn file writes is the fire-and-forget `turn_ended` broadcast. Miss it once — window closed between the reply rendering and the broadcast, webview suspended by the OS, WS dropped — and the next window open shows an unread dot on a session the user finished reading.

Reproduced with on-disk forensics: session file mtime 10:47:24, localStorage seen mark stuck at an earlier turn, phantom dot on the 11:01 window open, healed only by clicking the session again.

Two reinforcing causes:

1. **Server ordering**: `complete` carries the reply's persisted `message_index` — it claims the turn's content is settled on disk — yet the context-usage persist and title adoption ran *after* it, pushing mtime past the turn's visible completion.
2. **No recovery path**: a missed `turn_ended` is gone for good (the socket has no backlog), and nothing re-marks a session the user is watching except that one broadcast.

## Fix (three layers, two commits)

**`server: finish a turn's file writes before broadcasting complete`** — pure reorder in `doAgentTurn`: both writes depend only on turn-end state, never on `complete` having been sent. After this, the reply being fully visible implies the file's mtime has settled.

**`web: heal phantom unread dots from missed turn_ended events`** — client-side heals for the remaining paths:

- `markActiveSessionSeenOnLeave` (unread.ts, mounted in App.svelte): stamp the on-screen session seen on `pagehide` / `visibilitychange→hidden` — leaving the page is the last moment its transcript could have been read through.
- `session_list_reload` (ws.ts reconnect → App.svelte): refetch the session list on every WS reconnect, so sessions whose `turn_ended` fired while this tab was down reconcile against the server's real `updated_at` — heals both missed dots and phantom ones.

## Tests

- `TestDoAgentTurn_WritesPrecedeComplete` pins the server reorder via the adoption's `session_renamed` re-broadcast riding the same path as the write (verified to fail on the old ordering).
- `unread.test.ts` +4 cases for the leave-marking; new `ws.test.ts` (3 cases) with a fake WebSocket pinning the reconnect refetch.
- Full `web` suite green (633), `internal/server` + `internal/agent` green, `go vet` / `gofmt` clean.
