### PR TITLE
web: allow forms and modals in the Light App and artifact preview sandboxes

### DIFF
--- a/dev-docs/light-apps-design.md
+++ b/dev-docs/light-apps-design.md
@@ -69,16 +69,30 @@ octo-agent 已经有一套完整的生成 + 展示循环：Agent 生成 HTML →
 - **JS 内联**：`<script>` 直接写在 HTML 内
 - **文件处理**：`<input type="file">` + `FileReader` API，浏览器端搞定
 - **无服务端依赖**：不能发 fetch 到外部 API（Artifacts panel sandboxed iframe 限制）
-- **持久化存储可用**：直接用标准 `localStorage`，见下节
+- **持久化存储可用**：直接用标准 `localStorage`，见「运行时存储」
+- **表单 submit 处理器必须 `event.preventDefault()`**：沙箱里的表单无处可导航，不拦的话 frame 会被重载、应用内存态全丢
+
+### 运行沙箱
+
+轻应用和 Artifact 预览都跑在 `sandbox="allow-scripts allow-forms allow-modals"` 的 srcdoc iframe 里
+（常量 `ARTIFACT_SANDBOX`，`web/src/lib/artifacts.ts`，四处 iframe 共用——应用在保存前就是在预览里试用的，
+保存前后必须行为一致）。
+
+刻意不给 `allow-same-origin`：origin 是 opaque，文档碰不到任何存储、Cookie 和宿主状态，这是下面两条桥
+存在的前提。也不给 `allow-popups`、`allow-top-navigation`。
+
+`allow-forms` 是因为没有它表单的 submit 事件根本不触发（规范在派发事件之前就检查 sandboxed forms flag），
+`<form onsubmit>` + 回车提交全废；`allow-modals` 是因为没有它 `confirm()` 恒 false、`prompt()` 恒 null、
+`alert()` 静默——生成的应用常拿 `confirm` 做删除确认，等于永远删不掉。
+
+代价要说实话：`allow-modals` 交给应用的是浏览器原生对话框——alert/confirm/prompt、`window.print()`、
+`beforeunload` 提示——它们是 tab 级 modal，开着的时候会挡住宿主 UI，一个 `while(true) alert()` 的坏应用
+能把整个页面卡住直到用户勾"阻止此页再弹对话框"。接受这个取舍：轻应用是用户让自己的 agent 写的，
+origin 边界本身没动。
 
 ### 运行时存储
 
-轻应用跑在 `sandbox="allow-scripts allow-forms allow-modals"` 的 srcdoc iframe 里（刻意不给
-`allow-same-origin`；`allow-forms` 是因为没有它表单的 submit 事件根本不触发，`<form onsubmit>` + 回车
-提交全废；`allow-modals` 是因为没有它 `confirm()` 恒 false、`prompt()` 恒 null、`alert()` 静默——
-生成的应用常拿 `confirm` 做删除确认，等于永远删不掉。两者都不放宽安全边界：origin 仍是 opaque、
-不能开弹窗、不能导航顶层。Artifact 预览 iframe 用同一组 flag，保存前后行为一致）。
-origin 是 opaque，浏览器会拒掉所有持久化存储 API —
+沙箱里 origin 是 opaque，浏览器会拒掉所有持久化存储 API —
 localStorage / sessionStorage / Cookie / IndexedDB 在里面一律抛 SecurityError。
 
 沙箱不动，改由宿主页面代管：`web/src/lib/laStorage.ts` 在宿主开一个 IndexedDB

--- a/dev-docs/light-apps-design.md
+++ b/dev-docs/light-apps-design.md
@@ -73,8 +73,12 @@ octo-agent 已经有一套完整的生成 + 展示循环：Agent 生成 HTML →
 
 ### 运行时存储
 
-轻应用跑在 `sandbox="allow-scripts"` 的 srcdoc iframe 里（刻意不给
-`allow-same-origin`），origin 是 opaque，浏览器会拒掉所有持久化存储 API —
+轻应用跑在 `sandbox="allow-scripts allow-forms allow-modals"` 的 srcdoc iframe 里（刻意不给
+`allow-same-origin`；`allow-forms` 是因为没有它表单的 submit 事件根本不触发，`<form onsubmit>` + 回车
+提交全废；`allow-modals` 是因为没有它 `confirm()` 恒 false、`prompt()` 恒 null、`alert()` 静默——
+生成的应用常拿 `confirm` 做删除确认，等于永远删不掉。两者都不放宽安全边界：origin 仍是 opaque、
+不能开弹窗、不能导航顶层。Artifact 预览 iframe 用同一组 flag，保存前后行为一致）。
+origin 是 opaque，浏览器会拒掉所有持久化存储 API —
 localStorage / sessionStorage / Cookie / IndexedDB 在里面一律抛 SecurityError。
 
 沙箱不动，改由宿主页面代管：`web/src/lib/laStorage.ts` 在宿主开一个 IndexedDB

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -188,5 +188,6 @@ Create both files with `write_file`. No special tools needed.
 - No CDN links, no external images, no cross-origin fetch
 - Inline all CSS (`<style>`) and JS (`<script>`)
 - Use `FileReader` + `<input type="file">` for file processing
+- Form submit handlers must call `event.preventDefault()` — the sandboxed frame has nowhere to navigate to, and an unprevented submit reloads the app and drops its state
 - Use emoji or inline SVG for icons
 - Follow `artifact-design` skill conventions for layout and colors

--- a/web/src/components/ArtifactModal.svelte
+++ b/web/src/components/ArtifactModal.svelte
@@ -100,7 +100,8 @@
       {:else if !cur.loaded}
         <div class="body-loading"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon></div>
       {:else}
-        <iframe srcdoc={cur.preview} sandbox="allow-scripts" allow="clipboard-write" title={cur.name}></iframe>
+        <!-- Sandbox flags mirror ArtifactsPanel's frames (see the comment there). -->
+        <iframe srcdoc={cur.preview} sandbox="allow-scripts allow-forms allow-modals" allow="clipboard-write" title={cur.name}></iframe>
       {/if}
     </div>
   </div>

--- a/web/src/components/ArtifactModal.svelte
+++ b/web/src/components/ArtifactModal.svelte
@@ -2,7 +2,7 @@
   import { artifacts, panelContent, artifactSel, artifactModalOpen, showToast } from '../lib/stores'
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact, imagePreviewError } from '../lib/artifact-actions'
-  import { hydrateArtifact } from '../lib/artifacts'
+  import { ARTIFACT_SANDBOX, hydrateArtifact } from '../lib/artifacts'
 
   const cur = $derived($artifacts[$artifactSel] ?? $artifacts[0])
   let modalEl = $state<HTMLDivElement | null>(null)
@@ -100,8 +100,7 @@
       {:else if !cur.loaded}
         <div class="body-loading"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon></div>
       {:else}
-        <!-- Sandbox flags mirror ArtifactsPanel's frames (see the comment there). -->
-        <iframe srcdoc={cur.preview} sandbox="allow-scripts allow-forms allow-modals" allow="clipboard-write" title={cur.name}></iframe>
+        <iframe srcdoc={cur.preview} sandbox={ARTIFACT_SANDBOX} allow="clipboard-write" title={cur.name}></iframe>
       {/if}
     </div>
   </div>

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -521,7 +521,14 @@
       {/if}
       {#if laCurHTML}
         {#key laReloadGen}
-        <iframe bind:this={laFrameEl} srcdoc={withLaBridge(laCurHTML, laCurSlug)} sandbox="allow-scripts" allow="clipboard-write" title={laCurName}></iframe>
+        <!-- allow-forms / allow-modals: without them the sandbox silently
+             breaks two things generated apps lean on — the submit event never
+             fires (so <form onsubmit> + Enter is dead), and confirm() returns
+             false / prompt() null / alert() no-ops (so a "sure?" before delete
+             never deletes). Neither flag widens the security boundary: the
+             origin stays opaque (no allow-same-origin), no popups, no
+             top-level navigation. -->
+        <iframe bind:this={laFrameEl} srcdoc={withLaBridge(laCurHTML, laCurSlug)} sandbox="allow-scripts allow-forms allow-modals" allow="clipboard-write" title={laCurName}></iframe>
         {/key}
       {:else if laCurSlug || laLoading}
         <!-- A tab opens before its HTML arrives, so this covers the fetch. -->
@@ -624,7 +631,9 @@
         {:else if !cur.loaded}
           <div class="body-loading"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon></div>
         {:else if $artifactView === 'preview'}
-          <iframe srcdoc={cur.preview} sandbox="allow-scripts" allow="clipboard-write" title={cur.name}></iframe>
+          <!-- Same sandbox as the Light App frame above: this is where an app
+               is previewed before it is saved, so it must behave identically. -->
+          <iframe srcdoc={cur.preview} sandbox="allow-scripts allow-forms allow-modals" allow="clipboard-write" title={cur.name}></iframe>
         {:else}
           <pre class="code-view">{cur.code}</pre>
         {/if}

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -3,7 +3,7 @@
   import { titlebarDblClick } from '../lib/nativeWindow'
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact, imagePreviewError } from '../lib/artifact-actions'
-  import { hydrateArtifact, lightAppSource, pathIsInside } from '../lib/artifacts'
+  import { ARTIFACT_SANDBOX, hydrateArtifact, lightAppSource, pathIsInside } from '../lib/artifacts'
   import { CENTER_MIN } from '../lib/sidebarWidth'
   import { diffData, diffLoading, diffBadge, loadDiff } from '../lib/diff'
   import DiffView from './diff/DiffView.svelte'
@@ -521,14 +521,7 @@
       {/if}
       {#if laCurHTML}
         {#key laReloadGen}
-        <!-- allow-forms / allow-modals: without them the sandbox silently
-             breaks two things generated apps lean on — the submit event never
-             fires (so <form onsubmit> + Enter is dead), and confirm() returns
-             false / prompt() null / alert() no-ops (so a "sure?" before delete
-             never deletes). Neither flag widens the security boundary: the
-             origin stays opaque (no allow-same-origin), no popups, no
-             top-level navigation. -->
-        <iframe bind:this={laFrameEl} srcdoc={withLaBridge(laCurHTML, laCurSlug)} sandbox="allow-scripts allow-forms allow-modals" allow="clipboard-write" title={laCurName}></iframe>
+        <iframe bind:this={laFrameEl} srcdoc={withLaBridge(laCurHTML, laCurSlug)} sandbox={ARTIFACT_SANDBOX} allow="clipboard-write" title={laCurName}></iframe>
         {/key}
       {:else if laCurSlug || laLoading}
         <!-- A tab opens before its HTML arrives, so this covers the fetch. -->
@@ -631,9 +624,7 @@
         {:else if !cur.loaded}
           <div class="body-loading"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon></div>
         {:else if $artifactView === 'preview'}
-          <!-- Same sandbox as the Light App frame above: this is where an app
-               is previewed before it is saved, so it must behave identically. -->
-          <iframe srcdoc={cur.preview} sandbox="allow-scripts allow-forms allow-modals" allow="clipboard-write" title={cur.name}></iframe>
+          <iframe srcdoc={cur.preview} sandbox={ARTIFACT_SANDBOX} allow="clipboard-write" title={cur.name}></iframe>
         {:else}
           <pre class="code-view">{cur.code}</pre>
         {/if}

--- a/web/src/lib/artifacts.ts
+++ b/web/src/lib/artifacts.ts
@@ -29,6 +29,24 @@ import { artifacts, panelContent, panelExpanded, artifactSel } from './stores'
 import { renderMarkdown } from './markdown'
 import type { Artifact } from './types'
 
+// The sandbox every srcdoc preview frame runs with — artifact previews (panel,
+// modal, mobile) and saved Light Apps alike, since an app is exercised in the
+// preview before it is saved and must behave the same afterwards.
+//
+// No allow-same-origin: the origin stays opaque, so the document reaches no
+// storage, cookies or host state (the bridges in laStorage.ts / laDownload.ts
+// exist because of this). No allow-popups, no allow-top-navigation.
+//
+// allow-forms: without it the submit event never fires at all — the sandboxed
+// forms check runs before the event is dispatched — so <form onsubmit> plus
+// Enter is silently dead. allow-modals: without it confirm() returns false,
+// prompt() null and alert() no-ops, so a "sure?" before delete can never be
+// answered yes. What allow-modals hands the document in return: native
+// dialogs (alert/confirm/prompt, print(), the beforeunload prompt), which are
+// tab-level and can block the host UI while open. Accepted: the app is one the
+// user asked their own agent to write.
+export const ARTIFACT_SANDBOX = 'allow-scripts allow-forms allow-modals'
+
 // Tracks which session the current artifacts belong to, so an async fetch that
 // resolves after a session switch is discarded instead of polluting the new view.
 export const artifactSelSession = writable<string | null>(null)

--- a/web/src/lib/laStorage.ts
+++ b/web/src/lib/laStorage.ts
@@ -1,7 +1,7 @@
 // Light App storage bridge — makes `localStorage` WORK inside Light Apps.
 //
-// Light Apps render in a sandboxed srcdoc iframe (`sandbox="allow-scripts"`,
-// deliberately without `allow-same-origin`), so their origin is opaque and the
+// Light Apps render in a sandboxed srcdoc iframe (`allow-scripts allow-forms
+// allow-modals`, deliberately without `allow-same-origin`), so their origin is opaque and the
 // browser refuses every persistent storage API: localStorage, sessionStorage,
 // Cookie, IndexedDB all throw SecurityError in there. Persistent state
 // (scores, collections, settings) was impossible for Light Apps.

--- a/web/src/mobile/ArtifactViewer.svelte
+++ b/web/src/mobile/ArtifactViewer.svelte
@@ -88,7 +88,8 @@
     {:else if !artifact.loaded}
       <div class="body-loading"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon></div>
     {:else if view === 'preview'}
-      <iframe srcdoc={artifact.preview} sandbox="allow-scripts" allow="clipboard-write" title={artifact.name}></iframe>
+      <!-- Sandbox flags mirror ArtifactsPanel's frames (see the comment there). -->
+      <iframe srcdoc={artifact.preview} sandbox="allow-scripts allow-forms allow-modals" allow="clipboard-write" title={artifact.name}></iframe>
     {:else}
       <pre class="code-view">{artifact.code}</pre>
     {/if}

--- a/web/src/mobile/ArtifactViewer.svelte
+++ b/web/src/mobile/ArtifactViewer.svelte
@@ -8,7 +8,7 @@
   import type { Artifact } from '../lib/types'
   import { t } from '../lib/i18n'
   import { imagePreviewError } from '../lib/artifact-actions'
-  import { hydrateArtifact } from '../lib/artifacts'
+  import { ARTIFACT_SANDBOX, hydrateArtifact } from '../lib/artifacts'
 
   let { artifact, onClose }: { artifact: Artifact; onClose: () => void } = $props()
 
@@ -88,8 +88,7 @@
     {:else if !artifact.loaded}
       <div class="body-loading"><iconify-icon icon="ant-design:loading-outlined" width="28" class="spin"></iconify-icon></div>
     {:else if view === 'preview'}
-      <!-- Sandbox flags mirror ArtifactsPanel's frames (see the comment there). -->
-      <iframe srcdoc={artifact.preview} sandbox="allow-scripts allow-forms allow-modals" allow="clipboard-write" title={artifact.name}></iframe>
+      <iframe srcdoc={artifact.preview} sandbox={ARTIFACT_SANDBOX} allow="clipboard-write" title={artifact.name}></iframe>
     {:else}
       <pre class="code-view">{artifact.code}</pre>
     {/if}


### PR DESCRIPTION
## Why

Follow-up to #2318, from probing what the `sandbox="allow-scripts"` srcdoc iframe actually swallows. Two things generated apps lean on were silently dead:

- **Forms**: without `allow-forms` the `submit` event never fires — button click, Enter in a text field, `requestSubmit()`, all of it (the spec's sandboxed-forms check runs before the event is dispatched). Any `<form onsubmit="…; return false">` handler simply never runs, and the browser only logs a console warning the user never sees.
- **Modals**: without `allow-modals`, `confirm()` returns `false`, `prompt()` returns `null`, `alert()` is a no-op. A `confirm('确定删除?')` before a destructive action can therefore never be answered yes.

Neither can be proxied through the bridge (they must return synchronously), so this is a flag change, not a shim.

## What

One exported constant `ARTIFACT_SANDBOX = 'allow-scripts allow-forms allow-modals'` (`web/src/lib/artifacts.ts`, with the reasoning in one place) used by the four srcdoc iframes: the Light App frame and the three artifact preview frames (`ArtifactsPanel`, `ArtifactModal`, mobile `ArtifactViewer`). The preview frame is where an app is exercised *before* it is saved, so it must behave identically or a `confirm()` would work only after saving. Design doc gets its own 运行沙箱 section; the prompt now tells the agent that submit handlers must `preventDefault()` — with `allow-forms` an unprevented submit navigates the frame and drops the app's state.

## What changes at the boundary — stated honestly

The origin boundary does not move: still no `allow-same-origin` (opaque origin: no storage, no cookies, no reach into the app), no `allow-popups`, no `allow-top-navigation`. Re-probed after the change in Chrome: `window.open()` → `null`, `sessionStorage`/`document.cookie` → SecurityError, `top.location` → cross-origin blocked.

What `allow-modals` does hand the document: the browser's native dialogs — `alert`/`confirm`/`prompt`, `window.print()`, and the `beforeunload` prompt. These are tab-level modals: while one is open it blocks the host UI too, and a buggy `while(true) alert()` app can pin the page until the user ticks "prevent this page from creating additional dialogs". Dialogs are attributed to the host page ("127.0.0.1:8088 says…"). Accepted trade-off: the app is one the user asked their own agent to write, and this is what every artifact sandbox in the wild grants.

## Verification

Real Chrome (headless, CDP) with the new sandbox attribute: `submit` fires for both button click and `requestSubmit()`; `confirm()`/`prompt()`/`alert()` open real dialogs (CDP observed `Page.javascriptDialogOpening` ×3) and return `true` / the typed text / normally; the blocked list above stays blocked. `svelte-check` 0 errors, `vitest` 642 passed, `go test ./internal/prompt/` ok.

Not verified: whether the desktop webview (Wails v3 beta.12, WKWebView) implements the JS dialog delegate — if it doesn't, `confirm()` stays a no-op there and this fix is browser-only. Worth one real-device click.

Isolated code review (separate agent, no session context): no Critical issues; the wording and doc-structure items it raised are in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
