### PR TITLE
web: keep the Tasks section in fetch order — no mid-session reordering

### DIFF
--- a/web/src/lib/sidebarSections.test.ts
+++ b/web/src/lib/sidebarSections.test.ts
@@ -90,11 +90,10 @@ describe('splitSections', () => {
     expect(s.ungrouped.map(x => x.id)).toEqual(['a'])
   })
 
-  // Tasks is the recency list, ordered by updated_at rather than fetch order:
-  // a turn ending in an open tab re-stamps only that row (App.svelte), and the
-  // sort is what floats it to the top. The stamp is UTC "Z" while the server
-  // sends zone-offset strings, so the comparison must parse, not localeCompare.
-  it('orders ungrouped by updated_at descending across mixed formats', () => {
+  // Rows must not jump around while the user is looking at the list: a turn
+  // ending re-stamps its row's updated_at (App.svelte) for the timestamp
+  // display, but the ORDER stays as fetched until the next server sync.
+  it('keeps fetch order even when updated_at says otherwise', () => {
     const at = (id: string, updated_at: string): Session => ({ id, updated_at }) as Session
     const s = splitSections(
       [
@@ -104,12 +103,7 @@ describe('splitSections', () => {
       ],
       [], [], [],
     )
-    expect(s.ungrouped.map(x => x.id)).toEqual(['stamped', 'mid', 'old'])
-  })
-
-  it('keeps fetch order for sessions without a parseable updated_at', () => {
-    const s = splitSections([sess('a'), sess('b'), sess('c')], [], [], [])
-    expect(s.ungrouped.map(x => x.id)).toEqual(['a', 'b', 'c'])
+    expect(s.ungrouped.map(x => x.id)).toEqual(['old', 'stamped', 'mid'])
   })
 })
 

--- a/web/src/lib/sidebarSections.ts
+++ b/web/src/lib/sidebarSections.ts
@@ -14,7 +14,6 @@
 // kind of row.
 
 import type { Session, SessionGroup } from './types'
-import { updatedAtMs } from './unread'
 
 export interface GroupView {
   group: SessionGroup
@@ -79,15 +78,12 @@ export function splitSections(
   // group is gone from the registry the moment the server has run, and until
   // then showing its sessions twice would be worse than showing them nowhere.
   //
-  // Tasks is the flat recency list, so sort it here rather than trusting the
-  // input order: the REST list arrives newest-first, but a turn ending in an
-  // open tab only re-stamps that row's updated_at (App.svelte) — without this
-  // sort the just-finished session would stay wherever the last fetch left it.
-  // The sort is stable, so rows without a parseable timestamp keep their
-  // fetched order at the bottom rather than shuffling.
-  const ungrouped = [...byId.values()]
-    .filter(s => !claimed.has(s.id))
-    .sort((a, b) => updatedAtMs(b) - updatedAtMs(a))
+  // Deliberately NOT sorted by updated_at: rows must not jump around while the
+  // user is looking at the list (a turn ending re-stamps its row's updated_at
+  // in App.svelte, which would float it mid-session). Fetch order IS recency
+  // order at fetch time, so the list reorders exactly when it is next synced
+  // from the server — reload, reconnect, session_created.
+  const ungrouped = [...byId.values()].filter(s => !claimed.has(s.id))
 
   return {
     pinned,

--- a/web/src/lib/unread.ts
+++ b/web/src/lib/unread.ts
@@ -50,7 +50,7 @@ export const sessionTouchedAt = writable<Record<string, number>>({})
 // Parse rather than compare the ISO strings directly: the list mixes the
 // server's zone-offset format with the UTC "Z" stamps App.svelte writes on
 // turn_ended, and those don't order lexicographically. Exported for the
-// sidebar/mobile recency sorts, which face the same mix.
+// mobile feed's recency sort, which faces the same mix.
 export function updatedAtMs(s: Pick<Session, 'updated_at'>): number {
   const t = Date.parse(s.updated_at ?? '')
   return Number.isNaN(t) ? 0 : t


### PR DESCRIPTION
Follow-up to #2313, per feedback: rows must not jump around while the user is looking at the list.

#2313 sorted the Tasks section by `updated_at`, so the local turn_ended stamp floated the just-finished session to the top mid-session. This removes that live sort: the section stays in fetch order (which is recency order at fetch time), so ordering changes exactly when the list is next synced from the server — reload, WS reconnect, `session_created`.

What stays from #2313:
- the `turn_ended` local `updated_at` stamp (the relative-timestamp display still heals immediately);
- the numeric `updatedAtMs` comparator in the mobile feed, whose sections are live by design and which would mis-order lexicographically on the mixed ISO formats.

The mixed-format sort test is replaced by one asserting fetch order is preserved even when `updated_at` disagrees, documenting the decision.

Verification: `svelte-check` 0 errors, `vitest` 642 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)