### PR TITLE
web+server: fix phantom unread dot after a desktop quit

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -102,8 +102,21 @@ type Session struct {
 	// the system-prompt/tools overhead. 0 for sessions predating this field or
 	// that never completed a turn with a real token count. Updated once per turn
 	// via SetLastContextTokens.
-	LastContextTokens int       `json:"last_context_tokens,omitempty"`
-	Messages          []Message `json:"messages"`
+	LastContextTokens int `json:"last_context_tokens,omitempty"`
+	// ContentUpdatedAt is when the transcript itself last changed (a message
+	// appended, truncated, or rewritten) — deliberately distinct from the
+	// session file's OS mtime, which also moves on every binding/lease
+	// bookkeeping write (acquire/release around a turn, the idle-steer
+	// check that runs even when nothing is queued). Those churn the file
+	// seconds — or, per the post-turn cleanup, milliseconds — after the
+	// reply the client just marked "seen" against, which used to make the
+	// sidebar's unread watermark compare against a moving target that had
+	// nothing to do with new content. toSessionItem reports this instead of
+	// a raw file stat; Save only advances it when the message count actually
+	// changes. Zero for sessions predating this field until their next real
+	// content write — toSessionItem falls back to the file mtime then.
+	ContentUpdatedAt time.Time `json:"content_updated_at,omitempty"`
+	Messages         []Message `json:"messages"`
 
 	// Dir overrides the default ~/.octo/sessions location. Empty means use the
 	// default. Not serialized — it's a runtime override.
@@ -116,8 +129,18 @@ type Session struct {
 	// forceRewrite is set when SyncFrom observes that the source History was
 	// rewritten (compaction, repair, popLast): the on-disk prefix may no
 	// longer match Messages, so the next Save must rewrite the whole file.
-	// Cleared by a successful rewriteAll. Not serialized.
+	// Cleared by a successful rewriteAll. Not serialized. Also set, for
+	// unrelated reasons, by Bind/Unbind/MarkHookStarted and a dropped-tail
+	// load — none of those imply new content, which is why Save doesn't use
+	// this flag to decide whether to advance ContentUpdatedAt.
 	forceRewrite bool
+
+	// rewriteIsContent is set alongside forceRewrite specifically for the
+	// SyncFrom compaction/repair/popLast case above: a same-length history
+	// rewrite changes what the messages say without changing len(Messages),
+	// the signal Save otherwise uses to detect new content. Cleared with
+	// forceRewrite by a successful rewriteAll. Not serialized.
+	rewriteIsContent bool
 
 	// mu guards runtime binding state (BoundEntry, InFlight) and is not
 	// serialized. Session methods that mutate bound state are goroutine-safe;
@@ -556,7 +579,7 @@ func (s *Session) ChunkDir() (string, error) {
 // type as authoritative; rewriteAll folds them back into the meta header when
 // compacting.
 type sessionRecord struct {
-	Type                  string    `json:"type"` // "meta" | "message" | "title" | "model_config" | "agent_id" | "working_dir" | "permission_mode" | "context_tokens" | "composed_system" | "lease" | "goal"
+	Type                  string    `json:"type"` // "meta" | "message" | "title" | "model_config" | "agent_id" | "working_dir" | "permission_mode" | "context_tokens" | "content_updated_at" | "composed_system" | "lease" | "goal"
 	ID                    string    `json:"id,omitempty"`
 	CreatedAt             time.Time `json:"created_at,omitempty"`
 	Model                 string    `json:"model,omitempty"`
@@ -579,6 +602,7 @@ type sessionRecord struct {
 	HookStarted           bool      `json:"hook_started,omitempty"`
 	BranchedFrom          string    `json:"branched_from,omitempty"`
 	LastContextTokens     int       `json:"last_context_tokens,omitempty"`
+	ContentUpdatedAt      time.Time `json:"content_updated_at,omitempty"`
 	Message               *Message  `json:"message,omitempty"`
 	Goal                  *Goal     `json:"goal,omitempty"`
 }
@@ -595,7 +619,7 @@ func (s *Session) metaRecord() sessionRecord {
 		goal = &g
 	}
 	s.mu.Unlock()
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, ComposedSystem: s.ComposedSystem, ComposedLeanSystem: s.ComposedLeanSystem, ComposedForModel: s.ComposedForModel, ComposedForCWD: s.ComposedForCWD, ComposedForSourceDirs: s.ComposedForSourceDirs, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, AgentID: s.AgentID, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, ComposedSystem: s.ComposedSystem, ComposedLeanSystem: s.ComposedLeanSystem, ComposedForModel: s.ComposedForModel, ComposedForCWD: s.ComposedForCWD, ComposedForSourceDirs: s.ComposedForSourceDirs, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, AgentID: s.AgentID, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, ContentUpdatedAt: s.ContentUpdatedAt, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, BranchedFrom: s.BranchedFrom, Goal: goal}
 }
 
 // MarkHookStarted records that SessionStart has fired for this session, so a
@@ -628,12 +652,23 @@ func messageRecord(m Message) sessionRecord {
 // server persists mid-turn progress on every agent event) don't touch the
 // file at all between rounds.
 func (s *Session) Save() error {
+	// Whether the message list itself is changing — as opposed to a rewrite
+	// forced by binding/lease/meta bookkeeping (Bind/Unbind, MarkHookStarted,
+	// SetWorkingDir, ...) on an otherwise-unchanged transcript. rewriteIsContent
+	// covers the one case a length check alone can't see: a same-length
+	// compaction/repair rewrite from SyncFrom. Only a real content change
+	// advances ContentUpdatedAt; see its doc comment.
+	contentChanged := len(s.Messages) != s.persisted || s.rewriteIsContent
 	if s.forceRewrite || s.persisted == 0 || len(s.Messages) < s.persisted {
+		if contentChanged {
+			s.ContentUpdatedAt = time.Now()
+		}
 		return s.rewriteAll()
 	}
 	if len(s.Messages) == s.persisted {
 		return nil
 	}
+	s.ContentUpdatedAt = time.Now()
 	return s.appendDelta()
 }
 
@@ -677,6 +712,7 @@ func (s *Session) rewriteAll() error {
 	}
 	s.persisted = len(s.Messages)
 	s.forceRewrite = false
+	s.rewriteIsContent = false
 	return nil
 }
 
@@ -698,6 +734,16 @@ func (s *Session) appendDelta() error {
 		if err := enc.Encode(messageRecord(m)); err != nil {
 			return fmt.Errorf("session: append message: %w", err)
 		}
+	}
+	// appendDelta never rewrites the meta line, so ContentUpdatedAt (set by
+	// Save just before this call) needs its own append-only record — the
+	// same "last one wins" pattern as title/lease/context_tokens — or a
+	// reload between now and this session's next full rewriteAll (the
+	// binding acquire/release around every turn does exactly that) would see
+	// a stale or zero value and reintroduce the phantom-unread-dot bug this
+	// field exists to fix.
+	if err := enc.Encode(sessionRecord{Type: "content_updated_at", ContentUpdatedAt: s.ContentUpdatedAt}); err != nil {
+		return fmt.Errorf("session: append content_updated_at: %w", err)
 	}
 	if err := w.Flush(); err != nil {
 		return fmt.Errorf("session: flush %s: %w", path, err)
@@ -1375,6 +1421,7 @@ func LoadSession(id string) (*Session, error) {
 			s.WorkingDir = rec.WorkingDir
 			s.PermissionMode = rec.PermissionMode
 			s.LastContextTokens = rec.LastContextTokens // a rewritten file carries it in its meta header
+			s.ContentUpdatedAt = rec.ContentUpdatedAt   // a rewritten file carries it in its meta header
 			s.BoundEntry = rec.BoundEntry
 			s.BoundAt = rec.BoundAt
 			s.HookStarted = rec.HookStarted
@@ -1396,6 +1443,8 @@ func LoadSession(id string) (*Session, error) {
 			s.PermissionMode = rec.PermissionMode // last one wins, like title
 		case "context_tokens":
 			s.LastContextTokens = rec.LastContextTokens // last one wins, like title
+		case "content_updated_at":
+			s.ContentUpdatedAt = rec.ContentUpdatedAt // last one wins, like title — appendDelta's own record
 		case "composed_system":
 			// Last one wins — a mid-session model switch or a retargeted
 			// working directory each append a new record.
@@ -1724,5 +1773,6 @@ func (s *Session) SyncFrom(h *History) {
 	s.Messages = h.Snapshot()
 	if h.takeRewriteDirty() {
 		s.forceRewrite = true
+		s.rewriteIsContent = true
 	}
 }

--- a/internal/agent/session_persist_test.go
+++ b/internal/agent/session_persist_test.go
@@ -186,6 +186,163 @@ func TestSessionBoundRoundTrip(t *testing.T) {
 	}
 }
 
+// TestContentUpdatedAt_AdvancesOnRealContent checks that Save stamps
+// ContentUpdatedAt when new messages are actually persisted — the case the
+// sidebar's unread dot cares about.
+func TestContentUpdatedAt_AdvancesOnRealContent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	if !sess.ContentUpdatedAt.IsZero() {
+		t.Fatal("ContentUpdatedAt should start zero")
+	}
+	sess.Messages = []Message{NewUserMessage("hello")}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	first := sess.ContentUpdatedAt
+	if first.IsZero() {
+		t.Fatal("ContentUpdatedAt not stamped by a real content save")
+	}
+
+	sess.Messages = append(sess.Messages, NewAssistantMessage("hi"))
+	if err := sess.Save(); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	if !sess.ContentUpdatedAt.After(first) {
+		t.Fatalf("ContentUpdatedAt did not advance on a second content save: %v -> %v", first, sess.ContentUpdatedAt)
+	}
+}
+
+// TestContentUpdatedAt_SurvivesAppendDeltaReload is the actual regression
+// case: an existing, already-saved session's second message goes through
+// appendDelta, not rewriteAll — appendDelta never rewrites the meta line, so
+// ContentUpdatedAt needs its own append-only record or a reload right after
+// (the binding acquire/release around every turn does exactly that) sees the
+// stale value the first rewriteAll wrote, not the appendDelta save that just
+// happened.
+func TestContentUpdatedAt_SurvivesAppendDeltaReload(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	sess.Messages = []Message{NewUserMessage("hello")}
+	if err := sess.Save(); err != nil { // first save: persisted==0, goes through rewriteAll
+		t.Fatalf("save: %v", err)
+	}
+
+	sess.Messages = append(sess.Messages, NewAssistantMessage("hi"))
+	if err := sess.Save(); err != nil { // second save: goes through appendDelta
+		t.Fatalf("second save: %v", err)
+	}
+	want := sess.ContentUpdatedAt
+	if want.IsZero() {
+		t.Fatal("ContentUpdatedAt not stamped by the appendDelta save")
+	}
+
+	reloaded, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reloaded.ContentUpdatedAt.Equal(want) {
+		t.Fatalf("ContentUpdatedAt after reload = %v, want %v (appendDelta's write was lost)", reloaded.ContentUpdatedAt, want)
+	}
+}
+
+// TestContentUpdatedAt_UnaffectedByBindingChurn is the regression test for the
+// phantom-unread-dot bug: releasing and reacquiring the session's entry
+// binding (the post-turn cleanup that runs after every message, whether or
+// not anything is queued behind it) rewrites the file — but must not move
+// ContentUpdatedAt, or the sidebar's unread watermark chases a timestamp that
+// has nothing to do with new content.
+func TestContentUpdatedAt_UnaffectedByBindingChurn(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	sess.Messages = []Message{NewUserMessage("hello")}
+	if err := sess.Save(); err != nil { // first save: rewriteAll
+		t.Fatalf("save: %v", err)
+	}
+	// A second message so the binding-churn saves below are reloading a
+	// session whose latest content write went through appendDelta — the
+	// real-world shape (an existing session's Nth turn), not just the
+	// meta-line-carries-everything first save.
+	sess.Messages = append(sess.Messages, NewAssistantMessage("hi"))
+	if err := sess.Save(); err != nil { // second save: appendDelta
+		t.Fatalf("second save: %v", err)
+	}
+	want := sess.ContentUpdatedAt
+	if want.IsZero() {
+		t.Fatal("ContentUpdatedAt not stamped by the initial content save")
+	}
+
+	// Mirrors acquireSessionBinding/releaseSessionBinding: reload from disk
+	// (persisted == len(Messages), no message change), Bind or Unbind (forces
+	// a rewrite via forceRewrite), Save.
+	for i := 0; i < 3; i++ {
+		reloaded, err := LoadSession(sess.ID)
+		if err != nil {
+			t.Fatalf("reload %d: %v", i, err)
+		}
+		if i%2 == 0 {
+			reloaded.Bind(EntryWeb, false)
+		} else {
+			reloaded.Unbind(EntryWeb)
+		}
+		if err := reloaded.Save(); err != nil {
+			t.Fatalf("binding save %d: %v", i, err)
+		}
+		if !reloaded.ContentUpdatedAt.Equal(want) {
+			t.Fatalf("binding-only save %d moved ContentUpdatedAt: got %v, want %v", i, reloaded.ContentUpdatedAt, want)
+		}
+	}
+
+	final, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("final reload: %v", err)
+	}
+	if !final.ContentUpdatedAt.Equal(want) {
+		t.Fatalf("ContentUpdatedAt on disk after binding churn = %v, want %v", final.ContentUpdatedAt, want)
+	}
+}
+
+// TestContentUpdatedAt_AdvancesOnSameLengthCompaction covers the one case a
+// plain message-count check can't see: SyncFrom folding history into a
+// same-length summary (compaction) still counts as new content.
+func TestContentUpdatedAt_AdvancesOnSameLengthCompaction(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	h := NewHistory()
+	for _, m := range []Message{NewUserMessage("one"), NewAssistantMessage("two"), NewUserMessage("three")} {
+		h.Append(m)
+	}
+	sess.SyncFrom(h)
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	first := sess.ContentUpdatedAt
+	if first.IsZero() {
+		t.Fatal("ContentUpdatedAt not stamped by the initial content save")
+	}
+
+	h.ReplaceAll([]Message{NewUserMessage("[summary]"), NewUserMessage("three"), NewAssistantMessage("four")})
+	sess.SyncFrom(h)
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save after rewrite: %v", err)
+	}
+	if !sess.ContentUpdatedAt.After(first) {
+		t.Fatalf("ContentUpdatedAt did not advance on a same-length compaction: %v -> %v", first, sess.ContentUpdatedAt)
+	}
+}
+
 // TestSetTitle_RewritesAfterPartialTail: SetTitle appends a raw title record;
 // after a crash left a partial tail it must rewrite instead, or the title
 // record fuses with the dangling bytes into one corrupt line.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -95,8 +95,18 @@ type sessionCreateRequest struct {
 
 // toSessionItem builds a frontend-friendly session descriptor.
 func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) sessionItem {
+	// ContentUpdatedAt (set by Save only when the message count actually
+	// changes — see its doc comment) is preferred over the file's raw mtime:
+	// the same file also absorbs binding/lease bookkeeping writes (a turn's
+	// post-completion release, the idle-steer check that runs even with
+	// nothing queued) that land moments after the reply the sidebar's unread
+	// dot is comparing against, which used to make that comparison chase a
+	// timestamp that had nothing to do with new content. Sessions predating
+	// this field fall back to the file mtime until their next real save.
 	updated := s.CreatedAt
-	if p, err := s.SavePath(); err == nil {
+	if !s.ContentUpdatedAt.IsZero() {
+		updated = s.ContentUpdatedAt
+	} else if p, err := s.SavePath(); err == nil {
 		if st, err := os.Stat(p); err == nil {
 			updated = st.ModTime()
 		}

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -74,7 +74,6 @@
   import { insertPendingSend, takeConfirmedSend } from '../lib/pendingSendOrder'
   import { inlineSlashCommand } from '../lib/inlineSlash'
   import { exportModeStore, selectedMessagesStore } from '../lib/exportStore'
-  import { touchSession } from '../lib/unread'
   import { filenameStem } from '../lib/filename'
   import { anchorBgTasks } from '../lib/bgTaskAnchor'
   import DOMPurify from 'dompurify'
@@ -1070,15 +1069,6 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
     cleanups.push(ws.on('complete', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
-      // Mark the turn touched right here rather than waiting on the separate
-      // session_activity turn_ended broadcast App.svelte listens for: that
-      // broadcast is fire-and-forget and can still be in flight — or, on a
-      // desktop quit (Cmd+Q / tray exit bypasses the WindowClosing hook the
-      // pagehide/visibilitychange safety net in unread.ts relies on), never
-      // arrive at all — when the user closes the window moments after the
-      // reply they're already looking at finishes rendering. This event IS
-      // that rendering, so there's no gap left to race.
-      touchSession(sid)
       // Belt-and-braces: the describing line normally clears on its own
       // done/failed event, but a WS reconnect between started and done would
       // otherwise leave it hanging forever.

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -74,6 +74,7 @@
   import { insertPendingSend, takeConfirmedSend } from '../lib/pendingSendOrder'
   import { inlineSlashCommand } from '../lib/inlineSlash'
   import { exportModeStore, selectedMessagesStore } from '../lib/exportStore'
+  import { touchSession } from '../lib/unread'
   import { filenameStem } from '../lib/filename'
   import { anchorBgTasks } from '../lib/bgTaskAnchor'
   import DOMPurify from 'dompurify'
@@ -1069,6 +1070,15 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
     cleanups.push(ws.on('complete', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
+      // Mark the turn touched right here rather than waiting on the separate
+      // session_activity turn_ended broadcast App.svelte listens for: that
+      // broadcast is fire-and-forget and can still be in flight — or, on a
+      // desktop quit (Cmd+Q / tray exit bypasses the WindowClosing hook the
+      // pagehide/visibilitychange safety net in unread.ts relies on), never
+      // arrive at all — when the user closes the window moments after the
+      // reply they're already looking at finishes rendering. This event IS
+      // that rendering, so there's no gap left to race.
+      touchSession(sid)
       // Belt-and-braces: the describing line normally clears on its own
       // done/failed event, but a WS reconnect between started and done would
       // otherwise leave it hanging forever.


### PR DESCRIPTION
## Summary
- The sidebar's unread dot ([[project_sidebar_unread_indicator]] machinery, `web/src/lib/unread.ts`) compares the session's reported `updated_at` against a client-side "seen" watermark. `updated_at` came from the session file's raw OS mtime (`toSessionItem`, `internal/server/handlers.go`).
- That mtime moves on **every** write to the file — not just new messages. The post-turn cleanup that runs after every message (`internal/server/ws_handlers.go`) releases the entry binding, then unconditionally probes the idle-steer queue via an acquire/release pair even when nothing is queued — rewriting the file 2-3 times within milliseconds of the `turn_ended` broadcast the client marks "seen" against. Confirmed by logging a real turn: three `rewriteAll` saves land 2-7ms after `turn_ended`, every time, tracing back to `acquireSessionBinding`/`releaseSessionBinding`. That gap is small but deterministic, which is why it reproduced on effectively every desktop quit rather than intermittently.
- Fix: `Session` now tracks `ContentUpdatedAt` separately from the file's mtime (`internal/agent/session.go`). `Save` advances it only when the message count actually changes (or, for a same-length compaction rewrite, when `SyncFrom`'s rewrite-dirty signal says so) — never for Bind/Unbind/MarkHookStarted/SetWorkingDir/etc. `toSessionItem` reports it in place of the raw file stat, falling back to the stat for sessions predating this field.
- `appendDelta` (the common incremental-save path) gets its own `content_updated_at` append-only record — the same last-one-wins pattern already used for title/lease/context_tokens — since it never rewrites the meta line where the field otherwise lives. Missing this was a second, silent bug caught while verifying: the in-memory value advanced correctly but was never persisted for the common case, so a binding-churn reload moments later picked up a stale (often zero) value from disk.
- Also reverts this branch's earlier (wrong) fix attempt — touching the unread state from `ChatView`'s own `complete` event doesn't help when the server keeps moving `updated_at` after the client's snapshot regardless of how early that snapshot is taken.

## Test plan
- [x] New unit tests in `internal/agent/session_persist_test.go`: content saves advance `ContentUpdatedAt`, binding-only saves don't, a same-length compaction rewrite does, and the value survives a reload after an `appendDelta`-path save (the case that caught the second bug above).
- [x] `go test -race ./internal/agent/... ./internal/server/...` — all pass
- [x] `go vet ./...`, `gofmt -l` — clean
- [x] Manually verified against a real desktop build (temporary logging, since removed): reproduced the phantom dot pre-fix, confirmed it's gone post-fix, across several Cmd+Q round trips.