### PR TITLE
artifact origin: 64 MB entry cap, no cap on assets

### DIFF
--- a/dev-docs/artifact-origin-design.md
+++ b/dev-docs/artifact-origin-design.md
@@ -87,7 +87,7 @@ body: { "path": "<abs path of the html artifact>" }
 - token 未知或已过期 → 404，不区分原因。
 - `rel` 经 `path.Clean` 后不得以 `..` 开头；拼出的绝对路径 `filepath.EvalSymlinks` 之后必须仍在 `root` 之内（符号链接不能把目录带出去）。
 - 扩展名必须在资产表内（下节）；`.html` / `.htm` 不在表内，因此只有入口那一份 HTML 会被服务。
-- 入口 HTML 上限沿用 `artifactMaxBytes`（10 MB）；资产单文件上限 64 MB，流式 `io.Copy`。
+- 入口 HTML 与资产同一上限 64 MB（`artifactAssetMaxBytes`）：旧的 10 MB 是为 srcdoc 时代的 base64 膨胀和属性副本付的账，独立源上不存在；把数据或模型内联进页面的轻应用现实中已有 12 MB 的，旧 JSON 端点本来就不限。入口整文件读入（gate 要解析），资产流式 `io.Copy`。
 - 响应头：按扩展名的 `Content-Type`、`X-Content-Type-Options: nosniff`、`Cache-Control: no-store`、`Referrer-Policy: no-referrer`、`Origin-Agent-Cluster: ?1`、以及下一节的 `Content-Security-Policy`。**不发** `Content-Security-Policy: sandbox`，这一头留给旧的 `/api/sessions/{id}/artifacts` 直开端点。
 
 ### 出网边界：CSP

--- a/dev-docs/artifact-origin-design.md
+++ b/dev-docs/artifact-origin-design.md
@@ -87,7 +87,7 @@ body: { "path": "<abs path of the html artifact>" }
 - token 未知或已过期 → 404，不区分原因。
 - `rel` 经 `path.Clean` 后不得以 `..` 开头；拼出的绝对路径 `filepath.EvalSymlinks` 之后必须仍在 `root` 之内（符号链接不能把目录带出去）。
 - 扩展名必须在资产表内（下节）；`.html` / `.htm` 不在表内，因此只有入口那一份 HTML 会被服务。
-- 入口 HTML 与资产同一上限 64 MB（`artifactAssetMaxBytes`）：旧的 10 MB 是为 srcdoc 时代的 base64 膨胀和属性副本付的账，独立源上不存在；把数据或模型内联进页面的轻应用现实中已有 12 MB 的，旧 JSON 端点本来就不限。入口整文件读入（gate 要解析），资产流式 `io.Copy`。
+- 入口 HTML 上限 64 MB（`artifactEntryMaxBytes`），上限只因为 gate 要把整文件读进内存解析；旧的 10 MB 是为 srcdoc 时代的 base64 膨胀和属性副本付的账，独立源上不存在，而把数据内联进页面的轻应用现实中已有 12 MB 的，旧 JSON 端点本来就不限。**资产没有上限**：`http.ServeContent` 流式发出并支持 Range，一个几百 MB 的模型或录像是用户自己磁盘上的文件经回环发给用户自己的浏览器，限它没有理由。
 - 响应头：按扩展名的 `Content-Type`、`X-Content-Type-Options: nosniff`、`Cache-Control: no-store`、`Referrer-Policy: no-referrer`、`Origin-Agent-Cluster: ?1`、以及下一节的 `Content-Security-Policy`。**不发** `Content-Security-Policy: sandbox`，这一头留给旧的 `/api/sessions/{id}/artifacts` 直开端点。
 
 ### 出网边界：CSP
@@ -180,7 +180,7 @@ Markdown 预览继续用 srcdoc iframe，sandbox 常量沿用 `ARTIFACT_SANDBOX`
 宿主不再对入口 HTML 做任何"自包含化"处理，页面按原样从服务端加载：
 
 - **本地 JS / CSS 不再被剥、不再需要内联。** 今天 `stripExternalRefs` 把 `<script src="./app.js">` 和 `<link href="./style.css">` 当作外链一并剥掉，agent 只能把脚本和样式全部写进一个 HTML。独立源上它们是同目录资产，浏览器直接请求。
-- **图片不再序列化成 data: URI。** `<img src="chart.png">`、`background-image: url(bg.png)`、`<img srcset>` 全部按普通 URL 加载。随之消失的还有 `inlineRefBudget`（6 MB）、`inlineRefMax`（40 个文件）和内存开销（base64 的 1.37 倍、UTF-16 再翻倍、srcdoc 属性再存一份）。图片按资产上限 64 MB 单文件流式服务。
+- **图片不再序列化成 data: URI。** `<img src="chart.png">`、`background-image: url(bg.png)`、`<img srcset>` 全部按普通 URL 加载。随之消失的还有 `inlineRefBudget`（6 MB）、`inlineRefMax`（40 个文件）和内存开销（base64 的 1.37 倍、UTF-16 再翻倍、srcdoc 属性再存一份）。图片和其他资产流式服务，不设上限。
 - **白名单外链的剥离仍然存在**，只是唯一实现在 Go gate，规则不变。
 
 `web/src/lib/artifacts.ts` 里随之删除：`ARTIFACT_SANDBOX` 之外的 HTML 专用部分，即 `CDN_ALLOWLIST`、`isAllowedRef`、`stripExternalRefs`、`withStrippedBanner`、`selfContainedDocument`、`inlineLocalRefs` 的 `'document'` 模式及其 CSS `url()` 改写。fragment 模式（Markdown 图片）保留。

--- a/internal/server/artifact_origin.go
+++ b/internal/server/artifact_origin.go
@@ -352,8 +352,14 @@ func serveArtifactEntry(w http.ResponseWriter, r *http.Request, entry string, in
 		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
-	if fi.Size() > artifactMaxBytes {
-		writeError(w, http.StatusRequestEntityTooLarge, "artifact exceeds the 10 MB preview cap")
+	// The same ceiling as an asset, not the 10 MB of the srcdoc-era preview
+	// endpoint: that cap paid for base64 inflation and a copy in the srcdoc
+	// attribute, neither of which applies here, and a Light App that embeds
+	// its data or a model inline (12 MB in the wild) used to load fine from
+	// the old JSON endpoint, which had no cap at all. The file is still read
+	// whole, since the gate parses it.
+	if fi.Size() > artifactAssetMaxBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, "page exceeds the 64 MB cap")
 		return
 	}
 	src, err := os.ReadFile(entry)

--- a/internal/server/artifact_origin.go
+++ b/internal/server/artifact_origin.go
@@ -44,10 +44,13 @@ import (
 // dev-docs/artifact-origin-design.md is the full account.
 
 const (
-	artifactHostSuffix    = ".artifacts.localhost"
-	artifactHostBare      = "artifacts.localhost"
-	artifactGrantTTL      = 24 * time.Hour
-	artifactAssetMaxBytes = 64 << 20
+	artifactHostSuffix = ".artifacts.localhost"
+	artifactHostBare   = "artifacts.localhost"
+	artifactGrantTTL   = 24 * time.Hour
+	// The entry document is read whole so the gate can parse it; assets are
+	// streamed and carry no cap — a 3D scene's model or a recording is the
+	// user's own file going to the user's own browser over loopback.
+	artifactEntryMaxBytes = 64 << 20
 )
 
 // artifactGrant ties a hostname label to the one entry document it serves and
@@ -306,9 +309,10 @@ func (s *Server) serveArtifactOrigin(w http.ResponseWriter, r *http.Request) {
 }
 
 // serveArtifactAsset serves one file from under root by its cleaned relative
-// path: asset types only, no escaping the root through `..` or a symlink, a
-// size cap, and the type set explicitly so nothing is sniffed. Shared by the
-// artifact origin and the Light App origin.
+// path: asset types only, no escaping the root through `..` or a symlink, and
+// the type set explicitly so nothing is sniffed. No size cap — the bytes are
+// streamed, and a model or a recording can legitimately run to hundreds of
+// megabytes. Shared by the artifact origin and the Light App origin.
 func serveArtifactAsset(w http.ResponseWriter, r *http.Request, root, rel string) {
 	ctype, ok := tools.ArtifactAssetContentType(rel)
 	if !ok {
@@ -323,10 +327,6 @@ func serveArtifactAsset(w http.ResponseWriter, r *http.Request, root, rel string
 	fi, err := os.Stat(abs)
 	if err != nil || fi.IsDir() {
 		writeError(w, http.StatusNotFound, "not found")
-		return
-	}
-	if fi.Size() > artifactAssetMaxBytes {
-		writeError(w, http.StatusRequestEntityTooLarge, "asset exceeds the 64 MB cap")
 		return
 	}
 	f, err := os.Open(abs)
@@ -352,13 +352,13 @@ func serveArtifactEntry(w http.ResponseWriter, r *http.Request, entry string, in
 		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
-	// The same ceiling as an asset, not the 10 MB of the srcdoc-era preview
-	// endpoint: that cap paid for base64 inflation and a copy in the srcdoc
-	// attribute, neither of which applies here, and a Light App that embeds
-	// its data or a model inline (12 MB in the wild) used to load fine from
-	// the old JSON endpoint, which had no cap at all. The file is still read
-	// whole, since the gate parses it.
-	if fi.Size() > artifactAssetMaxBytes {
+	// Not the 10 MB of the srcdoc-era preview endpoint: that cap paid for
+	// base64 inflation and a copy in the srcdoc attribute, neither of which
+	// applies here, and a Light App that embeds its data or a model inline
+	// (12 MB in the wild) used to load fine from the old JSON endpoint, which
+	// had no cap at all. A ceiling remains only because the file is read
+	// whole for the gate to parse; anything larger belongs beside the page.
+	if fi.Size() > artifactEntryMaxBytes {
 		writeError(w, http.StatusRequestEntityTooLarge, "page exceeds the 64 MB cap")
 		return
 	}

--- a/internal/server/artifact_origin_test.go
+++ b/internal/server/artifact_origin_test.go
@@ -429,22 +429,41 @@ func TestArtifactOrigin_OnlyLocalPeersOnlyGET(t *testing.T) {
 	}
 }
 
-func TestArtifactOrigin_AssetSizeCap(t *testing.T) {
+// Assets have no size ceiling: a 3D model or a recording is streamed as-is,
+// with Range support for players that seek.
+func TestArtifactOrigin_LargeAssetsStream(t *testing.T) {
 	f := newOriginFixture(t, "<h1>hi</h1>")
 	big := filepath.Join(f.root, "big.bin")
 	fh, err := os.Create(big)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Sparse: no 65 MB actually hit the disk.
-	if err := fh.Truncate(artifactAssetMaxBytes + 1); err != nil {
+	// Sparse: nothing near 200 MB actually hits the disk.
+	const size = 200 << 20
+	if err := fh.Truncate(size); err != nil {
 		fh.Close()
 		t.Skip("cannot create sparse file:", err)
 	}
 	fh.Close()
 	tok := f.token(t)
-	if w := f.originGet(t, tok, "/big.bin"); w.Code != http.StatusRequestEntityTooLarge {
-		t.Errorf("oversized asset: status = %d, want 413", w.Code)
+
+	req := httptest.NewRequest(http.MethodHead, "/big.bin", nil)
+	req.RemoteAddr = "127.0.0.1:1"
+	req.Host = tok + ".artifacts.localhost:8080"
+	w := httptest.NewRecorder()
+	f.srv.http.Handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || w.Header().Get("Content-Length") != "209715200" {
+		t.Errorf("HEAD 200 MB asset: status = %d, Content-Length = %q", w.Code, w.Header().Get("Content-Length"))
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/big.bin", nil)
+	req.RemoteAddr = "127.0.0.1:1"
+	req.Host = tok + ".artifacts.localhost:8080"
+	req.Header.Set("Range", "bytes=0-15")
+	w = httptest.NewRecorder()
+	f.srv.http.Handler.ServeHTTP(w, req)
+	if w.Code != http.StatusPartialContent || w.Body.Len() != 16 {
+		t.Errorf("ranged GET: status = %d, body = %d bytes, want 206 / 16", w.Code, w.Body.Len())
 	}
 }
 

--- a/internal/server/lightapp_origin_test.go
+++ b/internal/server/lightapp_origin_test.go
@@ -114,7 +114,7 @@ func TestLightAppOrigin_LargeEntryIsServed(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "<h1>big</h1>") || !strings.Contains(w.Body.String(), "__octoLightApp") {
 		t.Errorf("large entry lost content or bridge")
 	}
-	over := strings.Repeat(" ", artifactAssetMaxBytes+1)
+	over := strings.Repeat(" ", artifactEntryMaxBytes+1)
 	srv2 := newLightAppFixture(t, Config{Addr: "127.0.0.1:0", Tools: false}, over)
 	if w := lightAppGet(srv2, "demo.apps.localhost:8080", "/"); w.Code != http.StatusRequestEntityTooLarge {
 		t.Errorf("over-cap entry: status = %d, want 413", w.Code)

--- a/internal/server/lightapp_origin_test.go
+++ b/internal/server/lightapp_origin_test.go
@@ -102,6 +102,25 @@ func TestLightAppOrigin_DesktopInjectsTheDownloadBridge(t *testing.T) {
 	}
 }
 
+// A Light App that inlines its data can run well past 10 MB; the old JSON
+// endpoint served it without a cap and the origin must not regress that.
+func TestLightAppOrigin_LargeEntryIsServed(t *testing.T) {
+	big := strings.Repeat(" ", 12<<20) + "<h1>big</h1>"
+	srv := newLightAppFixture(t, Config{Addr: "127.0.0.1:0", Tools: false}, big)
+	w := lightAppGet(srv, "demo.apps.localhost:8080", "/")
+	if w.Code != http.StatusOK {
+		t.Fatalf("12 MB entry: status = %d, body=%s", w.Code, w.Body.String()[:min(200, w.Body.Len())])
+	}
+	if !strings.Contains(w.Body.String(), "<h1>big</h1>") || !strings.Contains(w.Body.String(), "__octoLightApp") {
+		t.Errorf("large entry lost content or bridge")
+	}
+	over := strings.Repeat(" ", artifactAssetMaxBytes+1)
+	srv2 := newLightAppFixture(t, Config{Addr: "127.0.0.1:0", Tools: false}, over)
+	if w := lightAppGet(srv2, "demo.apps.localhost:8080", "/"); w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("over-cap entry: status = %d, want 413", w.Code)
+	}
+}
+
 func TestLightAppOrigin_EntryGoesThroughTheGate(t *testing.T) {
 	srv := newLightAppFixture(t, Config{Addr: "127.0.0.1:0", Tools: false},
 		`<html><head><script src="https://evil.example.com/x.js"></script></head><body><h1>demo</h1></body></html>`)


### PR DESCRIPTION
Regression from #2364 found on a real Light App: `shiyun/index.html` is 12.1 MB (data inlined), the old `/api/light-apps/{slug}` endpoint served it without a cap, and the new origin answered `{"error":"artifact exceeds the 10 MB preview cap"}`.

Two changes:
- **Entry pages**: 64 MB (`artifactEntryMaxBytes`). The old 10 MB paid for the srcdoc path's base64 inflation and attribute copy, neither of which exists on the origin; a ceiling remains only because the gate reads and parses the file whole. The `/api/sessions/{id}/artifacts` code-view endpoint keeps its own 10 MB.
- **Assets**: no cap. They are streamed by `http.ServeContent` (Range supported), cost the server nothing to hold, and are the user's own files going to the user's own browser over loopback — a 3D model or a recording legitimately runs to hundreds of megabytes.

Tests: a 12 MB Light App entry is served with content and bridge intact, one over 64 MB gets 413; a 200 MB sparse asset answers HEAD with the full Content-Length and a ranged GET with 206. Design doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)