### PR TITLE
release: bump version to 1.16.8

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.7"
+var Version = "1.16.8"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over v1.16.7.

- #2305 — fix: heal phantom unread dots on sessions the user already read
- #2306 — web: keep chat auto-scroll alive across pointer release and window switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)