### PR TITLE
image-gen: accept reference images (--ref / manifest reference_images)

### DIFF
--- a/internal/skills/defaults/image-gen/PROVENANCE.md
+++ b/internal/skills/defaults/image-gen/PROVENANCE.md
@@ -58,6 +58,18 @@ Moved verbatim out of `skills/ppt-master/`:
   `config.py` constants and the `.env` lookup-path examples — that shared
   config heritage (both skills carry the same `config.py`) is left as-is.
 
+## Reference images (added here, not upstream)
+
+`image_gen.py --ref <path-or-url>` (repeatable) and the manifest field
+`items[].reference_images` feed images to the model alongside the prompt, for
+character / product / style consistency. Backends opt in with a module-level
+`SUPPORTS_REFERENCE_IMAGES = True`; implemented for `qwen` (DashScope
+multimodal-generation `{"image": …}` content items, per the qwen-image-edit
+docs), `openai` (`/images/edits` multipart with `image[]` file parts, matching
+the official SDK's encoding) and `gemini` (`types.Part.from_bytes`). Other
+backends reject reference images with an explicit error. Local files are read
+from disk (Qwen receives them as `data:<mime>;base64,…`).
+
 ## Prompt-craft library (`references/prompt-craft/`)
 
 Vendored from [`wuyoscar/GPT-Image2-Skill`](https://github.com/wuyoscar/GPT-Image2-Skill)

--- a/internal/skills/defaults/image-gen/SKILL.md
+++ b/internal/skills/defaults/image-gen/SKILL.md
@@ -90,7 +90,16 @@ uv run <skill-dir>/scripts/image_gen.py "a serene alpine lake at dawn, soft mist
 # Web search (openly-licensed, downloads one best match + records the source)
 uv run <skill-dir>/scripts/image_search.py "diverse engineering team in a modern office" \
   --orientation landscape --output /abs/out/team.jpg
+
+# AI generation anchored on reference image(s) — keep a character / product / style consistent
+uv run <skill-dir>/scripts/image_gen.py "the man in the reference image, now seated at a desk by a window, same face and outfit" \
+  --ref /abs/refs/character.png --aspect_ratio 1:1 --output /abs/out/dir --filename avatar
 ```
+
+`--ref` is repeatable (refer to them in the prompt as "image 1", "image 2" …) and
+accepts local paths or http(s) URLs. It is supported by the `openai` (routes to
+`/images/edits`), `gemini` and `qwen` backends; any other backend fails fast with a
+clear message rather than silently ignoring the image.
 
 The positional-prompt form skips the manifest and leaves no audit trail — reserve
 it for quick fixups and standalone requests. **After it finishes, present the file
@@ -112,6 +121,9 @@ into the same file as each completes.
   "items": [
     { "filename": "cover.png", "prompt": "...", "aspect_ratio": "16:9",
       "image_size": "2K", "page_role": "hero_page", "text_policy": "none",
+      "status": "Pending" },
+    { "filename": "mascot_p07.png", "prompt": "the mascot from image 1, waving ...",
+      "aspect_ratio": "1:1", "reference_images": ["refs/mascot.png"],   // paths relative to this file, or URLs
       "status": "Pending" }
   ]
 }
@@ -124,8 +136,8 @@ uv run <skill-dir>/scripts/image_gen.py --render-md /abs/images/image_prompts.js
 uv run <skill-dir>/scripts/image_gen.py --manifest /abs/images/image_prompts.json
 ```
 
-Full field reference (`page_role`, `text_policy`, `type`, `slice_grid`/
-`slice_names`, back-compat) is in `references/image-generator.md` §6.
+Full field reference (`page_role`, `text_policy`, `type`, `reference_images`,
+`slice_grid`/`slice_names`, back-compat) is in `references/image-generator.md` §6.
 
 ### Slice a generated sheet into elements
 

--- a/internal/skills/defaults/image-gen/references/image-generator.md
+++ b/internal/skills/defaults/image-gen/references/image-generator.md
@@ -453,6 +453,7 @@ Write `project/images/image_prompts.json` with this shape:
 | `items[].prompt` | yes | §4 assembly | The full assembled paragraph |
 | `items[].image_size` | no | Container sizing | `512px` / `1K` / `2K` / `4K` |
 | `items[].alt_text` | no | Accessibility | Short caption |
+| `items[].reference_images` | no | Consistency anchor | Array of local paths (relative to the manifest file) or http(s) URLs passed to the model as image input, e.g. a mascot/character sheet reused across pages. Backends: `openai` (`/images/edits`), `gemini`, `qwen`; others fail the item with a clear error. Refer to them in the prompt as "image 1", "image 2" … |
 | `items[].slice_grid` | no | §4.3 sheet geometry | Illustration sheet only; exact `RxC` grid to pass to `slice_images.py --grid` |
 | `items[].slice_names` | no | §4.3 sheet geometry | Illustration sheet only; semantic filenames to pass to `slice_images.py --names` |
 | `items[].status` | yes | CLI manages | `Pending` initially; CLI updates to `Generated` / `Failed` / `Needs-Manual` |

--- a/internal/skills/defaults/image-gen/scripts/docs/image.md
+++ b/internal/skills/defaults/image-gen/scripts/docs/image.md
@@ -20,6 +20,9 @@ uv run scripts/image_gen.py "Abstract tech background" --aspect_ratio 16:9 --ima
 uv run scripts/image_gen.py "Concept car" -o projects/demo/images
 uv run scripts/image_gen.py "Beautiful landscape" -n "low quality, blurry, watermark"
 uv run scripts/image_gen.py --list-backends
+
+# Reference images (image-to-image): repeat --ref for several; openai / gemini / qwen only
+uv run scripts/image_gen.py "same character as image 1, now riding a bicycle" --ref refs/character.png
 ```
 
 Backends are grouped into Core / Extended / Experimental tiers. Run `uv run scripts/image_gen.py --list-backends` for the current list.

--- a/internal/skills/defaults/image-gen/scripts/image_backends/backend_common.py
+++ b/internal/skills/defaults/image-gen/scripts/image_backends/backend_common.py
@@ -64,6 +64,9 @@ CONTENT_TYPE_TO_EXT = {
     "image/tiff": ".tiff",
 }
 
+EXT_TO_MIME = {ext: mime for mime, ext in CONTENT_TYPE_TO_EXT.items() if ext != ".jpg"}
+EXT_TO_MIME[".jpg"] = "image/jpeg"
+
 EXT_TO_PIL_FORMAT = {
     ".png": "PNG",
     ".jpg": "JPEG",
@@ -256,3 +259,48 @@ def poll_json(
             )
 
         time.sleep(interval_seconds)
+
+
+# ╔══════════════════════════════════════════════════════════════════╗
+# ║  Reference images (image-to-image / identity anchoring)          ║
+# ╚══════════════════════════════════════════════════════════════════╝
+
+def is_http_url(ref: str) -> bool:
+    return ref.startswith("http://") or ref.startswith("https://")
+
+
+def load_reference_image(ref: str, timeout: int = 60) -> tuple[bytes, str]:
+    """Return ``(bytes, mime_type)`` for a reference image given as a local
+    path or an http(s) URL.
+
+    The MIME type comes from the real bytes (magic numbers), falling back to
+    the response Content-Type / file extension, so a mislabeled file does not
+    reach the provider with the wrong type.
+    """
+    if is_http_url(ref):
+        response = requests.get(ref, timeout=timeout)
+        if not response.ok:
+            raise RuntimeError(f"Failed to download reference image {ref}: HTTP {response.status_code}")
+        data = response.content
+        hint = response.headers.get("Content-Type")
+    else:
+        path = os.path.expanduser(ref)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Reference image not found: {ref}")
+        with open(path, "rb") as fh:
+            data = fh.read()
+        hint = None
+    ext = detect_image_extension(data, hint) or _normalize_extension(os.path.splitext(ref)[1])
+    mime = EXT_TO_MIME.get(_normalize_extension(ext) if ext else "")
+    if not mime:
+        raise ValueError(f"Reference image is not a recognised image format: {ref}")
+    return data, mime
+
+
+def reference_image_data_uri(ref: str) -> str:
+    """URLs pass through untouched; local files become ``data:<mime>;base64,…``."""
+    if is_http_url(ref):
+        return ref
+    import base64
+    data, mime = load_reference_image(ref)
+    return f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"

--- a/internal/skills/defaults/image-gen/scripts/image_backends/backend_gemini.py
+++ b/internal/skills/defaults/image-gen/scripts/image_backends/backend_gemini.py
@@ -38,11 +38,15 @@ from google.genai import types
 from image_backends.backend_common import (
     MAX_RETRIES,
     is_rate_limit_error,
+    load_reference_image,
     normalize_image_size,
     resolve_output_path,
     retry_delay,
     save_image_bytes,
 )
+
+# Reference images ride along as inline image Parts ahead of the prompt text.
+SUPPORTS_REFERENCE_IMAGES = True
 
 
 # ╔══════════════════════════════���═══════════════════════════════════╗
@@ -67,7 +71,8 @@ DEFAULT_MODEL = "gemini-3.1-flash-image-preview"
 def _generate_image(api_key: str, prompt: str,
                     aspect_ratio: str = "1:1", image_size: str = "1K",
                     output_dir: str = None, filename: str = None,
-                    model: str = DEFAULT_MODEL, base_url: str = None) -> str:
+                    model: str = DEFAULT_MODEL, base_url: str = None,
+                    reference_images: list[str] | None = None) -> str:
     """
     Image generation via Gemini API (streaming).
 
@@ -103,7 +108,15 @@ def _generate_image(api_key: str, prompt: str,
     print(f"  Prompt:       {prompt[:120]}{'...' if len(prompt) > 120 else ''}")
     print(f"  Aspect Ratio: {aspect_ratio}")
     print(f"  Image Size:   {image_size}")
+    if reference_images:
+        print(f"  References:   {len(reference_images)} image(s)")
     print()
+
+    contents = []
+    for ref in reference_images or []:
+        data, mime = load_reference_image(ref)
+        contents.append(types.Part.from_bytes(data=data, mime_type=mime))
+    contents.append(prompt)
 
     start_time = time.time()
     print(f"  [..] Generating...", end="", flush=True)
@@ -126,7 +139,7 @@ def _generate_image(api_key: str, prompt: str,
 
     for chunk in client.models.generate_content_stream(
         model=model,
-        contents=[prompt],
+        contents=contents,
         config=config,
     ):
         elapsed = time.time() - start_time
@@ -171,7 +184,8 @@ def _generate_image(api_key: str, prompt: str,
 def generate(prompt: str,
              aspect_ratio: str = "1:1", image_size: str = "1K",
              output_dir: str = None, filename: str = None,
-             model: str = None, max_retries: int = MAX_RETRIES) -> str:
+             model: str = None, max_retries: int = MAX_RETRIES,
+             reference_images: list[str] | None = None) -> str:
     """
     Gemini image generation with automatic retry.
 
@@ -216,7 +230,8 @@ def generate(prompt: str,
         try:
             return _generate_image(api_key, prompt,
                                    aspect_ratio, image_size, output_dir,
-                                   filename, model, base_url)
+                                   filename, model, base_url,
+                                   reference_images=reference_images)
         except Exception as e:
             last_error = e
             if attempt < max_retries and is_rate_limit_error(e):

--- a/internal/skills/defaults/image-gen/scripts/image_backends/backend_openai.py
+++ b/internal/skills/defaults/image-gen/scripts/image_backends/backend_openai.py
@@ -49,11 +49,16 @@ from image_backends.backend_common import (
     download_image,
     http_error,
     is_rate_limit_error,
+    load_reference_image,
     normalize_image_size,
     resolve_output_path,
     retry_delay,
     save_image_bytes,
 )
+
+# With reference images the request goes to `/images/edits` (multipart, files
+# in the `image[]` field) instead of `/images/generations`.
+SUPPORTS_REFERENCE_IMAGES = True
 
 
 # ╔══════════════════════════════════════════════════════════════════╗
@@ -312,6 +317,14 @@ def _image_generations_url(base_url: str | None) -> str:
     return f"{base}/images/generations"
 
 
+def _image_edits_url(base_url: str | None) -> str:
+    base = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    for suffix in ("/images/generations", "/images/edits"):
+        if base.endswith(suffix):
+            base = base[: -len(suffix)]
+    return f"{base}/images/edits"
+
+
 def _read_size_preset() -> str | None:
     """Read the optional size mapping preset for OpenAI-compatible providers."""
     return _read_env_choice("OPENAI_SIZE_PRESET", OPENAI_SIZE_PRESETS)
@@ -363,6 +376,35 @@ def _post_image_generation(api_key: str, base_url: str | None, request: dict) ->
         raise RuntimeError("OpenAI image generation returned invalid JSON.") from exc
 
 
+def _post_image_edit(api_key: str, base_url: str | None, request: dict,
+                     reference_images: list[str]) -> dict:
+    """POST to `/images/edits` with the reference images as multipart files.
+
+    Field naming follows the official OpenAI SDK's multipart encoding: the
+    `image` array is sent as repeated `image[]` file parts. `requests` sets the
+    multipart Content-Type (with boundary) itself, so it is not set here.
+    """
+    files = []
+    for index, ref in enumerate(reference_images):
+        data, mime = load_reference_image(ref)
+        ext = ".png" if mime == "image/png" else ".jpg" if mime == "image/jpeg" else ".webp"
+        files.append(("image[]", (f"reference_{index + 1}{ext}", data, mime)))
+    fields = {key: str(value) for key, value in request.items()}
+    response = requests.post(
+        _image_edits_url(base_url),
+        headers={"Authorization": f"Bearer {api_key}"},
+        data=fields,
+        files=files,
+        timeout=300,
+    )
+    if not response.ok:
+        raise http_error(response, "OpenAI image edit")
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise RuntimeError("OpenAI image edit returned invalid JSON.") from exc
+
+
 # ╔══════════════════════════════════════════════════════════════════╗
 # ║  Image Generation                                               ║
 # ╚══════════════════════════════════════════════════════════════════╝
@@ -370,7 +412,8 @@ def _post_image_generation(api_key: str, base_url: str | None, request: dict) ->
 def _generate_image(api_key: str, prompt: str,
                     aspect_ratio: str = "1:1", image_size: str = "1K",
                     output_dir: str = None, filename: str = None,
-                    model: str = DEFAULT_MODEL, base_url: str = None) -> str:
+                    model: str = DEFAULT_MODEL, base_url: str = None,
+                    reference_images: list[str] | None = None) -> str:
     """
     Image generation via OpenAI-compatible API.
 
@@ -403,6 +446,8 @@ def _generate_image(api_key: str, prompt: str,
     mode_label = f"Proxy: {base_url}" if base_url else "OpenAI API"
     print(f"[OpenAI - {mode_label}]")
     print(f"  Model:        {model}")
+    if reference_images:
+        print(f"  Endpoint:     /images/edits with {len(reference_images)} reference image(s)")
     print(f"  Prompt:       {prompt[:120]}{'...' if len(prompt) > 120 else ''}")
     print(f"  Size:         {size} (from aspect_ratio={aspect_ratio})")
     if size_preset and size_preset != "auto":
@@ -442,7 +487,10 @@ def _generate_image(api_key: str, prompt: str,
     hb_thread.start()
 
     try:
-        resp = _post_image_generation(api_key, base_url, request)
+        if reference_images:
+            resp = _post_image_edit(api_key, base_url, request, reference_images)
+        else:
+            resp = _post_image_generation(api_key, base_url, request)
     finally:
         heartbeat_stop.set()
         hb_thread.join(timeout=1)
@@ -472,7 +520,8 @@ def _generate_image(api_key: str, prompt: str,
 def generate(prompt: str,
              aspect_ratio: str = "1:1", image_size: str = "1K",
              output_dir: str = None, filename: str = None,
-             model: str = None, max_retries: int = MAX_RETRIES) -> str:
+             model: str = None, max_retries: int = MAX_RETRIES,
+             reference_images: list[str] | None = None) -> str:
     """
     OpenAI-compatible image generation with automatic retry.
 
@@ -518,7 +567,8 @@ def generate(prompt: str,
         try:
             return _generate_image(api_key, prompt,
                                    aspect_ratio, image_size, output_dir,
-                                   filename, model, base_url)
+                                   filename, model, base_url,
+                                   reference_images=reference_images)
         except Exception as e:
             last_error = e
             if attempt < max_retries and is_rate_limit_error(e):

--- a/internal/skills/defaults/image-gen/scripts/image_backends/backend_qwen.py
+++ b/internal/skills/defaults/image-gen/scripts/image_backends/backend_qwen.py
@@ -41,10 +41,15 @@ from image_backends.backend_common import (
     http_error,
     is_rate_limit_error,
     normalize_image_size,
+    reference_image_data_uri,
     require_api_key,
     resolve_output_path,
     retry_delay,
 )
+
+# qwen-image-2.0 / 2.0-pro accept reference images as `{"image": …}` content
+# items placed before the text item (DashScope multimodal-generation API).
+SUPPORTS_REFERENCE_IMAGES = True
 
 
 DEFAULT_ENDPOINT = "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation"
@@ -127,7 +132,8 @@ def _generate_image(api_key: str, prompt: str,
                     aspect_ratio: str = "1:1", image_size: str = "1K",
                     output_dir: str = None, filename: str = None,
                     model: str = DEFAULT_MODEL, base_url: str = DEFAULT_ENDPOINT,
-                    fallback: bool = True) -> str:
+                    fallback: bool = True,
+                    reference_images: list[str] | None = None) -> str:
     """Generate one image with the Qwen backend.
 
     When ``fallback`` is True (default) and the endpoint is one of the two
@@ -137,6 +143,8 @@ def _generate_image(api_key: str, prompt: str,
     """
     size = _resolve_size(aspect_ratio, image_size)
     url = _resolve_url(base_url)
+    content = [{"image": reference_image_data_uri(ref)} for ref in (reference_images or [])]
+    content.append({"text": prompt})
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
@@ -147,7 +155,7 @@ def _generate_image(api_key: str, prompt: str,
             "messages": [
                 {
                     "role": "user",
-                    "content": [{"text": prompt}],
+                    "content": content,
                 }
             ]
         },
@@ -163,6 +171,8 @@ def _generate_image(api_key: str, prompt: str,
     print(f"  Prompt:       {prompt[:120]}{'...' if len(prompt) > 120 else ''}")
     print(f"  Aspect Ratio: {aspect_ratio}")
     print(f"  Resolution:   {size}")
+    if reference_images:
+        print(f"  References:   {len(reference_images)} image(s)")
     print()
     print("  [..] Generating...", end="", flush=True)
     start = time.time()
@@ -208,7 +218,8 @@ def _fallback_endpoint(url: str) -> str:
 def generate(prompt: str,
              aspect_ratio: str = "1:1", image_size: str = "1K",
              output_dir: str = None, filename: str = None,
-             model: str = None, max_retries: int = MAX_RETRIES) -> str:
+             model: str = None, max_retries: int = MAX_RETRIES,
+             reference_images: list[str] | None = None) -> str:
     """Generate an image with retries using the Qwen backend."""
     api_key = require_api_key(
         "QWEN_API_KEY",
@@ -232,6 +243,7 @@ def generate(prompt: str,
                 model=resolved_model,
                 base_url=base_url,
                 fallback=(explicit_base_url is None),
+                reference_images=reference_images,
             )
         except Exception as exc:
             last_error = exc

--- a/internal/skills/defaults/image-gen/scripts/image_gen.py
+++ b/internal/skills/defaults/image-gen/scripts/image_gen.py
@@ -399,6 +399,9 @@ STATUS_FAILED = "Failed"
 STATUS_NEEDS_MANUAL = "Needs-Manual"
 VALID_STATUSES = {STATUS_PENDING, STATUS_GENERATED, STATUS_FAILED, STATUS_NEEDS_MANUAL}
 RETRYABLE_STATUSES = {STATUS_PENDING, STATUS_FAILED}
+
+# Backends whose modules set SUPPORTS_REFERENCE_IMAGES = True (kept in sync by hand).
+REFERENCE_IMAGE_BACKENDS = ("openai", "gemini", "qwen")
 REQUIRED_ITEM_FIELDS = ("filename", "prompt", "aspect_ratio", "status")
 
 
@@ -410,6 +413,8 @@ def load_manifest(path: str) -> dict:
 
     Each item requires: `filename`, `prompt`, `aspect_ratio`, `status`.
     Optional: `image_size`, `model`, `alt_text`, `purpose`, `type`,
+    `reference_images` (list of local paths — relative to the manifest's
+    directory — or http(s) URLs fed to the model as image input),
     `last_error`.
     """
     try:
@@ -451,8 +456,42 @@ def load_manifest(path: str) -> dict:
         if fname in seen_filenames:
             raise ValueError(f"{prefix} duplicate filename '{fname}'")
         seen_filenames.add(fname)
+        refs = item.get("reference_images")
+        if refs is not None and (
+            not isinstance(refs, list)
+            or not all(isinstance(r, str) and r.strip() for r in refs)
+        ):
+            raise ValueError(
+                f"{prefix} field 'reference_images' must be an array of non-empty strings"
+            )
 
     return data
+
+
+def _reference_kwargs(backend_module, backend_name: str,
+                      reference_images: list[str] | None,
+                      base_dir: str | None = None) -> dict:
+    """Build the `reference_images=` kwarg for a backend, or `{}` when none.
+
+    Backends opt in with a module-level `SUPPORTS_REFERENCE_IMAGES = True`;
+    anything else gets a clear error instead of a silently ignored image.
+    Relative local paths are resolved against `base_dir` (the manifest's
+    directory) so a manifest can ship its references alongside it.
+    """
+    if not reference_images:
+        return {}
+    if not getattr(backend_module, "SUPPORTS_REFERENCE_IMAGES", False):
+        raise ValueError(
+            f"Backend '{backend_name}' does not support reference images. "
+            "Use one of: " + ", ".join(REFERENCE_IMAGE_BACKENDS) + "."
+        )
+    resolved = []
+    for ref in reference_images:
+        if ref.startswith(("http://", "https://")) or os.path.isabs(ref) or not base_dir:
+            resolved.append(ref)
+        else:
+            resolved.append(os.path.normpath(os.path.join(base_dir, ref)))
+    return {"reference_images": resolved}
 
 
 def save_manifest(path: str, data: dict) -> None:
@@ -480,7 +519,8 @@ def _run_manifest(manifest: dict, manifest_path: str, backend_module, *,
                   initial_concurrency: int,
                   image_size: str,
                   output_dir: str,
-                  model: str | None) -> tuple[int, int, int]:
+                  model: str | None,
+                  backend_name: str = "") -> tuple[int, int, int]:
     """Run Pending/Failed items through the backend with adaptive concurrency.
 
     Strategy:
@@ -524,6 +564,8 @@ def _run_manifest(manifest: dict, manifest_path: str, backend_module, *,
     current = max(1, initial_concurrency)
     state_lock = threading.Lock()
 
+    manifest_dir = str(Path(manifest_path).resolve().parent)
+
     def _one(idx: int):
         item = items[idx]
         try:
@@ -534,6 +576,8 @@ def _run_manifest(manifest: dict, manifest_path: str, backend_module, *,
                 output_dir=output_dir,
                 filename=Path(item["filename"]).stem,
                 model=item.get("model", model),
+                **_reference_kwargs(backend_module, backend_name,
+                                    item.get("reference_images"), manifest_dir),
             )
             return idx, saved_path, None
         except Exception as exc:  # noqa: BLE001 — backend raises arbitrary types
@@ -722,6 +766,15 @@ def main() -> None:
         help="Override IMAGE_BACKEND env var."
     )
     parser.add_argument(
+        "--ref", dest="reference_images", action="append", default=None,
+        metavar="PATH_OR_URL",
+        help=(
+            "Reference image fed to the model alongside the prompt (repeatable). "
+            "Use it to keep a character, product or style consistent. Supported by: "
+            + ", ".join(REFERENCE_IMAGE_BACKENDS) + "."
+        ),
+    )
+    parser.add_argument(
         "--list-backends", action="store_true",
         help="List available backends grouped by support tier and exit."
     )
@@ -802,6 +855,7 @@ def main() -> None:
                 image_size=args.image_size,
                 output_dir=args.output or str(Path(args.manifest).parent),
                 model=args.model,
+                backend_name=backend_name,
             )
         except KeyboardInterrupt:
             print("\n\nInterrupted by user. Partial progress preserved in manifest.")
@@ -818,6 +872,7 @@ def main() -> None:
             output_dir=args.output,
             filename=args.filename,
             model=args.model,
+            **_reference_kwargs(backend, backend_name, args.reference_images),
         )
     except (ValueError, FileNotFoundError) as e:
         print(f"Error: {e}")


### PR DESCRIPTION
## What

The `image-gen` skill had no image-to-image path: `image_gen.py` only sent a text prompt, so a character, product or style could not be kept consistent across generations. This adds an opt-in reference-image input.

- **CLI**: `--ref PATH_OR_URL` (repeatable). **Manifest**: `items[].reference_images` — local paths (relative to the manifest file) or http(s) URLs.
- **Backend contract**: a backend opts in with a module-level `SUPPORTS_REFERENCE_IMAGES = True` and a `reference_images` kwarg on `generate()`. Any other backend fails fast with `Backend 'x' does not support reference images` instead of silently ignoring the image. Existing calls without references are unchanged.
- **qwen**: images become `{"image": …}` content items placed before the text item (DashScope multimodal-generation API, per the qwen-image-edit docs); local files are sent as `data:<mime>;base64,…`.
- **openai**: with references the request goes to `/images/edits` as multipart with `image[]` file parts — the same field encoding the official Python SDK emits (`extract_files(... array_format="brackets")`).
- **gemini**: images become `types.Part.from_bytes(data=…, mime_type=…)` parts ahead of the prompt.
- **Docs**: SKILL.md (one-off + manifest examples, support matrix), `scripts/docs/image.md`, `references/image-generator.md` §6 field table, PROVENANCE.

## Verification

- `py_compile` on all touched scripts; `go test ./internal/skills/` passes (embedded defaults still materialize).
- Offline: unsupported-backend guard, relative-path resolution against the manifest dir, manifest validation (accepts an array of strings, rejects a bare string), `--help` lists `--ref`.
- Live: `uv run image_gen.py "…" --backend qwen --ref character.png` reproduced the reference character in a new scene.
- **Not run here**: the `openai` and `gemini` reference paths — no keys on this machine. They are implemented against the SDK encodings above; a smoke run by someone with a key would be welcome.

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)