### PR TITLE
browser: read the field back after type and mark prefilled fields in observe

### DIFF
--- a/dev-docs/browser-computer-use-design.md
+++ b/dev-docs/browser-computer-use-design.md
@@ -91,8 +91,14 @@ content; it is live-only and has no recording step.
 
 Notable behaviours:
 - **`observe`** returns a text digest of the page's interactable elements
-  (URL/title + element → selector). Model-agnostic, the cheap way to look at an
-  unfamiliar page; works on any model with no vision.
+  (URL/title + element → selector). A text-entry field that already holds a
+  value is marked `(prefilled: "…")`, a password field `(prefilled password,
+  N chars)` — the value itself is withheld. Model-agnostic, the cheap way to
+  look at an unfamiliar page; works on any model with no vision.
+- **`type`** inserts at the caret and reads the field back afterwards; the
+  result reports what the field now holds and, when that differs from the text
+  sent, says so and points at `clear`. Password fields are reported by length
+  only.
 - **`screenshot`** returns an image for a vision-capable model. It is gated on
   the active model's vision capability (`tools.SetBrowserVision`, set from the
   model config); a text-only model gets a text note instead of an image block

--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -813,6 +813,41 @@ func (p *Page) Clear(ctx context.Context, selector string) error {
 	return nil
 }
 
+// FieldState is what a text-entry field holds right now, read back after an
+// action so the caller can tell the model what actually happened — TypeText
+// inserts at the caret, so a prefilled field (browser autofill on a login
+// form) ends up holding old+new, which the insert itself never reveals.
+type FieldState struct {
+	Found    bool   // selector matched an element
+	Value    string // current value (textContent for contenteditable); empty for a password field
+	ValueLen int    // length of the current value, reported even when Value is withheld
+	Password bool   // input type=password: Value is withheld so it never enters the transcript
+}
+
+// FieldState reads the current content of the field selector points at. A
+// read failure (page navigated away, element gone) reports Found=false rather
+// than an error: the readback is advisory, the action it follows already
+// succeeded or failed on its own terms.
+func (p *Page) FieldState(ctx context.Context, selector string) FieldState {
+	frame, elem := splitFrame(selector)
+	if frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return cp.FieldState(ctx, elem)
+		}
+	}
+	expr := fmt.Sprintf(`(()=>{const el=%s; if(!el) return null; const v=(('value' in el)?el.value:el.textContent)||''; const pw=(el.type||'')==='password'; return {found:true, value: pw?'':(''+v), value_len:(''+v).length, password:pw};})()`, elemRefJS(frame, elem))
+	var st struct {
+		Found    bool   `json:"found"`
+		Value    string `json:"value"`
+		ValueLen int    `json:"value_len"`
+		Password bool   `json:"password"`
+	}
+	if err := p.Eval(ctx, expr, &st); err != nil || !st.Found {
+		return FieldState{}
+	}
+	return FieldState{Found: true, Value: st.Value, ValueLen: st.ValueLen, Password: st.Password}
+}
+
 // fieldNonEmpty reports whether a form field currently holds any value/text —
 // the post-type sanity check, since programmatic input can be silently swallowed
 // by a disabled, re-rendering, or framework-controlled input. It checks

--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -819,8 +819,8 @@ func (p *Page) Clear(ctx context.Context, selector string) error {
 // form) ends up holding old+new, which the insert itself never reveals.
 type FieldState struct {
 	Found    bool   // selector matched an element
-	Value    string // current value (textContent for contenteditable); empty for a password field
-	ValueLen int    // length of the current value, reported even when Value is withheld
+	Value    string // the element's value when it has one, else its textContent (contenteditable); empty for a password field
+	ValueLen int    // length of the current value in code points (matches Go's rune count), reported even when Value is withheld
 	Password bool   // input type=password: Value is withheld so it never enters the transcript
 }
 
@@ -835,7 +835,11 @@ func (p *Page) FieldState(ctx context.Context, selector string) FieldState {
 			return cp.FieldState(ctx, elem)
 		}
 	}
-	expr := fmt.Sprintf(`(()=>{const el=%s; if(!el) return null; const v=(('value' in el)?el.value:el.textContent)||''; const pw=(el.type||'')==='password'; return {found:true, value: pw?'':(''+v), value_len:(''+v).length, password:pw};})()`, elemRefJS(frame, elem))
+	// Length is counted in code points (Array.from), not UTF-16 units, so it
+	// agrees with the rune count the caller compares against — otherwise an
+	// emoji in a password reads as two chars and triggers a false "field was
+	// prefilled" warning.
+	expr := fmt.Sprintf(`(()=>{const el=%s; if(!el) return null; const v=''+((('value' in el)?el.value:el.textContent)||''); const pw=(el.type||'')==='password'; return {found:true, value: pw?'':v, value_len:Array.from(v).length, password:pw};})()`, elemRefJS(frame, elem))
 	var st struct {
 		Found    bool   `json:"found"`
 		Value    string `json:"value"`

--- a/internal/browser/readback_test.go
+++ b/internal/browser/readback_test.go
@@ -1,0 +1,99 @@
+package browser
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// A login form the browser has autofilled: the digest must report the values
+// separately from the labels, withhold the password, and FieldState must show
+// TypeText appending rather than replacing.
+const readbackFixture = `<!doctype html><html><body>
+	<input name="user" placeholder="Username" value="alice">
+	<input name="pw" type="password" placeholder="Password" value="correct horse">
+	<input name="empty" placeholder="Nickname">
+	<textarea name="bio">hello</textarea>
+	<input type="submit" value="Sign in">
+	<button id="go">Go</button>
+	<div id="rich" contenteditable="true">rich</div>
+</body></html>`
+
+func TestFieldStateAndDigest_PrefilledLogin(t *testing.T) {
+	ctx := context.Background()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(readbackFixture))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#go", testWaitTimeout); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	// Digest: labels and values are separate; password content withheld;
+	// button-like inputs keep their value as text.
+	digest, err := InteractiveDigest(ctx, page, "", 60)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	bySel := map[string]DigestElement{}
+	for _, e := range digest {
+		bySel[e.Selector] = e
+	}
+	user := bySel[`input[name="user"]`]
+	if user.Text != "Username" || user.Value != "alice" || user.ValueLen != 5 || user.Password {
+		t.Errorf("user field = %+v, want text Username / value alice", user)
+	}
+	pw := bySel[`input[name="pw"]`]
+	if pw.Text != "Password" || pw.Value != "" || pw.ValueLen != len("correct horse") || !pw.Password {
+		t.Errorf("password field = %+v, want value withheld with length %d", pw, len("correct horse"))
+	}
+	empty := bySel[`input[name="empty"]`]
+	if empty.Text != "Nickname" || empty.Value != "" || empty.ValueLen != 0 {
+		t.Errorf("empty field = %+v, want placeholder text and no value", empty)
+	}
+	bio := bySel[`textarea[name="bio"]`]
+	if bio.Text != "bio" || bio.Value != "hello" {
+		t.Errorf("textarea = %+v, want name as text and hello as value", bio)
+	}
+	var submit DigestElement
+	for _, e := range digest {
+		if e.Text == "Sign in" {
+			submit = e
+		}
+	}
+	if submit.Selector == "" || submit.Value != "" {
+		t.Errorf("submit button should keep its value as text and report no field value: %+v", submit)
+	}
+
+	// FieldState: reading back after a type on a prefilled field shows old+new.
+	if err := page.TypeText(ctx, `input[name="user"]`, "alice"); err != nil {
+		t.Fatalf("type: %v", err)
+	}
+	st := page.FieldState(ctx, `input[name="user"]`)
+	if !st.Found || st.Value != "alicealice" || st.ValueLen != 10 || st.Password {
+		t.Errorf("FieldState after type = %+v, want alicealice", st)
+	}
+	st = page.FieldState(ctx, `input[name="pw"]`)
+	if !st.Found || !st.Password || st.Value != "" || st.ValueLen != len("correct horse") {
+		t.Errorf("FieldState password = %+v, want withheld value with length", st)
+	}
+	st = page.FieldState(ctx, "#rich")
+	if !st.Found || st.Value != "rich" {
+		t.Errorf("FieldState contenteditable = %+v, want textContent rich", st)
+	}
+	if st := page.FieldState(ctx, "#nope"); st.Found {
+		t.Errorf("FieldState on a missing selector should report Found=false: %+v", st)
+	}
+}

--- a/internal/browser/readback_test.go
+++ b/internal/browser/readback_test.go
@@ -12,7 +12,7 @@ import (
 // TypeText appending rather than replacing.
 const readbackFixture = `<!doctype html><html><body>
 	<input name="user" placeholder="Username" value="alice">
-	<input name="pw" type="password" placeholder="Password" value="correct horse">
+	<input name="pw" type="password" placeholder="Password" value="correct🔑horse">
 	<input name="empty" placeholder="Nickname">
 	<textarea name="bio">hello</textarea>
 	<input type="submit" value="Sign in">
@@ -20,10 +20,17 @@ const readbackFixture = `<!doctype html><html><body>
 	<div id="rich" contenteditable="true">rich</div>
 </body></html>`
 
+// pwLen is the fixture password's length in code points. The emoji is one
+// char to Array.from and to Go's rune count, two to JS .length — the readback
+// must agree with the former or a clean type warns about phantom content.
+const pwLen = 13 // len([]rune("correct🔑horse"))
+
 func TestFieldStateAndDigest_PrefilledLogin(t *testing.T) {
 	ctx := context.Background()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
+		// charset matters here: without it Chrome decodes the emoji's four
+		// UTF-8 bytes as four Latin-1 characters and every length is off.
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Write([]byte(readbackFixture))
 	}))
 	defer srv.Close()
@@ -56,8 +63,8 @@ func TestFieldStateAndDigest_PrefilledLogin(t *testing.T) {
 		t.Errorf("user field = %+v, want text Username / value alice", user)
 	}
 	pw := bySel[`input[name="pw"]`]
-	if pw.Text != "Password" || pw.Value != "" || pw.ValueLen != len("correct horse") || !pw.Password {
-		t.Errorf("password field = %+v, want value withheld with length %d", pw, len("correct horse"))
+	if pw.Text != "Password" || pw.Value != "" || pw.ValueLen != pwLen || !pw.Password {
+		t.Errorf("password field = %+v, want value withheld with length %d", pw, pwLen)
 	}
 	empty := bySel[`input[name="empty"]`]
 	if empty.Text != "Nickname" || empty.Value != "" || empty.ValueLen != 0 {
@@ -86,7 +93,7 @@ func TestFieldStateAndDigest_PrefilledLogin(t *testing.T) {
 		t.Errorf("FieldState after type = %+v, want alicealice", st)
 	}
 	st = page.FieldState(ctx, `input[name="pw"]`)
-	if !st.Found || !st.Password || st.Value != "" || st.ValueLen != len("correct horse") {
+	if !st.Found || !st.Password || st.Value != "" || st.ValueLen != pwLen {
 		t.Errorf("FieldState password = %+v, want withheld value with length", st)
 	}
 	st = page.FieldState(ctx, "#rich")

--- a/internal/browser/recording.go
+++ b/internal/browser/recording.go
@@ -1039,6 +1039,15 @@ func ListRecordings(dir string) []Recording {
 type DigestElement struct {
 	Text     string `json:"text"`
 	Selector string `json:"selector"`
+	// Value is the current content of a text-entry field (input/textarea),
+	// reported separately from Text so a prefilled value — browser autofill on
+	// a login form is the classic case — is not mistaken for a label or
+	// placeholder. Empty for non-fields. For a password field the content is
+	// withheld and only ValueLen is set, so a stored password never lands in
+	// the transcript.
+	Value    string `json:"value,omitempty"`
+	ValueLen int    `json:"value_len,omitempty"`
+	Password bool   `json:"password,omitempty"`
 }
 
 // InteractiveDigest lists interactive elements (with generated selectors) in the
@@ -1077,7 +1086,18 @@ func InteractiveDigest(ctx context.Context, page *Page, frame string, max int) (
 	  // offsetParent===null check also dropped position:fixed controls, which are
 	  // null-offsetParent in Chrome but very much clickable — fixed nav bars and
 	  // floating buttons were invisible to the healer.)
-	  for(var i=0;i<els.length && out.length<%d;i++){var el=els[i]; if(el.getClientRects().length===0 || getComputedStyle(el).visibility==='hidden') continue; var t=(el.textContent||el.value||el.getAttribute('aria-label')||el.getAttribute('placeholder')||'').trim().slice(0,50); out.push({text:t, selector:sel(el)});}
+	  // A text-entry field reports its label-ish text (aria-label / placeholder /
+	  // name) and its current value as separate things: folding value into text
+	  // made an autofilled login field read like a placeholder, so the model
+	  // typed on top of it. Button-like inputs keep value as their text — that
+	  // IS their label. Password content is withheld, only its length reported.
+	  var fieldTypes=/^(button|submit|reset|checkbox|radio|image|file|hidden|range|color)$/i;
+	  for(var i=0;i<els.length && out.length<%d;i++){var el=els[i]; if(el.getClientRects().length===0 || getComputedStyle(el).visibility==='hidden') continue;
+	    var tag=el.tagName.toLowerCase(); var isField=tag==='textarea'||(tag==='input'&&!fieldTypes.test(el.type||'text'));
+	    var t, e;
+	    if(isField){ t=(el.getAttribute('aria-label')||el.getAttribute('placeholder')||el.getAttribute('name')||'').trim().slice(0,50); var v=el.value||''; e={text:t, selector:sel(el)}; if(v){ if(el.type==='password'){e.password=true; e.value_len=v.length;} else {e.value=v.slice(0,50); e.value_len=v.length;} } }
+	    else { t=(el.textContent||el.value||el.getAttribute('aria-label')||el.getAttribute('placeholder')||'').trim().slice(0,50); e={text:t, selector:sel(el)}; }
+	    out.push(e);}
 	  return out;
 	})()`, doc, max)
 	var digest []DigestElement

--- a/internal/browser/recording.go
+++ b/internal/browser/recording.go
@@ -1043,8 +1043,14 @@ type DigestElement struct {
 	// reported separately from Text so a prefilled value — browser autofill on
 	// a login form is the classic case — is not mistaken for a label or
 	// placeholder. Empty for non-fields. For a password field the content is
-	// withheld and only ValueLen is set, so a stored password never lands in
-	// the transcript.
+	// withheld and only ValueLen (in code points) is set, so a stored password
+	// never lands in the transcript.
+	//
+	// Text for such a field is therefore its label-ish text (aria-label /
+	// placeholder / name), never its value. Both observe and the replay healer
+	// (which puts each element's Text into its prompt) see this: the healer
+	// now matches fields by label rather than by whatever the user had typed —
+	// and no longer receives an autofilled password as element text.
 	Value    string `json:"value,omitempty"`
 	ValueLen int    `json:"value_len,omitempty"`
 	Password bool   `json:"password,omitempty"`
@@ -1095,7 +1101,7 @@ func InteractiveDigest(ctx context.Context, page *Page, frame string, max int) (
 	  for(var i=0;i<els.length && out.length<%d;i++){var el=els[i]; if(el.getClientRects().length===0 || getComputedStyle(el).visibility==='hidden') continue;
 	    var tag=el.tagName.toLowerCase(); var isField=tag==='textarea'||(tag==='input'&&!fieldTypes.test(el.type||'text'));
 	    var t, e;
-	    if(isField){ t=(el.getAttribute('aria-label')||el.getAttribute('placeholder')||el.getAttribute('name')||'').trim().slice(0,50); var v=el.value||''; e={text:t, selector:sel(el)}; if(v){ if(el.type==='password'){e.password=true; e.value_len=v.length;} else {e.value=v.slice(0,50); e.value_len=v.length;} } }
+	    if(isField){ t=(el.getAttribute('aria-label')||el.getAttribute('placeholder')||el.getAttribute('name')||'').trim().slice(0,50); var v=el.value||''; var vr=Array.from(v); e={text:t, selector:sel(el)}; if(v){ if(el.type==='password'){e.password=true; e.value_len=vr.length;} else {e.value=vr.slice(0,50).join(''); e.value_len=vr.length;} } }
 	    else { t=(el.textContent||el.value||el.getAttribute('aria-label')||el.getAttribute('placeholder')||'').trim().slice(0,50); e={text:t, selector:sel(el)}; }
 	    out.push(e);}
 	  return out;

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -425,7 +425,7 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 				"action": map[string]any{
 					"type":        "string",
 					"enum":        browserActions,
-					"description": "The browser action to perform. type inserts at the caret and does not replace existing content — use clear first to empty an input/textarea/contenteditable. eval runs JavaScript (parameter js). observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page to actually see (use when content is visual); it needs either a vision-capable model or a configured vision_helper, and otherwise returns just the file path. ax returns an accessibility-tree digest (roles and names) — a semantic text view of the page, an alternative to observe when document structure matters more than selectors. pages lists open tabs; select_page switches between them. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable recording — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop (or record_cancel to discard the demo without saving). Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. replay replays a recording (deterministic, self-healing; run_skill is a deprecated alias of replay).",
+					"description": "The browser action to perform. type inserts at the caret and does not replace existing content — a field the browser autofilled (login forms) would end up holding old+new; observe marks such fields (prefilled: …), and clear empties an input/textarea/contenteditable before you type. type's result reports what the field holds afterwards — if it differs from what you sent, clear and retype. eval runs JavaScript (parameter js). observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page to actually see (use when content is visual); it needs either a vision-capable model or a configured vision_helper, and otherwise returns just the file path. ax returns an accessibility-tree digest (roles and names) — a semantic text view of the page, an alternative to observe when document structure matters more than selectors. pages lists open tabs; select_page switches between them. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable recording — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop (or record_cancel to discard the demo without saving). Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. replay replays a recording (deterministic, self-healing; run_skill is a deprecated alias of replay).",
 				},
 				"name":         map[string]any{"type": "string", "description": "Recording name (record_stop / replay)."},
 				"params":       map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (replay). Params declared secret:true in the recording are collected by the runtime OUTSIDE the conversation (session cache → OCTO_BROWSER_SECRET_<NAME> env → masked user prompt) — never pass a secret value here, just omit it. Omitting a required NON-secret param fails with a missing-param error; then decide whether to supply a value or ask the user."},
@@ -433,7 +433,7 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 				"selector":     map[string]any{"type": "string", "description": "Target element selector (click/hover/type/select/scroll/wait/upload/download). Plain CSS, or a Playwright-style form: :has-text(\"…\")/:text(\"…\")/:contains(\"…\"), text=…, :visible, xpath=…, css=…. Use observe to see real selectors."},
 				"network_idle": map[string]any{"type": "boolean", "description": "wait with no selector: settle until fetch/XHR activity stops (bounded by timeout_ms) instead of a fixed delay — the robust way to wait for an SPA's data to finish loading."},
 				"frame":        map[string]any{"type": "string", "description": "Optional CSS selector of a same-origin iframe to scope the selector into (e.g. iframe#app)."},
-				"text":         map[string]any{"type": "string", "description": "Text to type (type)."},
+				"text":         map[string]any{"type": "string", "description": "Text to type (type). Inserted at the caret, appended to any existing content — clear the field first if it may be prefilled."},
 				"value":        map[string]any{"type": "string", "description": "Option value, text, or label to pick in a <select> (select)."},
 				"keys":         map[string]any{"type": "string", "description": "Key or combo, e.g. enter, escape, ctrl+a (key)."},
 				"js":           map[string]any{"type": "string", "description": "JavaScript expression to evaluate (eval). Runs with full page access — use it to recursively traverse shadow roots or read DOM state that CSS selectors can't reach (click/type don't pierce shadow DOM)."},
@@ -481,6 +481,65 @@ var browserActions = []string{"navigate", "back", "click", "hover", "type", "cle
 
 func unknownBrowserAction(action string) error {
 	return fmt.Errorf("browser: unknown action %q (valid: %s)", action, strings.Join(browserActions, ", "))
+}
+
+// typeResultText is what the model reads after a type: not just what was sent
+// but what the field holds now. type inserts at the caret, so a field the
+// browser had autofilled (login forms, classically) ends up as old+new and the
+// login fails — with only "typed X" to go on, the model has no way to see why
+// and burns attempts. When the readback differs from the text, say so and
+// point at clear. A password field is reported by length only. A failed
+// readback (element gone) falls back to the plain confirmation.
+func typeResultText(text, sel string, st browser.FieldState) string {
+	if !st.Found {
+		return fmt.Sprintf("typed %q into %s", text, sel)
+	}
+	if st.Password {
+		s := fmt.Sprintf("typed %d chars into %s; field now holds %d chars", len([]rune(text)), sel, st.ValueLen)
+		if st.ValueLen != len([]rune(text)) {
+			s += " — the field already had content before typing (browser autofill?); use clear, then type again"
+		}
+		return s
+	}
+	s := fmt.Sprintf("typed %q into %s; field now holds %q", text, sel, uiHead(st.Value, 1, 200))
+	if st.Value != text {
+		s += " — differs from what was typed: the field already had content (browser autofill?) or the page reformats input; if it was prefilled, use clear, then type again"
+	}
+	return s
+}
+
+// renderObserve formats the observe result: page identity, then one line per
+// interactable element. A text-entry field that already holds a value gets it
+// spelled out as (prefilled: …) — that is the fact the model most often
+// misses before typing. Password fields show only a length.
+func renderObserve(title, url string, digest []browser.DigestElement, derr error) string {
+	var sb strings.Builder
+	if url != "" {
+		fmt.Fprintf(&sb, "page: %s — %s\n\n", title, url)
+	}
+	sb.WriteString("interactable elements:\n")
+	switch {
+	case derr != nil:
+		fmt.Fprintf(&sb, "(could not read elements: %v)\n", derr)
+	case len(digest) == 0:
+		sb.WriteString("(none found)\n")
+	default:
+		for _, e := range digest {
+			if e.Text != "" {
+				fmt.Fprintf(&sb, "- %s  →  %s", e.Text, e.Selector)
+			} else {
+				fmt.Fprintf(&sb, "- %s", e.Selector)
+			}
+			switch {
+			case e.Password && e.ValueLen > 0:
+				fmt.Fprintf(&sb, "  (prefilled password, %d chars)", e.ValueLen)
+			case e.Value != "":
+				fmt.Fprintf(&sb, "  (prefilled: %q)", e.Value)
+			}
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
 }
 
 func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
@@ -578,7 +637,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		if err := page.TypeText(ctx, sel, text); err != nil {
 			return agent.ToolResult{}, err
 		}
-		return agent.ToolResult{Text: fmt.Sprintf("typed %q into %s", text, sel)}, nil
+		return agent.ToolResult{Text: typeResultText(text, sel, page.FieldState(ctx, sel))}, nil
 
 	case "clear":
 		sel := targetSelector(input)
@@ -665,25 +724,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		}
 		_ = page.Eval(ctx, `({url: location.href, title: document.title})`, &meta)
 		digest, derr := browser.InteractiveDigest(ctx, page, frame, 60)
-		var sb strings.Builder
-		if meta.URL != "" {
-			fmt.Fprintf(&sb, "page: %s — %s\n\n", meta.Title, meta.URL)
-		}
-		sb.WriteString("interactable elements:\n")
-		if derr != nil {
-			fmt.Fprintf(&sb, "(could not read elements: %v)\n", derr)
-		} else if len(digest) == 0 {
-			sb.WriteString("(none found)\n")
-		} else {
-			for _, e := range digest {
-				if e.Text != "" {
-					fmt.Fprintf(&sb, "- %s  →  %s\n", e.Text, e.Selector)
-				} else {
-					fmt.Fprintf(&sb, "- %s\n", e.Selector)
-				}
-			}
-		}
-		return agent.ToolResult{Text: sb.String()}, nil
+		return agent.ToolResult{Text: renderObserve(meta.Title, meta.URL, digest, derr)}, nil
 
 	case "ax":
 		raw, err := page.AXTree(ctx)

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -501,11 +501,25 @@ func typeResultText(text, sel string, st browser.FieldState) string {
 		}
 		return s
 	}
-	s := fmt.Sprintf("typed %q into %s; field now holds %q", text, sel, uiHead(st.Value, 1, 200))
+	s := fmt.Sprintf("typed %q into %s; field now holds %s", text, sel, quoteFieldValue(st.Value))
 	if st.Value != text {
-		s += " — differs from what was typed: the field already had content (browser autofill?) or the page reformats input; if it was prefilled, use clear, then type again"
+		s += " — differs from what was typed: either the field already had content (browser autofill?) or the page reformats input (phone/card grouping, stripped newlines). If it was prefilled, use clear, then type again; if the page reformatted it, this is expected"
 	}
 	return s
+}
+
+// quoteFieldValue renders a field's content for the type readback: the whole
+// value with newlines escaped by %q — a textarea's later lines must stay
+// visible, since that is where the just-typed text lands — capped by rune so a
+// long CJK value neither costs the whole transcript nor gets cut inside a
+// code point, with an explicit marker when capped.
+func quoteFieldValue(v string) string {
+	const maxRunes = 200
+	r := []rune(v)
+	if len(r) <= maxRunes {
+		return fmt.Sprintf("%q", v)
+	}
+	return fmt.Sprintf("%q… (%d chars total)", string(r[:maxRunes]), len(r))
 }
 
 // renderObserve formats the observe result: page identity, then one line per

--- a/internal/tools/browser_readback_test.go
+++ b/internal/tools/browser_readback_test.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/browser"
+)
+
+// The type result must let the model see when the field did not end up
+// holding what it sent — the autofilled-login case — and point at clear.
+func TestTypeResultText(t *testing.T) {
+	cases := []struct {
+		name         string
+		text         string
+		st           browser.FieldState
+		want, absent []string
+	}{
+		{
+			name:   "clean type echoes the value and no warning",
+			text:   "alice",
+			st:     browser.FieldState{Found: true, Value: "alice", ValueLen: 5},
+			want:   []string{`typed "alice" into #u`, `field now holds "alice"`},
+			absent: []string{"clear"},
+		},
+		{
+			name: "prefilled field shows old+new and tells the model to clear",
+			text: "alice",
+			st:   browser.FieldState{Found: true, Value: "alicealice", ValueLen: 10},
+			want: []string{`field now holds "alicealice"`, "autofill", "use clear"},
+		},
+		{
+			name:   "password never echoes content, only lengths",
+			text:   "hunter2",
+			st:     browser.FieldState{Found: true, Password: true, ValueLen: 14},
+			want:   []string{"typed 7 chars into #u", "field now holds 14 chars", "use clear"},
+			absent: []string{"hunter2"},
+		},
+		{
+			name:   "password with matching length has no warning",
+			text:   "hunter2",
+			st:     browser.FieldState{Found: true, Password: true, ValueLen: 7},
+			want:   []string{"field now holds 7 chars"},
+			absent: []string{"clear", "hunter2"},
+		},
+		{
+			name:   "element gone falls back to the plain confirmation",
+			text:   "alice",
+			st:     browser.FieldState{},
+			want:   []string{`typed "alice" into #u`},
+			absent: []string{"holds"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := typeResultText(c.text, "#u", c.st)
+			for _, w := range c.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("result %q lacks %q", got, w)
+				}
+			}
+			for _, a := range c.absent {
+				if strings.Contains(got, a) {
+					t.Errorf("result %q should not contain %q", got, a)
+				}
+			}
+		})
+	}
+}
+
+// observe must make a prefilled field unmistakable and keep password content
+// out of the transcript.
+func TestRenderObserve_PrefilledFields(t *testing.T) {
+	digest := []browser.DigestElement{
+		{Text: "Username", Selector: `input[name="user"]`, Value: "alice", ValueLen: 5},
+		{Text: "Password", Selector: `input[name="pw"]`, Password: true, ValueLen: 14},
+		{Text: "Search", Selector: "#q"},
+		{Text: "Sign in", Selector: "#submit"},
+	}
+	out := renderObserve("Login", "https://x.test/login", digest, nil)
+
+	for _, w := range []string{
+		"page: Login — https://x.test/login",
+		`- Username  →  input[name="user"]  (prefilled: "alice")`,
+		`- Password  →  input[name="pw"]  (prefilled password, 14 chars)`,
+		"- Search  →  #q\n",
+		"- Sign in  →  #submit\n",
+	} {
+		if !strings.Contains(out, w) {
+			t.Errorf("observe output lacks %q:\n%s", w, out)
+		}
+	}
+	if strings.Contains(out, "#q  (") {
+		t.Errorf("empty field must not be marked prefilled:\n%s", out)
+	}
+}
+
+func TestRenderObserve_ErrorAndEmpty(t *testing.T) {
+	if out := renderObserve("", "", nil, errors.New("boom")); !strings.Contains(out, "(could not read elements: boom)") {
+		t.Errorf("error case: %q", out)
+	}
+	if out := renderObserve("T", "u", nil, nil); !strings.Contains(out, "(none found)") {
+		t.Errorf("empty case: %q", out)
+	}
+}

--- a/internal/tools/browser_readback_test.go
+++ b/internal/tools/browser_readback_test.go
@@ -45,6 +45,24 @@ func TestTypeResultText(t *testing.T) {
 			absent: []string{"clear", "hunter2"},
 		},
 		{
+			// JS reports code points, Go counts runes: an emoji is one on both
+			// sides, so a clean type into an empty password field must not warn.
+			name:   "emoji password counts code points on both sides",
+			text:   "pw🔑",
+			st:     browser.FieldState{Found: true, Password: true, ValueLen: 3},
+			want:   []string{"typed 3 chars into #u", "field now holds 3 chars"},
+			absent: []string{"clear"},
+		},
+		{
+			// A textarea's later lines are where the typed text lands; the
+			// readback must show them, not just the first line.
+			name:   "multi-line value is shown whole",
+			text:   "new",
+			st:     browser.FieldState{Found: true, Value: "old line\nnew", ValueLen: 12},
+			want:   []string{`field now holds "old line\nnew"`, "use clear"},
+			absent: []string{`holds "old line"` + " —"},
+		},
+		{
 			name:   "element gone falls back to the plain confirmation",
 			text:   "alice",
 			st:     browser.FieldState{},
@@ -66,6 +84,26 @@ func TestTypeResultText(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// A long CJK value is capped by rune with an explicit marker — never cut
+// inside a code point (which %q would render as \x escapes the model reads as
+// real content).
+func TestQuoteFieldValue_CapsByRune(t *testing.T) {
+	long := strings.Repeat("中", 260)
+	got := quoteFieldValue(long)
+	if strings.Contains(got, `\x`) {
+		t.Errorf("value cut inside a code point: %s", got)
+	}
+	if !strings.Contains(got, "… (260 chars total)") {
+		t.Errorf("missing truncation marker: %s", got)
+	}
+	if strings.Count(got, "中") != 200 {
+		t.Errorf("want exactly 200 runes kept, got %d", strings.Count(got, "中"))
+	}
+	if short := quoteFieldValue("ok"); short != `"ok"` {
+		t.Errorf("short value = %s", short)
 	}
 }
 


### PR DESCRIPTION
## Why

A user reported the model failing login over and over on a form Chrome had autofilled. `type` inserts at the caret via `Input.insertText`, so the username field ended up holding `alicealice`; nothing in the tool output showed that, and the model only worked it out after several failed submits, then cleared and retyped. The blind spots are in the tool, not the model or a skill.

## What

- **`type` reads the field back.** Result is now `typed "alice" into input[name="user"]; field now holds "alicealice" — differs from what was typed: either the field already had content (browser autofill?) or the page reformats input … If it was prefilled, use clear, then type again; if the page reformatted it, this is expected`. When the readback matches, no warning. Password fields are reported by length only (`typed 7 chars …; field now holds 14 chars`), so a stored password never enters the transcript. Value shown whole (newlines escaped), capped at 200 code points with an explicit `(N chars total)` marker. If the element is gone the plain confirmation is kept.
- **`observe` marks prefilled fields.** `DigestElement` gains `value` / `value_len` / `password`. Text-entry fields report label-ish text (aria-label / placeholder / name) and their value separately; the rendering appends `(prefilled: "alice")` or `(prefilled password, 14 chars)`. Button-like inputs (`submit`, `button`, `checkbox`, …) keep `value` as their label, unchanged.
- **Lengths are code points on both sides.** JS uses `Array.from(v).length`, Go counts runes, so an emoji in a password is one char to both and a clean type never warns about phantom content.
- **Schema text** for the action and the `text` parameter says the same: type appends, observe shows prefilled fields, clear first if it may be prefilled.
- New `Page.FieldState` helper (same OOPIF redirect pattern as `TypeText`); read failure reports `Found=false` rather than an error since the readback is advisory.

### Replay healer — intentional behaviour change

`InteractiveDigest` is also consumed by the replay healer (`internal/app/browser_heal.go`), which puts each element's `Text` into its prompt. For input fields that text used to be the current value (the old JS was `textContent||value||…`, and an input's textContent is empty); it is now the field's label-ish text. Net effect: the healer matches fields by label rather than by whatever the user had typed, and an autofilled password no longer reaches the healer prompt as element text — the old behaviour was a plaintext leak. Documented on `DigestElement` and in dev-docs. `internal/app/browser_heal_test.go` unaffected (constructs `DigestElement` directly).

## Review findings folded in (second commit)

- `uiHead` truncated by byte and kept only the first line: a textarea's just-typed text on a later line was invisible, and a long CJK value ended in `\xe4\xb8`-style escapes the model would read as content. Replaced by `quoteFieldValue` (whole value, rune cap, marker).
- JS `.length` vs Go rune count mismatch produced a false "prefilled" warning for emoji passwords. Fixed in both JS sites.
- Warning wording now says a page reformatting its input is expected, not a reason to clear and retype.

## Tests

- `internal/tools/browser_readback_test.go` (no Chrome): `typeResultText` for clean / prefilled / password-mismatch / password-match / emoji-password / multi-line / element-gone; `quoteFieldValue` rune cap with no `\x` escapes; `renderObserve` prefilled text, prefilled password (length only), empty field not marked, error and empty cases.
- `internal/browser/readback_test.go` (real Chrome): autofilled-login fixture with an emoji in the password — digest separates label and value, withholds the password with length 13 (code points), leaves submit's value as its text; `FieldState` after typing into a prefilled field reads `alicealice`; contenteditable and missing selector.
- Full `go test ./internal/browser/` (~280s, local Chrome) and `go test ./internal/tools/ -run Browser` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
