### PR TITLE
web: stamp updated_at locally on turn_ended so sidebar times don't go stale

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -361,14 +361,19 @@
       // sessions this tab isn't subscribed to (session_update carries status
       // only to subscribers).
       if (ev.kind === 'turn_started' || ev.kind === 'turn_ended') {
-        sessions.update(list => list.map(s =>
-          s.id === sid ? { ...s, status: ev.kind === 'turn_started' ? 'running' : 'idle' } : s
-        ))
+        sessions.update(list => list.map(s => {
+          if (s.id !== sid) return s
+          if (ev.kind === 'turn_started') return { ...s, status: 'running' }
+          // Also stamp updated_at: no broadcast carries the server's value, so
+          // without this the sidebar's relative timestamp keeps aging from the
+          // last REST fetch even as the user chats. The local clock stands in
+          // until the next list refetch reconciles with the server's mtime.
+          return { ...s, status: 'idle', updated_at: new Date().toISOString() }
+        }))
       }
       // A finished turn left something in that session to read. Stamped
       // unconditionally: the effect at the top of this file immediately
-      // un-marks it again if it's the session on screen, and nothing else
-      // refreshes updated_at for an open tab.
+      // un-marks it again if it's the session on screen.
       if (ev.kind === 'turn_ended') touchSession(sid)
       // The agent just finished changing files. Re-render the Git Diff panel if
       // it's open on this session, or move its badge if it isn't — that pair is

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -357,6 +357,13 @@
           s.id === sid ? { ...s, pending_confirmation: ev.kind === 'confirm_pending' } : s
         ))
       }
+      // A finished turn left something in that session to read. Stamped
+      // unconditionally: the effect at the top of this file immediately
+      // un-marks it again if it's the session on screen. Must run BEFORE the
+      // sessions.update below — that update synchronously triggers
+      // reconcileSeen, and a fresh browser's seen baseline has to cover this
+      // touch or the row flashes a phantom unread dot.
+      if (ev.kind === 'turn_ended') touchSession(sid)
       // Running-state pair — keeps the sidebar's activity spinner live for
       // sessions this tab isn't subscribed to (session_update carries status
       // only to subscribers).
@@ -371,10 +378,6 @@
           return { ...s, status: 'idle', updated_at: new Date().toISOString() }
         }))
       }
-      // A finished turn left something in that session to read. Stamped
-      // unconditionally: the effect at the top of this file immediately
-      // un-marks it again if it's the session on screen.
-      if (ev.kind === 'turn_ended') touchSession(sid)
       // The agent just finished changing files. Re-render the Git Diff panel if
       // it's open on this session, or move its badge if it isn't — that pair is
       // the whole refresh story, no polling anywhere.

--- a/web/src/lib/sidebarSections.test.ts
+++ b/web/src/lib/sidebarSections.test.ts
@@ -89,6 +89,28 @@ describe('splitSections', () => {
     expect(s.projects[0].items).toEqual([])
     expect(s.ungrouped.map(x => x.id)).toEqual(['a'])
   })
+
+  // Tasks is the recency list, ordered by updated_at rather than fetch order:
+  // a turn ending in an open tab re-stamps only that row (App.svelte), and the
+  // sort is what floats it to the top. The stamp is UTC "Z" while the server
+  // sends zone-offset strings, so the comparison must parse, not localeCompare.
+  it('orders ungrouped by updated_at descending across mixed formats', () => {
+    const at = (id: string, updated_at: string): Session => ({ id, updated_at }) as Session
+    const s = splitSections(
+      [
+        at('old', '2026-08-29T10:00:00+08:00'),
+        at('stamped', '2026-08-29T05:30:00.000Z'), // = 13:30+08:00, the newest
+        at('mid', '2026-08-29T11:00:00+08:00'),
+      ],
+      [], [], [],
+    )
+    expect(s.ungrouped.map(x => x.id)).toEqual(['stamped', 'mid', 'old'])
+  })
+
+  it('keeps fetch order for sessions without a parseable updated_at', () => {
+    const s = splitSections([sess('a'), sess('b'), sess('c')], [], [], [])
+    expect(s.ungrouped.map(x => x.id)).toEqual(['a', 'b', 'c'])
+  })
 })
 
 describe('swapWithinSection', () => {

--- a/web/src/lib/sidebarSections.ts
+++ b/web/src/lib/sidebarSections.ts
@@ -14,6 +14,7 @@
 // kind of row.
 
 import type { Session, SessionGroup } from './types'
+import { updatedAtMs } from './unread'
 
 export interface GroupView {
   group: SessionGroup
@@ -77,7 +78,16 @@ export function splitSections(
   // plain group was claimed by it above and so does NOT resurface here — that
   // group is gone from the registry the moment the server has run, and until
   // then showing its sessions twice would be worse than showing them nowhere.
-  const ungrouped = [...byId.values()].filter(s => !claimed.has(s.id))
+  //
+  // Tasks is the flat recency list, so sort it here rather than trusting the
+  // input order: the REST list arrives newest-first, but a turn ending in an
+  // open tab only re-stamps that row's updated_at (App.svelte) — without this
+  // sort the just-finished session would stay wherever the last fetch left it.
+  // The sort is stable, so rows without a parseable timestamp keep their
+  // fetched order at the bottom rather than shuffling.
+  const ungrouped = [...byId.values()]
+    .filter(s => !claimed.has(s.id))
+    .sort((a, b) => updatedAtMs(b) - updatedAtMs(a))
 
   return {
     pinned,

--- a/web/src/lib/unread.ts
+++ b/web/src/lib/unread.ts
@@ -47,7 +47,11 @@ sessionSeenAt.subscribe(m => {
  */
 export const sessionTouchedAt = writable<Record<string, number>>({})
 
-function updatedAtMs(s: Pick<Session, 'updated_at'>): number {
+// Parse rather than compare the ISO strings directly: the list mixes the
+// server's zone-offset format with the UTC "Z" stamps App.svelte writes on
+// turn_ended, and those don't order lexicographically. Exported for the
+// sidebar/mobile recency sorts, which face the same mix.
+export function updatedAtMs(s: Pick<Session, 'updated_at'>): number {
   const t = Date.parse(s.updated_at ?? '')
   return Number.isNaN(t) ? 0 : t
 }

--- a/web/src/mobile/feedGroups.ts
+++ b/web/src/mobile/feedGroups.ts
@@ -7,6 +7,7 @@
 // Within each section, pinned sessions float to the top.
 import { derived } from 'svelte/store'
 import { sessions } from '../lib/stores'
+import { updatedAtMs } from '../lib/unread'
 import type { Session } from '../lib/types'
 
 export type FeedKind = 'approval' | 'reply' | 'running' | 'done'
@@ -25,7 +26,9 @@ const RECENT_CAP = 8
 
 function byPinThenRecent(a: FeedItem, b: FeedItem): number {
   if (!!a.session.pinned !== !!b.session.pinned) return a.session.pinned ? -1 : 1
-  return (b.session.updated_at || '').localeCompare(a.session.updated_at || '')
+  // Numeric, not lexicographic: updated_at mixes the server's zone-offset
+  // format with the UTC "Z" stamps App.svelte writes on turn_ended.
+  return updatedAtMs(b.session) - updatedAtMs(a.session)
 }
 
 export const feedGroups = derived(


### PR DESCRIPTION
## Problem

The sidebar renders each session row's relative time from `updated_at`, but that field only arrives via REST list fetches — sidebar mount, WS reconnect (`session_list_reload`), `session_created`, and rename. A turn finishing in an open tab fires `session_activity: turn_ended`, which updates the unread watermark (`touchSession`) and the running spinner, but never the sessions store's `updated_at`.

Result: a session the user is actively chatting in keeps showing — and growing — the age from the last list fetch ("20 minutes ago" right after a reply), until a page reload or WS reconnect refetches the list. The Tasks section's ordering had the same staleness: it just mirrored fetch order, so the just-finished session never floated to the top either.

## Fix

**Commit 1 — timestamp.** In the `session_activity` handler's `turn_ended` branch, stamp the row's `updated_at` with the local clock. The next REST refetch reconciles with the server's authoritative mtime. This mirrors how the unread logic already treats `max(updated_at, touched)` as the row's last-change time.

**Commit 2 — ordering.** `splitSections` now sorts the ungrouped (Tasks) section by `updated_at` descending, so the re-stamped row floats to the top. The sort is stable — rows without a parseable timestamp keep fetch order. Comparison goes through `updatedAtMs` (now exported from `unread.ts`) rather than string comparison, because the list mixes the server's zone-offset ISO strings with the UTC "Z" stamps from commit 1, which don't order lexicographically; the mobile feed's recency comparator had the same latent mix and switches to the shared helper too.

Frontend-only; no server changes.

## Verification

- `svelte-check`: 0 errors / 0 warnings
- `vitest run`: 48 files, 643 tests passed (2 new: mixed-format recency sort, stable order without timestamps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)