### PR TITLE
server: retry the registry rename on Windows when a reader holds the file open

### DIFF
--- a/internal/server/registry_lock.go
+++ b/internal/server/registry_lock.go
@@ -24,7 +24,9 @@ import (
 // block on the CLI's writes and back, with no fairness guarantee between them.
 // Nothing is lost by leaving it out: cachedRegistry re-stats the file and
 // re-reads it when another process has changed it, which is what that cache is
-// for.
+// for. The one cost is on Windows, where a reader holding the file open makes
+// a concurrent writer's rename fail transiently; saveRegistry retries through
+// renameWithRetry to absorb that.
 //
 // That spares reads from waiting on another PROCESS directly, not from waiting
 // on this one: a local writer holds mu across its file-lock wait, so reads queue

--- a/internal/server/rename_retry_windows_test.go
+++ b/internal/server/rename_retry_windows_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestRenameWithRetry_WaitsForOpenDestination pins the Windows behaviour the
+// retry exists for: with the destination held open by a reader (as an unlocked
+// cachedRegistry read in another process does), a plain os.Rename fails with
+// ERROR_ACCESS_DENIED, and renameWithRetry succeeds once the reader closes.
+// Windows-only by filename — POSIX rename never fails this way.
+func TestRenameWithRetry_WaitsForOpenDestination(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "session-groups.json")
+	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tmp := dst + ".tmp"
+	if err := os.WriteFile(tmp, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := os.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: renaming over a file another handle has open is refused.
+	if err := os.Rename(tmp, dst); err == nil {
+		reader.Close()
+		t.Skip("rename over an open file succeeded on this Windows/Go build; nothing to retry")
+	}
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		reader.Close()
+	}()
+	if err := renameWithRetry(tmp, dst); err != nil {
+		t.Fatalf("renameWithRetry after reader closed: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("destination = %q, want the renamed content", got)
+	}
+}

--- a/internal/server/session_groups.go
+++ b/internal/server/session_groups.go
@@ -195,7 +195,7 @@ func saveRegistry(gf groupFile) error {
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return err
 	}
-	if err := os.Rename(tmp, path); err != nil {
+	if err := renameWithRetry(tmp, path); err != nil {
 		os.Remove(tmp)
 		return fmt.Errorf("session groups: write %s: %w", path, err)
 	}
@@ -204,6 +204,26 @@ func saveRegistry(gf groupFile) error {
 		notifyGroupsChanged()
 	}
 	return nil
+}
+
+// renameWithRetry replaces newpath with oldpath, retrying briefly when the
+// destination is momentarily open elsewhere. Reads of the registry deliberately
+// stay outside the cross-process file lock (see registryLock), so another
+// process can be mid-ReadFile on session-groups.json while this one renames
+// over it. That is harmless on POSIX, but Go opens files on Windows without
+// FILE_SHARE_DELETE, so MoveFileEx onto an open file fails with
+// ERROR_ACCESS_DENIED until the reader closes — microseconds later. Seen as
+// "rename ...: Access is denied." from TestEnsureProject_CrossProcessLock…
+// on windows-latest. Same shape as the scheduler's helper of the same name.
+func renameWithRetry(oldpath, newpath string) error {
+	var err error
+	for i := 0; i < 50; i++ {
+		if err = os.Rename(oldpath, newpath); err == nil {
+			return nil
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return err
 }
 
 // saveSessionGroups persists the group list while preserving every other list


### PR DESCRIPTION
## Summary

`TestEnsureProject_CrossProcessLockKeepsEveryGroup` failed on windows-latest in three of today's four Go CI runs, including the `main` run after #2347 merged ([run 33849782972](https://github.com/open-octo/octo-agent/actions/runs/33849782972)):

```
session groups: write ...\.octo\session-groups.json: rename ...tmp ...: Access is denied.
```

**Root cause.** Registry reads deliberately stay outside the cross-process file lock (documented on `registryLock`), so one child can be mid-`ReadFile` on `session-groups.json` while another renames its temp file onto it. POSIX rename does not care. Go opens files on Windows without `FILE_SHARE_DELETE` ([`syscall_windows.go`: `sharemode := FILE_SHARE_READ | FILE_SHARE_WRITE`](https://github.com/golang/go/blob/master/src/syscall/syscall_windows.go)), so `MoveFileEx` onto a file another handle has open fails with `ERROR_ACCESS_DENIED` until the reader closes, microseconds later. Not a lost-write bug and not a lock bug: the file lock is doing its job, this is the one cost of keeping readers out of it.

## Changes

- `internal/server/session_groups.go`: `saveRegistry` renames through a new private `renameWithRetry` (50 × 20 ms), the same shape `internal/scheduler` already uses for its task files for the same reason.
- `internal/server/registry_lock.go`: one sentence on the design comment naming this cost and where it is absorbed.
- `internal/server/rename_retry_windows_test.go` (Windows-only by filename): holds the destination open, asserts a plain `os.Rename` is refused, then asserts `renameWithRetry` succeeds once the reader closes and the content landed. Skips if a future Go/Windows build shares delete access.

The existing cross-process test stays the end-to-end regression check.

## Test plan

- [x] `gofmt -l` empty; `go vet ./internal/server/` on darwin and `GOOS=windows go vet ./internal/server/` (compiles the Windows-only test)
- [x] `go test -race -run 'TestEnsureProject|Registry|Groups' ./internal/server/` green on darwin
- [ ] windows-latest CI on this PR runs the new test and the cross-process test for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)
