### PR TITLE
desktop: hide the window on close instead of destroying it

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -44,9 +44,10 @@ type nativeBridge struct {
 	// option (ShouldQuit there always allows the quit), but the flag still tells
 	// the close hook whether the app is staying alive — see closeShouldHide.
 	allowQuit atomic.Bool
-	// quitting is set once ShouldQuit has allowed a termination, so the window
-	// close the shutdown performs is a real destroy rather than a hide.
-	quitting atomic.Bool
+	// hidden is set when a close was turned into a hide and cleared by the next
+	// show. The liveness probe consults it: a window the user just put away
+	// must not be replaced — and popped back up — because its page went quiet.
+	hidden atomic.Bool
 
 	// Webview liveness, fed by POST /api/native/heartbeat from the page in
 	// nativeShell mode (see startNativeHeartbeat in the frontend). All unix
@@ -564,15 +565,23 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		// including ours below — whereas listeners run concurrently and could
 		// not reliably veto the destroy. Every reason the window must really
 		// go away passes straight through: a quit in progress (allowQuit,
-		// updateRestart, quitting) and a revive discarding a detached corpse
-		// (b.window no longer points here). Liveness is unaffected — a hidden
-		// window that lost its renderer is reloaded by the terminate handler
-		// below, and the next show still runs probeAfterShow.
+		// updateRestart) and a revive discarding a detached corpse (b.window
+		// no longer points here). A fullscreen window also takes the old
+		// destroy path: ordering out a fullscreen NSWindow is a known AppKit
+		// trap (an empty Space left behind, a confused re-show) — exactly the
+		// blank-window class this shell has fought before. Liveness is
+		// otherwise unaffected — a hidden window that lost its renderer is
+		// reloaded by the terminate handler below, and the next show still
+		// runs probeAfterShow.
 		w.RegisterHook(events.Common.WindowClosing, func(ev *application.WindowEvent) {
-			if !closeShouldHide(b.currentWindow() == w, b.allowQuit.Load(), b.updateRestart.Load(), b.quitting.Load()) {
+			if !closeShouldHide(b.currentWindow() == w, b.allowQuit.Load(), b.updateRestart.Load()) {
+				return
+			}
+			if w.IsFullscreen() {
 				return
 			}
 			ev.Cancel()
+			b.hidden.Store(true)
 			w.Hide()
 		})
 		// Forget the window when it really closes so a later Show re-creates one;
@@ -650,6 +659,8 @@ func (b *nativeBridge) showWindowAt(hash string) {
 			win.SetURL(target)
 		}
 	}
+	// Cleared before Show so the probe below judges a window the user asked for.
+	b.hidden.Store(false)
 	win.Show()
 	// Only un-minimise here. Wails' Restore() also un-maximises (and exits
 	// fullscreen), so calling it unconditionally on every show/reopen — e.g.
@@ -698,10 +709,12 @@ func closeShouldQuit(goos string, allowQuit bool) bool {
 // Only the live window (current) qualifies — a detached corpse a revive is
 // discarding must really close — and only while the app is staying alive:
 // allowQuit means the close is meant to end the app (or requestQuit already
-// decided so), updateRestart and quitting mean a termination is under way and
-// the shutdown's window close must destroy for real.
-func closeShouldHide(current, allowQuit, updateRestart, quitting bool) bool {
-	return current && !allowQuit && !updateRestart && !quitting
+// decided so), updateRestart means the updater's restart is under way and its
+// window close must destroy for real. No flag is needed for an ordinary quit:
+// Wails' shutdown nils its window map before the closes it issues are
+// dispatched, so those never reach the hook.
+func closeShouldHide(current, allowQuit, updateRestart bool) bool {
+	return current && !allowQuit && !updateRestart
 }
 
 // reviveAllowed rate-limits automatic window re-creation so a page that is
@@ -792,6 +805,13 @@ func (b *nativeBridge) probeAfterShow(shown *application.WebviewWindow) {
 			if b.judgePage(shownAt) == pageHealthy {
 				return
 			}
+		}
+		// The user closed (hid) the window while the probe slept. Replacing it
+		// now would pop a fresh window onto their screen for a page they had
+		// already put away — and a healthy hidden page can legitimately go
+		// quiet. Nothing is lost: the next show probes again from scratch.
+		if b.hidden.Load() {
+			return
 		}
 		old := b.detachStalled(shown, time.Now())
 		if old == nil {

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -39,10 +39,14 @@ type nativeBridge struct {
 	// allowQuit gates the app's ShouldQuit on Windows/Linux, where closing the
 	// last window would otherwise terminate the app (and the hub with it). It
 	// starts false when KeepRunningInBackground is on, so a window close hides
-	// to the tray; requestQuit flips it true for a real quit. Unused on macOS
-	// (its close behavior is the ApplicationShouldTerminateAfterLastWindowClosed
-	// option; ShouldQuit there always allows the quit).
+	// to the tray; requestQuit flips it true for a real quit. On macOS the
+	// close behavior itself is the ApplicationShouldTerminateAfterLastWindowClosed
+	// option (ShouldQuit there always allows the quit), but the flag still tells
+	// the close hook whether the app is staying alive — see closeShouldHide.
 	allowQuit atomic.Bool
+	// quitting is set once ShouldQuit has allowed a termination, so the window
+	// close the shutdown performs is a real destroy rather than a hide.
+	quitting atomic.Bool
 
 	// Webview liveness, fed by POST /api/native/heartbeat from the page in
 	// nativeShell mode (see startNativeHeartbeat in the frontend). All unix
@@ -449,9 +453,10 @@ func (b *nativeBridge) Minimise() {
 	}
 }
 
-// Close closes the window (sends WindowClosing, after which the app's ShouldQuit
-// decides whether the hub actually terminates or keeps running in the tray).
-// No-op before the window exists.
+// Close closes the window (sends WindowClosing; the close hook then hides the
+// window when the hub keeps running in the tray, otherwise it is destroyed and
+// the app's ShouldQuit decides whether the process terminates). No-op before
+// the window exists.
 func (b *nativeBridge) Close() {
 	if win := b.currentWindow(); win != nil {
 		win.Close()
@@ -481,11 +486,12 @@ func (b *nativeBridge) openSettings() { b.showWindowAt("settings") }
 // "New Session" button and Cmd/Ctrl+N trigger.
 func (b *nativeBridge) openNewSession() { b.showWindowAt("new") }
 
-// showWindowAt brings the hub window to the foreground, re-creating it if it was
-// closed to the tray (KeepRunningInBackground), and navigates to the given
-// frontend hash route (empty = leave it where it is). The frontend routes on
-// location.hash, so a fresh window loads straight into the view and an existing
-// one navigates via a hashchange — no full reload.
+// showWindowAt brings the hub window to the foreground — un-hiding the one a
+// close put in the tray (KeepRunningInBackground) or re-creating it if it was
+// destroyed — and navigates to the given frontend hash route (empty = leave it
+// where it is). The frontend routes on location.hash, so a fresh window loads
+// straight into the view and an existing one navigates via a hashchange — no
+// full reload.
 func (b *nativeBridge) showWindowAt(hash string) {
 	// The marker rides on every navigation the shell performs (fresh window and
 	// SetURL alike) so nativeShell stays true across reloads and route changes.
@@ -548,8 +554,29 @@ func (b *nativeBridge) showWindowAt(hash string) {
 				TitleBar: application.MacTitleBarHiddenInset,
 			},
 		})
-		// Forget the window when it closes so a later Show re-creates one; the
-		// app itself stays alive via ApplicationShouldTerminateAfterLastWindowClosed.
+		// Closing while the hub keeps running in the tray hides the window
+		// instead of destroying it, so the next show is instant: destroying
+		// meant every reopen paid for a new WebContent process, a cold parse of
+		// the bundle and the full boot sequence (auth, config, session list,
+		// route restore). A hook, not a listener: Wails runs hooks synchronously
+		// before its own WindowClosing listener (the one that destroys the
+		// window) and skips every listener once the event is cancelled —
+		// including ours below — whereas listeners run concurrently and could
+		// not reliably veto the destroy. Every reason the window must really
+		// go away passes straight through: a quit in progress (allowQuit,
+		// updateRestart, quitting) and a revive discarding a detached corpse
+		// (b.window no longer points here). Liveness is unaffected — a hidden
+		// window that lost its renderer is reloaded by the terminate handler
+		// below, and the next show still runs probeAfterShow.
+		w.RegisterHook(events.Common.WindowClosing, func(ev *application.WindowEvent) {
+			if !closeShouldHide(b.currentWindow() == w, b.allowQuit.Load(), b.updateRestart.Load(), b.quitting.Load()) {
+				return
+			}
+			ev.Cancel()
+			w.Hide()
+		})
+		// Forget the window when it really closes so a later Show re-creates one;
+		// the app itself stays alive via ApplicationShouldTerminateAfterLastWindowClosed.
 		// Cancel any pending debounce and flush the last captured geometry — this
 		// only persists already-captured settings, so unlike reading the window
 		// here it can't race the window's destruction.
@@ -665,6 +692,16 @@ const (
 // the user has KeepRunningInBackground on, so closing hides to the tray.
 func closeShouldQuit(goos string, allowQuit bool) bool {
 	return goos == "windows" && allowQuit
+}
+
+// closeShouldHide reports whether a WindowClosing should be turned into a hide.
+// Only the live window (current) qualifies — a detached corpse a revive is
+// discarding must really close — and only while the app is staying alive:
+// allowQuit means the close is meant to end the app (or requestQuit already
+// decided so), updateRestart and quitting mean a termination is under way and
+// the shutdown's window close must destroy for real.
+func closeShouldHide(current, allowQuit, updateRestart, quitting bool) bool {
+	return current && !allowQuit && !updateRestart && !quitting
 }
 
 // reviveAllowed rate-limits automatic window re-creation so a page that is

--- a/cmd/octo-desktop/bridge_test.go
+++ b/cmd/octo-desktop/bridge_test.go
@@ -440,3 +440,28 @@ func TestCloseShouldQuit(t *testing.T) {
 		}
 	}
 }
+
+// Closing the window while the hub keeps running in the tray hides it instead
+// of destroying it, so the next show skips the webview cold start. Every reason
+// the window must really go must win over that: a detached corpse a revive is
+// discarding (not current), a close meant to end the app (allowQuit), and a
+// termination already under way (updateRestart, quitting) whose shutdown-time
+// window close has to destroy for real.
+func TestCloseShouldHide(t *testing.T) {
+	cases := []struct {
+		name                                        string
+		current, allowQuit, updateRestart, quitting bool
+		want                                        bool
+	}{
+		{"live window, app stays alive", true, false, false, false, true},
+		{"detached corpse from a revive", false, false, false, false, false},
+		{"close is meant to quit", true, true, false, false, false},
+		{"update restart in progress", true, false, true, false, false},
+		{"termination already allowed", true, false, false, true, false},
+	}
+	for _, tc := range cases {
+		if got := closeShouldHide(tc.current, tc.allowQuit, tc.updateRestart, tc.quitting); got != tc.want {
+			t.Errorf("%s: closeShouldHide = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/cmd/octo-desktop/bridge_test.go
+++ b/cmd/octo-desktop/bridge_test.go
@@ -444,24 +444,54 @@ func TestCloseShouldQuit(t *testing.T) {
 // Closing the window while the hub keeps running in the tray hides it instead
 // of destroying it, so the next show skips the webview cold start. Every reason
 // the window must really go must win over that: a detached corpse a revive is
-// discarding (not current), a close meant to end the app (allowQuit), and a
-// termination already under way (updateRestart, quitting) whose shutdown-time
-// window close has to destroy for real.
+// discarding (not current), a close meant to end the app (allowQuit), and an
+// update restart whose window close has to destroy for real.
 func TestCloseShouldHide(t *testing.T) {
 	cases := []struct {
-		name                                        string
-		current, allowQuit, updateRestart, quitting bool
-		want                                        bool
+		name                              string
+		current, allowQuit, updateRestart bool
+		want                              bool
 	}{
-		{"live window, app stays alive", true, false, false, false, true},
-		{"detached corpse from a revive", false, false, false, false, false},
-		{"close is meant to quit", true, true, false, false, false},
-		{"update restart in progress", true, false, true, false, false},
-		{"termination already allowed", true, false, false, true, false},
+		{"live window, app stays alive", true, false, false, true},
+		{"detached corpse from a revive", false, false, false, false},
+		{"close is meant to quit", true, true, false, false},
+		{"update restart in progress", true, false, true, false},
 	}
 	for _, tc := range cases {
-		if got := closeShouldHide(tc.current, tc.allowQuit, tc.updateRestart, tc.quitting); got != tc.want {
+		if got := closeShouldHide(tc.current, tc.allowQuit, tc.updateRestart); got != tc.want {
 			t.Errorf("%s: closeShouldHide = %v, want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+// TestProbeAfterShowLeavesHiddenWindowAlone pins the interaction between
+// hide-on-close and the liveness probe. Before hide-on-close a close cleared
+// b.window, so a probe waking up after one found nothing to replace. A hidden
+// window is still b.window, so without this guard a probe that judged the page
+// black or silent would build a fresh window and pop it onto the user's screen
+// seconds after they closed it — a healthy hidden page can go quiet, and a dead
+// one the user already dismissed is nobody's problem until the next show.
+func TestProbeAfterShowLeavesHiddenWindowAlone(t *testing.T) {
+	win := &application.WebviewWindow{}
+	revived := make(chan struct{}, 1)
+
+	b := &nativeBridge{window: win, testProbeDelay: 10 * time.Millisecond}
+	b.reviveFn = func(*application.WebviewWindow) { revived <- struct{}{} }
+
+	// Black-window evidence, then the user closes (hides) before the verdict.
+	b.Heartbeat(-1, false)
+	b.probeAfterShow(win)
+	b.hidden.Store(true)
+
+	select {
+	case <-revived:
+		t.Fatal("a window the user just hid was revived")
+	case <-time.After(200 * time.Millisecond):
+	}
+	if b.currentWindow() != win {
+		t.Error("the hidden window must stay attached so the next show reuses it")
+	}
+	if b.lastRevive.Load() != 0 {
+		t.Error("a skipped revive must not consume the revive budget")
 	}
 }

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -223,27 +223,19 @@ func main() {
 		// thanks to the option below and handles real quits (Cmd-Q) itself, so
 		// it always allows the quit.
 		ShouldQuit: func() bool {
-			allow := func() bool {
-				if runtime.GOOS == "darwin" {
-					return true
-				}
-				// A confirmed update restart quits so the updater's helper (which
-				// waits for this process to exit) can swap the binary. Vetoing
-				// that quit (keep-running-in-background) would deadlock the
-				// update. Keyed on the user's restart action, not on updater
-				// state: a staged-but-deferred update ("remind me later") must
-				// not quietly disable keep-running-in-background.
-				if bridge.updateRestart.Load() {
-					return true
-				}
-				return bridge.allowQuit.Load()
-			}()
-			// The shutdown that follows closes the window; the close hook must
-			// let that destroy it rather than hide it (see closeShouldHide).
-			if allow {
-				bridge.quitting.Store(true)
+			if runtime.GOOS == "darwin" {
+				return true
 			}
-			return allow
+			// A confirmed update restart quits so the updater's helper (which
+			// waits for this process to exit) can swap the binary. Vetoing
+			// that quit (keep-running-in-background) would deadlock the
+			// update. Keyed on the user's restart action, not on updater
+			// state: a staged-but-deferred update ("remind me later") must
+			// not quietly disable keep-running-in-background.
+			if bridge.updateRestart.Load() {
+				return true
+			}
+			return bridge.allowQuit.Load()
 		},
 		Mac: application.MacOptions{
 			// Closing the window must not quit the hub when the user wants it to

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -223,19 +223,27 @@ func main() {
 		// thanks to the option below and handles real quits (Cmd-Q) itself, so
 		// it always allows the quit.
 		ShouldQuit: func() bool {
-			if runtime.GOOS == "darwin" {
-				return true
+			allow := func() bool {
+				if runtime.GOOS == "darwin" {
+					return true
+				}
+				// A confirmed update restart quits so the updater's helper (which
+				// waits for this process to exit) can swap the binary. Vetoing
+				// that quit (keep-running-in-background) would deadlock the
+				// update. Keyed on the user's restart action, not on updater
+				// state: a staged-but-deferred update ("remind me later") must
+				// not quietly disable keep-running-in-background.
+				if bridge.updateRestart.Load() {
+					return true
+				}
+				return bridge.allowQuit.Load()
+			}()
+			// The shutdown that follows closes the window; the close hook must
+			// let that destroy it rather than hide it (see closeShouldHide).
+			if allow {
+				bridge.quitting.Store(true)
 			}
-			// A confirmed update restart quits so the updater's helper (which
-			// waits for this process to exit) can swap the binary. Vetoing
-			// that quit (keep-running-in-background) would deadlock the
-			// update. Keyed on the user's restart action, not on updater
-			// state: a staged-but-deferred update ("remind me later") must
-			// not quietly disable keep-running-in-background.
-			if bridge.updateRestart.Load() {
-				return true
-			}
-			return bridge.allowQuit.Load()
+			return allow
 		},
 		Mac: application.MacOptions{
 			// Closing the window must not quit the hub when the user wants it to

--- a/internal/server/native_handlers.go
+++ b/internal/server/native_handlers.go
@@ -50,8 +50,9 @@ type NativeBridge interface {
 	// Minimise minimises the window to the taskbar/dock.
 	Minimise()
 
-	// Close closes the window (the app's ShouldQuit hook decides whether the hub
-	// actually terminates or keeps running in the tray).
+	// Close closes the window. While the hub keeps running in the tray the shell
+	// hides the window instead of destroying it; otherwise the app's ShouldQuit
+	// hook decides whether the process terminates.
 	Close()
 
 	// WindowState reports whether the window is currently maximised. Used by the


### PR DESCRIPTION
## Why

Closing the desktop window and reopening it (dock icon / tray "Show Octo") was noticeably slow. The cause is structural: with KeepRunningInBackground on, the process stays alive but the `WindowClosing` handler dropped the window (`b.window = nil`) and Wails destroyed the `WebviewWindow`. Every reopen therefore created a brand-new webview and paid for the full cold start:

- a new WKWebView WebContent process (macOS) / WebView2 surface (Windows)
- fetching and parsing the ~600 KB entry bundle again
- the whole boot sequence in `App.svelte`: auth probe → onboard status → WS connect, config, session list, last-route restore

## What

A `WindowClosing` **hook** cancels the close and hides the window instead, so the next show is instant and keeps the page, WS connection and scroll state.

- `RegisterHook`, not `OnWindowEvent`: Wails runs hooks synchronously *before* its own destroying listener and skips all listeners once the event is cancelled. Listeners run concurrently and cannot reliably veto the destroy (verified against `wails/v3@beta.12` — `HandleWindowEvent`, `windowShouldClose`, `WM_CLOSE`, `handleDeleteEvent`; all three platforms route the user close through `Common.WindowClosing`).
- `closeShouldHide` keeps every case where the window must really be destroyed: a close that is meant to quit (`allowQuit`, i.e. KeepRunningInBackground off, or tray "Quit Octo"), an update restart, a termination already allowed by `ShouldQuit` (new `quitting` flag), and a detached corpse being discarded by a revive (`b.window != w`).
- The Windows `closeShouldQuit` path is unchanged — it runs in the listener, which only executes when the hook let the close through.

## Black/white window safety

Nothing in the liveness machinery is bypassed:

- A hidden window whose renderer is killed under memory pressure still hits the existing `WebViewWebContentProcessDidTerminate` handler → `SetURL` reload.
- Showing a hidden window goes through the `!created` branch of `showWindowAt`, so `probeAfterShow` still runs and a page that beats-but-never-paints or stays silent is still replaced (`detachStalled` → `Close()` → the hook sees it is no longer current and lets it destroy).
- `index.html` staleness is not affected by this PR (asset caching is a separate PR).

## Tests

- `TestCloseShouldHide` pins the decision table.
- `go vet` + `go test ./cmd/octo-desktop/` pass. This changes native shell behaviour, so a manual close → dock-click round trip on a real build is still worth doing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
