### PR TITLE
browser: add a clear action and list valid actions on an unknown one

### DIFF
--- a/dev-docs/browser-computer-use-design.md
+++ b/dev-docs/browser-computer-use-design.md
@@ -81,9 +81,13 @@ is dead (Chrome closed/restarted).
 ## The `browser` tool
 
 One action-multiplexed tool. Actions: `navigate`, `back`, `click`, `hover`,
-`type`, `select`, `key`, `scroll`, `wait`, `screenshot`, `observe`, `ax`,
-`cookies`, `upload`, `download`, `pages`, `select_page`, `close`, `eval`,
-`record_start`, `record_stop`, `replay`.
+`type`, `clear`, `select`, `key`, `scroll`, `wait`, `screenshot`, `observe`,
+`ax`, `cookies`, `upload`, `download`, `pages`, `select_page`, `close`, `eval`,
+`record_start`, `record_stop`, `record_cancel`, `replay` (`run_skill` is a
+deprecated alias). The list lives in one place (`browserActions`), feeding both
+the schema enum and the unknown-action error, which echoes the valid names.
+`clear` exists because `type` inserts at the caret and cannot replace existing
+content; it is live-only and has no recording step.
 
 Notable behaviours:
 - **`observe`** returns a text digest of the page's interactable elements

--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -756,6 +756,18 @@ func (p *Page) TypeText(ctx context.Context, selector, text string) error {
 // holds content afterwards (a widget that swallows synthetic keys, a masked
 // input), fall back to writing the empty value directly and firing input so
 // bound state resets anyway.
+//
+// The key press is only sent when focus verifiably landed on the target.
+// focus() is a silent no-op on a hidden or disabled element, and a Backspace
+// dispatched then would go to whatever was focused before — typically the
+// field the model just typed into — and delete from it with no trace. Such a
+// target goes straight to the value reset instead. A read-only field is an
+// error rather than a reset: the page said it must not change, and a direct
+// write would defeat that.
+//
+// An element that disappears between steps (a framework re-render swapping
+// the node) reads as empty and counts as cleared; the replacement starts
+// fresh, which is what the caller wanted.
 func (p *Page) Clear(ctx context.Context, selector string) error {
 	frame, elem := splitFrame(selector)
 	if frame != "" {
@@ -763,28 +775,36 @@ func (p *Page) Clear(ctx context.Context, selector string) error {
 			return cp.Clear(ctx, elem)
 		}
 	}
-	// execCommand runs against the element's own document so a field inside a
-	// same-origin iframe selects its own content, not the top document's.
+	// execCommand and activeElement are read off the element's own document so
+	// a field inside a same-origin iframe is handled in its own frame, not the
+	// top document.
 	selectAll := fmt.Sprintf(`(() => {
 		const el = %s;
-		if (!el) return false;
+		if (!el) return 'missing';
+		if (el.readOnly) return 'readonly';
 		el.focus();
+		const active = el.ownerDocument.activeElement;
+		if (active !== el && !el.contains(active)) return 'unfocused';
 		if (typeof el.select === 'function') el.select();
 		else if (el.isContentEditable) el.ownerDocument.execCommand('selectAll', false, null);
-		return true;
+		return 'ok';
 	})()`, elemRefJS(frame, elem))
-	var ok bool
-	if err := p.Eval(ctx, selectAll, &ok); err != nil {
+	var state string
+	if err := p.Eval(ctx, selectAll, &state); err != nil {
 		return err
 	}
-	if !ok {
+	switch state {
+	case "missing":
 		return fmt.Errorf("clear: selector %q matched nothing", selector)
-	}
-	if err := p.Key(ctx, "backspace"); err != nil {
-		return err
-	}
-	if !p.fieldNonEmpty(ctx, selector) {
-		return nil
+	case "readonly":
+		return fmt.Errorf("clear: %q is read-only", selector)
+	case "ok":
+		if err := p.Key(ctx, "backspace"); err != nil {
+			return err
+		}
+		if !p.fieldNonEmpty(ctx, selector) {
+			return nil
+		}
 	}
 	p.clearField(ctx, selector)
 	if p.fieldNonEmpty(ctx, selector) {

--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -748,6 +748,51 @@ func (p *Page) TypeText(ctx context.Context, selector, text string) error {
 	return err
 }
 
+// Clear empties a text field — input, textarea, or contenteditable — so the
+// next TypeText starts from nothing; TypeText inserts at the caret and has no
+// way to replace what is already there. The primary path is a real select-all
+// followed by a Backspace key press, so framework-controlled inputs (React,
+// Vue) see exactly the input events a user would produce. If the field still
+// holds content afterwards (a widget that swallows synthetic keys, a masked
+// input), fall back to writing the empty value directly and firing input so
+// bound state resets anyway.
+func (p *Page) Clear(ctx context.Context, selector string) error {
+	frame, elem := splitFrame(selector)
+	if frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return cp.Clear(ctx, elem)
+		}
+	}
+	// execCommand runs against the element's own document so a field inside a
+	// same-origin iframe selects its own content, not the top document's.
+	selectAll := fmt.Sprintf(`(() => {
+		const el = %s;
+		if (!el) return false;
+		el.focus();
+		if (typeof el.select === 'function') el.select();
+		else if (el.isContentEditable) el.ownerDocument.execCommand('selectAll', false, null);
+		return true;
+	})()`, elemRefJS(frame, elem))
+	var ok bool
+	if err := p.Eval(ctx, selectAll, &ok); err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("clear: selector %q matched nothing", selector)
+	}
+	if err := p.Key(ctx, "backspace"); err != nil {
+		return err
+	}
+	if !p.fieldNonEmpty(ctx, selector) {
+		return nil
+	}
+	p.clearField(ctx, selector)
+	if p.fieldNonEmpty(ctx, selector) {
+		return fmt.Errorf("clear: %q still has content after select-all+Backspace and a direct reset", selector)
+	}
+	return nil
+}
+
 // fieldNonEmpty reports whether a form field currently holds any value/text —
 // the post-type sanity check, since programmatic input can be silently swallowed
 // by a disabled, re-rendering, or framework-controlled input. It checks

--- a/internal/browser/clear_test.go
+++ b/internal/browser/clear_test.go
@@ -1,0 +1,68 @@
+package browser
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Clear must empty a field that already has content and leave it ready for a
+// fresh TypeText — the whole point is that type inserts at the caret and cannot
+// replace what is there.
+func TestClear_EmptiesFieldBeforeRetype(t *testing.T) {
+	ctx := context.Background()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><html><body>
+			<input id="q" value="stale">
+			<textarea id="notes">old notes</textarea>
+			<div id="rich" contenteditable="true">rich text</div>
+		</body></html>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#q", testWaitTimeout); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	for _, sel := range []string{"#q", "#notes", "#rich"} {
+		if err := page.Clear(ctx, sel); err != nil {
+			t.Fatalf("clear %s: %v", sel, err)
+		}
+		if page.fieldNonEmpty(ctx, sel) {
+			t.Errorf("%s still has content after Clear", sel)
+		}
+	}
+
+	// Clearing an already-empty field is a no-op, not an error.
+	if err := page.Clear(ctx, "#q"); err != nil {
+		t.Fatalf("clear empty field: %v", err)
+	}
+
+	// The field is usable afterwards: a fresh type lands alone, not appended.
+	if err := page.TypeText(ctx, "#q", "fresh"); err != nil {
+		t.Fatalf("type after clear: %v", err)
+	}
+	var got string
+	if err := page.Eval(ctx, `document.querySelector('#q').value`, &got); err != nil {
+		t.Fatalf("read value: %v", err)
+	}
+	if got != "fresh" {
+		t.Errorf("value after clear+type = %q, want %q", got, "fresh")
+	}
+
+	if err := page.Clear(ctx, "#nope"); err == nil {
+		t.Error("clear on a missing selector should error")
+	}
+}

--- a/internal/browser/clear_test.go
+++ b/internal/browser/clear_test.go
@@ -4,37 +4,78 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+// clearFixture exercises every branch of Page.Clear:
+//   - plain input / textarea / contenteditable: the select-all + Backspace path
+//   - #swallow: a keydown handler cancels Backspace, so the key path leaves the
+//     value intact and Clear must fall back to the direct reset
+//   - #sticky: an input handler writes the old value back on every change, so
+//     both paths fail and Clear must report it
+//   - #ro: read-only, must be refused rather than overwritten
+//   - #hidden: display:none, so focus() is a no-op — Clear must not send a
+//     Backspace to whatever was focused before (#neighbour) and must still
+//     empty the hidden value through the reset path
+const clearFixture = `<!doctype html><html><body>
+	<input id="q" value="stale">
+	<textarea id="notes">old notes</textarea>
+	<div id="rich" contenteditable="true">rich text</div>
+	<input id="swallow" value="kept">
+	<input id="sticky" value="glue">
+	<input id="ro" value="locked" readonly>
+	<input id="neighbour" value="keep me">
+	<input id="hidden" value="secret" style="display:none">
+	<script>
+		document.querySelector('#swallow').addEventListener('keydown', e => {
+			if (e.key === 'Backspace') e.preventDefault();
+		});
+		document.querySelector('#sticky').addEventListener('input', e => { e.target.value = 'glue'; });
+	</script>
+</body></html>`
+
+func newClearPage(t *testing.T, ctx context.Context) (*Browser, *Page) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(clearFixture))
+	}))
+	t.Cleanup(srv.Close)
+
+	b := newBrowser(t, ctx)
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		b.Close()
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		b.Close()
+		t.Fatalf("navigate: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#q", testWaitTimeout); err != nil {
+		b.Close()
+		t.Fatalf("wait: %v", err)
+	}
+	return b, page
+}
+
+func fieldValue(t *testing.T, ctx context.Context, page *Page, sel string) string {
+	t.Helper()
+	var got string
+	if err := page.Eval(ctx, `(()=>{const el=document.querySelector(`+jsString(sel)+`); return ('value' in el)?el.value:el.textContent;})()`, &got); err != nil {
+		t.Fatalf("read %s: %v", sel, err)
+	}
+	return got
+}
 
 // Clear must empty a field that already has content and leave it ready for a
 // fresh TypeText — the whole point is that type inserts at the caret and cannot
 // replace what is there.
 func TestClear_EmptiesFieldBeforeRetype(t *testing.T) {
 	ctx := context.Background()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(`<!doctype html><html><body>
-			<input id="q" value="stale">
-			<textarea id="notes">old notes</textarea>
-			<div id="rich" contenteditable="true">rich text</div>
-		</body></html>`))
-	}))
-	defer srv.Close()
-
-	b := newBrowser(t, ctx)
+	b, page := newClearPage(t, ctx)
 	defer b.Close()
-
-	page, err := b.NewPage(ctx, "about:blank")
-	if err != nil {
-		t.Fatalf("new page: %v", err)
-	}
-	if err := page.Navigate(ctx, srv.URL); err != nil {
-		t.Fatalf("navigate: %v", err)
-	}
-	if err := page.WaitFor(ctx, "#q", testWaitTimeout); err != nil {
-		t.Fatalf("wait: %v", err)
-	}
 
 	for _, sel := range []string{"#q", "#notes", "#rich"} {
 		if err := page.Clear(ctx, sel); err != nil {
@@ -54,15 +95,71 @@ func TestClear_EmptiesFieldBeforeRetype(t *testing.T) {
 	if err := page.TypeText(ctx, "#q", "fresh"); err != nil {
 		t.Fatalf("type after clear: %v", err)
 	}
-	var got string
-	if err := page.Eval(ctx, `document.querySelector('#q').value`, &got); err != nil {
-		t.Fatalf("read value: %v", err)
-	}
-	if got != "fresh" {
+	if got := fieldValue(t, ctx, page, "#q"); got != "fresh" {
 		t.Errorf("value after clear+type = %q, want %q", got, "fresh")
 	}
 
 	if err := page.Clear(ctx, "#nope"); err == nil {
 		t.Error("clear on a missing selector should error")
+	}
+}
+
+// When the page cancels the Backspace, Clear falls back to the direct reset
+// and still succeeds; when the page fights the reset too, Clear says so.
+func TestClear_FallbackAndFailure(t *testing.T) {
+	ctx := context.Background()
+	b, page := newClearPage(t, ctx)
+	defer b.Close()
+
+	if err := page.Clear(ctx, "#swallow"); err != nil {
+		t.Fatalf("clear #swallow (fallback path): %v", err)
+	}
+	if got := fieldValue(t, ctx, page, "#swallow"); got != "" {
+		t.Errorf("#swallow = %q after fallback clear, want empty", got)
+	}
+
+	err := page.Clear(ctx, "#sticky")
+	if err == nil || !strings.Contains(err.Error(), "still has content") {
+		t.Fatalf("clear #sticky err = %v, want a still-has-content error", err)
+	}
+}
+
+// A read-only field is refused, not silently overwritten.
+func TestClear_RefusesReadOnly(t *testing.T) {
+	ctx := context.Background()
+	b, page := newClearPage(t, ctx)
+	defer b.Close()
+
+	err := page.Clear(ctx, "#ro")
+	if err == nil || !strings.Contains(err.Error(), "read-only") {
+		t.Fatalf("clear #ro err = %v, want a read-only error", err)
+	}
+	if got := fieldValue(t, ctx, page, "#ro"); got != "locked" {
+		t.Errorf("#ro = %q, want untouched %q", got, "locked")
+	}
+}
+
+// focus() on a hidden element is a no-op, so a Backspace sent regardless would
+// land on the previously focused field. Clear must leave that neighbour alone
+// and still empty the hidden field via the reset path.
+func TestClear_HiddenTargetDoesNotHitNeighbour(t *testing.T) {
+	ctx := context.Background()
+	b, page := newClearPage(t, ctx)
+	defer b.Close()
+
+	// Put real focus on the neighbour with the caret at the end, the way a
+	// preceding type action would leave it.
+	if err := page.Eval(ctx, `(()=>{const el=document.querySelector('#neighbour'); el.focus(); el.setSelectionRange(el.value.length, el.value.length); return document.activeElement === el;})()`, nil); err != nil {
+		t.Fatalf("focus neighbour: %v", err)
+	}
+
+	if err := page.Clear(ctx, "#hidden"); err != nil {
+		t.Fatalf("clear #hidden: %v", err)
+	}
+	if got := fieldValue(t, ctx, page, "#hidden"); got != "" {
+		t.Errorf("#hidden = %q, want empty", got)
+	}
+	if got := fieldValue(t, ctx, page, "#neighbour"); got != "keep me" {
+		t.Errorf("#neighbour = %q, want untouched %q — Backspace leaked to the focused field", got, "keep me")
 	}
 }

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -423,8 +424,8 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 			"properties": map[string]any{
 				"action": map[string]any{
 					"type":        "string",
-					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "cookies", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "record_cancel", "replay", "run_skill"},
-					"description": "The browser action to perform. observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page to actually see (use when content is visual); it needs either a vision-capable model or a configured vision_helper, and otherwise returns just the file path. ax returns an accessibility-tree digest (roles and names) — a semantic text view of the page, an alternative to observe when document structure matters more than selectors. pages lists open tabs; select_page switches between them. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable recording — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop (or record_cancel to discard the demo without saving). Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. replay replays a recording (deterministic, self-healing; run_skill is a deprecated alias of replay).",
+					"enum":        browserActions,
+					"description": "The browser action to perform. type inserts at the caret and does not replace existing content — use clear first to empty an input/textarea/contenteditable. eval runs JavaScript (parameter js). observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page to actually see (use when content is visual); it needs either a vision-capable model or a configured vision_helper, and otherwise returns just the file path. ax returns an accessibility-tree digest (roles and names) — a semantic text view of the page, an alternative to observe when document structure matters more than selectors. pages lists open tabs; select_page switches between them. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable recording — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop (or record_cancel to discard the demo without saving). Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. replay replays a recording (deterministic, self-healing; run_skill is a deprecated alias of replay).",
 				},
 				"name":         map[string]any{"type": "string", "description": "Recording name (record_stop / replay)."},
 				"params":       map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (replay). Params declared secret:true in the recording are collected by the runtime OUTSIDE the conversation (session cache → OCTO_BROWSER_SECRET_<NAME> env → masked user prompt) — never pass a secret value here, just omit it. Omitting a required NON-secret param fails with a missing-param error; then decide whether to supply a value or ask the user."},
@@ -472,10 +473,25 @@ func resolveBrowserProgress(ctx context.Context) func(string) {
 	return p
 }
 
+// browserActions is the single source of truth for the action enum the model
+// sees and for the "unknown action" error. Models routinely guess synonyms
+// (clear/evaluate/exec) — echoing the real list back turns three blind retries
+// into one corrected call.
+var browserActions = []string{"navigate", "back", "click", "hover", "type", "clear", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "cookies", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "record_cancel", "replay", "run_skill"}
+
+func unknownBrowserAction(action string) error {
+	return fmt.Errorf("browser: unknown action %q (valid: %s)", action, strings.Join(browserActions, ", "))
+}
+
 func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	action, _ := input["action"].(string)
 	if action == "" {
 		return agent.ToolResult{}, fmt.Errorf("browser: action is required")
+	}
+	// Reject a bad action before touching the browser: a typo should cost one
+	// round-trip with the valid list, not a CDP connection attempt first.
+	if !slices.Contains(browserActions, action) {
+		return agent.ToolResult{}, unknownBrowserAction(action)
 	}
 
 	// Bound every action so a CDP call a janky/loading page never acks (e.g. a
@@ -563,6 +579,16 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 			return agent.ToolResult{}, err
 		}
 		return agent.ToolResult{Text: fmt.Sprintf("typed %q into %s", text, sel)}, nil
+
+	case "clear":
+		sel := targetSelector(input)
+		if sel == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: clear requires selector")
+		}
+		if err := page.Clear(ctx, sel); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: "cleared " + sel}, nil
 
 	case "key":
 		combo := getStr(input, "keys")
@@ -944,7 +970,9 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: string(j)}, nil
 
 	default:
-		return agent.ToolResult{}, fmt.Errorf("browser: unknown action %q", action)
+		// Unreachable after the up-front check; kept so a case added to
+		// browserActions without a branch here still fails loudly.
+		return agent.ToolResult{}, unknownBrowserAction(action)
 	}
 }
 

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -394,19 +394,21 @@ func TestBrowserTool_UnknownActionListsValidOnes(t *testing.T) {
 	}
 }
 
-// The enum the model sees and the dispatch switch must agree: every listed
-// action has a branch, so none can fall through to the unknown-action error.
+// The enum the model sees must be fed from browserActions — the same list the
+// unknown-action error echoes — so the two can never drift back into a
+// hand-maintained literal that forgets a new action.
 func TestBrowserTool_EnumMatchesActions(t *testing.T) {
 	def := BrowserTool{}.Definition()
 	props := def.Parameters["properties"].(map[string]any)
-	enum := props["action"].(map[string]any)["enum"].([]string)
-	if len(enum) != len(browserActions) {
-		t.Fatalf("enum has %d actions, browserActions has %d", len(enum), len(browserActions))
+	enum, ok := props["action"].(map[string]any)["enum"].([]string)
+	if !ok {
+		t.Fatalf("action enum is %T, want []string", props["action"].(map[string]any)["enum"])
 	}
-	for _, want := range []string{"clear", "eval", "type"} {
-		if !slices.Contains(enum, want) {
-			t.Errorf("enum missing %q", want)
-		}
+	if !slices.Equal(enum, browserActions) {
+		t.Fatalf("enum = %v\nbrowserActions = %v", enum, browserActions)
+	}
+	if !slices.Contains(enum, "clear") {
+		t.Error("enum missing clear")
 	}
 }
 

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -368,6 +369,44 @@ func TestBrowserTool_RequiresAction(t *testing.T) {
 	_, err := BrowserTool{}.Execute(context.Background(), "browser", map[string]any{})
 	if err == nil {
 		t.Fatal("expected error for missing action")
+	}
+}
+
+// A guessed action name (models try clear-alikes and eval synonyms) must fail
+// before any browser connection is attempted, and the error must carry the
+// valid list so the next call can be right. No Chrome is needed for this test
+// precisely because the check runs up front.
+func TestBrowserTool_UnknownActionListsValidOnes(t *testing.T) {
+	for _, bad := range []string{"evaluate", "exec", "clearx"} {
+		_, err := BrowserTool{}.Execute(context.Background(), "browser", map[string]any{"action": bad})
+		if err == nil {
+			t.Fatalf("action %q: expected error", bad)
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, `unknown action "`+bad+`"`) {
+			t.Errorf("action %q: error %q does not name the bad action", bad, msg)
+		}
+		for _, want := range []string{"clear", "eval", "navigate", "replay"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("action %q: error %q does not list valid action %q", bad, msg, want)
+			}
+		}
+	}
+}
+
+// The enum the model sees and the dispatch switch must agree: every listed
+// action has a branch, so none can fall through to the unknown-action error.
+func TestBrowserTool_EnumMatchesActions(t *testing.T) {
+	def := BrowserTool{}.Definition()
+	props := def.Parameters["properties"].(map[string]any)
+	enum := props["action"].(map[string]any)["enum"].([]string)
+	if len(enum) != len(browserActions) {
+		t.Fatalf("enum has %d actions, browserActions has %d", len(enum), len(browserActions))
+	}
+	for _, want := range []string{"clear", "eval", "type"} {
+		if !slices.Contains(enum, want) {
+			t.Errorf("enum missing %q", want)
+		}
 	}
 }
 

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -154,7 +154,7 @@
         let detail = ''
         switch (act) {
           case 'navigate': detail = pick('url'); break
-          case 'click': case 'hover': case 'scroll': case 'download':
+          case 'click': case 'hover': case 'clear': case 'scroll': case 'download':
             detail = sel; break
           case 'wait':
             detail = sel || (a.network_idle ? 'network idle' : (a.timeout_ms ? `${a.timeout_ms}ms` : '')); break


### PR DESCRIPTION
## Why

A user's Web transcript showed the model calling the browser tool with `clear`, then `evaluate`, then `exec` — three failed tool calls in a row, each answered only with `browser: unknown action "…"`. Two separate problems:

1. **There was no way to empty a field.** `type` inserts at the caret via `Input.insertText`; it cannot replace existing content, so "clear this input and retype" had no primitive. The model's first guess was reasonable.
2. **The error carried no correction.** With 25 actions buried in one long description and no valid list in the error, every retry was a blind guess (`evaluate`/`exec` for `eval`).

## What

- **New `clear` action** (`Page.Clear`): focus → select-all (`select()` for input/textarea, `execCommand('selectAll')` on the element's own document for contenteditable) → a real Backspace key press through `Page.Key`, so React/Vue-controlled inputs see the same input events a user produces. If content survives (synthetic keys swallowed, masked input), falls back to the existing `clearField` value reset + `input` event; errors only if the field is still non-empty after both. Same OOPIF redirect as `TypeText`. Idempotent on an already-empty field.
- **Focus is verified before the key press.** `focus()` is a silent no-op on a hidden or disabled element; sending Backspace regardless would delete from whatever was focused before (typically the field the model just typed into). Unfocused targets skip the key and go straight to the value reset. Read-only fields are refused, not overwritten.
- **Single action list.** `browserActions` is now the one slice behind the schema enum and the unknown-action error, which reads `unknown action "exec" (valid: navigate, back, …)`.
- **Validate before connecting.** The action check now runs before `browserPage(ctx)`, so a typo costs one round-trip and never a CDP connection attempt.
- Schema description gains one sentence: `type` does not replace content, use `clear` first; `eval` runs JS via `js`.
- dev-docs action list and the Web tool-card summary (`ToolGroup.svelte`) gain `clear`. `clear` is live-only; no recording step type.

## Tests (all against real Chrome unless noted)

- `TestClear_EmptiesFieldBeforeRetype`: `<input>` with a value, `<textarea>`, `contenteditable`; clearing an empty field is a no-op; a subsequent `type` lands alone; missing selector errors.
- `TestClear_FallbackAndFailure`: a page that cancels Backspace on keydown is still cleared via the reset path; a page that rewrites the value on every `input` yields a `still has content` error.
- `TestClear_RefusesReadOnly`: read-only field errors and keeps its value.
- `TestClear_HiddenTargetDoesNotHitNeighbour`: focus on a neighbour, clear a `display:none` input — hidden value emptied, neighbour untouched.
- `internal/tools/browser_test.go` (no Chrome): unknown actions fail before any connection and the message names the bad action and lists valid ones; the schema enum is `browserActions` itself.
- `go test ./internal/browser/` (full, ~270s), `go test ./internal/tools/ -run Browser`, `svelte-check` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
