### PR TITLE
provider: fix the race in TestLimiterSerialisesCalls' own measurement

### DIFF
--- a/internal/provider/anthropic/ratelimit_test.go
+++ b/internal/provider/anthropic/ratelimit_test.go
@@ -106,10 +106,23 @@ func TestLimiterSerialisesCalls(t *testing.T) {
 						break
 					}
 				}
-				defer inFlight.Add(-1)
 				// Hold the request open long enough that an ungated caller
 				// would overlap with it.
 				time.Sleep(10 * time.Millisecond)
+
+				// Leave the in-flight window before writing the response rather
+				// than in a defer. A streaming client is finished the moment it
+				// has read the end-of-stream sentinel — it never waits for the
+				// body to reach EOF — so it releases its rate-limit slot, and
+				// the next caller arrives here, while a deferred decrement is
+				// still pending in this handler. That ordering made the peak
+				// read 2 with the gate working perfectly, which is what this
+				// test used to fail on intermittently in CI.
+				//
+				// Nothing is lost by moving it: two callers overlapping because
+				// the gate is missing do so during the sleep above, which is
+				// inside the window either way.
+				inFlight.Add(-1)
 
 				if r.Header.Get("Accept") == "text/event-stream" {
 					w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/provider/openai/ratelimit_test.go
+++ b/internal/provider/openai/ratelimit_test.go
@@ -50,10 +50,23 @@ func TestLimiterSerialisesCalls(t *testing.T) {
 						break
 					}
 				}
-				defer inFlight.Add(-1)
 				// Hold the request open long enough that an ungated caller
 				// would overlap with it.
 				time.Sleep(10 * time.Millisecond)
+
+				// Leave the in-flight window before writing the response rather
+				// than in a defer. A streaming client is finished the moment it
+				// has read the end-of-stream sentinel — it never waits for the
+				// body to reach EOF — so it releases its rate-limit slot, and
+				// the next caller arrives here, while a deferred decrement is
+				// still pending in this handler. That ordering made the peak
+				// read 2 with the gate working perfectly, which is what this
+				// test used to fail on intermittently in CI.
+				//
+				// Nothing is lost by moving it: two callers overlapping because
+				// the gate is missing do so during the sleep above, which is
+				// inside the window either way.
+				inFlight.Add(-1)
 
 				if r.Header.Get("Accept") == "text/event-stream" {
 					w.Header().Set("Content-Type", "text/event-stream")


### PR DESCRIPTION
## Problem

`TestLimiterSerialisesCalls/SendStream` fails intermittently on CI. It hit two unrelated PRs in a row today (#2380, #2382) with identical output:

```
ratelimit_test.go:97: peak concurrent requests at the server = 2, want 1
```

The rate limiter is fine. `stream.go:78` takes the slot with a function-level `defer release()`, so it does cover the body read, exactly as intended. What's broken is how the test measures.

The handler counts requests in flight and decrements **in a defer**, so the window it measures runs to the end of the handler. But a streaming client is finished as soon as it has read the end-of-stream sentinel — it never waits for the body to reach EOF. So the sequence is:

1. Client reads the last chunk, returns, releases its slot.
2. Next caller acquires a slot and reaches the handler: `inFlight` → 2.
3. Only then does the first handler return and run its deferred decrement.

Peak reads 2 while exactly one call was ever in flight. The buffered `Send` path doesn't show it because it reads to EOF, and the body close covers the gap.

## Change

Decrement before writing the response instead of in a defer. Two callers overlapping because the gate is missing still overlap during the 10ms sleep, which is inside the measured window either way — so the test keeps its bite while no longer depending on when the server-side goroutine happens to be scheduled.

Both providers carry the same test with the same defer. Both fixed.

## Verification

The flake would not reproduce locally in 200 runs, so I widened the window instead of guessing: a 5ms sleep after `Flush()` and before the handler returns, which is what a loaded CI runner does to that goroutine for free.

| | before | after |
|---|---|---|
| widened window (`-count=10`) | **fails 5/5** at count=5 | passes 10/10 |
| concurrency cap raised 1 → 4, standing in for a broken gate | fails | **still fails**, both subtests |
| as committed, `-count=150` each package | — | openai clean, anthropic clean |

The middle row is the one that matters most: it shows the test still detects the thing it exists to detect, rather than having been quietly turned into one that always passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
