### PR TITLE
chore: bump version to 1.16.12

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.11"
+var Version = "1.16.12"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Patch release over 1.16.11: #2340 (drop the Go SDK — CLI headless one-shot takes its place among the eight interfaces), #2341 (fix a phantom unread dot on the sidebar after a desktop Cmd+Q quit — binding/lease bookkeeping writes were moving the reported `updated_at` after every turn).