### PR TITLE
app: add glm-5.3 and glm-5.3-flash to the GLM catalogue, flash with vision on

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -183,6 +183,8 @@ func contextWindow(model string) int {
 		return 128_000
 
 	// ── GLM (Zhipu) ──
+	case strings.Contains(m, "glm-5.3") || strings.Contains(m, "glm5.3"):
+		return 1_000_000
 	case strings.Contains(m, "glm-5.2") || strings.Contains(m, "glm5.2"):
 		return 1_000_000
 	case strings.Contains(m, "glm-4-air") || strings.Contains(m, "glm-4.5-air"):

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -127,6 +127,9 @@ func TestContextWindow(t *testing.T) {
 	if got := contextWindow("glm-5.2"); got != 1_000_000 {
 		t.Errorf("glm-5.2 window = %d, want 1000000", got)
 	}
+	if got := contextWindow("glm-5.3-flash"); got != 1_000_000 {
+		t.Errorf("glm-5.3-flash window = %d, want 1000000", got)
+	}
 	if got := contextWindow("x-ai/grok-4.5"); got != 500_000 {
 		t.Errorf("grok-4.5 window = %d, want 500000", got)
 	}

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -241,7 +241,7 @@ var Registry = []Vendor{
 		Protocol:       "openai",
 		API:            "openai-completions",
 		DefaultBaseURL: "https://open.bigmodel.cn/api/paas/v4",
-		DefaultModel:   "glm-4.5",
+		DefaultModel:   "glm-5.3",
 		// glm-5.3-flash is the one multimodal entry (image/video/file input, 1M
 		// context — docs.z.ai/guides/vlm/glm-5.3-flash, 2026-08-29). The rest of
 		// the GLM-4.5/5.x line is text-only; GLM-4.5V isn't offered here.
@@ -253,7 +253,7 @@ var Registry = []Vendor{
 			{ID: "glm-4.5-air", Vision: false},
 			{ID: "glm-4.5-flash", Vision: false},
 		},
-		LiteModel:    "glm-4.5-flash",
+		LiteModel:    "glm-5.3-flash",
 		APIKeyEnvVar: "ZHIPU_API_KEY",
 		WebsiteURL:   "https://open.bigmodel.cn/usercenter/apikey",
 		EndpointVariants: []EndpointVariant{

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -242,8 +242,12 @@ var Registry = []Vendor{
 		API:            "openai-completions",
 		DefaultBaseURL: "https://open.bigmodel.cn/api/paas/v4",
 		DefaultModel:   "glm-4.5",
-		// GLM-4.5/5.2 line is text-only; the vision variant (GLM-4.5V) isn't offered here.
+		// glm-5.3-flash is the one multimodal entry (image/video/file input, 1M
+		// context — docs.z.ai/guides/vlm/glm-5.3-flash, 2026-08-29). The rest of
+		// the GLM-4.5/5.x line is text-only; GLM-4.5V isn't offered here.
 		Models: []VendorModel{
+			{ID: "glm-5.3", Vision: false},
+			{ID: "glm-5.3-flash", Vision: true},
 			{ID: "glm-5.2", Vision: false},
 			{ID: "glm-4.5", Vision: false},
 			{ID: "glm-4.5-air", Vision: false},

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -310,6 +310,8 @@ func TestVendorModelVision(t *testing.T) {
 		{"bailian", "qwen3.7-plus", true, true},
 		{"bailian", "qwen3.7-max", false, true}, // text-only flagship
 		{"kimi", "kimi-k2.6", true, true},       // MoonViT multimodal
+		{"glm", "glm-5.3", false, true},         // text-only
+		{"glm", "glm-5.3-flash", true, true},    // image/video/file input
 		{"openai", "o3-mini", false, true},      // no image input
 		{"openai", "o4-mini", true, true},
 		{"xai", "grok-4.5", true, true},


### PR DESCRIPTION
## Summary
- Add `glm-5.3` (`Vision: false`) and `glm-5.3-flash` (`Vision: true`) to the built-in GLM (Zhipu) vendor catalogue.
- Move the vendor defaults onto the new line: `DefaultModel` `glm-4.5` → `glm-5.3`, `LiteModel` `glm-4.5-flash` → `glm-5.3-flash`.
- `contextWindow`: new `glm-5.3` case → 1M. Previously only `glm-5.2` matched, so the new ids fell through to the 64K bare-`glm` fallback.
- Tests: `TestVendorModelVision` covers both new entries; `contextWindow("glm-5.3-flash")` asserted at 1M.

## Why
Verified against Z.AI docs (2026-08-29):
- https://docs.z.ai/guides/llm/glm-5.3 — 1M context, 128K max output, text-only input, function calling.
- https://docs.z.ai/guides/vlm/glm-5.3-flash — 1M context, 128K max output, image/video/text/file input, function calling.

Both ride the existing `openai-completions` path. Existing endpoints keep whatever model they have stored; the new defaults only affect a freshly added GLM endpoint and the implicit lite model for endpoints without one.

## Test plan
- [x] `go test ./internal/app/ ./internal/agent/ ./cmd/octo/`
- [x] `go vet`, `gofmt -l .` clean
- [ ] Manual: pick `glm-5.3-flash` in Settings → Models, send an image, confirm the model describes it (needs a Zhipu key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)