### PR TITLE
chore: bump version to 1.16.16

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.15"
+var Version = "1.16.16"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over v1.16.15.

Carries #2370 (terminal command shown in the expanded tool card) and #2371 (optional `rpm` / `max_concurrency` rate-limit gates per endpoint, plus the `Retry-After` cap fix and the IM `/model` header-projection fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)