### PR TITLE
chore: bump version to 1.16.11

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.10"
+var Version = "1.16.11"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## What
Bump the version string for the 1.16.11 patch release.

## Why
Ships #2338 (mobile sidebar width / header button visibility fixes).

## User-visible impact
None beyond the fixes already merged in #2338.