### PR TITLE
chore: bump version to 1.16.13

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.12"
+var Version = "1.16.13"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over v1.16.12.

- #2349 Allow keyless Custom endpoints (Ollama, vLLM) instead of forcing the setup wizard
- #2348 docs: local-models recipe (Ollama, vLLM)
- #2347 feishu: decode bot/v3/info from the top-level `bot` field so group @-mentions work
- dependabot: #2342 #2343 #2345

🤖 Generated with [Claude Code](https://claude.com/claude-code)