### PR TITLE
agent: surface malformed tool-call JSON instead of running the tool on nil input

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1937,6 +1937,17 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 			continue
 		}
 		c := toolCall{block: b}
+		// Malformed arguments never reach the gate or the tool: the call is
+		// answered with the parse failure so the model fixes its JSON instead
+		// of re-sending the same broken call against a "missing parameter"
+		// error. Rides the denyReason path — same shape as a permission denial,
+		// an error tool_result with nothing executed.
+		if b.InputError != "" {
+			c.denyReason = "tool call not run: its arguments were not valid JSON — " + b.InputError +
+				". Resend the call as one JSON object with strings properly escaped (newlines as \\n, quotes as \\\")."
+			calls = append(calls, c)
+			continue
+		}
 		if gate != nil {
 			if allowed, reason := gate.Check(ctx, b.Name, b.Input); !allowed {
 				if reason == "" {

--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -1,5 +1,12 @@
 package agent
 
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
 // ContentBlock is a single element of a multi-part message. It unifies the
 // roles a block can play in an LLM conversation:
 //
@@ -30,6 +37,15 @@ type ContentBlock struct {
 	// (type=="tool_use"). Keys and value types are defined by the tool's
 	// JSON Schema Parameters.
 	Input map[string]any `json:"input,omitempty"`
+
+	// InputError is set on a tool_use block whose arguments arrived as
+	// malformed JSON — an unescaped newline or quote inside a string, or a
+	// call truncated at max_tokens. Input is then an empty map (never nil, so
+	// the block still round-trips to the provider as `"input": {}`), and the
+	// agent loop answers the call with this message instead of running the
+	// tool: the model must learn its JSON was broken, not go hunting for a
+	// "missing" parameter.
+	InputError string `json:"input_error,omitempty"`
 
 	// ToolUseID links this result back to its originating tool_use block
 	// (type=="tool_result"). Must equal the ID field of the paired block.
@@ -117,6 +133,46 @@ func NewToolUseBlock(id, name string, input map[string]any) ContentBlock {
 		Name:  name,
 		Input: input,
 	}
+}
+
+// NewToolUseBlockFromJSON builds a tool_use block from the raw argument JSON a
+// provider streamed. Every adapter used to `_ = json.Unmarshal` here and hand
+// the tool a nil map, so a model that emitted broken JSON was told "path is
+// required" and retried the identical broken call. Now the parse failure is
+// kept on the block (InputError) with the offending spot quoted, and Input is
+// an empty — not nil — map so the block is still valid on the wire.
+func NewToolUseBlockFromJSON(id, name, raw string) ContentBlock {
+	b := NewToolUseBlock(id, name, map[string]any{})
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return b
+	}
+	var input map[string]any
+	if err := json.Unmarshal([]byte(raw), &input); err != nil {
+		b.InputError = describeInputError(raw, err)
+		return b
+	}
+	if input != nil { // "null" parses cleanly into a nil map; keep the empty one
+		b.Input = input
+	}
+	return b
+}
+
+// describeInputError turns a json error into something the model can act on:
+// the decoder's message, the bytes around the failure, and a truncation hint
+// when the text simply stops before the closing brace.
+func describeInputError(raw string, err error) string {
+	msg := err.Error()
+	var se *json.SyntaxError
+	if errors.As(err, &se) {
+		off := int(se.Offset)
+		lo, hi := max(0, off-40), min(len(raw), off+20)
+		msg = fmt.Sprintf("%s near byte %d: …%s…", se.Error(), off, strings.ToValidUTF8(raw[lo:hi], "?"))
+	}
+	if !strings.HasSuffix(raw, "}") {
+		msg += " (the arguments end without a closing brace — the call may have been truncated by the output token limit)"
+	}
+	return msg
 }
 
 // NewThinkingBlock creates a ContentBlock with Type=="thinking". The signature

--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -39,8 +39,9 @@ type ContentBlock struct {
 	Input map[string]any `json:"input,omitempty"`
 
 	// InputError is set on a tool_use block whose arguments arrived as
-	// malformed JSON — an unescaped newline or quote inside a string, or a
-	// call truncated at max_tokens. Input is then an empty map (never nil, so
+	// malformed JSON — an unescaped newline or quote inside a string, or an
+	// endpoint that reported the turn complete but delivered half the
+	// arguments. Input is then an empty map (never nil, so
 	// the block still round-trips to the provider as `"input": {}`), and the
 	// agent loop answers the call with this message instead of running the
 	// tool: the model must learn its JSON was broken, not go hunting for a
@@ -158,21 +159,27 @@ func NewToolUseBlockFromJSON(id, name, raw string) ContentBlock {
 	return b
 }
 
-// describeInputError turns a json error into something the model can act on:
-// the decoder's message, the bytes around the failure, and a truncation hint
-// when the text simply stops before the closing brace.
+// describeInputError turns a json error into something the model can act on.
+// A syntax error quotes the bytes around the failure; one whose offset is at
+// the very end of the text means the decoder ran out of input, i.e. the
+// arguments arrived incomplete — said explicitly so the model resends the whole
+// call rather than hunting for a typo. Valid JSON of the wrong shape (an array,
+// a bare string) gets a plain-language message instead of Go's type names.
 func describeInputError(raw string, err error) string {
-	msg := err.Error()
 	var se *json.SyntaxError
 	if errors.As(err, &se) {
 		off := int(se.Offset)
+		if off >= len(raw) {
+			return fmt.Sprintf("%s — the arguments end before the closing brace, so the call arrived incomplete", se.Error())
+		}
 		lo, hi := max(0, off-40), min(len(raw), off+20)
-		msg = fmt.Sprintf("%s near byte %d: …%s…", se.Error(), off, strings.ToValidUTF8(raw[lo:hi], "?"))
+		return fmt.Sprintf("%s near byte %d: …%s…", se.Error(), off, strings.ToValidUTF8(raw[lo:hi], "?"))
 	}
-	if !strings.HasSuffix(raw, "}") {
-		msg += " (the arguments end without a closing brace — the call may have been truncated by the output token limit)"
+	var te *json.UnmarshalTypeError
+	if errors.As(err, &te) {
+		return fmt.Sprintf("arguments must be a single JSON object, got %s", te.Value)
 	}
-	return msg
+	return err.Error()
 }
 
 // NewThinkingBlock creates a ContentBlock with Type=="thinking". The signature

--- a/internal/agent/tool_input_test.go
+++ b/internal/agent/tool_input_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// A provider hands over the raw argument JSON; the block must carry either the
+// parsed map or a usable description of why it could not be parsed — never a
+// nil map that a tool would read as "no arguments".
+func TestNewToolUseBlockFromJSON(t *testing.T) {
+	t.Run("valid object", func(t *testing.T) {
+		b := NewToolUseBlockFromJSON("c1", "edit_file", `{"path":"a.go","old_string":"x","new_string":"y"}`)
+		if b.InputError != "" {
+			t.Fatalf("unexpected InputError %q", b.InputError)
+		}
+		if b.Input["path"] != "a.go" || b.Input["new_string"] != "y" {
+			t.Errorf("Input = %v", b.Input)
+		}
+	})
+
+	t.Run("empty and null give an empty non-nil map", func(t *testing.T) {
+		for _, raw := range []string{"", "   ", "null"} {
+			b := NewToolUseBlockFromJSON("c1", "t", raw)
+			if b.InputError != "" || b.Input == nil || len(b.Input) != 0 {
+				t.Errorf("raw %q: Input=%v (nil=%v) InputError=%q", raw, b.Input, b.Input == nil, b.InputError)
+			}
+		}
+	})
+
+	t.Run("unescaped newline inside a string", func(t *testing.T) {
+		raw := "{\"path\":\"a.go\",\"old_string\":\"line one\nline two\",\"new_string\":\"z\"}"
+		b := NewToolUseBlockFromJSON("c1", "edit_file", raw)
+		if b.InputError == "" {
+			t.Fatal("expected InputError for a raw newline in a JSON string")
+		}
+		if b.Input == nil || len(b.Input) != 0 {
+			t.Errorf("Input should be an empty map on parse failure, got %v", b.Input)
+		}
+		if !strings.Contains(b.InputError, "near byte") || !strings.Contains(b.InputError, "line one") {
+			t.Errorf("InputError should quote the failing spot: %q", b.InputError)
+		}
+		if strings.Contains(b.InputError, "truncated") {
+			t.Errorf("complete-but-invalid JSON must not be called truncated: %q", b.InputError)
+		}
+	})
+
+	t.Run("truncated at the token limit", func(t *testing.T) {
+		b := NewToolUseBlockFromJSON("c1", "edit_file", `{"path":"a.go","old_string":"func main() {`)
+		if b.InputError == "" || !strings.Contains(b.InputError, "truncated") {
+			t.Errorf("expected a truncation hint, got %q", b.InputError)
+		}
+	})
+
+	t.Run("valid JSON but not an object", func(t *testing.T) {
+		b := NewToolUseBlockFromJSON("c1", "t", `["a.go"]`)
+		if b.InputError == "" {
+			t.Error("an array is not a valid argument object")
+		}
+	})
+}
+
+// A tool_use with broken arguments is answered, not executed: the executor is
+// never called, the tool_result is an error naming the JSON problem, and the
+// turn continues to the model's next reply.
+func TestAgent_Run_MalformedToolInput_AnsweredNotExecuted(t *testing.T) {
+	bad := NewToolUseBlockFromJSON("call-1", "edit_file", `{"path":"a.go","old_string":"x`)
+	send := &fakeToolSender{
+		replies: []Reply{
+			{StopReason: "tool_use", Blocks: []ContentBlock{bad}},
+			{Content: "fixed", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "edit_file", Description: "edit"}}
+
+	reply, err := a.Run(context.Background(), "edit it", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "fixed" {
+		t.Errorf("Content = %q", reply.Content)
+	}
+	if len(exec.called) != 0 {
+		t.Errorf("executor must not run a call with malformed arguments; called = %v", exec.called)
+	}
+
+	snap := a.History.Snapshot()
+	if len(snap) < 3 {
+		t.Fatalf("history len = %d", len(snap))
+	}
+	var result *ContentBlock
+	for i := range snap[2].Blocks {
+		if snap[2].Blocks[i].Type == "tool_result" && snap[2].Blocks[i].ToolUseID == "call-1" {
+			result = &snap[2].Blocks[i]
+		}
+	}
+	if result == nil {
+		t.Fatalf("no tool_result for call-1 in %+v", snap[2].Blocks)
+	}
+	if !result.IsError {
+		t.Error("tool_result should be flagged as an error")
+	}
+	for _, want := range []string{"not valid JSON", "truncated", "Resend"} {
+		if !strings.Contains(result.Result, want) {
+			t.Errorf("tool_result %q lacks %q", result.Result, want)
+		}
+	}
+	// The tool_use that goes back to the provider must carry an object, not
+	// null: an Anthropic-protocol endpoint rejects `"input": null`.
+	if snap[1].Blocks[0].Input == nil {
+		t.Error("tool_use Input must be a non-nil map after a parse failure")
+	}
+}

--- a/internal/agent/tool_input_test.go
+++ b/internal/agent/tool_input_test.go
@@ -41,22 +41,44 @@ func TestNewToolUseBlockFromJSON(t *testing.T) {
 		if !strings.Contains(b.InputError, "near byte") || !strings.Contains(b.InputError, "line one") {
 			t.Errorf("InputError should quote the failing spot: %q", b.InputError)
 		}
-		if strings.Contains(b.InputError, "truncated") {
-			t.Errorf("complete-but-invalid JSON must not be called truncated: %q", b.InputError)
+		if strings.Contains(b.InputError, "incomplete") {
+			t.Errorf("complete-but-invalid JSON must not be called incomplete: %q", b.InputError)
 		}
 	})
 
-	t.Run("truncated at the token limit", func(t *testing.T) {
+	t.Run("arguments cut off mid-way", func(t *testing.T) {
 		b := NewToolUseBlockFromJSON("c1", "edit_file", `{"path":"a.go","old_string":"func main() {`)
-		if b.InputError == "" || !strings.Contains(b.InputError, "truncated") {
-			t.Errorf("expected a truncation hint, got %q", b.InputError)
+		if b.InputError == "" || !strings.Contains(b.InputError, "incomplete") {
+			t.Errorf("expected an incomplete-arguments message, got %q", b.InputError)
 		}
 	})
 
-	t.Run("valid JSON but not an object", func(t *testing.T) {
-		b := NewToolUseBlockFromJSON("c1", "t", `["a.go"]`)
-		if b.InputError == "" {
-			t.Error("an array is not a valid argument object")
+	// Complete text that is simply the wrong shape must not be mistaken for a
+	// cut-off call — that would send the model shortening a call it needs to
+	// restructure.
+	t.Run("wrong shape is not called incomplete", func(t *testing.T) {
+		cases := map[string]string{
+			"array":          `["a.go"]`,
+			"string":         `"a.go"`,
+			"number":         `42`,
+			"markdown fence": "```json\n{\"path\":\"a.go\"}\n```",
+			"trailing text":  `{"path":"a.go"} and more`,
+		}
+		for name, raw := range cases {
+			b := NewToolUseBlockFromJSON("c1", "t", raw)
+			if b.InputError == "" {
+				t.Errorf("%s: expected InputError", name)
+				continue
+			}
+			if strings.Contains(b.InputError, "incomplete") {
+				t.Errorf("%s: must not claim the call was incomplete: %q", name, b.InputError)
+			}
+			if strings.Contains(b.InputError, "Go value") || strings.Contains(b.InputError, "interface {}") {
+				t.Errorf("%s: Go type names leak into the model-facing message: %q", name, b.InputError)
+			}
+		}
+		if b := NewToolUseBlockFromJSON("c1", "t", `["a.go"]`); !strings.Contains(b.InputError, "single JSON object, got array") {
+			t.Errorf("array message = %q", b.InputError)
 		}
 	})
 }
@@ -103,7 +125,7 @@ func TestAgent_Run_MalformedToolInput_AnsweredNotExecuted(t *testing.T) {
 	if !result.IsError {
 		t.Error("tool_result should be flagged as an error")
 	}
-	for _, want := range []string{"not valid JSON", "truncated", "Resend"} {
+	for _, want := range []string{"not valid JSON", "incomplete", "Resend"} {
 		if !strings.Contains(result.Result, want) {
 			t.Errorf("tool_result %q lacks %q", result.Result, want)
 		}

--- a/internal/provider/anthropic/malformed_args_test.go
+++ b/internal/provider/anthropic/malformed_args_test.go
@@ -1,0 +1,67 @@
+package anthropic
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/provider"
+)
+
+// The endpoint reports stop_reason tool_use but the accumulated input_json_delta
+// text stops mid-object — an incomplete call that must reach the agent as a
+// block carrying the parse failure, with a non-nil Input so the follow-up
+// request never serializes `"input": null` (which this protocol rejects).
+const incompleteToolInputStream = "" +
+	"event: message_start\n" +
+	`data: {"type":"message_start","message":{"id":"m","model":"x","usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
+	"event: content_block_start\n" +
+	`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"edit_file","input":{}}}` + "\n\n" +
+	"event: content_block_delta\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"a.go\",\"old_string\":"}}` + "\n\n" +
+	"event: content_block_stop\n" +
+	`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+	"event: message_delta\n" +
+	`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":0,"output_tokens":3}}` + "\n\n" +
+	"event: message_stop\n" +
+	`data: {"type":"message_stop"}` + "\n\n"
+
+func TestSendStream_IncompleteToolInputSurfacesOnBlock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, incompleteToolInputStream)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := New("test-key")
+	c.BaseURL = srv.URL
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model: "x", Messages: []agent.Message{agent.NewUserMessage("edit it")},
+	}, provider.StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("SendStream: %v", err)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", resp.StopReason)
+	}
+	for _, b := range resp.Blocks {
+		if b.Type != "tool_use" {
+			continue
+		}
+		if b.InputError == "" || !strings.Contains(b.InputError, "incomplete") {
+			t.Errorf("InputError = %q, want an incomplete-arguments message", b.InputError)
+		}
+		if b.Input == nil || len(b.Input) != 0 {
+			t.Errorf("Input must be an empty non-nil map, got %v (nil=%v)", b.Input, b.Input == nil)
+		}
+		return
+	}
+	t.Fatal("no tool_use block in the reply")
+}

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -306,11 +306,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			// tool-call round-trip.
 			blocks = append(blocks, agent.NewThinkingBlock(acc.text.String(), acc.signature.String()))
 		case "tool_use":
-			var input map[string]any
-			if s := acc.inputJSON.String(); s != "" {
-				_ = json.Unmarshal([]byte(s), &input)
-			}
-			blocks = append(blocks, agent.NewToolUseBlock(acc.id, acc.name, input))
+			blocks = append(blocks, agent.NewToolUseBlockFromJSON(acc.id, acc.name, acc.inputJSON.String()))
 			hasToolUse = true
 		}
 	}

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -341,11 +341,7 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 	}
 	if len(first.Message.ToolCalls) > 0 {
 		for _, tc := range first.Message.ToolCalls {
-			var input map[string]any
-			if tc.Function.Arguments != "" {
-				_ = json.Unmarshal([]byte(tc.Function.Arguments), &input)
-			}
-			blocks = append(blocks, agent.NewToolUseBlock(tc.ID, tc.Function.Name, input))
+			blocks = append(blocks, agent.NewToolUseBlockFromJSON(tc.ID, tc.Function.Name, tc.Function.Arguments))
 		}
 		// A response carrying tool calls is a tool-use turn — dispatch them
 		// regardless of finish_reason. The expected signal is "tool_calls", but

--- a/internal/provider/openai/malformed_args_test.go
+++ b/internal/provider/openai/malformed_args_test.go
@@ -1,0 +1,84 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/provider"
+)
+
+// Two argument fragments concatenate to a JSON string holding a raw newline —
+// the classic broken edit_file call. The adapter must keep the parse failure on
+// the block instead of handing the tool a nil map.
+const malformedArgsStream = "" +
+	`data: {"id":"c1","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"edit_file","arguments":"{\"path\":\"a.go\",\"old_string\":\"x"}}]}}]}` + "\n\n" +
+	`data: {"id":"c1","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\ny\"}"}}]}}]}` + "\n\n" +
+	`data: {"id":"c1","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n" +
+	"data: [DONE]\n\n"
+
+func TestSendStream_MalformedToolArgumentsSurfaceOnBlock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, malformedArgsStream)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model: "m", Messages: []agent.Message{agent.NewUserMessage("edit it")},
+	}, provider.StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("SendStream: %v", err)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", resp.StopReason)
+	}
+	assertMalformedToolUse(t, resp.Blocks, "near byte")
+}
+
+// The non-streaming path parses the same way.
+func TestSend_MalformedToolArgumentsSurfaceOnBlock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"edit_file","arguments":"{\"path\":\"a.go\",\"old_string\":\"func main() {"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	resp, err := c.Send(context.Background(), provider.Request{
+		Model: "m", Messages: []agent.Message{agent.NewUserMessage("edit it")},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	assertMalformedToolUse(t, resp.Blocks, "incomplete")
+}
+
+func assertMalformedToolUse(t *testing.T, blocks []agent.ContentBlock, wantHint string) {
+	t.Helper()
+	for _, b := range blocks {
+		if b.Type != "tool_use" || b.Name != "edit_file" {
+			continue
+		}
+		if b.InputError == "" {
+			t.Fatalf("expected InputError on the malformed tool_use, got none (Input=%v)", b.Input)
+		}
+		if !strings.Contains(b.InputError, wantHint) {
+			t.Errorf("InputError %q lacks %q", b.InputError, wantHint)
+		}
+		if b.Input == nil || len(b.Input) != 0 {
+			t.Errorf("Input must be an empty non-nil map, got %v (nil=%v)", b.Input, b.Input == nil)
+		}
+		return
+	}
+	t.Fatal("no edit_file tool_use block in the reply")
+}

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -277,11 +277,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 	}
 	for _, idx := range toolOrder {
 		st := toolStates[idx]
-		var input map[string]any
-		if s := st.args.String(); s != "" {
-			_ = json.Unmarshal([]byte(s), &input)
-		}
-		blocks = append(blocks, agent.NewToolUseBlock(st.id, st.name, input))
+		blocks = append(blocks, agent.NewToolUseBlockFromJSON(st.id, st.name, st.args.String()))
 	}
 	// Accumulated tool calls make this a tool-use turn — dispatch them
 	// regardless of finish_reason. Some OpenAI-compatible backends (e.g. a

--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -1,8 +1,32 @@
 package tools
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 )
+
+// requiredPath reads the file-path argument of a file tool, and when it is
+// missing says what WAS received. A model that sends `file_path` (another
+// agent's convention) or drops the key otherwise sees only "path is required"
+// and retries the same call; naming the keys it actually sent makes the
+// second attempt right. The path is returned untrimmed so callers keep the
+// exact string the model gave.
+func requiredPath(tool string, input map[string]any) (string, error) {
+	p := stringArg(input, "path")
+	if strings.TrimSpace(p) != "" {
+		return p, nil
+	}
+	if len(input) == 0 {
+		return "", fmt.Errorf("%s: path is required (no arguments were received)", tool)
+	}
+	keys := make([]string, 0, len(input))
+	for k := range input {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return "", fmt.Errorf(`%s: path is required — the file parameter is named "path"; received keys: %s`, tool, strings.Join(keys, ", "))
+}
 
 // stringArg reads a string argument from a tool-call input map, defaulting to
 // "" when absent or not a string.

--- a/internal/tools/args_test.go
+++ b/internal/tools/args_test.go
@@ -1,0 +1,34 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// The missing-path error must tell the model what it actually sent, so a
+// wrong key name (file_path) is fixed on the next call instead of retried.
+func TestRequiredPath(t *testing.T) {
+	if p, err := requiredPath("edit_file", map[string]any{"path": " a.go "}); err != nil || p != " a.go " {
+		t.Errorf("present path: p=%q err=%v (must be returned untrimmed)", p, err)
+	}
+
+	_, err := requiredPath("edit_file", map[string]any{"file_path": "a.go", "old_string": "x", "new_string": "y"})
+	if err == nil {
+		t.Fatal("expected error when path is missing")
+	}
+	for _, want := range []string{"edit_file: path is required", `named "path"`, "received keys: file_path, new_string, old_string"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q lacks %q", err.Error(), want)
+		}
+	}
+
+	_, err = requiredPath("read_file", map[string]any{"path": "   "})
+	if err == nil || !strings.Contains(err.Error(), "received keys: path") {
+		t.Errorf("blank path should still list the received keys: %v", err)
+	}
+
+	_, err = requiredPath("write_file", nil)
+	if err == nil || !strings.Contains(err.Error(), "no arguments were received") {
+		t.Errorf("nil input: %v", err)
+	}
+}

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -428,9 +428,9 @@ func lineEndingAt(body string, origStart, origEnd int) string {
 }
 
 func (EditFileTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	path, _ := input["path"].(string)
-	if strings.TrimSpace(path) == "" {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: path is required")
+	path, err := requiredPath("edit_file", input)
+	if err != nil {
+		return agent.ToolResult{Text: ""}, err
 	}
 	oldStr, ok1 := input["old_string"].(string)
 	newStr, ok2 := input["new_string"].(string)

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -85,9 +85,9 @@ func (ReadFileTool) Definition() agent.ToolDefinition {
 }
 
 func (ReadFileTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	path, _ := input["path"].(string)
-	if strings.TrimSpace(path) == "" {
-		return agent.ToolResult{}, fmt.Errorf("read_file: path is required")
+	path, err := requiredPath("read_file", input)
+	if err != nil {
+		return agent.ToolResult{}, err
 	}
 	// Refuse UNC / network paths (\\server\share, //server/share) before
 	// resolving. On Windows these trigger an SMB connection that can leak

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -40,9 +40,9 @@ func (WriteFileTool) Definition() agent.ToolDefinition {
 }
 
 func (WriteFileTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	path, _ := input["path"].(string)
-	if strings.TrimSpace(path) == "" {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: path is required")
+	path, err := requiredPath("write_file", input)
+	if err != nil {
+		return agent.ToolResult{Text: ""}, err
 	}
 	content, ok := input["content"].(string)
 	if !ok {


### PR DESCRIPTION
## Why

A user transcript showed `edit_file` failing three times in a row with `edit_file: path is required`, the model retrying the identical call each time. Two things could produce that, and in both cases our error hid the cause:

1. **Malformed argument JSON, silently swallowed.** All three provider parse sites (anthropic stream, openai stream, openai non-stream) did `_ = json.Unmarshal(...)`. A model that emits an unescaped newline inside `old_string`, or an endpoint that reports the turn complete with half the arguments, produced a nil input map; the tool then reported a missing parameter. The model went looking for a parameter it hadn't dropped, and resent the same broken JSON. A side effect on Anthropic-protocol endpoints: the nil map went back on the wire as `"input": null`, which the API rejects.
2. **Wrong key name** (`file_path`, another agent's convention). Same bare error, no hint.

## What

- **`agent.NewToolUseBlockFromJSON`** replaces the three ad-hoc parses. On failure the block carries `InputError` and `Input` is an empty, non-nil map so the block still round-trips as `"input": {}`. `null`/empty arguments also yield the empty map. The message is model-facing: a syntax error quotes the bytes around the failure; a decoder that ran out of input says the call arrived incomplete; valid JSON of the wrong shape says `arguments must be a single JSON object, got array` rather than leaking Go type names.
- **Agent loop**: a tool_use with `InputError` is answered with an error tool_result (`tool call not run: its arguments were not valid JSON — … Resend the call as one JSON object with strings properly escaped …`) and never reaches the permission gate or the executor. Rides the existing `denyReason` path, same shape as a permission denial.
- **`requiredPath`** (tools): when `path` is genuinely missing, the error names the keys that were received and the correct parameter name: `edit_file: path is required — the file parameter is named "path"; received keys: file_path, new_string, old_string`. Used by `edit_file`, `read_file`, `write_file`. Path is returned untrimmed, so behaviour for present paths is unchanged.

### Why not rename `path` → `file_path`

`path` is read in nine tool sites plus the permission gate, the read-before-write tracker, and the TUI tool cards; a rename is a mass change across permission rule matching and every prompt/doc that mentions it, for a convention only some models default to. An alias would have to be applied before the permission gate (which runs before the tool layer), i.e. in the agent, where tool-specific knowledge does not belong. Naming the received keys fixes the model's next call for any wrong key, not just this one.

## Review findings folded in (second commit)

- The "may have been truncated" hint keyed on the text not ending in `}` and so fired on every complete-but-wrong-shaped input (array, bare string, markdown fence, trailing text), steering the model to shorten a call it needed to restructure. It now appears only when the syntax error offset is at the end of the text. Attribution reworded: a max_tokens cut never reaches dispatch (the loop budget-stops on that stop reason), so what arrives here is an endpoint that claimed completion with half the arguments.
- `*json.UnmarshalTypeError` is rewritten in plain language.
- Provider-level tests added so the adapters' switch to the shared constructor is covered end to end.

## Tests

- `internal/agent/tool_input_test.go`: valid object; empty/whitespace/`null` → empty non-nil map; unescaped newline → `InputError` quoting the failing spot, not called incomplete; cut-off arguments → incomplete; array / string / number / markdown fence / trailing text → error, never called incomplete, no Go type names. Full `Run` with a malformed tool_use: executor never called, tool_result is an error naming the JSON problem, the persisted tool_use keeps a non-nil `Input`, turn continues to the next reply.
- `internal/provider/openai/malformed_args_test.go`: streamed fragments concatenating to a raw newline → `InputError` on the block, empty non-nil `Input`, `StopReason` still `tool_use`; non-stream `Send` with cut-off arguments → incomplete message.
- `internal/provider/anthropic/malformed_args_test.go`: `input_json_delta` stopping mid-object with `stop_reason: tool_use` → incomplete message, non-nil `Input`.
- `internal/tools/args_test.go`: present path returned untrimmed; missing path lists received keys sorted and names `"path"`; blank path still lists keys; nil input says no arguments were received.
- `go test -race ./internal/agent/` (minus the known locally-failing image-compression test on Go 1.27), `./internal/tools/`, `./internal/provider/...` all green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
