### PR TITLE
web(sidebar): commit session rename on Enter, cancel on Escape

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -931,6 +931,7 @@
             value={$editDraft}
             oninput={(e) => editDraft.set((e.target as HTMLInputElement).value)}
             onclick={(e) => e.stopPropagation()}
+            onkeydown={(e) => { if (e.key === 'Enter') commitRename(); if (e.key === 'Escape') editId.set(null) }}
           />
           <span class="row-action" onclick={(e) => { e.stopPropagation(); commitRename() }} style="color:var(--success)">
             <iconify-icon icon="ant-design:check-outlined" width="13"></iconify-icon>


### PR DESCRIPTION
## What

The session rename input in the sidebar had no `onkeydown` handler, so Enter and Escape did nothing — the only way to commit a rename was clicking the green check glyph.

The **group** rename input sitting a few hundred lines above already had the handler. This adds the same one to the session row, with the same semantics:

- `Enter` → `commitRename()`
- `Escape` → `editId.set(null)` (discard)

One line, no behavior change anywhere else. Outside-click still commits (unchanged).

## Verification

- `npx svelte-check --threshold error` — 772 files, 0 errors
- `npx vitest run` — 50 files, 634 tests passed

`Sidebar.svelte` has no unit test today and the handler is inline, matching the untested group-rename handler next to it; no test scaffolding added for this one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)