### PR TITLE
agent: end the turn when a tool_use stop reason carries no tool call

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1258,7 +1258,29 @@ func (a *Agent) runLoop(
 					"Raise --max-tokens / --max-tokens-escalate, or ask me to continue in smaller steps.")
 		}
 
-		if reply.StopReason == "tool_use" {
+		// A "tool_use" stop reason with no tool_use block is a reply that
+		// promised a tool call and delivered none. Taking the dispatch branch
+		// anyway appends an assistant message with neither content nor blocks
+		// — which providers reject on the next request — dispatches an empty
+		// batch, appends an empty tool_result message, and loops. Nothing
+		// stops that loop either: the duplicate-batch detector fingerprints
+		// the batch and returns early on an empty one, so it never trips, and
+		// the turn runs to its iteration cap burning a provider call each
+		// time.
+		//
+		// Falling through to the end-of-turn path below ends the turn on
+		// whatever the reply did carry — text blocks included — and logs the
+		// empty case like any other empty reply.
+		toolUseRound := reply.StopReason == "tool_use" && hasToolUseBlock(reply.Blocks)
+		if reply.StopReason == "tool_use" && !toolUseRound {
+			slog.Warn("agent: stop reason is tool_use but the reply has no tool call",
+				"model", reply.Model,
+				"blocks", len(reply.Blocks),
+				"has_text", textFromBlocks(reply.Blocks) != "" || reply.Content != "",
+			)
+		}
+
+		if toolUseRound {
 			// Pre-dispatch checkpoint. accrueUsage above just learned what the
 			// prompt really cost, and this batch may run for many minutes —
 			// leaving the next checkpoint (the pre-send one, a full batch away)
@@ -2197,6 +2219,16 @@ func assistantReplyMessage(reply Reply, carriedText bool) Message {
 	return msg
 }
 
+// hasToolUseBlock reports whether blocks carries anything to dispatch.
+func hasToolUseBlock(blocks []ContentBlock) bool {
+	for _, b := range blocks {
+		if b.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
+}
+
 // logEmptyReply records a turn whose assistant reply carried no text at all.
 //
 // NewAssistantMessage substitutes a "[no content]" placeholder so the history
@@ -2218,10 +2250,8 @@ func assistantReplyMessage(reply Reply, carriedText bool) Message {
 // branch never reaches here, so this guard is for a provider that returns
 // tool_use blocks under some other stop reason.
 func logEmptyReply(reply Reply, carriedText bool) {
-	for _, b := range reply.Blocks {
-		if b.Type == "tool_use" {
-			return
-		}
+	if hasToolUseBlock(reply.Blocks) {
+		return
 	}
 	slog.Warn("agent: assistant reply carried no text",
 		"model", reply.Model,

--- a/internal/agent/toolcall_missing_test.go
+++ b/internal/agent/toolcall_missing_test.go
@@ -1,0 +1,165 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// captureToolCallSlog swaps the slog default for a buffer-backed handler and
+// restores the real one on cleanup. Capturing slog.Default() inside the
+// cleanup instead would restore the buffer handler, silencing later tests.
+func captureToolCallSlog(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// A provider that answers "tool_use" without a tool_use block used to send
+// runLoop around again: an empty batch dispatches to nothing, the duplicate
+// detector skips empty batches, and the turn ran to its iteration cap. The
+// sender here holds exactly one reply and errors on a second call, so a
+// regression shows up as that error rather than as a slow test.
+func TestRunLoop_ToolUseStopWithNoToolCall_EndsTurn(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{{Model: "some-model", StopReason: "tool_use"}},
+	}
+	a := New(send, "m")
+	exec := &fakeExecutor{}
+
+	reply, err := a.Run(context.Background(), "go", []ToolDefinition{{Name: "bash"}}, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if send.calls != 1 {
+		t.Errorf("provider called %d times, want 1 — the loop went around again", send.calls)
+	}
+	if reply.Content != "" {
+		t.Errorf("Content = %q, want empty", reply.Content)
+	}
+}
+
+// The reply's text is the only thing the model actually produced, so ending
+// the turn must not throw it away.
+func TestRunLoop_ToolUseStopWithNoToolCall_KeepsText(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{{
+			Model:      "some-model",
+			StopReason: "tool_use",
+			Blocks:     []ContentBlock{{Type: "text", Text: "here is the answer"}},
+		}},
+	}
+	a := New(send, "m")
+
+	reply, err := a.Run(context.Background(), "go", []ToolDefinition{{Name: "bash"}}, &fakeExecutor{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if send.calls != 1 {
+		t.Errorf("provider called %d times, want 1", send.calls)
+	}
+	// runLoop rebuilds Content from the text blocks when the reply carried
+	// none of its own.
+	if reply.Content != "here is the answer" {
+		t.Errorf("Content = %q, want the text block preserved", reply.Content)
+	}
+}
+
+// History must not gain a message with neither content nor blocks: that is
+// what the next request would be rejected for.
+func TestRunLoop_ToolUseStopWithNoToolCall_LeavesNoEmptyMessage(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{{Model: "some-model", StopReason: "tool_use"}},
+	}
+	a := New(send, "m")
+
+	if _, err := a.Run(context.Background(), "go", []ToolDefinition{{Name: "bash"}}, &fakeExecutor{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for i, m := range a.History.Snapshot() {
+		if m.Content == "" && len(m.Blocks) == 0 {
+			t.Errorf("messages[%d] (%s) has neither content nor blocks", i, m.Role)
+		}
+	}
+}
+
+func TestRunLoop_ToolUseStopWithNoToolCall_Warns(t *testing.T) {
+	logs := captureToolCallSlog(t)
+
+	send := &fakeToolSender{
+		replies: []Reply{{Model: "some-model", StopReason: "tool_use"}},
+	}
+	a := New(send, "m")
+
+	if _, err := a.Run(context.Background(), "go", []ToolDefinition{{Name: "bash"}}, &fakeExecutor{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	out := logs.String()
+	for _, want := range []string{
+		"stop reason is tool_use but the reply has no tool call",
+		"model=some-model",
+		"has_text=false",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log %q missing %q", out, want)
+		}
+	}
+}
+
+// The ordinary path must be untouched: a real tool_use round still dispatches
+// and still runs the second provider call that produces the answer.
+func TestRunLoop_RealToolUseRoundStillDispatches(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks: []ContentBlock{
+					NewToolUseBlock("call-1", "bash", map[string]any{"command": "echo hi"}),
+				},
+			},
+			{Content: "the output was: hi", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{results: map[string]string{"bash": "hi"}}
+	a := New(send, "m")
+
+	reply, err := a.Run(context.Background(), "run echo hi", []ToolDefinition{{Name: "bash"}}, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if send.calls != 2 {
+		t.Errorf("provider called %d times, want 2", send.calls)
+	}
+	if reply.Content != "the output was: hi" {
+		t.Errorf("Content = %q", reply.Content)
+	}
+}
+
+func TestHasToolUseBlock(t *testing.T) {
+	cases := []struct {
+		name   string
+		blocks []ContentBlock
+		want   bool
+	}{
+		{"nil", nil, false},
+		{"empty", []ContentBlock{}, false},
+		{"text only", []ContentBlock{{Type: "text", Text: "hi"}}, false},
+		{"thinking only", []ContentBlock{{Type: "thinking", Thinking: "hmm"}}, false},
+		{"tool_use", []ContentBlock{{Type: "tool_use", ID: "t1", Name: "bash"}}, true},
+		{"text then tool_use", []ContentBlock{
+			{Type: "text", Text: "on it"},
+			{Type: "tool_use", ID: "t1", Name: "bash"},
+		}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasToolUseBlock(c.blocks); got != c.want {
+				t.Errorf("hasToolUseBlock() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`runLoop` decided to dispatch tools on the stop reason alone:

```go
if reply.StopReason == "tool_use" {
```

A provider that answers `"tool_use"` without actually putting a `tool_use` block in the reply therefore sent the loop around with nothing to run:

1. `NewToolUseMessage(reply.Blocks)` appends an assistant message with neither content nor blocks — the shape providers reject on the next request.
2. `dispatchTools` runs an empty batch, and `NewToolResultMessage` appends an empty user message after it.
3. The duplicate-batch detector cannot catch it: `fingerprintToolUseBatch` returns an empty slice for a reply with no tool_use blocks, and `hasConsecutiveDuplicates` returns early on `len(current) == 0`. The stuck check is guarded by `len(fp) > 0` and never runs.
4. `continue` — and the turn runs to its iteration cap (`defaultMaxTurns = 1000` unless configured lower), spending a provider call each time round.

So the one failure mode the loop has no defence against is also the one that costs the most. It surfaced while reviewing the empty-reply logging in #2380 — same family of provider misbehaviour, separate bug.

## Change

Gate the branch on there being something to dispatch. The reply then falls through to the end-of-turn path, which already does the right thing: it rebuilds `Content` from any text blocks the reply carried, and reports the genuinely-empty case the same way every other empty reply is reported. A warning records the model, the block count and whether text was present.

Ending the turn beats stopping with an error message. If the model produced text and simply mislabelled the stop reason, that text is the answer and the user should see it; if it produced nothing, the turn is over either way.

## Testing

The four regression tests fail without the gate, with `Run: agent: loop[1]: fakeToolSender: no more replies (call 1)` — `loop[1]` being the second round that should never happen. The fake sender holds exactly one reply and errors on a second call, so a regression shows up immediately rather than as a 1000-iteration test.

Covered: the turn ends after one provider call; a text block in the reply survives; history gains no message with neither content nor blocks; the warning carries the model and `has_text`. Plus one test that an ordinary tool round still dispatches and still makes its second call — that one passes with and without the gate, which is the point.

`go test -race ./internal/agent/` — everything passes except `TestCompressImageData_KeepsSmaller`, which fails the same way on an unmodified checkout of `main` (local Go 1.27 JPEG/PNG encoder sizes vs. the test's threshold) and touches nothing in this diff.

`go vet ./...` and `gofmt -l .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
