### PR TITLE
chore: bump version to 1.16.10

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.9"
+var Version = "1.16.10"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Bumps `internal/version/version.go` for the release covering #2330, #2331, #2332 (legal-helper, learning-coach, writing-partner/trip-planner expert-scoped skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)