### PR TITLE
ci: run internal/browser alone on windows-latest so Chrome is not starved by neighbour packages

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -93,4 +93,24 @@ jobs:
       # testWaitTimeout) a bad-weather run must fail those tests cleanly
       # instead of hitting the go-test default 10m panic.
       - name: go test
+        if: matrix.os != 'windows-latest'
         run: go test -timeout 20m ${{ matrix.os == 'ubuntu-latest' && '-race' || '' }} ./...
+
+      # Windows runs internal/browser on its own. `go test ./...` runs up to
+      # GOMAXPROCS package test binaries at once, and on the 4-core
+      # windows-latest runner the browser tests' headless Chrome shared the
+      # machine with internal/tools (~3-5min) and internal/server. Under that
+      # load, three different browser tests failed in one day (2026-09-04) on
+      # ceilings that are already 60-90s — a first fixture page not rendering in
+      # 60s, a local download not starting in 30s — while the same commit passed
+      # on rerun once the neighbours had thinned out (browser package 528s in
+      # the failing run vs 314s in the passing one). Giving Chrome the whole
+      # runner removes the contention instead of chasing each ceiling upward.
+      - name: go test (all but internal/browser)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: go test -timeout 20m $(go list ./... | grep -v '/internal/browser$')
+
+      - name: go test (internal/browser, alone)
+        if: matrix.os == 'windows-latest'
+        run: go test -timeout 20m ./internal/browser/


### PR DESCRIPTION
## Summary

Three different `internal/browser` tests failed on windows-latest on 2026-09-04, on different runs of the same or adjacent commits, all against ceilings that are already generous:

| Test | Failure | Run |
|---|---|---|
| `TestUploadViaChooser` | first fixture page not rendering within 60s | [33847081444](https://github.com/open-octo/octo-agent/actions/runs/33847081444) attempt 1 |
| `TestReplayRecordingDownloadNoDoubleBindOnHeal` | local download not starting within 30s | [33849782972](https://github.com/open-octo/octo-agent/actions/runs/33849782972) (`main`) |

Both passed on rerun. The browser package took 528s in the failing run vs 314s in the passing one; `internal/tools` took 336s vs 183s in the same pair. The default test invocation runs up to GOMAXPROCS package binaries at once, so on the 4-core Windows runner headless Chrome was competing with `internal/tools` and `internal/server` for the machine.

## Change

`.github/workflows/go.yml`, Windows only: run everything except `internal/browser` first, then `internal/browser` on its own with the whole runner. ubuntu and macos keep their single all-packages step, which has not flaked.

The bulk step uses `shell: bash` (Git Bash on the Windows runner) for the package-list exclusion. `internal/browser` has no subpackages, so the anchored pattern excludes exactly one of 50 packages.

This attacks the contention rather than raising each ceiling again (the history is 5s → 20s → 60s across #989 / #1659 / #1718, plus a Windows-only skip). Cost: the browser package no longer overlaps other packages on Windows, so that job gets longer by roughly the browser package's runtime minus the contention it was suffering. If that turns out too slow we can revisit; the alternative of lowering the package parallelism slows every package.

## Test plan

- [x] YAML parses; the three test steps carry the intended `if` / `shell`
- [x] The package-list exclusion drops exactly one package locally (49 of 50)
- [ ] This PR's own windows-latest job runs both new steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
