### PR TITLE
artifact origin: resolve asset paths from directory entries, drop capacity arithmetic

### DIFF
--- a/internal/server/artifact_gate.go
+++ b/internal/server/artifact_gate.go
@@ -218,11 +218,9 @@ func withStrippedBanner(doc []byte, removed int, dark bool) []byte {
 		if loc == nil {
 			continue
 		}
-		out := make([]byte, 0, len(doc)+len(banner))
-		out = append(out, doc[:loc[1]]...)
+		out := append([]byte{}, doc[:loc[1]]...)
 		out = append(out, banner...)
-		out = append(out, doc[loc[1]:]...)
-		return out
+		return append(out, doc[loc[1]:]...)
 	}
 	return append([]byte(banner), doc...)
 }

--- a/internal/server/artifact_origin.go
+++ b/internal/server/artifact_origin.go
@@ -315,7 +315,7 @@ func serveArtifactAsset(w http.ResponseWriter, r *http.Request, root, rel string
 		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
-	abs, ok := resolveWithinRoot(root, filepath.Join(root, filepath.FromSlash(rel)))
+	abs, ok := resolveAssetPath(root, rel)
 	if !ok {
 		writeError(w, http.StatusNotFound, "not found")
 		return
@@ -369,6 +369,46 @@ func serveArtifactEntry(w http.ResponseWriter, r *http.Request, entry string, in
 		return
 	}
 	_, _ = w.Write(out)
+}
+
+// resolveAssetPath turns a cleaned, slash-separated relative path into the
+// on-disk path of that file under root, or reports that no such file is
+// served. It walks the request one segment at a time and, at each step, takes
+// the directory entry whose name matches — so the path it returns is assembled
+// from names the filesystem reported, never from request bytes, and a segment
+// that is not a real entry (`..`, `.`, an empty one, a name with a separator
+// inside) simply matches nothing. The walked path is then checked against the
+// root through symlinks like everything else (resolveWithinRoot).
+func resolveAssetPath(root, rel string) (string, bool) {
+	cur := root
+	segs := strings.Split(rel, "/")
+	for i, seg := range segs {
+		if seg == "" || seg == "." || seg == ".." {
+			return "", false
+		}
+		entries, err := os.ReadDir(cur)
+		if err != nil {
+			return "", false
+		}
+		found := ""
+		for _, e := range entries {
+			if e.Name() == seg {
+				found = e.Name()
+				break
+			}
+		}
+		if found == "" {
+			return "", false
+		}
+		cur = filepath.Join(cur, found)
+		if i < len(segs)-1 {
+			// An intermediate segment has to be a directory (or a link to one).
+			if fi, err := os.Stat(cur); err != nil || !fi.IsDir() {
+				return "", false
+			}
+		}
+	}
+	return resolveWithinRoot(root, cur)
 }
 
 // resolveWithinRoot follows symlinks on both sides and reports the real path

--- a/internal/server/artifact_origin_test.go
+++ b/internal/server/artifact_origin_test.go
@@ -315,6 +315,49 @@ func TestArtifactOrigin_RefusesWhatIsNotAnAsset(t *testing.T) {
 	}
 }
 
+// The asset path is assembled from directory entries, so it can only ever
+// name something that exists under the root by exact name.
+func TestResolveAssetPath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{"a.js", "sub/x.css"} {
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(p)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	outside := filepath.Join(filepath.Dir(root), "outside-"+filepath.Base(root)+".js")
+	if err := os.WriteFile(outside, []byte("o"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(outside)
+
+	for rel, want := range map[string]string{
+		"a.js":      filepath.Join(root, "a.js"),
+		"sub/x.css": filepath.Join(root, "sub", "x.css"),
+	} {
+		got, ok := resolveAssetPath(root, rel)
+		if !ok {
+			t.Errorf("%q: not resolved", rel)
+			continue
+		}
+		wantReal, _ := filepath.EvalSymlinks(want)
+		if got != wantReal {
+			t.Errorf("%q: got %q, want %q", rel, got, wantReal)
+		}
+	}
+	// A directory resolves (the caller's Stat refuses it); everything that is
+	// not an exact entry name along the way does not.
+	for _, rel := range []string{
+		"", ".", "..", "../" + filepath.Base(outside), "sub/../a.js", "sub//x.css", "A.js", "a.js/x", "missing.js",
+	} {
+		if got, ok := resolveAssetPath(root, rel); ok {
+			t.Errorf("%q: resolved to %q, want refusal", rel, got)
+		}
+	}
+}
+
 func TestArtifactOrigin_SymlinkOutOfRootIsRefused(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlinks need privileges on Windows")

--- a/internal/server/lightapp_origin.go
+++ b/internal/server/lightapp_origin.go
@@ -118,9 +118,7 @@ func injectBeforeBody(doc, script []byte) []byte {
 		return append(append([]byte{}, doc...), script...)
 	}
 	loc := all[len(all)-1]
-	out := make([]byte, 0, len(doc)+len(script))
-	out = append(out, doc[:loc[0]]...)
+	out := append([]byte{}, doc[:loc[0]]...)
 	out = append(out, script...)
-	out = append(out, doc[loc[0]:]...)
-	return out
+	return append(out, doc[loc[0]:]...)
 }


### PR DESCRIPTION
Follow-up to #2364, which auto-merged before this commit landed on its branch.

CodeQL flagged two things on #2364: `go/path-injection` on the asset path handed to `os.Stat`/`os.Open` in `serveArtifactAsset`, and `go/allocation-size-overflow` on the pre-sized `make` in the two byte-splice helpers.

- The asset path is now resolved by `resolveAssetPath`: it walks the cleaned relative path one segment at a time against `os.ReadDir` and assembles the result from the entry names the filesystem reported, so what reaches `Stat`/`Open` is never request bytes. A segment that is not an exact entry name (`..`, `.`, empty, wrong case) matches nothing. The symlink containment check (`resolveWithinRoot`) still runs on the walked path. Behaviour is otherwise unchanged; `TestResolveAssetPath` pins it.
- `injectBeforeBody` and `withStrippedBanner` build their output with plain appends.

Verified: `go test ./internal/server/` green; the origin/Light App suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)