### PR TITLE
chore: bump version to 1.16.14

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.13"
+var Version = "1.16.14"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over v1.16.13.

- #2353 web: kill a background process from the popover
- #2354 browser: `clear` action; unknown action lists valid ones
- #2355 browser: `type` reads the field back; `observe` marks prefilled fields
- #2356 agent: malformed tool-call JSON surfaced to the model instead of a nil input; file tools name received keys when `path` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)