### PR TITLE
chore: bump version to 1.16.9

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.8"
+var Version = "1.16.9"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over v1.16.8, 2 commits:

- #2322 — a loose session can now be filed into a project (sidebar "Move to project")
- #2323 — artifacts: external scripts/styles from an allowlist of CDN hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)