### PR TITLE
feishu: decode bot/v3/info from the top-level `bot` field so group @-mentions work

### DIFF
--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -492,7 +492,9 @@ func (a *Adapter) getBotOpenID() string {
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
-		log.Printf("[feishu] bot info: decode response: %v", err)
+		// Include the status so an HTML error page from a proxy is
+		// distinguishable from a malformed Feishu reply.
+		log.Printf("[feishu] bot info: decode response (HTTP %d): %v", resp.StatusCode, err)
 		return ""
 	}
 	if r.Code != 0 {

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -463,27 +463,52 @@ func (a *Adapter) readEvents(ctx context.Context, conn *websocket.Conn, onMessag
 
 // ─── Bot info ──────────────────────────────────────────────────────────────
 
+type botInfo struct {
+	OpenID string `json:"open_id"`
+}
+
+// getBotOpenID resolves the bot's own open_id via GET /open-apis/bot/v3/info.
+// Unlike most Feishu endpoints, this legacy v3 API returns `bot` at the top
+// level of the response rather than under `data`. The official larksuite SDKs
+// read the top level and fall back to `data.bot`, so we accept both shapes.
+// Every failure is logged: an empty result silently disables all group chats
+// because handleEvent fails closed without it (#2346).
 func (a *Adapter) getBotOpenID() string {
 	req, _ := http.NewRequest("GET", a.domain+"/open-apis/bot/v3/info", nil)
 	req.Header.Set("Authorization", "Bearer "+a.getToken())
 	resp, err := a.http.Do(req)
 	if err != nil {
+		log.Printf("[feishu] bot info: %v", err)
 		return ""
 	}
 	defer resp.Body.Close()
 
 	var r struct {
-		Code int `json:"code"`
+		Code int     `json:"code"`
+		Msg  string  `json:"msg"`
+		Bot  botInfo `json:"bot"`
 		Data struct {
-			Bot struct {
-				OpenID string `json:"open_id"`
-			} `json:"bot"`
+			Bot botInfo `json:"bot"`
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		log.Printf("[feishu] bot info: decode response: %v", err)
 		return ""
 	}
-	return r.Data.Bot.OpenID
+	if r.Code != 0 {
+		log.Printf("[feishu] bot info: code %d: %s", r.Code, r.Msg)
+		return ""
+	}
+	id := r.Bot.OpenID
+	if id == "" {
+		id = r.Data.Bot.OpenID
+	}
+	if id == "" {
+		log.Printf("[feishu] bot info: response carried no open_id")
+		return ""
+	}
+	log.Printf("[feishu] bot open_id: %s", id)
+	return id
 }
 
 // ─── Message handling ──────────────────────────────────────────────────────

--- a/internal/channel/adapters/feishu/feishu_test.go
+++ b/internal/channel/adapters/feishu/feishu_test.go
@@ -439,5 +439,10 @@ func TestHandleEvent_GroupMentionGate(t *testing.T) {
 		if delivered {
 			t.Fatal("group message that does not mention the bot must be dropped")
 		}
+		// The drop must come from the mention gate, not from an unresolved
+		// identity — otherwise this subtest would also pass on the old decoder.
+		if a.botOpenID != fakeBotOpenID {
+			t.Fatalf("botOpenID = %q, want %q (dropped for the wrong reason)", a.botOpenID, fakeBotOpenID)
+		}
 	})
 }

--- a/internal/channel/adapters/feishu/feishu_test.go
+++ b/internal/channel/adapters/feishu/feishu_test.go
@@ -22,6 +22,8 @@ type fakeFeishu struct {
 	srv         *httptest.Server
 }
 
+const fakeBotOpenID = "ou_bot"
+
 func newFakeFeishu(t *testing.T) *fakeFeishu {
 	f := &fakeFeishu{}
 	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -29,6 +31,12 @@ func newFakeFeishu(t *testing.T) *fakeFeishu {
 		case "/open-apis/auth/v3/tenant_access_token/internal":
 			json.NewEncoder(w).Encode(map[string]any{
 				"code": 0, "tenant_access_token": "tok", "expire": 7200,
+			})
+		case "/open-apis/bot/v3/info":
+			// Real wire shape: `bot` sits at the top level, not under `data`.
+			json.NewEncoder(w).Encode(map[string]any{
+				"code": 0, "msg": "ok",
+				"bot": map[string]any{"open_id": fakeBotOpenID, "app_name": "octo"},
 			})
 		case "/open-apis/im/v1/images":
 			f.mu.Lock()
@@ -344,4 +352,92 @@ func TestBuildMsgPayload_CodeFenceTriggersCardMode(t *testing.T) {
 	if msgType != "interactive" {
 		t.Fatalf("expected interactive (card) rendering for a code fence, got %q", msgType)
 	}
+}
+
+// #2346: the bot info response was decoded as `data.bot.open_id`, but the v3
+// endpoint returns `bot` at the top level. The decode "succeeded" with an
+// empty open_id, so every group message was dropped as un-mentioned.
+func TestGetBotOpenID_ResponseShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"top-level bot (real wire shape)", `{"code":0,"msg":"ok","bot":{"open_id":"ou_top","app_name":"x"}}`, "ou_top"},
+		{"data-wrapped bot (tolerated)", `{"code":0,"data":{"bot":{"open_id":"ou_data"}}}`, "ou_data"},
+		{"non-zero code", `{"code":99991663,"msg":"permission denied","bot":{"open_id":"ou_x"}}`, ""},
+		{"no open_id", `{"code":0,"bot":{}}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/open-apis/auth/v3/tenant_access_token/internal":
+					json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "tok", "expire": 7200})
+				case "/open-apis/bot/v3/info":
+					w.Write([]byte(tc.body))
+				default:
+					w.WriteHeader(404)
+				}
+			}))
+			defer srv.Close()
+			a, err := New(channel.PlatformConfig{cfgAppID: "app", cfgAppSecret: "secret", cfgDomain: srv.URL})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if got := a.(*Adapter).getBotOpenID(); got != tc.want {
+				t.Fatalf("getBotOpenID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// #2346: end-to-end through handleEvent — a group message that @-mentions the
+// bot must be admitted once the bot's open_id resolves from the real response
+// shape, and one that does not mention it must still be dropped.
+func TestHandleEvent_GroupMentionGate(t *testing.T) {
+	groupMsg := func(mentionOpenID string) []byte {
+		mentions := "[]"
+		if mentionOpenID != "" {
+			mentions = `[{"key":"@_user_1","id":{"open_id":"` + mentionOpenID + `"},"name":"octo"}]`
+		}
+		return []byte(`{
+			"schema": "2.0",
+			"header": {"event_type": "im.message.receive_v1"},
+			"event": {
+				"message": {
+					"message_id": "m-1",
+					"chat_id": "chat-g",
+					"chat_type": "group",
+					"message_type": "text",
+					"content": "{\"text\":\"@_user_1 hello\"}",
+					"mentions": ` + mentions + `
+				},
+				"sender": {"sender_id": {"open_id": "user-1"}}
+			}
+		}`)
+	}
+
+	t.Run("mentioned bot is admitted", func(t *testing.T) {
+		f := newFakeFeishu(t)
+		a := newTestAdapter(t, f)
+		var got *channel.InboundEvent
+		a.handleEvent(groupMsg(fakeBotOpenID), func(ev channel.InboundEvent) { got = &ev })
+		if got == nil {
+			t.Fatal("expected the @-mentioned group message to produce an InboundEvent")
+		}
+		if a.botOpenID != fakeBotOpenID {
+			t.Fatalf("botOpenID = %q, want %q", a.botOpenID, fakeBotOpenID)
+		}
+	})
+
+	t.Run("unmentioned message is dropped", func(t *testing.T) {
+		f := newFakeFeishu(t)
+		a := newTestAdapter(t, f)
+		delivered := false
+		a.handleEvent(groupMsg("ou_someone_else"), func(channel.InboundEvent) { delivered = true })
+		if delivered {
+			t.Fatal("group message that does not mention the bot must be dropped")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #2346 — every Feishu group message was dropped with `bot_open_id unavailable; dropping group message to avoid spam`, while p2p messages worked.

**Root cause.** `getBotOpenID` decoded the `GET /open-apis/bot/v3/info` response as `data.bot.open_id`. That legacy v3 endpoint returns `bot` at the **top level** (no `data` wrapper), which the reporter's curl output shows verbatim and the official larksuite [Go](https://github.com/larksuite/oapi-sdk-go/blob/b059ee1824d45444306559b5c33c3f268c0de10d/channel/channel.go#L222-L229) / [Python](https://github.com/larksuite/oapi-sdk-python/blob/0b9e6e48b74bb4b34462fc67b7e738b27e73e697/lark_oapi/channel/bot_identity.py#L75) SDKs also read. JSON decoding "succeeded" with an empty `open_id`, no error was logged, and `handleEvent` failed closed on every group message. This has been the behaviour since the adapter landed in #418, so Feishu group @-mentions never worked.

## Changes

- `internal/channel/adapters/feishu/feishu.go`: read `bot` at the top level, fall back to `data.bot` (same tolerance as the Python SDK), check `code`, and log every failure path (transport, decode, non-zero code, missing `open_id`). Success logs the resolved open_id once.
- `feishu_test.go`: fake server now serves `bot/v3/info` in the real wire shape. New `TestGetBotOpenID_ResponseShapes` (top-level / data-wrapped / error code / missing id) and `TestHandleEvent_GroupMentionGate` (mentioned → admitted, unmentioned → dropped). Both fail against the old decoder.

## Not done

The issue asks for a manual `bot_open_id` override in `channels.yml`. With the root cause fixed it is unnecessary, so no new config key.

## Test plan

- [x] `go test -race ./internal/channel/adapters/feishu/` green; the two new tests confirmed red on the pre-fix `getBotOpenID`
- [x] `gofmt -l` empty, `go vet` clean
- [ ] Reporter to confirm on a real self-built app (group @-mention → reply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
