### PR TITLE
desktop(macos): allow plain HTTP to *.localhost so the artifact and Light App origins load

### DIFF
--- a/cmd/octo-desktop/build/darwin/Info.plist
+++ b/cmd/octo-desktop/build/darwin/Info.plist
@@ -22,11 +22,27 @@
 	<string>11.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
-	<!-- Loopback-only HTTP to the in-process server; no arbitrary loads. -->
+	<!-- Loopback-only HTTP to the in-process server; no arbitrary loads.
+	     NSAllowsLocalNetworking covers "localhost" and IP literals but not
+	     its subdomains, and artifacts / Light Apps render from
+	     <token>.artifacts.localhost and <slug>.apps.localhost
+	     (internal/server/artifact_origin.go) — without the explicit
+	     exception the webview refuses those frames with "App Transport
+	     Security policy requires the use of a secure connection". -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Since v1.16.15 artifacts and Light Apps render from `<token>.artifacts.localhost` / `<slug>.apps.localhost`. On macOS the desktop webview refused every such frame:

    Failed to load resource: The resource could not be loaded because the App Transport Security policy requires the use of a secure connection.

`NSAllowsLocalNetworking` exempts `localhost` and IP literals from ATS but not subdomains of `localhost`. This adds an `NSExceptionDomains` entry for `localhost` with `NSIncludesSubdomains` + `NSExceptionAllowsInsecureHTTPLoads`; nothing else is widened (no `NSAllowsArbitraryLoads`). `plutil -lint` passes.

This is the macOS half of the "webview must reach *.localhost" prerequisite the design doc listed: DNS was fine (system resolver), ATS was the blocker. Windows (WebView2/Chromium resolves *.localhost internally, no ATS) and Linux (WebKitGTK via glibc/systemd-resolved, which map *.localhost to loopback) are expected to work but are not verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)