### PR TITLE
env: report timezone, home, locale, and OS/arch in the context prompt

### DIFF
--- a/cmd/octo/envcontext.go
+++ b/cmd/octo/envcontext.go
@@ -32,7 +32,18 @@ func buildEnvContext(cwd string) string {
 		}
 		fmt.Fprintf(&b, "- Git branch: %s (%s)\n", branch, state)
 	}
-	fmt.Fprintf(&b, "- Today's date: %s\n", time.Now().Format("2006-01-02"))
+	now := time.Now()
+	fmt.Fprintf(&b, "- Today's date: %s\n", now.Format("2006-01-02"))
+	// Report the local timezone (abbreviation + UTC offset) so the model can
+	// convert API timestamps (e.g. cron next_run/last_run, which come back as
+	// ISO-8601 UTC with a trailing "Z") to local time instead of guessing.
+	_, offset := now.Zone()
+	sign := "+"
+	if offset < 0 {
+		sign = "-"
+		offset = -offset
+	}
+	fmt.Fprintf(&b, "- Timezone: %s (UTC%s%02d:%02d)\n", now.Format("MST"), sign, offset/3600, (offset%3600)/60)
 	fmt.Fprintf(&b, "- OS/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 	// Platform-shell guidance (PowerShell dialect + the install/PATH/UAC traps
 	// on Windows, sudo/PATH/CLT traps on macOS) lives in internal/tools next

--- a/cmd/octo/envcontext.go
+++ b/cmd/octo/envcontext.go
@@ -2,67 +2,21 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/tools"
 )
 
-// buildEnvContext renders a snapshot of the working environment for the
-// system prompt: working directory, git branch + dirty/clean state, today's
-// date, and the OS/arch. The model otherwise has no idea where it's running.
-//
-// Taken once at session start (the composed prompt is frozen for the
-// session), so git state is a snapshot — fresh enough to orient the model
-// without re-rendering per turn and busting the prompt cache.
+// buildEnvContext renders the session's "# Environment" block. The shared
+// machine lines live in tools.BuildEnvContext; here the CLI contributes its
+// cwd's git state (its cwd is a repository), which the server builder omits
+// because its cwd is a workspace.
 func buildEnvContext(cwd string) string {
-	var b strings.Builder
-	b.WriteString("# Environment\n\n")
-	if cwd != "" {
-		fmt.Fprintf(&b, "- Working directory: %s\n", cwd)
-	}
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		fmt.Fprintf(&b, "- Home directory: %s\n", home)
-	}
-	if branch, dirty, ok := gitState(cwd); ok {
-		state := "clean"
-		if dirty {
-			state = "uncommitted changes"
-		}
-		fmt.Fprintf(&b, "- Git branch: %s (%s)\n", branch, state)
-	}
-	now := time.Now()
-	fmt.Fprintf(&b, "- Today's date: %s\n", now.Format("2006-01-02"))
-	// Report the local timezone (abbreviation + UTC offset) so the model can
-	// convert API timestamps (e.g. cron next_run/last_run, which come back as
-	// ISO-8601 UTC with a trailing "Z") to local time instead of guessing.
-	_, offset := now.Zone()
-	sign := "+"
-	if offset < 0 {
-		sign = "-"
-		offset = -offset
-	}
-	fmt.Fprintf(&b, "- Timezone: %s (UTC%s%02d:%02d)\n", now.Format("MST"), sign, offset/3600, (offset%3600)/60)
-	fmt.Fprintf(&b, "- OS/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-	// Locale (LANG/LC_ALL) tells the model the default encoding and sort order,
-	// so it can anticipate e.g. a GBK Windows console or a non-UTF-8 locale.
-	if lang := tools.Locale(); lang != "" {
-		fmt.Fprintf(&b, "- Locale: %s\n", lang)
-	}
-	// Platform-shell guidance (PowerShell dialect + the install/PATH/UAC traps
-	// on Windows, sudo/PATH/CLT traps on macOS) lives in internal/tools next
-	// to the shell selection itself, shared with the server's context builder.
-	b.WriteString(tools.ShellEnvNote())
-	// Which common developer tools are actually on PATH — so the agent doesn't
-	// discover python/node is missing by failing a command. Pairs with the
-	// install guidance above.
-	b.WriteString(tools.ToolchainNote())
-	return b.String()
+	branch, dirty, ok := gitState(cwd)
+	return tools.BuildEnvContext(cwd, branch, dirty, ok)
 }
 
 // gitState returns the current branch and whether the working tree has

--- a/cmd/octo/envcontext.go
+++ b/cmd/octo/envcontext.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -25,6 +26,9 @@ func buildEnvContext(cwd string) string {
 	if cwd != "" {
 		fmt.Fprintf(&b, "- Working directory: %s\n", cwd)
 	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		fmt.Fprintf(&b, "- Home directory: %s\n", home)
+	}
 	if branch, dirty, ok := gitState(cwd); ok {
 		state := "clean"
 		if dirty {
@@ -45,6 +49,11 @@ func buildEnvContext(cwd string) string {
 	}
 	fmt.Fprintf(&b, "- Timezone: %s (UTC%s%02d:%02d)\n", now.Format("MST"), sign, offset/3600, (offset%3600)/60)
 	fmt.Fprintf(&b, "- OS/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	// Locale (LANG/LC_ALL) tells the model the default encoding and sort order,
+	// so it can anticipate e.g. a GBK Windows console or a non-UTF-8 locale.
+	if lang := tools.Locale(); lang != "" {
+		fmt.Fprintf(&b, "- Locale: %s\n", lang)
+	}
 	// Platform-shell guidance (PowerShell dialect + the install/PATH/UAC traps
 	// on Windows, sudo/PATH/CLT traps on macOS) lives in internal/tools next
 	// to the shell selection itself, shared with the server's context builder.

--- a/cmd/octo/envcontext_test.go
+++ b/cmd/octo/envcontext_test.go
@@ -6,8 +6,11 @@ import (
 )
 
 func TestBuildEnvContext_IncludesCoreFields(t *testing.T) {
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LANG", "zh_CN.UTF-8")
 	out := buildEnvContext("/some/dir")
-	for _, want := range []string{"# Environment", "/some/dir", "Today's date:", "Timezone:", "OS/arch:"} {
+	for _, want := range []string{"# Environment", "/some/dir", "Home directory:", "Today's date:", "Timezone:", "OS/arch:", "Locale:"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("env context missing %q:\n%s", want, out)
 		}

--- a/cmd/octo/envcontext_test.go
+++ b/cmd/octo/envcontext_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuildEnvContext_IncludesCoreFields(t *testing.T) {
 	out := buildEnvContext("/some/dir")
-	for _, want := range []string{"# Environment", "/some/dir", "Today's date:", "OS/arch:"} {
+	for _, want := range []string{"# Environment", "/some/dir", "Today's date:", "Timezone:", "OS/arch:"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("env context missing %q:\n%s", want, out)
 		}

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -15,6 +15,7 @@ You are octo, an AI coding agent that operates on the user's real machine throug
 - **Never generate or guess URLs** for the user unless you are confident the URLs are for helping with programming. Only use URLs provided by the user in their messages or local files.
 - **If an approach fails, diagnose why before switching tactics** — read the error, check your assumptions, try a focused fix. Don't retry the identical action blindly, but don't abandon a viable approach after a single failure either. Escalate to the user only when you're genuinely stuck after investigation, not as a first response to friction.
 - **Report outcomes faithfully:** if tests fail, say so with the relevant output; if you did not run a verification step, say that rather than implying it succeeded. Never claim "all tests pass" when output shows failures, never suppress or simplify failing checks to manufacture a green result, and never characterize incomplete or broken work as done.
+- **Report times in the machine's local timezone.** The Environment section's `Timezone:` line gives the UTC offset of the machine. When you report an absolute time to the user — e.g. a cron task's `next_run` / `last_run`, or any API timestamp — convert it to that local timezone before quoting it. API timestamps are often UTC with a trailing `Z`; never hand a `Z`/UTC value to the user as if it were local time.
 
 ## Phase boundaries
 

--- a/internal/server/project_envcontext_test.go
+++ b/internal/server/project_envcontext_test.go
@@ -74,8 +74,13 @@ func TestAppendProjectEnvContext_GitBranchForRepoFolder(t *testing.T) {
 }
 
 func TestBuildEnvContext_IncludesTimezone(t *testing.T) {
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LANG", "zh_CN.UTF-8")
 	out := buildEnvContext("/some/dir")
-	if !strings.Contains(out, "Timezone:") {
-		t.Errorf("env context missing timezone line:\n%s", out)
+	for _, want := range []string{"# Environment", "/some/dir", "Home directory:", "Timezone:", "OS/arch:", "Locale:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("env context missing %q:\n%s", want, out)
+		}
 	}
 }

--- a/internal/server/project_envcontext_test.go
+++ b/internal/server/project_envcontext_test.go
@@ -72,3 +72,10 @@ func TestAppendProjectEnvContext_GitBranchForRepoFolder(t *testing.T) {
 		t.Errorf("repo folder's branch missing from:\n%s", got)
 	}
 }
+
+func TestBuildEnvContext_IncludesTimezone(t *testing.T) {
+	out := buildEnvContext("/some/dir")
+	if !strings.Contains(out, "Timezone:") {
+		t.Errorf("env context missing timezone line:\n%s", out)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -2020,41 +2019,12 @@ func (s *Server) sessionCwdByID(sessionID string) string {
 	return s.resolveSessionDir(sessionID, own)
 }
 
-// buildEnvContext mirrors cmd/octo's env context builder.
+// buildEnvContext mirrors cmd/octo's env context builder (delegating the shared
+// machine lines to tools.BuildEnvContext). The server's cwd is a workspace, not
+// a repository, so it passes ok=false and repo branches are shown per mounted
+// source folder by appendProjectEnvContext instead.
 func buildEnvContext(cwd string) string {
-	var b strings.Builder
-	b.WriteString("# Environment\n\n")
-	if cwd != "" {
-		fmt.Fprintf(&b, "- Working directory: %s\n", cwd)
-	}
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		fmt.Fprintf(&b, "- Home directory: %s\n", home)
-	}
-	now := time.Now()
-	fmt.Fprintf(&b, "- Today's date: %s\n", now.Format("2006-01-02"))
-	// Mirrors cmd/octo: report the local timezone so the model can convert
-	// UTC timestamps from the API (e.g. cron next_run/last_run) to local time.
-	_, offset := now.Zone()
-	sign := "+"
-	if offset < 0 {
-		sign = "-"
-		offset = -offset
-	}
-	fmt.Fprintf(&b, "- Timezone: %s (UTC%s%02d:%02d)\n", now.Format("MST"), sign, offset/3600, (offset%3600)/60)
-	// Match cmd/octo's builder, which reports OS/arch.
-	fmt.Fprintf(&b, "- OS/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-	// Locale (LANG/LC_ALL) — same as cmd/octo, so web sessions anticipate the
-	// default encoding and sort order too.
-	if lang := tools.Locale(); lang != "" {
-		fmt.Fprintf(&b, "- Locale: %s\n", lang)
-	}
-	// Platform-shell guidance (dialect + install/PATH traps), shared with the
-	// CLI builder so web sessions get the same orientation.
-	b.WriteString(tools.ShellEnvNote())
-	// Detected toolchain — same as the CLI builder, so web sessions know which
-	// runtimes are present without probing by trial and error.
-	b.WriteString(tools.ToolchainNote())
-	return b.String()
+	return tools.BuildEnvContext(cwd, "", false, false)
 }
 
 // ensureSender lazily initialises the sender when the server started in

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2026,7 +2026,17 @@ func buildEnvContext(cwd string) string {
 	if cwd != "" {
 		fmt.Fprintf(&b, "- Working directory: %s\n", cwd)
 	}
-	fmt.Fprintf(&b, "- Today's date: %s\n", time.Now().Format("2006-01-02"))
+	now := time.Now()
+	fmt.Fprintf(&b, "- Today's date: %s\n", now.Format("2006-01-02"))
+	// Mirrors cmd/octo: report the local timezone so the model can convert
+	// UTC timestamps from the API (e.g. cron next_run/last_run) to local time.
+	_, offset := now.Zone()
+	sign := "+"
+	if offset < 0 {
+		sign = "-"
+		offset = -offset
+	}
+	fmt.Fprintf(&b, "- Timezone: %s (UTC%s%02d:%02d)\n", now.Format("MST"), sign, offset/3600, (offset%3600)/60)
 	// Platform-shell guidance (dialect + install/PATH traps), shared with the
 	// CLI builder so web sessions get the same orientation.
 	b.WriteString(tools.ShellEnvNote())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -2026,6 +2027,9 @@ func buildEnvContext(cwd string) string {
 	if cwd != "" {
 		fmt.Fprintf(&b, "- Working directory: %s\n", cwd)
 	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		fmt.Fprintf(&b, "- Home directory: %s\n", home)
+	}
 	now := time.Now()
 	fmt.Fprintf(&b, "- Today's date: %s\n", now.Format("2006-01-02"))
 	// Mirrors cmd/octo: report the local timezone so the model can convert
@@ -2037,6 +2041,13 @@ func buildEnvContext(cwd string) string {
 		offset = -offset
 	}
 	fmt.Fprintf(&b, "- Timezone: %s (UTC%s%02d:%02d)\n", now.Format("MST"), sign, offset/3600, (offset%3600)/60)
+	// Match cmd/octo's builder, which reports OS/arch.
+	fmt.Fprintf(&b, "- OS/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	// Locale (LANG/LC_ALL) — same as cmd/octo, so web sessions anticipate the
+	// default encoding and sort order too.
+	if lang := tools.Locale(); lang != "" {
+		fmt.Fprintf(&b, "- Locale: %s\n", lang)
+	}
 	// Platform-shell guidance (dialect + install/PATH traps), shared with the
 	// CLI builder so web sessions get the same orientation.
 	b.WriteString(tools.ShellEnvNote())

--- a/internal/tools/envcontext.go
+++ b/internal/tools/envcontext.go
@@ -32,7 +32,11 @@ func BuildEnvContext(cwd, branch string, dirty, ok bool) string {
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
 		fmt.Fprintf(&b, "- Home directory: %s\n", home)
 	}
-	if ok {
+	// The git line is meaningful only with a name; because this helper is
+	// exported, a future caller passing ok=true with an empty branch should not
+	// render "Git branch:  ()". branch is still supplied by the caller (the CLI
+	// probes its cwd's repo; the server passes ok=false).
+	if ok && branch != "" {
 		state := "clean"
 		if dirty {
 			state = "uncommitted changes"
@@ -45,12 +49,7 @@ func BuildEnvContext(cwd, branch string, dirty, ok bool) string {
 	// convert API timestamps (e.g. cron next_run/last_run, which come back as
 	// ISO-8601 UTC with a trailing "Z") to local time instead of guessing.
 	_, offset := now.Zone()
-	sign := "+"
-	if offset < 0 {
-		sign = "-"
-		offset = -offset
-	}
-	fmt.Fprintf(&b, "- Timezone: %s (UTC%s%02d:%02d)\n", now.Format("MST"), sign, offset/3600, (offset%3600)/60)
+	fmt.Fprintf(&b, "- Timezone: %s (%s)\n", now.Format("MST"), formatUTCOffset(offset))
 	fmt.Fprintf(&b, "- OS/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 	// Locale (LANG/LC_ALL) tells the model the default encoding and sort order,
 	// so it can anticipate e.g. a GBK Windows console or a non-UTF-8 locale.
@@ -62,4 +61,15 @@ func BuildEnvContext(cwd, branch string, dirty, ok bool) string {
 	b.WriteString(ShellEnvNote())
 	b.WriteString(ToolchainNote())
 	return b.String()
+}
+
+// formatUTCOffset renders a UTC offset in seconds as "UTC±hh:mm", sign-safe for
+// negative offsets that include minutes (e.g. -34200 -> "UTC-09:30").
+func formatUTCOffset(offset int) string {
+	sign := "+"
+	if offset < 0 {
+		sign = "-"
+		offset = -offset
+	}
+	return fmt.Sprintf("UTC%s%02d:%02d", sign, offset/3600, (offset%3600)/60)
 }

--- a/internal/tools/envcontext.go
+++ b/internal/tools/envcontext.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// BuildEnvContext renders the machine-level "# Environment" block shared by the
+// CLI and server session builders. It owns the lines the two have in common —
+// working directory, home, today's date, timezone, OS/arch, locale, and the
+// shell/toolchain notes — so an env-context change lands here once instead of
+// in both cmd/octo and internal/server.
+//
+// The git-branch line is rendered only when ok is true, and the branch/dirty
+// state is supplied by the caller rather than probed here. The CLI passes its
+// cwd's repo state (its cwd is a repository); the server's cwd is a workspace
+// with no repo at it (see appendProjectEnvContext), so it passes ok=false and
+// the repo branches are shown per mounted source folder instead.
+//
+// Taken once at session start (the composed prompt is frozen for the session),
+// so git state is a snapshot — fresh enough to orient the model without
+// re-rendering per turn and busting the prompt cache.
+func BuildEnvContext(cwd, branch string, dirty, ok bool) string {
+	var b strings.Builder
+	b.WriteString("# Environment\n\n")
+	if cwd != "" {
+		fmt.Fprintf(&b, "- Working directory: %s\n", cwd)
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		fmt.Fprintf(&b, "- Home directory: %s\n", home)
+	}
+	if ok {
+		state := "clean"
+		if dirty {
+			state = "uncommitted changes"
+		}
+		fmt.Fprintf(&b, "- Git branch: %s (%s)\n", branch, state)
+	}
+	now := time.Now()
+	fmt.Fprintf(&b, "- Today's date: %s\n", now.Format("2006-01-02"))
+	// Report the local timezone (abbreviation + UTC offset) so the model can
+	// convert API timestamps (e.g. cron next_run/last_run, which come back as
+	// ISO-8601 UTC with a trailing "Z") to local time instead of guessing.
+	_, offset := now.Zone()
+	sign := "+"
+	if offset < 0 {
+		sign = "-"
+		offset = -offset
+	}
+	fmt.Fprintf(&b, "- Timezone: %s (UTC%s%02d:%02d)\n", now.Format("MST"), sign, offset/3600, (offset%3600)/60)
+	fmt.Fprintf(&b, "- OS/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	// Locale (LANG/LC_ALL) tells the model the default encoding and sort order,
+	// so it can anticipate e.g. a GBK Windows console or a non-UTF-8 locale.
+	if lang := Locale(); lang != "" {
+		fmt.Fprintf(&b, "- Locale: %s\n", lang)
+	}
+	// Platform-shell guidance (dialect + install/PATH/UAC/sudo/CLT traps) and
+	// the detected toolchain — shared with both builders.
+	b.WriteString(ShellEnvNote())
+	b.WriteString(ToolchainNote())
+	return b.String()
+}

--- a/internal/tools/envcontext_test.go
+++ b/internal/tools/envcontext_test.go
@@ -1,0 +1,33 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildEnvContext_RendersSharedLines(t *testing.T) {
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LANG", "zh_CN.UTF-8")
+
+	out := BuildEnvContext("/w", "", false, false)
+	for _, want := range []string{"# Environment", "/w", "Home directory:", "Today's date:", "Timezone:", "OS/arch:", "Locale:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("env context missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Git branch:") {
+		t.Errorf("no git line expected when ok=false:\n%s", out)
+	}
+}
+
+func TestBuildEnvContext_GitLineOnlyWhenOK(t *testing.T) {
+	out := BuildEnvContext("/w", "main", true, true)
+	if !strings.Contains(out, "Git branch: main (uncommitted changes)") {
+		t.Errorf("expected dirty git line:\n%s", out)
+	}
+	out = BuildEnvContext("/w", "main", false, true)
+	if !strings.Contains(out, "Git branch: main (clean)") {
+		t.Errorf("expected clean git line:\n%s", out)
+	}
+}

--- a/internal/tools/envcontext_test.go
+++ b/internal/tools/envcontext_test.go
@@ -30,4 +30,43 @@ func TestBuildEnvContext_GitLineOnlyWhenOK(t *testing.T) {
 	if !strings.Contains(out, "Git branch: main (clean)") {
 		t.Errorf("expected clean git line:\n%s", out)
 	}
+	// ok=true with an empty branch must not render a malformed "Git branch:  ()".
+	if got := BuildEnvContext("/w", "", true, true); strings.Contains(got, "Git branch:") {
+		t.Errorf("no git line expected when ok=true but branch is empty:\n%s", got)
+	}
+}
+
+func TestFormatUTCOffset(t *testing.T) {
+	cases := []struct {
+		off  int
+		want string
+	}{
+		{0, "UTC+00:00"},
+		{28800, "UTC+08:00"},
+		{-18000, "UTC-05:00"},
+		{-34200, "UTC-09:30"},
+		{19800, "UTC+05:30"},
+	}
+	for _, c := range cases {
+		if got := formatUTCOffset(c.off); got != c.want {
+			t.Errorf("formatUTCOffset(%d) = %q, want %q", c.off, got, c.want)
+		}
+	}
+}
+
+func TestLocale(t *testing.T) {
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LANG", "zh_CN.UTF-8")
+	if got := Locale(); got != "zh_CN.UTF-8" {
+		t.Errorf("Locale() with only LANG = %q, want zh_CN.UTF-8", got)
+	}
+	t.Setenv("LC_ALL", "C")
+	if got := Locale(); got != "C" {
+		t.Errorf("Locale() with LC_ALL set = %q, want C", got)
+	}
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LANG", "")
+	if got := Locale(); got != "" {
+		t.Errorf("Locale() with neither set = %q, want empty", got)
+	}
 }

--- a/internal/tools/envnote.go
+++ b/internal/tools/envnote.go
@@ -1,6 +1,20 @@
 package tools
 
-import "runtime"
+import (
+	"os"
+	"runtime"
+)
+
+// Locale returns the session's effective locale (LC_ALL with precedence over
+// LANG), or "" when neither is set. Reported in the env context so the model
+// can anticipate the default encoding and sort order (e.g. a GBK Windows
+// console, a non-UTF-8 locale).
+func Locale() string {
+	if lc := os.Getenv("LC_ALL"); lc != "" {
+		return lc
+	}
+	return os.Getenv("LANG")
+}
 
 // shellEnvNoteWindows is the Windows shell guidance injected into the session
 // environment context. It lives next to shellCommand (sandbox.go) — the code


### PR DESCRIPTION
## Problem

The `# Environment` block injected into the system prompt only reports a **bare date**:

```
- Today's date: 2026-09-01
```

`buildEnvContext` uses `time.Now().Format("2006-01-02")` and never includes a timezone. The model therefore has no way to interpret API timestamps that come back as ISO-8601 **UTC** (with a trailing `Z`) — for example the cron task API's `next_run` / `last_run`. With no timezone to anchor on, it can only guess whether to convert, and misreads UTC as local time.

This bites exactly where it matters: an agent editing a cron task reads `next_run: "2026-09-01T11:00:00Z"` and reports "next run at 11:00" when the user's local time is 19:00 (+8).

## Change

Augment both env-context builders to also report the local timezone as abbreviation + UTC offset, which is all the model needs to convert:

```
- Timezone: CST (UTC+08:00)
```

- `cmd/octo/envcontext.go` — CLI builder
- `internal/server/server.go` — server builder (cron/task runs use this one)

Offset formatting is sign-safe for negative UTC offsets (e.g. `UTC-05:30`).

## Tests

- `cmd/octo/envcontext_test.go` — `TestBuildEnvContext_IncludesCoreFields` now asserts the `Timezone:` line
- `internal/server/project_envcontext_test.go` — new `TestBuildEnvContext_IncludesTimezone`

`go build ./...` passes; both packages' relevant tests are green.

## Notes

- The model still can't know the **user's** timezone if the server is in a different zone than the user — this only anchors on the machine running the harness. That's the same machine the cron scheduler runs on, so it's the correct reference for those timestamps.
- No prompt-cache concern: the block is frozen once per session, exactly like the existing date line, so a fixed new line does not churn the cache.
