### PR TITLE
docs: add a local-models recipe (Ollama, vLLM) to choose-a-provider

### DIFF
--- a/docs/src/content/docs/getting-started/choose-a-provider.mdx
+++ b/docs/src/content/docs/getting-started/choose-a-provider.mdx
@@ -43,6 +43,40 @@ CUSTOM_API_KEY=sk-... \
 </TabItem>
 </Tabs>
 
+## Local models (Ollama, vLLM)
+
+Local servers expose an OpenAI-compatible API, so they are a `custom` endpoint with
+`protocol: openai`. Two details trip people up:
+
+- **`base_url` is the OpenAI-compatible root, not the server's native API.** For Ollama that is
+  `http://localhost:11434/v1` — not `/api`, which is Ollama's own API. octo appends
+  `/chat/completions` to a URL ending in `/v1` (and the full `/v1/chat/completions` otherwise), so
+  `http://localhost:11434/api` turns into `…/api/v1/chat/completions` and Ollama answers 404.
+  vLLM's default is `http://localhost:8000/v1`.
+- **The API key must be non-empty.** Local servers ignore it, but octo treats an empty key as
+  "not configured yet" and opens the setup wizard. Put any placeholder in `api_key`.
+
+```yaml
+endpoints:
+  - id: ollama
+    provider: custom
+    protocol: openai
+    base_url: http://localhost:11434/v1
+    api_key: ollama              # ignored by Ollama, but must not be empty
+    models:
+      - model: qwen3-coder:30b
+        vision: false            # text-only model: keep images away from it
+default: ollama::qwen3-coder:30b
+```
+
+The same via env vars, without touching the config file:
+
+```bash
+CUSTOM_BASE_URL=http://localhost:11434/v1 \
+CUSTOM_API_KEY=ollama \
+  octo --model qwen3-coder:30b "..."
+```
+
 ## Save it as your default
 
 ```bash

--- a/docs/src/content/docs/zh/getting-started/choose-a-provider.mdx
+++ b/docs/src/content/docs/zh/getting-started/choose-a-provider.mdx
@@ -42,6 +42,38 @@ CUSTOM_API_KEY=sk-... \
 </TabItem>
 </Tabs>
 
+## 本地模型（Ollama、vLLM）
+
+本地推理服务都提供 OpenAI 兼容接口，所以按 `custom` 端点配置，`protocol: openai`。有两个地方容易踩坑：
+
+- **`base_url` 填 OpenAI 兼容接口的根路径，不是服务自己的原生 API。** Ollama 是
+  `http://localhost:11434/v1`，不是 `/api`（那是 Ollama 自己的 API）。octo 对以 `/v1` 结尾的 URL
+  追加 `/chat/completions`，否则追加完整的 `/v1/chat/completions`，所以填 `http://localhost:11434/api`
+  会变成 `…/api/v1/chat/completions`，Ollama 直接返回 404。vLLM 默认是 `http://localhost:8000/v1`。
+- **API key 不能为空。** 本地服务会忽略 key，但 octo 把空 key 当作"还没配置"，会拉起配置向导。
+  在 `api_key` 里随便填一个占位值即可。
+
+```yaml
+endpoints:
+  - id: ollama
+    provider: custom
+    protocol: openai
+    base_url: http://localhost:11434/v1
+    api_key: ollama              # Ollama 会忽略，但不能留空
+    models:
+      - model: qwen3-coder:30b
+        vision: false            # 纯文本模型，别把图片发给它
+default: ollama::qwen3-coder:30b
+```
+
+不改配置文件、只用环境变量也可以：
+
+```bash
+CUSTOM_BASE_URL=http://localhost:11434/v1 \
+CUSTOM_API_KEY=ollama \
+  octo --model qwen3-coder:30b "..."
+```
+
 ## 存成默认值
 
 ```bash


### PR DESCRIPTION
## Summary

Refs #2286 — the reporter pointed octo at Ollama with `base_url: http://localhost:11434/api` and got 404s.

Ollama's OpenAI-compatible API lives under `/v1`; `/api` is Ollama's native API. octo's openai client appends `/chat/completions` to a base URL ending in `/v1` and the full `/v1/chat/completions` otherwise (`internal/provider/openai/client.go` `endpointURL`), so `…/api` becomes `…/api/v1/chat/completions`. The docs never showed an Ollama example — only vLLM/OpenRouter under the `custom` vendor — while the landing page advertises Ollama support.

This PR adds a **Local models (Ollama, vLLM)** section to `getting-started/choose-a-provider` (EN + ZH) with:

- the correct `base_url` and an explanation of the `/v1` join rule, including the exact wrong URL the reporter hit;
- a note that `api_key` must currently be a non-empty placeholder (local servers have no key, but octo treats an empty key as "not configured" and opens the wizard) — the code-side fix for that is a follow-up PR;
- a full `config.yml` snippet plus the env-var one-liner.

Docs only; no code changes.

## Test plan

- [x] `astro build` in `docs/` — both pages compile and render the new section (Pagefind indexing fails in the sandbox because it can't download its binary; unrelated to content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)