### PR TITLE
web: scope "/" menu expert skills to the current expert

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -408,7 +408,16 @@
         .filter(({ score }) => score > 0)
         .sort((a, b) => b.score - a.score || a.cmd.name.localeCompare(b.cmd.name))
         .map(({ cmd }) => ({ kind: 'builtin', name: cmd.name, descKey: cmd.descKey, takesArgs: cmd.takesArgs }))
-      let scored = skills
+      // Skills tagged source "expert" ship bundled for a specific curated
+      // expert (see internal/skills/experts/) and are noise outside it —
+      // mirrors RenderManifest/ManifestForProfile on the server, which never
+      // shows one expert's skills to another. General ("default"/"user")
+      // skills stay visible regardless of the picked expert.
+      const visibleSkills = skills.filter(s => {
+        if (s.source !== 'expert') return true
+        return currentExpertToolSkills != null && currentExpertToolSkills.includes(s.name)
+      })
+      let scored = visibleSkills
         .map(s => ({ skill: s, score: scoreSkillMatch(s, q) }))
         .filter(({ score }) => score > 0)
       scored.sort((a, b) => b.score - a.score || a.skill.name.localeCompare(b.skill.name))
@@ -809,6 +818,12 @@
   let agentLabel = $derived.by(() => {
     if (!effectiveAgentId || effectiveAgentId === 'default') return ''
     return agents.find(a => a.id === effectiveAgentId)?.name ?? effectiveAgentId
+  })
+  // null (no expert, or an expert with no tool_skills configured) means the
+  // "/" menu shows no expert-scoped skills at all — see filteredItems.
+  let currentExpertToolSkills = $derived.by((): string[] | null => {
+    if (!effectiveAgentId || effectiveAgentId === 'default') return null
+    return agents.find(a => a.id === effectiveAgentId)?.tool_skills ?? null
   })
   async function pickAgent(id: string) {
     agentMenu = false


### PR DESCRIPTION
## Summary
- The composer's `/` slash-command menu listed every skill globally, including ones bundled exclusively for other curated experts (e.g. picking the learning-coach expert still showed the legal-helper expert's `/contract-review`).
- Filter skills tagged `source: "expert"` to the current expert's `tool_skills`, mirroring `RenderManifest`/`ManifestForProfile` on the server. General (`default`/`user`) skills and built-in commands (`/clear`, `/compact`, `/goal`, `/loop`, `/reload`) stay visible regardless of which expert is picked.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npm run build` — succeeds
- [x] Manually verified in a real browser against an isolated `octo serve` instance (own HOME dir, throwaway port): with no expert selected, `/` showed 26 general items; with the learning-coach expert selected, it showed 31 (the same 26 plus its own `tool_skills` — flashcards/exam-forecast/weak-point-drill/outline-builder/study-plan), and none of legal-helper's or copywriter's expert-only skills leaked in.
- [x] Isolated code review (subagent) — no Critical/blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)