### PR TITLE
agent: warn when a turn's assistant reply carries no text

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -934,6 +934,18 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// OCTO_TUI=0 all take the one-shot path (tests, octo-eval, CI included).
 	useTUI := isREPL && stdinIsTTY(stdin) && !*noTUI && !tuiDisabledByEnv() && seedPrompt == ""
 
+	// The TUI owns the terminal: bubbletea redraws in place, and a log line
+	// arriving on stderr tears the frame it is mid-way through painting. Route
+	// slog to a file for the TUI's lifetime rather than silencing it — the
+	// per-turn diagnostics the agent writes are exactly what a bug report
+	// needs, and until now they had nowhere to go on this path. The one-shot
+	// path keeps stderr, where logs belong and stdout stays clean.
+	if useTUI {
+		if closeLog := setupCLILog(); closeLog != nil {
+			defer closeLog()
+		}
+	}
+
 	// Resuming a session (-c) is an interactive affordance — it only makes sense
 	// in the TUI. A headless one-shot starts fresh.
 	if resumeID != "" && !useTUI {

--- a/cmd/octo/clilog.go
+++ b/cmd/octo/clilog.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"log"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/open-octo/octo-agent/internal/logfile"
+	"github.com/open-octo/octo-agent/internal/serveproc"
+)
+
+// setupCLILog routes slog and the stdlib logger to a self-rotating
+// ~/.octo/cli.log, returning a close func — or nil if the file can't be
+// opened, which leaves the default stderr in place.
+//
+// Only the TUI calls this. bubbletea paints the terminal in place, so a log
+// line on stderr lands in the middle of a frame and corrupts it; the headless
+// one-shot path has no such conflict and keeps stderr. The stdlib logger is
+// redirected alongside slog because several subsystems still log through it,
+// and a torn frame doesn't care which package wrote the line.
+//
+// Mirrors setupHubLog in cmd/octo-desktop, including the OCTO_LOG_LEVEL
+// handling, so all three backends behave alike.
+func setupCLILog() func() {
+	path, err := serveproc.CLILogPath()
+	if err != nil {
+		return nil
+	}
+	lw, err := logfile.Open(path, logfile.DefaultMaxBytes, logfile.DefaultBackups)
+	if err != nil {
+		return nil
+	}
+	prevWriter := log.Writer()
+	slog.SetDefault(slog.New(slog.NewTextHandler(lw, &slog.HandlerOptions{Level: cliLogLevel()})))
+	log.SetOutput(lw)
+	return func() {
+		// Put the stdlib logger back before the file closes: anything logged
+		// during shutdown should still reach the terminal rather than a
+		// closed writer.
+		log.SetOutput(prevWriter)
+		_ = lw.Close()
+	}
+}
+
+// cliLogLevel reads OCTO_LOG_LEVEL (debug|info|warn|error), defaulting to
+// info — matching `octo serve` and the desktop hub.
+func cliLogLevel() slog.Level {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("OCTO_LOG_LEVEL"))) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -702,7 +702,7 @@ func (a *Agent) turn(ctx context.Context, userInput string, finishInterrupt bool
 		return Reply{}, fmt.Errorf("agent: send: %w", err)
 	}
 
-	a.History.Append(assistantReplyMessage(reply))
+	a.History.Append(assistantReplyMessage(reply, false))
 	a.accrueUsage(reply)
 	a.accountGoalUsage(nil)
 	return reply, nil
@@ -784,7 +784,7 @@ func (a *Agent) turnStream(
 		return Reply{}, fmt.Errorf("agent: stream: %w", err)
 	}
 
-	a.History.Append(assistantReplyMessage(reply))
+	a.History.Append(assistantReplyMessage(reply, false))
 	a.accrueUsage(reply)
 	a.accountGoalUsage(handler)
 	return reply, nil
@@ -1334,7 +1334,7 @@ func (a *Agent) runLoop(
 		if content == "" {
 			content = textFromBlocks(reply.Blocks)
 		}
-		a.History.Append(assistantReplyMessage(reply))
+		a.History.Append(assistantReplyMessage(reply, reminderCarry != ""))
 		reply.Content = content
 
 		// A mid-turn steer (text and/or pasted images) arrived while the model
@@ -2182,13 +2182,13 @@ func flattenResults(slices [][]ContentBlock) []ContentBlock {
 // round-tripping those blocks is the same contract already honored for tool-use
 // turns, and the OpenAI adapter ignores the thinking block and falls back to
 // Content. Plain replies with no thinking keep the lightweight Content form.
-func assistantReplyMessage(reply Reply) Message {
+func assistantReplyMessage(reply Reply, carriedText bool) Message {
 	content := reply.Content
 	if content == "" {
 		content = textFromBlocks(reply.Blocks)
 	}
 	if content == "" {
-		logEmptyReply(reply)
+		logEmptyReply(reply, carriedText)
 	}
 	msg := NewAssistantMessage(content)
 	if hasThinkingBlock(reply.Blocks) {
@@ -2201,28 +2201,38 @@ func assistantReplyMessage(reply Reply) Message {
 //
 // NewAssistantMessage substitutes a "[no content]" placeholder so the history
 // stays valid for providers that reject empty assistant content, but that
-// placeholder is the only trace such a turn leaves: nothing in the session
-// file or the logs says which model produced it or why. Endpoints reach this
-// state when a content filter or rate limiter returns an empty choice with a
-// "stop" finish reason, or when a stream drops after the role-only first
-// chunk, so the stop reason and the token counts are what a bug report needs.
+// placeholder is the only trace such a turn leaves: neither the session file
+// nor the logs record which model produced it, what stop reason came back, or
+// what the call cost. One shape is confirmed in this repo — a stream that
+// drops after the role-only first chunk, which the openai aggregator handles
+// and TestSendStream_RoleOnlyChunk covers — and the fields below are what
+// distinguishes it from the others a report might turn out to involve.
 //
-// A round that called tools is not this case — a tool_use reply legitimately
-// carries no text, and the agent loop keeps going.
-func logEmptyReply(reply Reply) {
+// carriedText says the user is not looking at a blank bubble: a turn-end
+// reminder is holding earlier text that runLoop re-attaches after this
+// append, so the empty round is the model declining to add to it. Still worth
+// a line — the reminder round bought nothing — but it is not the reported
+// symptom.
+//
+// A round that called tools is not this case at all. runLoop's tool_use
+// branch never reaches here, so this guard is for a provider that returns
+// tool_use blocks under some other stop reason.
+func logEmptyReply(reply Reply, carriedText bool) {
 	for _, b := range reply.Blocks {
 		if b.Type == "tool_use" {
 			return
 		}
 	}
-	slog.Warn("assistant reply carried no text",
+	slog.Warn("agent: assistant reply carried no text",
 		"model", reply.Model,
 		"stop_reason", reply.StopReason,
 		"blocks", len(reply.Blocks),
 		"has_thinking", hasThinkingBlock(reply.Blocks),
+		"carried_text", carriedText,
 		"input_tokens", reply.InputTokens,
 		"output_tokens", reply.OutputTokens,
 		"cache_read_tokens", reply.CacheReadTokens,
+		"cache_write_tokens", reply.CacheWriteTokens,
 	)
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2187,11 +2187,43 @@ func assistantReplyMessage(reply Reply) Message {
 	if content == "" {
 		content = textFromBlocks(reply.Blocks)
 	}
+	if content == "" {
+		logEmptyReply(reply)
+	}
 	msg := NewAssistantMessage(content)
 	if hasThinkingBlock(reply.Blocks) {
 		msg.Blocks = reply.Blocks
 	}
 	return msg
+}
+
+// logEmptyReply records a turn whose assistant reply carried no text at all.
+//
+// NewAssistantMessage substitutes a "[no content]" placeholder so the history
+// stays valid for providers that reject empty assistant content, but that
+// placeholder is the only trace such a turn leaves: nothing in the session
+// file or the logs says which model produced it or why. Endpoints reach this
+// state when a content filter or rate limiter returns an empty choice with a
+// "stop" finish reason, or when a stream drops after the role-only first
+// chunk, so the stop reason and the token counts are what a bug report needs.
+//
+// A round that called tools is not this case — a tool_use reply legitimately
+// carries no text, and the agent loop keeps going.
+func logEmptyReply(reply Reply) {
+	for _, b := range reply.Blocks {
+		if b.Type == "tool_use" {
+			return
+		}
+	}
+	slog.Warn("assistant reply carried no text",
+		"model", reply.Model,
+		"stop_reason", reply.StopReason,
+		"blocks", len(reply.Blocks),
+		"has_thinking", hasThinkingBlock(reply.Blocks),
+		"input_tokens", reply.InputTokens,
+		"output_tokens", reply.OutputTokens,
+		"cache_read_tokens", reply.CacheReadTokens,
+	)
 }
 
 // hasThinkingBlock reports whether blocks carries a reasoning trace worth

--- a/internal/agent/empty_reply_test.go
+++ b/internal/agent/empty_reply_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"log/slog"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ func TestAssistantReplyMessage_EmptyReplyWarns(t *testing.T) {
 		StopReason:   "stop",
 		InputTokens:  1200,
 		OutputTokens: 0,
-	})
+	}, false)
 
 	if msg.Content != "[no content]" {
 		t.Errorf("Content = %q, want the placeholder", msg.Content)
@@ -36,6 +37,7 @@ func TestAssistantReplyMessage_EmptyReplyWarns(t *testing.T) {
 		"assistant reply carried no text",
 		"model=some-model",
 		"stop_reason=stop",
+		"carried_text=false",
 		"input_tokens=1200",
 		"output_tokens=0",
 	} {
@@ -53,15 +55,30 @@ func TestAssistantReplyMessage_ThinkingOnlyWarns(t *testing.T) {
 	assistantReplyMessage(Reply{
 		Model:  "some-model",
 		Blocks: []ContentBlock{{Type: "thinking", Thinking: "hmm"}},
-	})
+	}, false)
 
 	if out := logs.String(); !strings.Contains(out, "has_thinking=true") {
 		t.Errorf("log %q missing has_thinking=true", out)
 	}
 }
 
-// A tool-use round legitimately carries no text; warning on it would fire on
-// every tool call the agent makes.
+// A turn-end reminder holds text the user has already read and runLoop
+// re-attaches it after this append, so the round still warrants a line but
+// must not read as the blank-bubble symptom.
+func TestAssistantReplyMessage_CarriedTextIsMarked(t *testing.T) {
+	logs := captureAgentSlog(t)
+
+	assistantReplyMessage(Reply{Model: "some-model"}, true)
+
+	if out := logs.String(); !strings.Contains(out, "carried_text=true") {
+		t.Errorf("log %q missing carried_text=true", out)
+	}
+}
+
+// Defensive: runLoop's tool_use branch continues before reaching
+// assistantReplyMessage, so this can only fire for a provider that returns
+// tool_use blocks under some other stop reason. Pin it anyway — a tool round
+// has no text by design and must never be reported as an empty reply.
 func TestAssistantReplyMessage_ToolUseDoesNotWarn(t *testing.T) {
 	logs := captureAgentSlog(t)
 
@@ -69,7 +86,7 @@ func TestAssistantReplyMessage_ToolUseDoesNotWarn(t *testing.T) {
 		Model:      "some-model",
 		StopReason: "tool_use",
 		Blocks:     []ContentBlock{{Type: "tool_use", ID: "t1", Name: "terminal"}},
-	})
+	}, false)
 
 	if out := logs.String(); out != "" {
 		t.Errorf("tool_use reply logged %q, want silence", out)
@@ -79,10 +96,60 @@ func TestAssistantReplyMessage_ToolUseDoesNotWarn(t *testing.T) {
 func TestAssistantReplyMessage_TextReplyDoesNotWarn(t *testing.T) {
 	logs := captureAgentSlog(t)
 
-	if msg := assistantReplyMessage(Reply{Content: "hello"}); msg.Content != "hello" {
+	if msg := assistantReplyMessage(Reply{Content: "hello"}, false); msg.Content != "hello" {
 		t.Errorf("Content = %q, want %q", msg.Content, "hello")
 	}
 	if out := logs.String(); out != "" {
 		t.Errorf("non-empty reply logged %q, want silence", out)
+	}
+}
+
+// The cases above call assistantReplyMessage directly, which proves the
+// function is right but not that it is wired in. These drive the real loop.
+
+func TestRun_EmptyReplyWarnsThroughTheLoop(t *testing.T) {
+	logs := captureAgentSlog(t)
+
+	send := &fakeToolSender{
+		replies: []Reply{{Model: "some-model", StopReason: "stop"}},
+	}
+	a := New(send, "m")
+
+	reply, err := a.Run(context.Background(), "hello", nil, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "" {
+		t.Errorf("Content = %q, want the empty reply passed through", reply.Content)
+	}
+	if out := logs.String(); !strings.Contains(out, "assistant reply carried no text") {
+		t.Errorf("log %q missing the warning", out)
+	}
+}
+
+// The guard that matters in practice: an ordinary tool round produces an
+// assistant message with no text of its own, and must stay silent.
+func TestRun_ToolRoundStaysSilent(t *testing.T) {
+	logs := captureAgentSlog(t)
+
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks: []ContentBlock{
+					NewToolUseBlock("call-1", "bash", map[string]any{"command": "echo hi"}),
+				},
+			},
+			{Content: "the output was: hi", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{results: map[string]string{"bash": "hi"}}
+	a := New(send, "m")
+
+	if _, err := a.Run(context.Background(), "run echo hi", []ToolDefinition{{Name: "bash"}}, exec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out := logs.String(); out != "" {
+		t.Errorf("tool round logged %q, want silence", out)
 	}
 }

--- a/internal/agent/empty_reply_test.go
+++ b/internal/agent/empty_reply_test.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// captureAgentSlog swaps the slog default for a buffer-backed handler and
+// restores the real one on cleanup. Capturing slog.Default() inside the
+// cleanup instead would restore the buffer handler, silencing later tests.
+func captureAgentSlog(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func TestAssistantReplyMessage_EmptyReplyWarns(t *testing.T) {
+	logs := captureAgentSlog(t)
+
+	msg := assistantReplyMessage(Reply{
+		Model:        "some-model",
+		StopReason:   "stop",
+		InputTokens:  1200,
+		OutputTokens: 0,
+	})
+
+	if msg.Content != "[no content]" {
+		t.Errorf("Content = %q, want the placeholder", msg.Content)
+	}
+	out := logs.String()
+	for _, want := range []string{
+		"assistant reply carried no text",
+		"model=some-model",
+		"stop_reason=stop",
+		"input_tokens=1200",
+		"output_tokens=0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log %q missing %q", out, want)
+		}
+	}
+}
+
+// A thinking-only reply is still a blank bubble for the user, so it warns —
+// but the trace it did produce is worth naming in the log line.
+func TestAssistantReplyMessage_ThinkingOnlyWarns(t *testing.T) {
+	logs := captureAgentSlog(t)
+
+	assistantReplyMessage(Reply{
+		Model:  "some-model",
+		Blocks: []ContentBlock{{Type: "thinking", Thinking: "hmm"}},
+	})
+
+	if out := logs.String(); !strings.Contains(out, "has_thinking=true") {
+		t.Errorf("log %q missing has_thinking=true", out)
+	}
+}
+
+// A tool-use round legitimately carries no text; warning on it would fire on
+// every tool call the agent makes.
+func TestAssistantReplyMessage_ToolUseDoesNotWarn(t *testing.T) {
+	logs := captureAgentSlog(t)
+
+	assistantReplyMessage(Reply{
+		Model:      "some-model",
+		StopReason: "tool_use",
+		Blocks:     []ContentBlock{{Type: "tool_use", ID: "t1", Name: "terminal"}},
+	})
+
+	if out := logs.String(); out != "" {
+		t.Errorf("tool_use reply logged %q, want silence", out)
+	}
+}
+
+func TestAssistantReplyMessage_TextReplyDoesNotWarn(t *testing.T) {
+	logs := captureAgentSlog(t)
+
+	if msg := assistantReplyMessage(Reply{Content: "hello"}); msg.Content != "hello" {
+		t.Errorf("Content = %q, want %q", msg.Content, "hello")
+	}
+	if out := logs.String(); out != "" {
+		t.Errorf("non-empty reply logged %q, want silence", out)
+	}
+}

--- a/internal/serveproc/serveproc.go
+++ b/internal/serveproc/serveproc.go
@@ -47,6 +47,19 @@ func LogPath() (string, error) {
 	return filepath.Join(dir, "serve.log"), nil
 }
 
+// CLILogPath returns the path of the interactive CLI's log
+// (~/.octo/cli.log), creating ~/.octo if needed. Separate from serve.log
+// because the two can run at once — a desktop or daemon backend serving while
+// the user also has a terminal session open — and interleaving them would
+// make both harder to read.
+func CLILogPath() (string, error) {
+	dir, err := octoDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "cli.log"), nil
+}
+
 // CrashLogPath returns the path of the crash log (~/.octo/crash.log), creating
 // ~/.octo if needed. Kept separate from serve.log: this file holds only the
 // output of a process dying, so it stays short enough to paste into a bug


### PR DESCRIPTION
## Problem

A user reported a transcript ending in a bare `[no content]` bubble. That string is ours — `NewAssistantMessage` (`internal/agent/message.go:46`) substitutes it when the reply text is empty, because Anthropic rejects an assistant message with empty content.

The substitution is correct. What's missing is any way to find out *why* the reply was empty:

- `internal/provider/` and `internal/agent/` log nothing on the main turn path (the only `slog` calls there are title generation).
- The session file doesn't persist `StopReason` or per-turn usage — `agent.Message` is `role` / `content` / `blocks` / `created_at`.
- So `serve.log` holds nothing, and `OCTO_LOG_LEVEL=debug` adds nothing either.

An empty reply is not a protocol violation on its own — a `tool_use`-only round has no text by design, and OpenAI's `message.content: null` alongside `tool_calls` is standard. But a round with no text, no tool call, and no reasoning trace is an endpoint anomaly, and right now it is completely undiagnosable after the fact.

## Change

`assistantReplyMessage` is the single construction point for a completed turn's history message, and it already computes whether any text survived. When nothing did, it now logs:

```
level=WARN msg="assistant reply carried no text" model=… stop_reason=… blocks=0
  has_thinking=false input_tokens=… output_tokens=… cache_read_tokens=…
```

Those fields separate the usual causes: a content filter or rate limiter returning an empty choice with `finish_reason: "stop"`, a stream that dropped after the role-only first chunk (`internal/provider/openai/stream_test.go:634` covers that shape), or a `max_tokens` budget consumed entirely by reasoning.

A round carrying a `tool_use` block returns early — that reply is legitimately text-free, and warning there would fire on every tool call.

## Note on the CLI

`cmd/octo` installs no `slog` handler, so in TUI mode this warning goes to the default handler on stderr and will print over the interface. That is pre-existing behavior shared with the `slog.Warn` calls in `internal/config` and `internal/lockfile`, and an empty reply is rare, so I left the handler setup alone rather than widening this PR. Say the word if you'd rather it be addressed.

## Testing

`go test -race ./internal/agent/` — four new tests pass (empty reply warns; thinking-only reply warns with `has_thinking=true`; `tool_use` round stays silent; normal text reply stays silent).

`TestCompressImageData_KeepsSmaller` fails on this machine under Go 1.27, unrelated to this change and pre-existing.

`gofmt -l .` clean, `go vet ./internal/agent/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
