### PR TITLE
web: give the question preview layout a visible submit button

### DIFF
--- a/web/src/components/overlays/QuestionModal.svelte
+++ b/web/src/components/overlays/QuestionModal.svelte
@@ -134,6 +134,12 @@
     // committing), so Enter is the confirm key — Claude Code's own binding.
     // Also reached from the note input, submitting the note with the choice.
     if (e.key === 'Enter' && preview && !onReview && focusedLabel) {
+      // An IME committing composed text also arrives as Enter (same guard as
+      // Composer.svelte) — that keystroke is typing, not confirmation. And a
+      // focused button's own activation must win: without this, Enter on a
+      // tabbed-to Cancel (or any row) would submit the focused option instead.
+      if (e.isComposing || e.keyCode === 229) return
+      if (e.target instanceof HTMLElement && e.target.tagName === 'BUTTON') return
       e.preventDefault()
       pick(focusedLabel)
     }
@@ -218,7 +224,7 @@
               placeholder={$t('question.custom_placeholder')}
               value={draft.custom}
               oninput={(e) => setDraft({ ...draft, custom: e.currentTarget.value })}
-              onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commitOther() } }}
+              onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.stopPropagation(); commitOther() } }}
             />
             <button class="btn-primary btn-primary-sm" onclick={commitOther}>{$t('common.submit')}</button>
           </div>

--- a/web/src/components/overlays/QuestionModal.svelte
+++ b/web/src/components/overlays/QuestionModal.svelte
@@ -130,6 +130,13 @@
   function softClose() { expanded = false }
   function onKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') { e.preventDefault(); softClose() }
+    // Preview layout: a click only focuses (so previews can be browsed without
+    // committing), so Enter is the confirm key — Claude Code's own binding.
+    // Also reached from the note input, submitting the note with the choice.
+    if (e.key === 'Enter' && preview && !onReview && focusedLabel) {
+      e.preventDefault()
+      pick(focusedLabel)
+    }
   }
 </script>
 
@@ -297,6 +304,14 @@
           >
             {hasReviewTab(questions) ? $t('question.next') : $t('common.submit')}
           </button>
+        {:else if preview}
+          <!-- Preview layout: a single click only focuses a row so its preview
+               can be inspected without committing, which leaves no visible way
+               to answer (double-click and Enter both work, but nothing says
+               so). This commits the focused option, note included. -->
+          <button class="btn-primary" onclick={() => pick(focusedLabel)} disabled={!focusedLabel}>
+            {hasReviewTab(questions) ? $t('question.next') : $t('common.submit')}
+          </button>
         {/if}
       </div>
     </div>
@@ -334,6 +349,11 @@
             onclick={() => { const to = advanceIndex(questions, qIdx); if (to === -1) finish('submitted'); else goTab(to) }}
             disabled={draft.choices.length === 0}
           >
+            {hasReviewTab(questions) ? $t('question.next') : $t('common.submit')}
+          </button>
+        {:else if preview}
+          <!-- Same confirm affordance as the modal footer above. -->
+          <button class="btn-primary btn-primary-sm" onclick={() => pick(focusedLabel)} disabled={!focusedLabel}>
             {hasReviewTab(questions) ? $t('question.next') : $t('common.submit')}
           </button>
         {/if}


### PR DESCRIPTION
## Why

Reported with a screenshot: a single-select `ask_user_question` in the preview layout renders with no submit button — only "Cancel".

The preview layout deliberately makes a single click focus-only (so each option's preview can be browsed without committing, `QuestionModal.svelte`), and the flat layout's click-to-answer therefore doesn't apply. But the footer's primary button only rendered on the review tab and for multi-select questions, so the only ways to answer were double-click (undiscoverable) — Enter wasn't even bound (`onKeydown` handled Escape only).

## What

- The modal and banner footers show the usual Next/Submit primary button for the preview layout, committing the focused option via the existing `pick()` (single-select `toggleChoice` replaces, so re-committing an already-selected option is safe). The note typed in the preview column rides along in the draft as before.
- Enter commits the focused option — Claude Code's own confirm key for this layout — including from the note input, so typing a note and hitting Enter submits it with the choice.
- Double-click keeps working.

`svelte-check` 0 errors, `vitest` 641/641. Not walked through with CDP — the button reuses the exact `pick()` path double-click already exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
