### PR TITLE
chore: bump version to 1.16.15

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.14"
+var Version = "1.16.15"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over v1.16.14: #2364 (artifacts and Light Apps render from their own origins, CSP egress boundary, storage shim retired, mobile artifact preview removed), #2366 (CodeQL follow-up), #2363 (design doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)