### PR TITLE
app: add deepseek-v4-flash-vision-exp to the DeepSeek catalogue with vision on

### DIFF
--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -168,11 +168,15 @@ var Registry = []Vendor{
 		API:            "openai-completions",
 		DefaultBaseURL: "https://api.deepseek.com",
 		DefaultModel:   "deepseek-v4-pro",
-		// DeepSeek V4 has vision in the chat app but not over the API — image
-		// content isn't accepted on the endpoint, so treat as text-only here.
+		// deepseek-v4-flash / -pro have vision in the chat app but not over the
+		// API — image content isn't accepted on those endpoints, so they stay
+		// text-only here. deepseek-v4-flash-vision-exp is the API-facing vision
+		// variant: 1M context, images billed as input tokens by dimension, tool
+		// calls supported (api-docs.deepseek.com/quick_start/pricing, 2026-08-29).
 		Models: []VendorModel{
 			{ID: "deepseek-v4-flash", Vision: false},
 			{ID: "deepseek-v4-pro", Vision: false},
+			{ID: "deepseek-v4-flash-vision-exp", Vision: true},
 		},
 		LiteModel:    "deepseek-v4-flash",
 		APIKeyEnvVar: "DEEPSEEK_API_KEY",

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -282,7 +282,7 @@ func TestImplicitLiteModel(t *testing.T) {
 func TestVendorModels_ReturnsIDs(t *testing.T) {
 	// VendorModels flattens the catalogue to plain ids for the UI dropdown.
 	ids := VendorModels("deepseek")
-	want := []string{"deepseek-v4-flash", "deepseek-v4-pro"}
+	want := []string{"deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-flash-vision-exp"}
 	if len(ids) != len(want) {
 		t.Fatalf("VendorModels(deepseek) = %v, want %v", ids, want)
 	}
@@ -307,6 +307,7 @@ func TestVendorModelVision(t *testing.T) {
 	}{
 		{"anthropic", "claude-opus-4-8", true, true},
 		{"deepseek", "deepseek-v4-pro", false, true}, // vision not on the API
+		{"deepseek", "deepseek-v4-flash-vision-exp", true, true},
 		{"bailian", "qwen3.7-plus", true, true},
 		{"bailian", "qwen3.7-max", false, true}, // text-only flagship
 		{"kimi", "kimi-k2.6", true, true},       // MoonViT multimodal


### PR DESCRIPTION
## Summary
- Add `deepseek-v4-flash-vision-exp` to the built-in DeepSeek vendor catalogue with `Vision: true`.
- Extend `TestVendorModels_ReturnsIDs` and `TestVendorModelVision` to cover the new entry.

## Why
DeepSeek now ships an API-facing vision variant of V4 Flash. Verified against https://api-docs.deepseek.com/quick_start/pricing (2026-08-29): 1M context, images converted to input tokens by dimension, Tool Calls / JSON Output supported. It rides the existing `openai-completions` path with no adapter change. `deepseek-v4-flash` / `-pro` remain `Vision: false` — image input is still rejected on those endpoints.

`contextWindow` already maps the new id to 1M through the `deepseek-v4-flash` substring case, so no compaction change.

## Test plan
- [x] `go test ./internal/app/ ./internal/agent/`
- [x] `go vet ./internal/app/`, `gofmt -l .` clean
- [ ] Manual: pick the model in Settings → Models, send an image, confirm the model describes it (needs a DeepSeek key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)