### PR TITLE
web: let the user kill a background process from the popover

### DIFF
--- a/internal/server/bg_kill_test.go
+++ b/internal/server/bg_kill_test.go
@@ -11,9 +11,14 @@ import (
 )
 
 // Killing a running background process from the popover must take the
-// process down and let the existing exit hook do the rest: a "cancelled"
-// notice (not "success" — the model is told it was killed, not finished) and
-// a badge refresh with the row gone.
+// process down and let the exit hook do the rest: a "cancelled" notice (not
+// "success" — the model is told it was killed, not finished) and a badge
+// refresh with the row gone.
+//
+// Deliberately does NOT call wireBackgroundTaskNotices first: a process
+// launched from a REST-driven turn (runTurn) lives in the same per-session
+// manager but that path never installs the hook, so the handler must wire it
+// itself or the kill lands silently.
 func TestHandleWSKillBackground_KillsAndBroadcastsCancelled(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("spawns a real shell; PowerShell startup is slow and flaky on CI")
@@ -24,7 +29,6 @@ func TestHandleWSKillBackground_KillsAndBroadcastsCancelled(t *testing.T) {
 	const sid = "bg-kill-test-session"
 	defer tools.CloseSessionBackgroundManager(sid)
 	conn := subscribedConn(t, srv, sid)
-	srv.wireBackgroundTaskNotices(sid)
 
 	mgr := tools.SessionBackgroundManager(sid)
 	id, err := mgr.Start(context.Background(), "sleep 60", tools.BgModeAsync)
@@ -93,6 +97,31 @@ func TestHandleWSKillBackground_UnknownIDResyncsBadge(t *testing.T) {
 	case b := <-conn.send:
 		t.Fatalf("unexpected second event: %s", b)
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// The raw WS frame the browser sends (ws.ts killBackground) must reach the
+// handler through dispatch with both JSON tags decoded — the wire contract is
+// only visible from this end.
+func TestHandleWSKillBackground_DispatchFromRawJSON(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "bg-kill-dispatch-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+	conn := subscribedConn(t, srv, sid)
+
+	raw := []byte(`{"type":"kill_background","session_id":"bg-kill-dispatch-session","handle_id":"bg_404"}`)
+	conn.dispatch("kill_background", raw)
+
+	// Unknown id → the resync broadcast, proving session_id was decoded (the
+	// broadcast is per-session) and the handler ran at all.
+	ev := nextEvent(t, conn)
+	if ev["type"] != "background_tasks_update" {
+		t.Fatalf("type = %v, want background_tasks_update", ev["type"])
+	}
+	if ev["session_id"] != sid {
+		t.Errorf("session_id = %v, want %s", ev["session_id"], sid)
 	}
 }
 

--- a/internal/server/bg_kill_test.go
+++ b/internal/server/bg_kill_test.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/open-octo/octo-agent/internal/tools"
+)
+
+// Killing a running background process from the popover must take the
+// process down and let the existing exit hook do the rest: a "cancelled"
+// notice (not "success" — the model is told it was killed, not finished) and
+// a badge refresh with the row gone.
+func TestHandleWSKillBackground_KillsAndBroadcastsCancelled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("spawns a real shell; PowerShell startup is slow and flaky on CI")
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "bg-kill-test-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+	conn := subscribedConn(t, srv, sid)
+	srv.wireBackgroundTaskNotices(sid)
+
+	mgr := tools.SessionBackgroundManager(sid)
+	id, err := mgr.Start(context.Background(), "sleep 60", tools.BgModeAsync)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	srv.handleWSKillBackground(sid, id)
+
+	var gotNotice, gotUpdate bool
+	deadline := time.After(5 * time.Second)
+	for !(gotNotice && gotUpdate) {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if err := json.Unmarshal(b, &ev); err != nil {
+				continue
+			}
+			switch ev["type"] {
+			case "background_task_notice":
+				gotNotice = true
+				if ev["status"] != "cancelled" {
+					t.Errorf("notice status = %v, want cancelled", ev["status"])
+				}
+				if ev["handle_id"] != id {
+					t.Errorf("notice handle_id = %v, want %s", ev["handle_id"], id)
+				}
+			case "background_tasks_update":
+				gotUpdate = true
+				if ev["running"] != float64(0) {
+					t.Errorf("update running = %v, want 0 after kill", ev["running"])
+				}
+			}
+		case <-deadline:
+			t.Fatalf("timed out; notice=%v update=%v", gotNotice, gotUpdate)
+		}
+	}
+	if len(mgr.ListRunning()) != 0 {
+		t.Errorf("process still listed as running after kill")
+	}
+}
+
+// An id the manager no longer knows (the process exited between two badge
+// broadcasts, so the popover showed a ghost row) must not error out; the
+// handler re-broadcasts the live list so the stale row disappears, and no
+// notice is fabricated for a kill that never happened.
+func TestHandleWSKillBackground_UnknownIDResyncsBadge(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "bg-kill-unknown-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+	conn := subscribedConn(t, srv, sid)
+	srv.wireBackgroundTaskNotices(sid)
+
+	srv.handleWSKillBackground(sid, "bg_404")
+
+	ev := nextEvent(t, conn)
+	if ev["type"] != "background_tasks_update" {
+		t.Fatalf("type = %v, want background_tasks_update", ev["type"])
+	}
+	if ev["running"] != float64(0) {
+		t.Errorf("running = %v, want 0", ev["running"])
+	}
+	select {
+	case b := <-conn.send:
+		t.Fatalf("unexpected second event: %s", b)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// An empty handle id is a malformed message, not a request: nothing is killed
+// and nothing is broadcast.
+func TestHandleWSKillBackground_EmptyIDIsNoop(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "bg-kill-empty-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+	conn := subscribedConn(t, srv, sid)
+
+	srv.handleWSKillBackground(sid, "")
+
+	select {
+	case b := <-conn.send:
+		t.Fatalf("unexpected event: %s", b)
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/internal/server/bg_tasks.go
+++ b/internal/server/bg_tasks.go
@@ -46,14 +46,20 @@ func (s *Server) broadcastBackgroundTasks(sessionID string) {
 // with no one to ask). SIGKILL only: a graceful-signal choice is the model's
 // business via kill_shell, the user just wants it gone. On success nothing
 // else needs doing here — the manager's exit hook (wireBackgroundTaskNotices)
-// already broadcasts the cancelled notice, refreshes the badge and tells the
-// model the process was killed rather than finished. An unknown id means the
-// badge is stale (the process exited between broadcasts), so re-broadcast the
-// live list to clear the ghost row.
+// broadcasts the cancelled notice, refreshes the badge and tells the model the
+// process was killed rather than finished. The hook is (re)wired first because
+// not every turn path installs it: a process launched from a REST-driven turn
+// (runTurn) shares this session's manager but never had the hook set, and
+// without it the kill would land silently — no notice, row stuck in the badge.
+// SetOnExit is idempotent, so re-wiring on a session that already has it is
+// free. An unknown id means the manager has never heard of it (a fabricated id,
+// or a session whose manager was already closed); re-broadcast the live list so
+// whatever the popover was showing gets corrected.
 func (s *Server) handleWSKillBackground(sessionID, handleID string) {
 	if handleID == "" {
 		return
 	}
+	s.wireBackgroundTaskNotices(sessionID)
 	if !tools.SessionBackgroundManager(sessionID).Kill(handleID) {
 		s.broadcastBackgroundTasks(sessionID)
 	}
@@ -72,7 +78,7 @@ func (s *Server) wireBackgroundTaskNotices(sessionID string) {
 			SessionID: sessionID,
 			Command:   e.Command,
 			HandleID:  e.ID,
-			Status:    bgNoticeStatus(e.Status),
+			Status:    bgNoticeStatus(e),
 		})
 		s.broadcastBackgroundTasks(sessionID)
 		s.notifyAgentBgExit(sessionID, e)
@@ -205,14 +211,18 @@ func (s *Server) kickIdleTurn(sessionID string, next func(*agent.Session) (strin
 	return true
 }
 
-// bgNoticeStatus maps a BackgroundManager exit status ("exited: 0",
-// "exited: signal: killed", …) onto the frontend notice levels
-// (success / cancelled / failed).
-func bgNoticeStatus(status string) string {
+// bgNoticeStatus maps a BackgroundManager exit onto the frontend notice levels
+// (success / cancelled / failed). A deliberate kill is cancelled regardless of
+// the status string: on Windows a taskkill'd process reports a plain non-zero
+// exit with no signal in it, so the "killed" substring check alone would show
+// a user- or model-initiated kill as a red failure.
+func bgNoticeStatus(e tools.BgExit) string {
 	switch {
-	case status == "exited: 0":
+	case e.Killed:
+		return "cancelled"
+	case e.Status == "exited: 0":
 		return "success"
-	case strings.Contains(status, "killed"):
+	case strings.Contains(e.Status, "killed"):
 		return "cancelled"
 	default:
 		return "failed"

--- a/internal/server/bg_tasks.go
+++ b/internal/server/bg_tasks.go
@@ -41,6 +41,24 @@ func (s *Server) broadcastBackgroundTasks(sessionID string) {
 	s.wsHub.broadcast(sessionID, backgroundTasksUpdate(sessionID, infos, time.Now()))
 }
 
+// handleWSKillBackground kills one background process on the user's behalf —
+// the recourse when the model can't (turn dead on a provider error, or idle
+// with no one to ask). SIGKILL only: a graceful-signal choice is the model's
+// business via kill_shell, the user just wants it gone. On success nothing
+// else needs doing here — the manager's exit hook (wireBackgroundTaskNotices)
+// already broadcasts the cancelled notice, refreshes the badge and tells the
+// model the process was killed rather than finished. An unknown id means the
+// badge is stale (the process exited between broadcasts), so re-broadcast the
+// live list to clear the ghost row.
+func (s *Server) handleWSKillBackground(sessionID, handleID string) {
+	if handleID == "" {
+		return
+	}
+	if !tools.SessionBackgroundManager(sessionID).Kill(handleID) {
+		s.broadcastBackgroundTasks(sessionID)
+	}
+}
+
 // wireBackgroundTaskNotices registers the session manager's exit hook so a
 // finished background process surfaces as a chat notice, the badge count
 // drops, and the model is notified. Re-registered (idempotently) at each turn

--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -16,16 +16,20 @@ import (
 
 func TestBgNoticeStatus(t *testing.T) {
 	cases := []struct {
-		in, want string
+		in   tools.BgExit
+		want string
 	}{
-		{"exited: 0", "success"},
-		{"exited: exit status 1", "failed"},
-		{"exited: signal: killed", "cancelled"},
-		{"exited: something else", "failed"},
+		{tools.BgExit{Status: "exited: 0"}, "success"},
+		{tools.BgExit{Status: "exited: exit status 1"}, "failed"},
+		{tools.BgExit{Status: "exited: signal: killed"}, "cancelled"},
+		{tools.BgExit{Status: "exited: something else"}, "failed"},
+		// Windows: a taskkill'd process exits with a plain non-zero status and no
+		// signal in the string — only the Killed flag says it was deliberate.
+		{tools.BgExit{Status: "exited: exit status 1", Killed: true}, "cancelled"},
 	}
 	for _, c := range cases {
 		if got := bgNoticeStatus(c.in); got != c.want {
-			t.Errorf("bgNoticeStatus(%q) = %q, want %q", c.in, got, c.want)
+			t.Errorf("bgNoticeStatus(%+v) = %q, want %q", c.in, got, c.want)
 		}
 	}
 }

--- a/internal/server/ws_hub.go
+++ b/internal/server/ws_hub.go
@@ -365,6 +365,13 @@ func (c *wsConn) dispatch(msgType string, raw []byte) {
 			mgr.PromoteSync()
 		}
 
+	case "kill_background":
+		var msg wsInKillBackground
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			return
+		}
+		c.hub.s.handleWSKillBackground(msg.SessionID, msg.HandleID)
+
 	default:
 		log.Printf("[ws] unknown message type: %q", msgType)
 	}
@@ -381,6 +388,7 @@ type wsHubOwner interface {
 	handleWSRollback(conn *wsConn, sessionID string)
 	handleWSRunTask(conn *wsConn, sessionID string)
 	handleWSRetractSteer(sessionID, pendingID, text string)
+	handleWSKillBackground(sessionID, handleID string)
 	handleWSConfirmation(confID, result string)
 	handleWSUserQuestionAnswer(qid, outcome string, answers []wsMsgAskAnswer)
 	replayLiveState(sessionID string, conn *wsConn)

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -413,3 +413,11 @@ type wsInPromoteSyncTerminal struct {
 type wsInPromoteSyncSubAgent struct {
 	SessionID string `json:"session_id"`
 }
+
+// wsInKillBackground is sent by the browser when the user kills a process from
+// the background-process popover. HandleID is the BackgroundManager id shown
+// in background_tasks_update (e.g. "bg_1").
+type wsInKillBackground struct {
+	SessionID string `json:"session_id"`
+	HandleID  string `json:"handle_id"`
+}

--- a/web/src/components/chat/BackgroundProcesses.svelte
+++ b/web/src/components/chat/BackgroundProcesses.svelte
@@ -5,11 +5,31 @@
   // Each task: { handle_id, command, startedAt } — ChatView anchors the
   // server's one-shot `elapsed` to a local timestamp, since the server only
   // re-broadcasts on tool calls and process exits.
-  let { tasks = [], now = 0 }: { tasks?: any[]; now?: number } = $props()
+  // onkill fires with the handle_id once the user has confirmed; the parent
+  // owns the session id and the socket.
+  let { tasks = [], now = 0, onkill }: { tasks?: any[]; now?: number; onkill?: (handleId: string) => void } = $props()
 
   let open = $state(false)
   let rootEl: HTMLElement | undefined = $state()
   let triggerEl: HTMLButtonElement | undefined = $state()
+
+  // Two-step kill without a modal: the first click on a row's × turns it into a
+  // "confirm" button, the second click kills. Only one row can be armed at a
+  // time, and the arm is dropped when the popover closes or the row vanishes
+  // (process exited on its own), so a stale arm can't fire on the wrong row.
+  let armedId = $state<string | null>(null)
+  $effect(() => {
+    if (!open) armedId = null
+    else if (armedId && !tasks.some(p => p.handle_id === armedId)) armedId = null
+  })
+  function onKillClick(handleId: string) {
+    if (armedId !== handleId) {
+      armedId = handleId
+      return
+    }
+    armedId = null
+    onkill?.(handleId)
+  }
 
   function fmtElapsed(startedAt: number): string {
     const sec = now > 0 && startedAt > 0 ? (now - startedAt) / 1000 : 0
@@ -64,6 +84,19 @@
               <span class="proc-cmd mono">{p.command}</span>
             </div>
             <span class="proc-time">{$t('bgtask.running_elapsed').replace('{elapsed}', fmtElapsed(p.startedAt))}</span>
+            <button
+              class="proc-kill"
+              class:armed={armedId === p.handle_id}
+              title={armedId === p.handle_id ? $t('bgtask.kill_confirm') : $t('bgtask.kill')}
+              aria-label={armedId === p.handle_id ? $t('bgtask.kill_confirm') : $t('bgtask.kill')}
+              onclick={(e) => { e.stopPropagation(); onKillClick(p.handle_id) }}
+            >
+              {#if armedId === p.handle_id}
+                <span class="proc-kill-lbl">{$t('bgtask.kill_confirm')}</span>
+              {:else}
+                <iconify-icon icon="ant-design:close-outlined" width="12"></iconify-icon>
+              {/if}
+            </button>
           </div>
           {/each}
         </div>
@@ -105,5 +138,16 @@
 .proc-info { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
 .proc-cmd { font-size: 13px; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .proc-time { font-size: 12px; color: var(--success); flex: 0 0 auto; }
+.proc-kill {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 20px; height: 20px; padding: 0 4px; margin-left: 2px; flex: 0 0 auto;
+  border: none; border-radius: 4px; background: transparent;
+  font-family: inherit; font-size: 12px; color: var(--text-secondary);
+  cursor: pointer;
+}
+.proc-kill:hover { color: var(--error, #ff4d4f); background: var(--bg-table-header); }
+.proc-kill.armed { color: #fff; background: var(--error, #ff4d4f); }
+.proc-kill.armed:hover { filter: brightness(0.92); }
+.proc-kill-lbl { white-space: nowrap; line-height: 1; }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 </style>

--- a/web/src/components/chat/BackgroundProcesses.svelte
+++ b/web/src/components/chat/BackgroundProcesses.svelte
@@ -89,7 +89,7 @@
               class:armed={armedId === p.handle_id}
               title={armedId === p.handle_id ? $t('bgtask.kill_confirm') : $t('bgtask.kill')}
               aria-label={armedId === p.handle_id ? $t('bgtask.kill_confirm') : $t('bgtask.kill')}
-              onclick={(e) => { e.stopPropagation(); onKillClick(p.handle_id) }}
+              onclick={() => onKillClick(p.handle_id)}
             >
               {#if armedId === p.handle_id}
                 <span class="proc-kill-lbl">{$t('bgtask.kill_confirm')}</span>
@@ -145,8 +145,8 @@
   font-family: inherit; font-size: 12px; color: var(--text-secondary);
   cursor: pointer;
 }
-.proc-kill:hover { color: var(--error, #ff4d4f); background: var(--bg-table-header); }
-.proc-kill.armed { color: #fff; background: var(--error, #ff4d4f); }
+.proc-kill:hover { color: var(--error); background: var(--bg-table-header); }
+.proc-kill.armed { color: #fff; background: var(--error); }
 .proc-kill.armed:hover { filter: brightness(0.92); }
 .proc-kill-lbl { white-space: nowrap; line-height: 1; }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -307,6 +307,8 @@ export const en: Record<string, string> = {
   "bgtask.n_processes": "{n} background processes",
   "bgtask.n_process": "{n} background process",
   "bgtask.running_elapsed": "running · {elapsed}",
+  "bgtask.kill": "Kill process",
+  "bgtask.kill_confirm": "Kill?",
   // Artifacts panel
   "artifacts.copied": "Copied to clipboard",
   "artifacts.copy_failed": "Copy failed — clipboard access denied",
@@ -1257,6 +1259,8 @@ export const zh: Record<string, string> = {
   "bgtask.n_processes": "{n} 个后台进程",
   "bgtask.n_process": "{n} 个后台进程",
   "bgtask.running_elapsed": "运行中 · {elapsed}",
+  "bgtask.kill": "终止进程",
+  "bgtask.kill_confirm": "确认终止？",
   // 制品面板
   "artifacts.copied": "已复制到剪贴板",
   "artifacts.copy_failed": "复制失败 — 剪贴板访问被拒绝",

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -236,6 +236,17 @@ export class WsManager {
     this.send({ type: "promote_sync_sub_agent", session_id: sessionId });
   }
 
+  // Kill one background process from the popover. The server answers through
+  // the normal exit path: a "cancelled" background_task_notice plus a refreshed
+  // background_tasks_update — there is no dedicated ack.
+  killBackground(sessionId: string, handleId: string): void {
+    this.send({
+      type: "kill_background",
+      session_id: sessionId,
+      handle_id: handleId,
+    });
+  }
+
   rollback(sessionId: string): void {
     this.send({ type: "rollback", session_id: sessionId });
   }

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -3171,7 +3171,7 @@ import QuestionModal from '../components/overlays/QuestionModal.svelte'
 
       <!-- Background processes: a text trigger opening a popover list -->
       {#if bgTasks && bgTasks.length > 0}
-        <BackgroundProcesses tasks={bgTasks} {now} />
+        <BackgroundProcesses tasks={bgTasks} {now} onkill={(handleId) => { if (id) ws.killBackground(id, handleId) }} />
       {/if}
 
       <!-- Question banner (aligned with composer) -->


### PR DESCRIPTION
## Why

Background processes are deliberately decoupled from the turn context, so the Stop button never touches them. Until now the only way to end one was for the model to call `kill_shell`. When the turn itself is dead (provider 429 / quota exhausted) that path is gone too, and a user reported exactly this: a runaway `taskkill /F /IM node.exe ...` sat in the "1 background process" badge for 24+ minutes with no recourse short of closing the session.

## What

- **Web popover**: each row in the background-process list gets a kill button. First click arms the row (× becomes "Kill?"), second click kills. Only one row can be armed; the arm drops when the popover closes or the row disappears (process exited on its own), so a stale arm can't fire on the wrong process.
- **WS**: new inbound `kill_background { session_id, handle_id }` next to `promote_sync_terminal`.
- **Server**: `handleWSKillBackground` (re)wires the session's exit hook, then calls `BackgroundManager.Kill`. No new broadcast path: the exit hook (`wireBackgroundTaskNotices`) emits the `cancelled` notice, refreshes the badge, and tells the model the process was killed rather than finished (`BgExit.Killed`). Unknown id re-broadcasts the live list instead of erroring; empty id is a no-op.
- **`bgNoticeStatus`** now classifies by `BgExit.Killed` first. On Windows a taskkill'd process exits with a plain non-zero status and no signal in the string, so a deliberate kill used to render as a red "failed".
- **i18n**: `bgtask.kill` / `bgtask.kill_confirm` in en + zh.

## Scope decisions

- SIGKILL only. Graceful signals remain the model's business via `kill_shell`.
- Web only. The TUI has the same gap but is a separate change.

## Review findings folded in (second commit)

- REST-driven turns (`runTurn`) share the per-session manager but never install the exit hook, so a kill on a process they launched would have landed silently. The handler wires the hook itself now; `SetOnExit` is idempotent.
- Windows kill status mislabelled as failed (above).

## Tests

- `internal/server/bg_kill_test.go`: real process killed **without** pre-wiring the hook → `cancelled` notice + `running: 0` (covers the REST path; skipped on Windows like the existing bg notice test); raw-JSON `dispatch("kill_background", …)` reaches the handler with both tags decoded; unknown id → badge resync only, no fabricated notice; empty id → nothing broadcast.
- `TestBgNoticeStatus` gains the Windows-shaped `{Status: "exited: exit status 1", Killed: true} → cancelled` case, runnable on every platform.
- `go test -race ./internal/server/`, `svelte-check` (0 errors), full `vitest` suite all green.
- Not done: a real-browser click-through of the armed button. The popover only appears with a live `background_tasks_update`; the styling is a plain variant of the existing row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
