### PR TITLE
web: scope "/" menu strictly to the picked expert's tool_skills

### DIFF
--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -408,15 +408,16 @@
         .filter(({ score }) => score > 0)
         .sort((a, b) => b.score - a.score || a.cmd.name.localeCompare(b.cmd.name))
         .map(({ cmd }) => ({ kind: 'builtin', name: cmd.name, descKey: cmd.descKey, takesArgs: cmd.takesArgs }))
-      // Skills tagged source "expert" ship bundled for a specific curated
-      // expert (see internal/skills/experts/) and are noise outside it —
-      // mirrors RenderManifest/ManifestForProfile on the server, which never
-      // shows one expert's skills to another. General ("default"/"user")
-      // skills stay visible regardless of the picked expert.
-      const visibleSkills = skills.filter(s => {
-        if (s.source !== 'expert') return true
-        return currentExpertToolSkills != null && currentExpertToolSkills.includes(s.name)
-      })
+      // Mirrors RenderManifest/ManifestForProfile on the server: with no
+      // expert picked, every skill except one bundled for a specific curated
+      // expert (source "expert") is fair game — same as the Default Agent's
+      // own manifest. Once an expert is picked, only its own tool_skills
+      // show, general ("default"/"user") skills included — an expert with no
+      // tool_skills configured sees none at all, same as the server showing
+      // it an empty manifest rather than falling back to "everything".
+      const visibleSkills = currentExpertToolSkills != null
+        ? skills.filter(s => currentExpertToolSkills!.includes(s.name))
+        : skills.filter(s => s.source !== 'expert')
       let scored = visibleSkills
         .map(s => ({ skill: s, score: scoreSkillMatch(s, q) }))
         .filter(({ score }) => score > 0)
@@ -819,11 +820,13 @@
     if (!effectiveAgentId || effectiveAgentId === 'default') return ''
     return agents.find(a => a.id === effectiveAgentId)?.name ?? effectiveAgentId
   })
-  // null (no expert, or an expert with no tool_skills configured) means the
-  // "/" menu shows no expert-scoped skills at all — see filteredItems.
+  // null means "no expert" — the "/" menu falls back to every general skill.
+  // A non-null array (empty or not) means an expert IS picked, so the menu
+  // shows only its own tool_skills, however few — including while `agents`
+  // hasn't loaded yet, which must not read as "no expert" (see filteredItems).
   let currentExpertToolSkills = $derived.by((): string[] | null => {
     if (!effectiveAgentId || effectiveAgentId === 'default') return null
-    return agents.find(a => a.id === effectiveAgentId)?.tool_skills ?? null
+    return agents.find(a => a.id === effectiveAgentId)?.tool_skills ?? []
   })
   async function pickAgent(id: string) {
     agentMenu = false


### PR DESCRIPTION
## Summary
- Follow-up to #2334: that fix only hid *other* experts' skills, but every general (`default`/`user`-source) skill still showed regardless of which expert was picked — e.g. picking legal-helper still surfaced dev-tooling skills like `/skill-creator`, `/tech-design`, `/workflow-creator` that legal-helper never opted into.
- Once an expert is picked, the `/` menu now shows only its own `tool_skills` (general skills it opted into included, e.g. legal-helper's own `deep-research`/`web-access`), matching `ManifestForProfile`'s strict allow-list on the server. With no expert picked, it still falls back to every non-`expert`-source skill, matching `RenderManifest`.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npm run build` — succeeds
- [x] Manually verified in a real browser against an isolated `octo serve` instance: learning-coach shows 12 items (5 builtins + its own 7 tool_skills), legal-helper shows 13 (5 builtins + its own 8 tool_skills, no more `/skill-creator` etc.), no-expert baseline unchanged at 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)