### PR TITLE
server: cache hashed assets, gzip the Web UI, parallelise the boot probes

### DIFF
--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"compress/gzip"
 	"embed"
 	"io/fs"
 	"net/http"
@@ -38,7 +39,13 @@ func (s *Server) staticHandler() http.Handler {
 		})
 	}
 
-	fileServer := http.FileServer(http.FS(sub))
+	return staticFileHandler(sub)
+}
+
+// staticFileHandler serves a built Web UI from dist. Split from staticHandler
+// so tests can drive it over an in-memory FS — webdist/ is empty in a checkout.
+func staticFileHandler(dist fs.FS) http.Handler {
+	fileServer := http.FileServer(http.FS(dist))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// API routes should never reach here (mux routes them first), but
 		// guard defensively so a missing API route doesn't fall through to
@@ -52,9 +59,10 @@ func (s *Server) staticHandler() http.Handler {
 		// to an embedded file are served the SPA entrypoint.
 		name := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
 		if name != "" {
-			if f, err := sub.Open(name); err == nil {
+			if f, err := dist.Open(name); err == nil {
 				_ = f.Close()
-				fileServer.ServeHTTP(w, r)
+				setStaticCacheControl(w.Header(), name)
+				serveCompressed(w, r, name, fileServer)
 				return
 			}
 		}
@@ -65,8 +73,101 @@ func (s *Server) staticHandler() http.Handler {
 		// "./", which resolves back to "/" and loops forever. ServeFileFS
 		// keys its redirect off r.URL.Path (here "/" or an SPA route), so it
 		// serves the file without redirecting.
-		http.ServeFileFS(w, r, sub, "index.html")
+		setStaticCacheControl(w.Header(), "index.html")
+		serveCompressed(w, r, "index.html", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.ServeFileFS(w, r, dist, "index.html")
+		}))
 	})
+}
+
+// setStaticCacheControl picks the cache policy for a Web UI file. Vite names
+// everything under assets/ by content hash, so those may be cached forever: a
+// rebuild changes the name, never the bytes behind an existing one. The
+// entrypoint and anything else unhashed must be revalidated on every load —
+// left without a policy, WKWebView caches heuristically, and a stale index.html
+// pointing at hashes the upgraded binary no longer embeds is a blank window.
+// Embedded files carry no modtime, so there is no validator to offer and
+// no-cache means a (small) full fetch each time, exactly as before.
+func setStaticCacheControl(h http.Header, name string) {
+	if strings.HasPrefix(name, "assets/") {
+		h.Set("Cache-Control", "public, max-age=31536000, immutable")
+		return
+	}
+	h.Set("Cache-Control", "no-cache")
+}
+
+// compressible reports whether a Web UI file is worth gzipping on the fly.
+// Images and fonts are already compressed; text-like assets shrink 3-5×.
+func compressible(name string) bool {
+	switch path.Ext(name) {
+	case ".js", ".mjs", ".css", ".html", ".svg", ".json", ".map", ".txt", ".wasm":
+		return true
+	}
+	return false
+}
+
+// serveCompressed runs next with the response gzipped when the client accepts
+// it and the file is worth it. http.FileServer sends the embedded FS as-is, so
+// a cold load was moving the whole ~600 KB entry bundle uncompressed on every
+// window open. Range and non-GET requests pass through untouched: a byte range
+// of gzipped output is meaningless, and a HEAD must not grow a body.
+func serveCompressed(w http.ResponseWriter, r *http.Request, name string, next http.Handler) {
+	if r.Method != http.MethodGet || r.Header.Get("Range") != "" || !compressible(name) ||
+		!strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+		next.ServeHTTP(w, r)
+		return
+	}
+	gw := &gzipResponseWriter{ResponseWriter: w, gz: gzip.NewWriter(w)}
+	next.ServeHTTP(gw, r)
+	gw.close()
+}
+
+// gzipResponseWriter compresses a 200 body. Any other status (a redirect, an
+// error, a 304) is passed through untouched so its body and headers stay what
+// the inner handler meant.
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	gz          *gzip.Writer
+	wroteHeader bool
+	passthrough bool
+}
+
+func (g *gzipResponseWriter) WriteHeader(code int) {
+	if g.wroteHeader {
+		return
+	}
+	g.wroteHeader = true
+	if code != http.StatusOK {
+		g.passthrough = true
+		g.ResponseWriter.WriteHeader(code)
+		return
+	}
+	h := g.Header()
+	// The inner handler's length describes the uncompressed body; the
+	// compressed one is chunked instead.
+	h.Del("Content-Length")
+	h.Set("Content-Encoding", "gzip")
+	h.Add("Vary", "Accept-Encoding")
+	g.ResponseWriter.WriteHeader(code)
+}
+
+func (g *gzipResponseWriter) Write(p []byte) (int, error) {
+	if !g.wroteHeader {
+		g.WriteHeader(http.StatusOK)
+	}
+	if g.passthrough {
+		return g.ResponseWriter.Write(p)
+	}
+	return g.gz.Write(p)
+}
+
+// close flushes the gzip trailer. Only a compressed body has one — closing an
+// untouched writer would append a gzip header to a response that carries no
+// Content-Encoding.
+func (g *gzipResponseWriter) close() {
+	if g.wroteHeader && !g.passthrough {
+		_ = g.gz.Close()
+	}
 }
 
 // indexHTMLFallback is a minimal placeholder served when the embedded static/

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -144,8 +144,11 @@ func (g *gzipResponseWriter) WriteHeader(code int) {
 	}
 	h := g.Header()
 	// The inner handler's length describes the uncompressed body; the
-	// compressed one is chunked instead.
+	// compressed one is chunked instead. Likewise its Accept-Ranges offer
+	// refers to identity bytes — a Range against this gzip representation is
+	// not served (see serveCompressed), so don't advertise it.
 	h.Del("Content-Length")
+	h.Del("Accept-Ranges")
 	h.Set("Content-Encoding", "gzip")
 	h.Add("Vary", "Accept-Encoding")
 	g.ResponseWriter.WriteHeader(code)

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -175,3 +175,36 @@ func TestStaticFileHandler_HeadHasNoBody(t *testing.T) {
 		t.Errorf("Content-Encoding = %q, want none on HEAD", ce)
 	}
 }
+
+// A non-200 from the inner handler passes through untouched. "/index.html" is
+// the one such case this handler produces (ServeFileFS canonicalises it to a
+// 301 → "./"); the redirect must keep its headers and an empty body — no gzip
+// header or trailer appended by a writer that never compressed anything.
+func TestStaticFileHandler_RedirectPassesThrough(t *testing.T) {
+	w := getStatic(t, staticFileHandler(testDist()), "/index.html", map[string]string{"Accept-Encoding": "gzip"})
+
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "./" {
+		t.Errorf("Location = %q, want ./", loc)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "" {
+		t.Errorf("Content-Encoding = %q, want none on a redirect", ce)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("redirect body = %q, want empty", w.Body.String())
+	}
+}
+
+// The gzip path must not re-advertise byte ranges it will not honour.
+func TestStaticFileHandler_GzipDropsAcceptRanges(t *testing.T) {
+	w := getStatic(t, staticFileHandler(testDist()), "/assets/index-abc123.js", map[string]string{"Accept-Encoding": "gzip"})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ar := w.Header().Get("Accept-Ranges"); ar != "" {
+		t.Errorf("Accept-Ranges = %q, want unset on a gzipped response", ar)
+	}
+}

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// The built UI is exercised over an in-memory dist: webdist/ holds only
+// .gitkeep in a checkout, so the real embed can't be used here.
+func testDist() fstest.MapFS {
+	return fstest.MapFS{
+		"index.html":             {Data: []byte(`<html><script src="/assets/index-abc123.js"></script></html>`)},
+		"assets/index-abc123.js": {Data: []byte(strings.Repeat("console.log('octo');\n", 200))},
+		"assets/logo.png":        {Data: []byte{0x89, 'P', 'N', 'G', 0, 0, 0, 0}},
+	}
+}
+
+func getStatic(t *testing.T, h http.Handler, target string, hdr map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	for k, v := range hdr {
+		req.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func gunzip(t *testing.T, body []byte) string {
+	t.Helper()
+	zr, err := gzip.NewReader(strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	out, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("gunzip: %v", err)
+	}
+	return string(out)
+}
+
+// Hashed assets are immutable and gzipped when the client accepts it; the
+// body must round-trip to the original bytes.
+func TestStaticFileHandler_HashedAssetImmutableAndGzipped(t *testing.T) {
+	dist := testDist()
+	w := getStatic(t, staticFileHandler(dist), "/assets/index-abc123.js", map[string]string{"Accept-Encoding": "gzip, deflate, br"})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "public, max-age=31536000, immutable" {
+		t.Errorf("Cache-Control = %q, want immutable", cc)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", ce)
+	}
+	if v := w.Header().Get("Vary"); !strings.Contains(v, "Accept-Encoding") {
+		t.Errorf("Vary = %q, want Accept-Encoding", v)
+	}
+	if cl := w.Header().Get("Content-Length"); cl != "" {
+		t.Errorf("Content-Length = %q, want unset (describes the uncompressed body)", cl)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "javascript") {
+		t.Errorf("Content-Type = %q, want javascript", ct)
+	}
+	want := string(dist["assets/index-abc123.js"].Data)
+	if got := gunzip(t, w.Body.Bytes()); got != want {
+		t.Errorf("gunzipped body differs from the asset (%d vs %d bytes)", len(got), len(want))
+	}
+	if w.Body.Len() >= len(want) {
+		t.Errorf("compressed body %d bytes is not smaller than the %d-byte asset", w.Body.Len(), len(want))
+	}
+}
+
+// Without Accept-Encoding the asset is served verbatim, with its real length.
+func TestStaticFileHandler_IdentityWhenNotAccepted(t *testing.T) {
+	dist := testDist()
+	w := getStatic(t, staticFileHandler(dist), "/assets/index-abc123.js", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "" {
+		t.Errorf("Content-Encoding = %q, want none", ce)
+	}
+	if got, want := w.Body.String(), string(dist["assets/index-abc123.js"].Data); got != want {
+		t.Errorf("body differs from the asset")
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "public, max-age=31536000, immutable" {
+		t.Errorf("Cache-Control = %q, want immutable", cc)
+	}
+}
+
+// Already-compressed formats are never gzipped, even when accepted — but they
+// are still hashed assets and cache forever.
+func TestStaticFileHandler_ImageNotCompressed(t *testing.T) {
+	dist := testDist()
+	w := getStatic(t, staticFileHandler(dist), "/assets/logo.png", map[string]string{"Accept-Encoding": "gzip"})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "" {
+		t.Errorf("Content-Encoding = %q, want none for a PNG", ce)
+	}
+	if got, want := w.Body.Bytes(), dist["assets/logo.png"].Data; string(got) != string(want) {
+		t.Errorf("PNG body altered")
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "public, max-age=31536000, immutable" {
+		t.Errorf("Cache-Control = %q, want immutable", cc)
+	}
+}
+
+// A Range request must get real bytes of the file, never a slice of gzip output.
+func TestStaticFileHandler_RangeBypassesGzip(t *testing.T) {
+	dist := testDist()
+	w := getStatic(t, staticFileHandler(dist), "/assets/index-abc123.js", map[string]string{
+		"Accept-Encoding": "gzip",
+		"Range":           "bytes=0-9",
+	})
+
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", w.Code)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "" {
+		t.Errorf("Content-Encoding = %q, want none on a range", ce)
+	}
+	if got, want := w.Body.String(), string(dist["assets/index-abc123.js"].Data[:10]); got != want {
+		t.Errorf("range body = %q, want %q", got, want)
+	}
+}
+
+// The entrypoint — served at "/" and for every SPA route — is unhashed, so it
+// must be revalidated on each load, and it is gzipped like any other text.
+func TestStaticFileHandler_IndexNoCacheAndGzipped(t *testing.T) {
+	dist := testDist()
+	h := staticFileHandler(dist)
+	for _, target := range []string{"/", "/some/spa/route"} {
+		w := getStatic(t, h, target, map[string]string{"Accept-Encoding": "gzip"})
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d, want 200", target, w.Code)
+		}
+		if cc := w.Header().Get("Cache-Control"); cc != "no-cache" {
+			t.Errorf("%s: Cache-Control = %q, want no-cache", target, cc)
+		}
+		if ce := w.Header().Get("Content-Encoding"); ce != "gzip" {
+			t.Fatalf("%s: Content-Encoding = %q, want gzip", target, ce)
+		}
+		if got, want := gunzip(t, w.Body.Bytes()), string(dist["index.html"].Data); got != want {
+			t.Errorf("%s: gunzipped body differs from index.html", target)
+		}
+	}
+}
+
+// HEAD carries no body, so the gzip writer must not append its header/trailer
+// to an otherwise empty response.
+func TestStaticFileHandler_HeadHasNoBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodHead, "/assets/index-abc123.js", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	staticFileHandler(testDist()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("HEAD body = %d bytes, want 0", w.Body.Len())
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "" {
+		t.Errorf("Content-Encoding = %q, want none on HEAD", ce)
+	}
+}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -161,6 +161,12 @@
     // for exactly that reason — see the comment there.
     const stopPanelGC = sessions.subscribe(list => pruneSessions(list.map(s => s.id)))
     const cleanup = () => { cancelled = true; uninstallLinks(); stopHeartbeat(); stopPanelGC(); ws.disconnect() }
+    // The onboard-status read is issued alongside the auth probe rather than
+    // after it, taking one serial round trip out of every cold start. On
+    // loopback both pass at once. A networked server rejects the early read
+    // until the key prompt has completed, so a failed early read is retried
+    // once auth is settled — same outcome, one fewer hop on the common path.
+    const earlyStatus = api.getOnboardStatus().catch(() => null)
     checkAuth().then(async ok => {
       if (cancelled) return
       if (!ok) {
@@ -170,12 +176,15 @@
       // First-run gate: decide the onboard phase BEFORE booting the main UI so it
       // never flashes behind the setup panel. Default to '' on error so a status
       // hiccup doesn't trap a configured user behind a blank splash.
-      try {
-        const status = await api.getOnboardStatus()
-        onboardPhase.set(status.phase ?? '')
-      } catch {
-        onboardPhase.set('')
+      let status = await earlyStatus
+      if (!status) {
+        try {
+          status = await api.getOnboardStatus()
+        } catch {
+          status = null
+        }
       }
+      onboardPhase.set(status?.phase ?? '')
     })
     return cleanup
   })

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -162,12 +162,16 @@
     const stopPanelGC = sessions.subscribe(list => pruneSessions(list.map(s => s.id)))
     const cleanup = () => { cancelled = true; uninstallLinks(); stopHeartbeat(); stopPanelGC(); ws.disconnect() }
     // The onboard-status read is issued alongside the auth probe rather than
-    // after it, taking one serial round trip out of every cold start. On
-    // loopback both pass at once. A networked server rejects the early read
-    // until the key prompt has completed, so a failed early read is retried
-    // once auth is settled — same outcome, one fewer hop on the common path.
+    // after it, taking one serial round trip out of every cold start. checkAuth
+    // goes first: it runs synchronously up to its first await, which is where a
+    // stored or ?access_key= key is seeded into the cookie — so the early read
+    // already carries it. On loopback both pass at once. A networked server
+    // with no key yet rejects the early read until the prompt has completed,
+    // so a failed early read is retried once auth is settled — same outcome,
+    // one fewer hop on the common path.
+    const auth = checkAuth()
     const earlyStatus = api.getOnboardStatus().catch(() => null)
-    checkAuth().then(async ok => {
+    auth.then(async ok => {
       if (cancelled) return
       if (!ok) {
         authDenied = true


### PR DESCRIPTION
## Why

Part two of making the desktop window come back quickly after a close/reopen (part one, hiding instead of destroying the window, is #2308). This one makes the Web UI cold start itself cheaper, which also benefits every browser tab pointed at `octo serve`.

Before:

- `http.FileServer` served the embedded `webdist/` as-is: no `Cache-Control`, no compression. The ~600 KB entry bundle was refetched and re-transferred uncompressed on every page open. Embedded files have no modtime, so there was no `Last-Modified`/`ETag` to revalidate against either.
- `App.svelte` ran two serial round trips — auth probe, *then* onboard status — before `bootMain()` could start.

## What

**`internal/server/static.go`**

- `assets/*` (content-hashed by Vite) → `Cache-Control: public, max-age=31536000, immutable`. A rebuild changes the name, never the bytes behind an existing one.
- `index.html` and any other unhashed file → explicit `Cache-Control: no-cache`. This closes a latent blank-window hazard: WKWebView caches GET 200s heuristically when no policy is set (the same behaviour that bit `/api/onboard/status` in #1660), so a cached `index.html` referencing hashes the upgraded binary no longer embeds would 404 its own bundle.
- On-the-fly gzip for text-like assets (`.js .mjs .css .html .svg .json .map .txt .wasm`) when `Accept-Encoding` allows. Range requests and non-GET pass through untouched; only a 200 body is compressed so redirects/errors keep their headers; `Content-Length` is dropped and `Vary: Accept-Encoding` added. Stdlib `compress/gzip` — no new dependency.
- The handler body is split into `staticFileHandler(fs.FS)` so it can be tested over `fstest.MapFS` (`webdist/` is empty in a checkout).

**`web/src/App.svelte`**

- `api.getOnboardStatus()` is issued alongside `checkAuth()` instead of after it. On loopback both pass at once. A networked server rejects the early read until the key prompt completes, so a failed early read is retried once after auth is settled — same outcome, one fewer serial hop on the common path. The auth middleware has no attempt counting, so the early 401 has no side effect.

## Tests

- New `static_test.go`: immutable + gzip round-trip for a hashed asset, identity when not accepted, PNG never compressed, Range bypasses gzip, `index.html` / SPA routes get `no-cache` and gzip, HEAD gets no body.
- `go test -race ./internal/server/`, `svelte-check` (0 errors) and `vitest` (641 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
