### PR TITLE
rgembed: stop re-extracting rg on every call on Windows

### DIFF
--- a/internal/tools/rgembed/rgembed.go
+++ b/internal/tools/rgembed/rgembed.go
@@ -51,7 +51,7 @@ func extract() (string, error) {
 	bin := filepath.Join(dir, rgBinName())
 
 	// Already extracted and valid — nothing to do.
-	if info, err := os.Stat(bin); err == nil && info.Mode()&0111 != 0 {
+	if extracted(bin) {
 		return bin, nil
 	}
 
@@ -78,10 +78,31 @@ func extract() (string, error) {
 
 	if err := os.Rename(tmp.Name(), bin); err != nil {
 		os.Remove(tmp.Name())
+		// Windows refuses to replace an .exe that any process is currently
+		// running, so a concurrent grep/glob whose rg is still alive makes
+		// this rename fail with "Access is denied". A complete copy already
+		// sitting at bin is precisely what we were trying to write, so treat
+		// the race as success rather than failing the tool call.
+		if extracted(bin) {
+			return bin, nil
+		}
 		return "", fmt.Errorf("rgembed: rename: %w", err)
 	}
 
 	return bin, nil
+}
+
+// extracted reports whether bin already holds a complete copy of the embedded
+// binary. Size is the portable signal: on Windows os.Stat synthesises the mode
+// from file attributes and only ever sets 0111 for directories, so an
+// executable-bit check there never matches a cached copy and every call
+// re-extracts. Unix keeps the bit check as an extra guard.
+func extracted(bin string) bool {
+	info, err := os.Stat(bin)
+	if err != nil || info.IsDir() || info.Size() != int64(len(embeddedRG)) {
+		return false
+	}
+	return runtime.GOOS == "windows" || info.Mode()&0111 != 0
 }
 
 // octoBinDir returns ~/.octo/bin, creating it if necessary.

--- a/internal/tools/rgembed/rgembed.go
+++ b/internal/tools/rgembed/rgembed.go
@@ -14,6 +14,10 @@ import (
 	"runtime"
 )
 
+// renameFile is os.Rename, indirected so tests can exercise the race
+// fallback in extract() without holding a real Windows file lock.
+var renameFile = os.Rename
+
 // version is the ripgrep release version embedded at build time.
 // Overridden via -ldflags in the Makefile.
 var version = "unknown"
@@ -76,13 +80,14 @@ func extract() (string, error) {
 		return "", fmt.Errorf("rgembed: chmod: %w", err)
 	}
 
-	if err := os.Rename(tmp.Name(), bin); err != nil {
+	if err := renameFile(tmp.Name(), bin); err != nil {
 		os.Remove(tmp.Name())
-		// Windows refuses to replace an .exe that any process is currently
-		// running, so a concurrent grep/glob whose rg is still alive makes
-		// this rename fail with "Access is denied". A complete copy already
-		// sitting at bin is precisely what we were trying to write, so treat
-		// the race as success rather than failing the tool call.
+		// Windows refuses to replace an .exe while any process still holds a
+		// handle to it — another octo extracting concurrently, an rg that has
+		// not fully exited, or a virus scanner or search indexer sweeping the
+		// freshly written file — and reports "Access is denied". A complete
+		// copy already sitting at bin is precisely what we were about to
+		// write, so treat that as success rather than failing the tool call.
 		if extracted(bin) {
 			return bin, nil
 		}
@@ -97,6 +102,10 @@ func extract() (string, error) {
 // from file attributes and only ever sets 0111 for directories, so an
 // executable-bit check there never matches a cached copy and every call
 // re-extracts. Unix keeps the bit check as an extra guard.
+//
+// Matching size is taken as proof the copy is ours. Anyone able to plant a
+// same-sized file in the user's own ~/.octo/bin can already do worse, so the
+// cheaper check wins over hashing 5 MB on every grep and glob.
 func extracted(bin string) bool {
 	info, err := os.Stat(bin)
 	if err != nil || info.IsDir() || info.Size() != int64(len(embeddedRG)) {

--- a/internal/tools/rgembed/rgembed_test.go
+++ b/internal/tools/rgembed/rgembed_test.go
@@ -42,8 +42,33 @@ func TestPath_ExtractEmbedded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat(%q): %v", p, err)
 	}
-	if info.Mode()&0111 == 0 {
+	// Windows synthesises the mode from file attributes and never sets 0111
+	// for regular files, so the bit only carries meaning elsewhere.
+	if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
 		t.Errorf("%q is not executable", p)
+	}
+
+	// A second call must reuse the extracted copy instead of rewriting it;
+	// on Windows rewriting means renaming over an .exe that a concurrent
+	// grep/glob may still be running, which fails with "Access is denied".
+	before, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat(%q): %v", p, err)
+	}
+	p2, err := Path()
+	if err != nil {
+		t.Fatalf("second Path() error: %v", err)
+	}
+	if p2 != p {
+		t.Errorf("second Path() = %q, want %q", p2, p)
+	}
+	after, err := os.Stat(p2)
+	if err != nil {
+		t.Fatalf("stat(%q): %v", p2, err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("second Path() re-extracted the binary (mtime %v -> %v)",
+			before.ModTime(), after.ModTime())
 	}
 
 	out, err := exec.Command(p, "--version").Output()
@@ -73,4 +98,46 @@ func TestRgBinName(t *testing.T) {
 
 func hasSuffix(s, suffix string) bool {
 	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}
+
+func TestExtracted(t *testing.T) {
+	orig := embeddedRG
+	defer func() { embeddedRG = orig }()
+	embeddedRG = []byte("0123456789")
+
+	dir := t.TempDir()
+
+	if extracted(filepath.Join(dir, "absent")) {
+		t.Error("extracted() = true for a missing file")
+	}
+
+	short := filepath.Join(dir, "short")
+	if err := os.WriteFile(short, embeddedRG[:5], 0755); err != nil {
+		t.Fatal(err)
+	}
+	if extracted(short) {
+		t.Error("extracted() = true for a truncated copy")
+	}
+
+	full := filepath.Join(dir, "full")
+	if err := os.WriteFile(full, embeddedRG, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !extracted(full) {
+		t.Error("extracted() = false for a complete copy")
+	}
+
+	if extracted(dir) {
+		t.Error("extracted() = true for a directory")
+	}
+
+	if runtime.GOOS != "windows" {
+		noexec := filepath.Join(dir, "noexec")
+		if err := os.WriteFile(noexec, embeddedRG, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if extracted(noexec) {
+			t.Error("extracted() = true for a non-executable copy")
+		}
+	}
 }

--- a/internal/tools/rgembed/rgembed_test.go
+++ b/internal/tools/rgembed/rgembed_test.go
@@ -1,11 +1,13 @@
 package rgembed
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
 
 func TestPath_SystemRG(t *testing.T) {
@@ -26,9 +28,14 @@ func TestPath_ExtractEmbedded(t *testing.T) {
 		t.Skip("embeddedRG is nil — build with -tags=embedrg to run this test")
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", "/nonexistent")
-	defer os.Setenv("PATH", origPath)
+	// Extract into a throwaway home. A bare `go test` leaves version at
+	// "unknown" (it is only injected via -ldflags), so without this the test
+	// drops a multi-megabyte rg-unknown into the developer's real ~/.octo/bin
+	// — a directory internal/tools/sandbox.go puts on the child PATH.
+	home := t.TempDir()
+	t.Setenv("HOME", home)        // os.UserHomeDir on unix
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on windows
+	t.Setenv("PATH", "/nonexistent")
 
 	p, err := Path()
 	if err != nil {
@@ -49,11 +56,14 @@ func TestPath_ExtractEmbedded(t *testing.T) {
 	}
 
 	// A second call must reuse the extracted copy instead of rewriting it;
-	// on Windows rewriting means renaming over an .exe that a concurrent
-	// grep/glob may still be running, which fails with "Access is denied".
-	before, err := os.Stat(p)
-	if err != nil {
-		t.Fatalf("stat(%q): %v", p, err)
+	// rewriting is what lands on a live .exe on Windows. Backdating the file
+	// first means a rewrite is visible regardless of filesystem timestamp
+	// granularity. This only separates the two implementations on Windows —
+	// on unix the executable bit already cached correctly — and it needs
+	// -tags=embedrg, so TestExtracted is what CI relies on.
+	past := time.Now().Add(-time.Hour).Truncate(time.Second)
+	if err := os.Chtimes(p, past, past); err != nil {
+		t.Fatalf("chtimes(%q): %v", p, err)
 	}
 	p2, err := Path()
 	if err != nil {
@@ -66,9 +76,9 @@ func TestPath_ExtractEmbedded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat(%q): %v", p2, err)
 	}
-	if !after.ModTime().Equal(before.ModTime()) {
-		t.Errorf("second Path() re-extracted the binary (mtime %v -> %v)",
-			before.ModTime(), after.ModTime())
+	if !after.ModTime().Equal(past) {
+		t.Errorf("second Path() re-extracted the binary (mtime %v, want %v)",
+			after.ModTime(), past)
 	}
 
 	out, err := exec.Command(p, "--version").Output()
@@ -139,5 +149,50 @@ func TestExtracted(t *testing.T) {
 		if extracted(noexec) {
 			t.Error("extracted() = true for a non-executable copy")
 		}
+	}
+}
+
+// TestExtract_RenameFallback covers the branch where the rename loses a race
+// with another process: the failure may be swallowed only when a complete
+// binary is actually in place.
+func TestExtract_RenameFallback(t *testing.T) {
+	origEmbedded := embeddedRG
+	defer func() { embeddedRG = origEmbedded }()
+	embeddedRG = []byte("0123456789")
+
+	origRename := renameFile
+	defer func() { renameFile = origRename }()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	dir, err := octoBinDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, rgBinName())
+
+	renameFile = func(string, string) error {
+		return errors.New("Access is denied.")
+	}
+	if _, err := extract(); err == nil {
+		t.Error("extract() error = nil when the rename failed with no binary in place")
+	}
+
+	// Now the loser of the race finds the complete copy the winner just put
+	// there, which is exactly what it was about to write itself.
+	renameFile = func(_, newpath string) error {
+		if err := os.WriteFile(newpath, embeddedRG, 0755); err != nil {
+			t.Fatal(err)
+		}
+		return errors.New("Access is denied.")
+	}
+	got, err := extract()
+	if err != nil {
+		t.Fatalf("extract() error = %v, want nil (complete binary in place)", err)
+	}
+	if got != bin {
+		t.Errorf("extract() = %q, want %q", got, bin)
 	}
 }


### PR DESCRIPTION
## Problem

A Windows user hit this on nearly every `glob` call (and `grep` would hit it the same way):

```
glob: rgembed: rename: rename C:\Users\Administrator\.octo\bin\rg-1900134466
  C:\Users\Administrator\.octo\bin\rg-15.1.0.exe: Access is denied.
```

Two things stack up:

1. **The extraction cache never hits on Windows.** `extract()` short-circuited on
   `os.Stat(bin).Mode()&0111 != 0`, but `os/types_windows.go` synthesises the mode from
   file attributes and only ORs `0111` for **directories** — a regular file is always
   `0666` (or `0444` when read-only). So with no system `rg` on PATH, every single
   grep/glob rewrote the ~5 MB embedded binary and renamed it into place.
2. **Windows will not rename over a running `.exe`.** `os.Rename` uses
   `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`, which fails with `Access is denied` while
   any process still has the target image mapped. Back-to-back or concurrent tool calls
   (a sub-agent firing several globs) reliably land on a live `rg`, hence the errors —
   and the occasional call that happens to miss the window succeeds, matching the
   user's screenshot where one of three globs went through.

macOS/Linux never saw this: the executable-bit check hits after the first extraction,
so the rename runs at most once per version.

## Fix

- `extracted(bin)` replaces the inline check and compares the on-disk size against
  `len(embeddedRG)`. Size is portable and also rejects a half-written copy; Unix keeps
  the executable-bit check as an extra guard.
- When `os.Rename` fails but a complete copy is already at the destination, return it
  instead of erroring — that copy is exactly what this call was about to write.

## Tests

- `TestExtracted` covers missing / truncated / complete / directory / non-executable
  cases. It stubs `embeddedRG`, so it runs **without** `-tags=embedrg` and is therefore
  covered by CI on all three platforms — on Windows the "complete copy" case is what
  pins the fix, since a file written `0755` there carries no executable bit.
- `TestPath_ExtractEmbedded` now asserts a second `Path()` call returns the same path
  with an unchanged mtime (no re-extraction), and its executable-bit assertion is
  skipped on Windows.
- Verified locally with a real embedded binary:
  `make rg-embed && go test -tags=embedrg -ldflags "-X …rgembed.version=99.0.0-test" ./internal/tools/rgembed/` — both tests pass.
- `go test ./internal/tools/...`, `go vet`, `gofmt -l .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
