### PR TITLE
registry: one deepseek model, and no more implicit lite model

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -463,25 +463,6 @@ func resumeModelRef(sess *agent.Session) string {
 	return sess.Model
 }
 
-// resumeLite re-infers the session's implicit lite model after a resume
-// changed the active model. The startup lite inference ran against the config
-// default; after resume the conversation runs on the session's own model, so
-// compaction should follow the session's endpoint, key, and prompt cache.
-// Only a lite that came from the startup sender (implicit inference) or was
-// absent is touched — an explicit cfg.Lite entry built from its own sender is
-// left alone.
-func resumeLite(a *agent.Agent, prevSender agent.Sender, provider, model string, entry config.ModelEntry) {
-	if a.LiteSender != prevSender && a.LiteSender != nil {
-		return
-	}
-	if lm := app.ImplicitLiteModel(provider, model, resolveBaseURL(provider, entry)); lm != "" {
-		a.LiteSender = a.GetSender()
-		a.LiteModel = lm
-	} else {
-		a.LiteSender, a.LiteModel = nil, ""
-	}
-}
-
 // runChat handles `octo [flags] [message]` — every invocation that isn't a
 // named subcommand.
 //
@@ -898,15 +879,6 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// Images become text for a text-only model when a vision helper is
 	// configured. Nil (unconfigured) leaves every image path unchanged.
 	a.SetImageDescriber(app.NewVisionDescriber(a, cfg))
-	if a.LiteSender == nil {
-		// No explicit lite entry — fall back to the vendor's registry lite
-		// model on the SAME sender, so compaction stays on the endpoint, key,
-		// and prompt cache the conversation is already using.
-		if lm := app.ImplicitLiteModel(provName, resolvedModel, resolveBaseURL(provName, entry)); lm != "" {
-			a.LiteSender = llmSender
-			a.LiteModel = lm
-		}
-	}
 
 	// Build the tool executor up-front (REPL mode only — single-turn mode
 	// doesn't dispatch tools) and register the sub-agent dispatcher BEFORE the
@@ -1213,7 +1185,6 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 					a.Model = resolvedModel
 				} else {
 					prevProvider, prevModel, prevEntry := provName, resolvedModel, entry
-					prevSender := llmSender
 					provName, resolvedModel, entry = p, m, e
 					if rebuild {
 						newSender, serr := buildSender(p, e, stderr, senderTuning{
@@ -1232,15 +1203,9 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 							llmSender = newSender
 							a.SetSender(llmSender)
 							a.Model = m
-							// Compaction's lite model was inferred for the
-							// config default above; re-infer it on the session's
-							// own sender (resumeLite no-ops when the lite is an
-							// explicit cfg.Lite entry).
-							resumeLite(a, prevSender, p, m, e)
 						}
 					} else {
 						a.Model = m
-						resumeLite(a, prevSender, p, m, e)
 					}
 				}
 				// The startup banner (above) printed the config-default

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -656,7 +656,6 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 	for _, existingEp := range full.Endpoints {
 		if existingEp.ID == endpointID {
 			ep.Name = existingEp.Name
-			ep.LiteModel = existingEp.LiteModel
 			ep.Headers = existingEp.Headers
 			ep.RPM = existingEp.RPM
 			ep.MaxConcurrency = existingEp.MaxConcurrency

--- a/dev-docs/multi-model-config-design.md
+++ b/dev-docs/multi-model-config-design.md
@@ -178,19 +178,12 @@ Each transport that constructs an `Agent` resolves `lite_model` to an entry,
 builds its sender through the same cache / `app.NewSender` path, and sets the
 pair.
 
-**Implicit lite.** With no `lite_model` configured, the vendor's registry
-`LiteModel` (e.g. deepseek → `deepseek-v4-flash`, anthropic →
-`claude-haiku-4-5`) serves as the lite model, riding the session's **own
-sender** — same endpoint, key, and prompt-cache routing, so no extra
-credentials and, where the backend caches by shared prefix, the summarisation
-call can reuse the cache the conversation already built.
-`app.ImplicitLiteModel(provider, model, baseURL)` resolves it and returns
-nothing when the vendor is unknown or has no `LiteModel`, when the primary model
-already is the lite model, or when the base URL points off the vendor's own
-endpoints (a custom endpoint is a different backend behind a compatible
-protocol; its catalogue won't include the vendor's lite model). An explicit
-`lite_model` entry always wins. For a session bound to a config entry, the
-implicit lookup uses that entry's vendor and endpoint.
+The lite model is always explicit. With no `lite` configured there is no
+lite pair at all and compaction runs on the primary sender: the registry
+carries no per-vendor lite model, and nothing is inferred from the vendor or
+the endpoint's base URL. A model guessed from the vendor is reachable only on
+that vendor's own endpoint and absent from every relay's catalogue, so the
+lite model is named by the user or there is none.
 
 ## Frontend
 

--- a/docs/src/content/docs/concepts/compaction.md
+++ b/docs/src/content/docs/concepts/compaction.md
@@ -84,9 +84,10 @@ every transport, so the TUI, Web UI, and IM channels show identical behavior:
 
 ## Controlling the cost
 
-Set `lite_model` in [`config.yml`](/docs/reference/config-file/) and the summarize call runs on that
+Set `lite` in [`config.yml`](/docs/reference/config-file/) and the summarize call runs on that
 cheaper model first, falling back to your primary model only if the lite call fails — the main lever
-for keeping compaction's own token cost down on a long-running session.
+for keeping compaction's own token cost down on a long-running session. Leave it empty and the
+summarize call runs on your primary model; nothing cheaper is picked for you.
 
 Next: an error mid-turn from an over-length *reply* (not the input) is a different mechanism — see
 [The agent loop](/docs/concepts/agent-loop/#recovering-from-a-truncated-reply).

--- a/docs/src/content/docs/reference/config-file.mdx
+++ b/docs/src/content/docs/reference/config-file.mdx
@@ -24,7 +24,7 @@ anything friendly.
 |---|---|---|
 | `endpoints` | list of [endpoint](#endpoint) | Configured providers, each bundling shared connection params and a list of models |
 | `default` | string | Composite id `<endpoint-id>::<model>` used when nothing else selects one; empty falls back to the first endpoint's first model |
-| `lite` | string | Composite id `<endpoint-id>::<model>` for cheap internal calls ([history compaction](/docs/concepts/compaction/)'s summarize step and session-title generation); empty infers from the endpoint's `lite_model` or the vendor default |
+| `lite` | string | Composite id `<endpoint-id>::<model>` for cheap internal calls ([history compaction](/docs/concepts/compaction/)'s summarize step and session-title generation); empty means no lite model — those calls run on the session's primary model |
 | `vision_helper` | string | Composite id `<endpoint-id>::<model>` of a vision-capable model that describes images for text-only models. Empty (the default) leaves images refused as before. The model it names must have `vision: true` |
 | `permission_mode` | string | `interactive` \| `strict` \| `auto` |
 | `coauthor` | bool | Append `Co-authored-by` to git commits the agent writes (default `true`) |
@@ -93,7 +93,6 @@ the official Anthropic endpoint and a relay — which the old flat list couldn't
 | `base_url` | string | Endpoint URL; empty uses the vendor default. Required for the `custom` vendor |
 | `api_key` | string | Plaintext fallback used only if the provider's env var is empty (mode `0600`). Optional for the `custom` vendor — local servers such as Ollama take none, and no auth header is sent |
 | `protocol` | string | Wire format for the `custom` vendor only: `anthropic` \| `openai` |
-| `lite_model` | string | Optional: name a model in this endpoint's `models` to serve as its compaction lite model |
 | `rpm` | int | Optional: cap on provider calls started against this endpoint per rolling 60-second window. `0`/absent = unlimited |
 | `max_concurrency` | int | Optional: cap on provider calls in flight against this endpoint at once. `0`/absent = unlimited |
 | `models` | list of [model](#model) | The models offered through this endpoint |

--- a/docs/src/content/docs/zh/concepts/compaction.md
+++ b/docs/src/content/docs/zh/concepts/compaction.md
@@ -73,8 +73,9 @@ Web UI、IM 渠道看到的表现完全一致：
 
 ## 控制成本
 
-在 [`config.yml`](/docs/zh/reference/config-file/) 里设置 `lite_model`，总结调用会先跑在这个更便宜
+在 [`config.yml`](/docs/zh/reference/config-file/) 里设置 `lite`，总结调用会先跑在这个更便宜
 的模型上，只有 lite 调用失败才回退到你的主模型——这是在一个长会话里控制压缩本身开销的主要手段。
+留空则总结直接跑主模型，octo 不会替你挑一个更便宜的。
 
 下一步：一次回复本身（不是输入）超长导致的中途错误是另一套机制——见
 [Agent 循环](/docs/zh/concepts/agent-loop/)里"从截断的回复里恢复"一节。

--- a/docs/src/content/docs/zh/reference/config-file.mdx
+++ b/docs/src/content/docs/zh/reference/config-file.mdx
@@ -22,7 +22,7 @@ flag。所有字段都是可选的——文件不存在，或者字段缺失，�
 |---|---|---|
 | `endpoints` | [端点](#端点) 列表 | 配置好的 provider，每个端点打包共享的连接参数和一组模型 |
 | `default` | string | 复合 id `<端点id>::<model>`，没有其他选择时使用；留空则回退到第一个端点的第一个模型 |
-| `lite` | string | 用于低成本内部调用（[历史压缩](/docs/zh/concepts/compaction/)的总结步骤和会话标题生成）的复合 id `<端点id>::<model>`；留空则从端点的 `lite_model` 或 vendor 默认推断 |
+| `lite` | string | 用于低成本内部调用（[历史压缩](/docs/zh/concepts/compaction/)的总结步骤和会话标题生成）的复合 id `<端点id>::<model>`；留空则没有 lite 模型，这些调用直接走会话的主模型 |
 | `vision_helper` | string | 复合 id `<端点id>::<model>`，指定一个有视觉能力的模型替纯文本模型描述图片。留空（默认）则图片仍按原样拒绝。指向的模型必须是 `vision: true` |
 | `permission_mode` | string | `interactive` \| `strict` \| `auto` |
 | `coauthor` | bool | 在 agent 写的 git commit 里追加 `Co-authored-by`（默认 `true`） |
@@ -82,7 +82,6 @@ octo 按不同界面分别追踪工作目录,而不是一个全局 cwd:
 | `base_url` | string | 端点 URL；留空使用该 vendor 的默认端点。`custom` vendor 必填 |
 | `api_key` | string | 明文兜底，仅当对应环境变量为空时使用（权限 `0600`）。`custom` vendor 可以不填——Ollama 等本地服务不需要密钥，此时不发认证头 |
 | `protocol` | string | 仅 `custom` vendor 使用的协议：`anthropic` \| `openai` |
-| `lite_model` | string | 可选：指定本端点 `models` 里的某个模型作为它的压缩 lite 模型 |
 | `rpm` | int | 可选：每滚动 60 秒内针对该端点发起的模型调用次数上限。`0`/不填 = 不限 |
 | `max_concurrency` | int | 可选：针对该端点同时在途的模型调用数上限。`0`/不填 = 不限 |
 | `models` | [模型](#模型) 列表 | 通过这个端点提供的模型 |

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -35,6 +35,25 @@ const defaultContextWindow = 128_000
 // Tool Search threshold) without duplicating the model→window table.
 func ContextWindow(model string) int { return contextWindow(model) }
 
+// ContextWindowKnown is ContextWindow plus whether the model matched an entry
+// in the table at all. The registry-coverage test uses it to catch a model
+// added to app.Registry without a window here — a miss is silent otherwise,
+// since the fallback is a plausible-looking 128k.
+func ContextWindowKnown(model string) (int, bool) {
+	if w := lookupContextWindow(model); w > 0 {
+		return w, true
+	}
+	return defaultContextWindow, false
+}
+
+// contextWindow is lookupContextWindow with the fallback applied.
+func contextWindow(model string) int {
+	if w := lookupContextWindow(model); w > 0 {
+		return w
+	}
+	return defaultContextWindow
+}
+
 // EstimateTokens exposes estimateMessages to other packages (e.g. the web
 // server's cold-start context-percent estimate for a resumed session with no
 // live Agent yet) so they share the exact same heuristic as compaction and
@@ -46,11 +65,12 @@ func EstimateTokens(msgs []Message) int { return estimateMessages(msgs) }
 // context-percent estimate, which the transcript-only count omits.
 func EstimateTextTokens(s string) int { return estimateText(s) }
 
-// contextWindow returns the approximate context-window size (in tokens) for a
-// model. Values are deliberately conservative; matched case-insensitively by
-// substring so dated/aliased names ("claude-haiku-4-5-2025…") still resolve.
-// Raise a model's entry when a larger window is confirmed.
-func contextWindow(model string) int {
+// lookupContextWindow returns the approximate context-window size (in tokens)
+// for a model, or 0 when the model matches no entry. Values are deliberately
+// conservative; matched case-insensitively by substring so dated/aliased names
+// ("claude-haiku-4-5-2025…") still resolve. Raise a model's entry when a larger
+// window is confirmed.
+func lookupContextWindow(model string) int {
 	m := strings.ToLower(model)
 	switch {
 	// ── Anthropic Claude ──
@@ -74,6 +94,8 @@ func contextWindow(model string) int {
 		return 256_000
 
 	// ── OpenAI GPT / O-series ──
+	case strings.Contains(m, "gpt-6") || strings.Contains(m, "gpt6"):
+		return 1_000_000
 	case strings.Contains(m, "gpt-5.6") || strings.Contains(m, "gpt5.6"):
 		return 1_000_000
 	case strings.Contains(m, "gpt-5.5") || strings.Contains(m, "gpt5.5"):
@@ -106,6 +128,8 @@ func contextWindow(model string) int {
 		return 1_000_000
 
 	// ── DeepSeek ──
+	case strings.Contains(m, "deepseek-flash") || strings.Contains(m, "deepseekflash"):
+		return 1_000_000
 	case strings.Contains(m, "deepseek-v4-pro") || strings.Contains(m, "deepseekv4-pro"):
 		return 1_000_000
 	case strings.Contains(m, "deepseek-v4-flash") || strings.Contains(m, "deepseekv4-flash"):
@@ -136,6 +160,8 @@ func contextWindow(model string) int {
 		return 200_000
 
 	// ── Alibaba Qwen ──
+	case strings.Contains(m, "qwen3.8") || strings.Contains(m, "qwen-3.8"):
+		return 1_000_000
 	case strings.Contains(m, "qwen3.7") || strings.Contains(m, "qwen-3.7"):
 		return 1_000_000
 	case strings.Contains(m, "qwen3-max") || strings.Contains(m, "qwen-3-max"):
@@ -247,7 +273,7 @@ func contextWindow(model string) int {
 		return 16_000
 
 	default:
-		return defaultContextWindow
+		return 0
 	}
 }
 

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -11,8 +11,6 @@ package app
 
 import (
 	"strings"
-
-	"github.com/open-octo/octo-agent/internal/config"
 )
 
 // EndpointVariant is a regional endpoint alternative for a vendor.
@@ -41,7 +39,6 @@ type Vendor struct {
 	DefaultBaseURL   string            // vendor's official endpoint (host only; the client appends the protocol path)
 	DefaultModel     string            // cheapest/reasoning-capable default
 	Models           []VendorModel     // available models (for UI dropdown), each with its vision capability
-	LiteModel        string            // lightweight/cheaper model variant
 	APIKeyEnvVar     string            // environment variable name for the key
 	WebsiteURL       string            // link to the key-management page
 	EndpointVariants []EndpointVariant // regional endpoint alternatives
@@ -62,6 +59,7 @@ var Registry = []Vendor{
 		DefaultBaseURL: "https://api.openai.com",
 		DefaultModel:   "gpt-5.4",
 		Models: []VendorModel{
+			{ID: "gpt-6-astra", Vision: true},
 			{ID: "gpt-5.6-sol", Vision: true},
 			{ID: "gpt-5.6-terra", Vision: true},
 			{ID: "gpt-5.6-luna", Vision: true},
@@ -76,7 +74,6 @@ var Registry = []Vendor{
 			{ID: "o3-mini", Vision: false}, // o3-mini has no image input (unlike o3 / o4-mini)
 			{ID: "o4-mini", Vision: true},
 		},
-		LiteModel:    "gpt-5.4-mini",
 		APIKeyEnvVar: "OPENAI_API_KEY",
 		WebsiteURL:   "https://platform.openai.com/api-keys",
 	},
@@ -88,6 +85,7 @@ var Registry = []Vendor{
 		DefaultBaseURL: "https://api.anthropic.com",
 		DefaultModel:   "claude-sonnet-4-6",
 		Models: []VendorModel{
+			{ID: "claude-fable-5-1", Vision: true},
 			{ID: "claude-fable-5", Vision: true},
 			{ID: "claude-opus-4-8", Vision: true},
 			{ID: "claude-opus-4-7", Vision: true},
@@ -97,7 +95,6 @@ var Registry = []Vendor{
 			{ID: "claude-sonnet-4-5", Vision: true},
 			{ID: "claude-haiku-4-5", Vision: true},
 		},
-		LiteModel:    "claude-haiku-4-5",
 		APIKeyEnvVar: "ANTHROPIC_API_KEY",
 		WebsiteURL:   "https://console.anthropic.com/settings/keys",
 	},
@@ -157,7 +154,6 @@ var Registry = []Vendor{
 			{ID: "grok-4.3", Vision: true},
 			{ID: "grok-build-0.1", Vision: true},
 		},
-		LiteModel:    "grok-4.20-non-reasoning",
 		APIKeyEnvVar: "XAI_API_KEY",
 		WebsiteURL:   "https://console.x.ai/",
 	},
@@ -167,18 +163,10 @@ var Registry = []Vendor{
 		Protocol:       "openai",
 		API:            "openai-completions",
 		DefaultBaseURL: "https://api.deepseek.com",
-		DefaultModel:   "deepseek-v4-pro",
-		// deepseek-v4-flash / -pro have vision in the chat app but not over the
-		// API — image content isn't accepted on those endpoints, so they stay
-		// text-only here. deepseek-v4-flash-vision-exp is the API-facing vision
-		// variant: 1M context, images billed as input tokens by dimension, tool
-		// calls supported (api-docs.deepseek.com/quick_start/pricing, 2026-08-29).
+		DefaultModel:   "deepseek-flash",
 		Models: []VendorModel{
-			{ID: "deepseek-v4-flash", Vision: false},
-			{ID: "deepseek-v4-pro", Vision: false},
-			{ID: "deepseek-v4-flash-vision-exp", Vision: true},
+			{ID: "deepseek-flash", Vision: true},
 		},
-		LiteModel:    "deepseek-v4-flash",
 		APIKeyEnvVar: "DEEPSEEK_API_KEY",
 		WebsiteURL:   "https://platform.deepseek.com/api_keys",
 	},
@@ -257,7 +245,6 @@ var Registry = []Vendor{
 			{ID: "glm-4.5-air", Vision: false},
 			{ID: "glm-4.5-flash", Vision: false},
 		},
-		LiteModel:    "glm-5.3-flash",
 		APIKeyEnvVar: "ZHIPU_API_KEY",
 		WebsiteURL:   "https://open.bigmodel.cn/usercenter/apikey",
 		EndpointVariants: []EndpointVariant{
@@ -272,16 +259,16 @@ var Registry = []Vendor{
 		API:            "openai-completions",
 		DefaultBaseURL: "https://dashscope.aliyuncs.com/compatible-mode",
 		DefaultModel:   "qwen3.7-plus",
-		// qwen3.7-plus and the flash generations accept image input; qwen3.7-max
-		// and the legacy qwen-plus alias are text-only.
+		// qwen3.8-max, qwen3.7-plus and the flash generations accept image
+		// input; qwen3.7-max and the legacy qwen-plus alias are text-only.
 		Models: []VendorModel{
+			{ID: "qwen3.8-max", Vision: true},
 			{ID: "qwen3.7-max", Vision: false},
 			{ID: "qwen3.7-plus", Vision: true},
 			{ID: "qwen3.6-flash", Vision: true},
 			{ID: "qwen3.5-flash", Vision: true},
 			{ID: "qwen-plus", Vision: false},
 		},
-		LiteModel:    "qwen3.5-flash",
 		APIKeyEnvVar: "DASHSCOPE_API_KEY",
 		WebsiteURL:   "https://bailian.console.aliyun.com",
 		EndpointVariants: []EndpointVariant{
@@ -485,103 +472,6 @@ func VendorWebsiteURL(id string) string {
 // IsKnownVendor reports whether id is a registered vendor ID.
 func IsKnownVendor(id string) bool {
 	return vendorByID(id) != nil
-}
-
-// ImplicitLiteModel returns the lite model a session should compact on when
-// the user configured none explicitly: the vendor's registry LiteModel,
-// served over the SAME sender as the primary model — same endpoint, key, and
-// prompt-cache routing. It returns "" (no implicit lite) when:
-//   - the vendor is unknown or has no LiteModel,
-//   - the primary model already IS the lite model, or
-//   - baseURL points off the vendor's own endpoints — a custom endpoint is a
-//     different backend wearing a compatible protocol, and its catalogue
-//     won't include the vendor's lite model.
-//
-// Deprecated: prefer ImplicitLiteModelForEndpoint, which takes a config.Endpoint
-// and consults endpoint.LiteModel first. This form is kept for callers that
-// haven't migrated yet (they pass the provider/model/baseURL they already
-// have); it's equivalent to ImplicitLiteModelForEndpoint with an endpoint
-// whose LiteModel is empty.
-func ImplicitLiteModel(provider, model, baseURL string) string {
-	v := vendorByID(provider)
-	if v == nil || v.LiteModel == "" || v.LiteModel == model {
-		return ""
-	}
-	if baseURL != "" && VendorByBaseURL(baseURL) != provider {
-		return ""
-	}
-	return v.LiteModel
-}
-
-// ImplicitLiteModelForEndpoint returns the lite model a session should compact
-// on when the user configured none explicitly (design §5.5). The precedence:
-//
-//  1. endpoint.LiteModel non-empty and != model → endpoint.LiteModel. The
-//     user explicitly marked this endpoint's lite model (e.g. a custom relay
-//     endpoint carrying both claude-sonnet and gpt-5.4-mini, with mini marked
-//     as lite) — that wins over any vendor inference.
-//  2. Otherwise, if the endpoint points at an official vendor (via
-//     VendorByBaseURL) and that vendor has a LiteModel != model → vendor
-//     LiteModel. An official endpoint (e.g. anthropic's api.anthropic.com)
-//     can safely serve the vendor's lite model over the same sender, sharing
-//     key and prompt-cache routing.
-//  3. Otherwise "" — a custom endpoint without an explicit LiteModel has no
-//     implicit lite. Custom relays carry arbitrary catalogues the registry
-//     doesn't know about, so guessing a vendor LiteModel would serve a model
-//     the relay doesn't expose. The user must set endpoint.LiteModel.
-//
-// Step 2's vendor inference uses the endpoint's effective base URL — when
-// the user omits base_url (legal for named vendors, design §3.1: "命名 vendor
-// 可空, 用 vendor 默认"), we fall back to the vendor's DefaultBaseURL so the
-// inference still fires. Without this fallback, a named-vendor endpoint
-// configured without base_url would silently lose its compaction lite model,
-// which is a regression from the legacy ImplicitLiteModel (which treated
-// baseURL=="" as "trust the provider field").
-//
-// Migrating from the old ImplicitLiteModel(provider, model, baseURL): the old
-// form is equivalent to ImplicitLiteModelForEndpoint with an endpoint whose
-// LiteModel is empty, Provider = provider, and BaseURL = baseURL. Callers
-// that haven't migrated yet (cmd/octo/chat.go, internal/server/server.go) stay
-// on the old form because the ModelEntry they hold has no LiteModel field;
-// they'll migrate in PR4 when the entry becomes a config.Endpoint.
-func ImplicitLiteModelForEndpoint(endpoint config.Endpoint, model string) string {
-	// Step 1: explicit endpoint LiteModel wins when it differs from the
-	// primary model. If they're equal, the lite would be a no-op — fall
-	// through to vendor inference so an official endpoint still gets its
-	// vendor's lite (e.g. endpoint.LiteModel="claude-sonnet-4-6" on the
-	// anthropic endpoint, primary is also claude-sonnet-4-6 → infer
-	// claude-haiku-4-5 rather than returning a useless self-reference).
-	if endpoint.LiteModel != "" && endpoint.LiteModel != model {
-		return endpoint.LiteModel
-	}
-
-	// Step 2: official vendor endpoint → vendor LiteModel. The provider field
-	// alone isn't enough — a user can set provider="anthropic" on an endpoint
-	// whose base_url points elsewhere (a relay wearing the anthropic
-	// protocol). VendorByBaseURL confirms the endpoint actually points at the
-	// named vendor's host before inferring its LiteModel.
-	//
-	// When base_url is empty (legal for named vendors per §3.1), fall back to
-	// the vendor's DefaultBaseURL so the inference still fires. This matches
-	// the legacy ImplicitLiteModel's treatment of baseURL=="" as "trust the
-	// provider field".
-	baseURL := endpoint.BaseURL
-	if baseURL == "" {
-		baseURL = VendorBaseURL(endpoint.Provider)
-	}
-	if baseURL != "" {
-		inferredProvider := VendorByBaseURL(baseURL)
-		if inferredProvider != "" && inferredProvider == endpoint.Provider {
-			if v := vendorByID(inferredProvider); v != nil && v.LiteModel != "" && v.LiteModel != model {
-				return v.LiteModel
-			}
-		}
-	}
-
-	// Step 3: no inference. Either a custom endpoint (no vendor match) or a
-	// vendor with no LiteModel in the registry, or the primary model already
-	// is the vendor LiteModel.
-	return ""
 }
 
 // VendorByBaseURL returns the vendor whose default endpoint or one of whose

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -3,7 +3,7 @@ package app
 import (
 	"testing"
 
-	"github.com/open-octo/octo-agent/internal/config"
+	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/provider/anthropic"
 	"github.com/open-octo/octo-agent/internal/provider/openai"
 )
@@ -192,18 +192,6 @@ func TestVendor_XAI(t *testing.T) {
 	if v.APIKeyEnvVar != "XAI_API_KEY" {
 		t.Errorf("APIKeyEnvVar = %q, want XAI_API_KEY", v.APIKeyEnvVar)
 	}
-	if v.LiteModel != "grok-4.20-non-reasoning" {
-		t.Errorf("LiteModel = %q, want grok-4.20-non-reasoning", v.LiteModel)
-	}
-	found := false
-	for _, m := range v.Models {
-		if m.ID == v.LiteModel {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("LiteModel %q must be a member of Models", v.LiteModel)
-	}
 	// All current Grok chat models accept image input (docs.x.ai, 2026-07-09).
 	for _, m := range v.Models {
 		if !m.Vision {
@@ -247,42 +235,10 @@ func TestVendorEnvVars(t *testing.T) {
 	}
 }
 
-func TestImplicitLiteModel(t *testing.T) {
-	cases := []struct {
-		name                     string
-		provider, model, baseURL string
-		want                     string
-	}{
-		{"deepseek pro gets flash", "deepseek", "deepseek-v4-pro", "", "deepseek-v4-flash"},
-		{"vendor default endpoint ok", "deepseek", "deepseek-v4-pro", "https://api.deepseek.com", "deepseek-v4-flash"},
-		{"anthropic gets haiku", "anthropic", "claude-sonnet-4-6", "", "claude-haiku-4-5"},
-		{"already on the lite model", "deepseek", "deepseek-v4-flash", "", ""},
-		{"custom endpoint is a different backend", "openai", "gpt-5.4", "https://dashscope.example/v1", ""},
-		{"unknown vendor", "bogus", "m", "", ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := ImplicitLiteModel(tc.provider, tc.model, tc.baseURL); got != tc.want {
-				t.Errorf("ImplicitLiteModel(%q, %q, %q) = %q, want %q", tc.provider, tc.model, tc.baseURL, got, tc.want)
-			}
-		})
-	}
-
-	// A vendor without a LiteModel in the registry yields no implicit lite.
-	for _, v := range Registry {
-		if v.LiteModel == "" {
-			if got := ImplicitLiteModel(v.ID, v.DefaultModel, ""); got != "" {
-				t.Errorf("vendor %q has no LiteModel but ImplicitLiteModel = %q", v.ID, got)
-			}
-			break
-		}
-	}
-}
-
 func TestVendorModels_ReturnsIDs(t *testing.T) {
 	// VendorModels flattens the catalogue to plain ids for the UI dropdown.
 	ids := VendorModels("deepseek")
-	want := []string{"deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-flash-vision-exp"}
+	want := []string{"deepseek-flash"}
 	if len(ids) != len(want) {
 		t.Fatalf("VendorModels(deepseek) = %v, want %v", ids, want)
 	}
@@ -306,8 +262,8 @@ func TestVendorModelVision(t *testing.T) {
 		vision, known bool
 	}{
 		{"anthropic", "claude-opus-4-8", true, true},
-		{"deepseek", "deepseek-v4-pro", false, true}, // vision not on the API
-		{"deepseek", "deepseek-v4-flash-vision-exp", true, true},
+		{"deepseek", "deepseek-flash", true, true},
+		{"deepseek", "deepseek-v4-pro", false, false}, // dropped from the catalogue
 		{"bailian", "qwen3.7-plus", true, true},
 		{"bailian", "qwen3.7-max", false, true}, // text-only flagship
 		{"kimi", "kimi-k2.6", true, true},       // MoonViT multimodal
@@ -342,6 +298,51 @@ func TestVendorModelVisionMap(t *testing.T) {
 	}
 }
 
+// A model added to the registry without a context window in
+// agent.lookupContextWindow silently inherits the 128k fallback, which is
+// plausible enough to go unnoticed while auto-compaction fires far too early.
+// Every catalogue model must match the table explicitly, and so must every
+// vendor's DefaultModel.
+func TestRegistryModelsHaveContextWindow(t *testing.T) {
+	// Guard the guard: a model outside the table must report known=false, or
+	// the loop below would pass vacuously.
+	if w, known := agent.ContextWindowKnown("no-such-model-42"); known {
+		t.Fatalf("ContextWindowKnown(unknown model) = (%d, true), want known=false", w)
+	}
+	for _, v := range Registry {
+		if v.CustomEndpoint {
+			continue // no catalogue: the user names arbitrary models
+		}
+		if _, known := agent.ContextWindowKnown(v.DefaultModel); !known {
+			t.Errorf("vendor %q DefaultModel %q has no context-window entry", v.ID, v.DefaultModel)
+		}
+		for _, m := range v.Models {
+			if _, known := agent.ContextWindowKnown(m.ID); !known {
+				t.Errorf("vendor %q model %q has no context-window entry", v.ID, m.ID)
+			}
+		}
+	}
+}
+
+// Every vendor's DefaultModel must be one of its catalogue models — otherwise
+// the onboarding form offers a default the dropdown can't show.
+func TestRegistryDefaultModelIsInCatalogue(t *testing.T) {
+	for _, v := range Registry {
+		if v.CustomEndpoint {
+			continue
+		}
+		found := false
+		for _, m := range v.Models {
+			if m.ID == v.DefaultModel {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("vendor %q DefaultModel %q is not in Models", v.ID, v.DefaultModel)
+		}
+	}
+}
+
 // TestRegistryModelsHaveDeterministicVision guards against a half-migrated
 // entry: every catalogue model must be reachable via VendorModelVision.
 func TestRegistryModelsHaveDeterministicVision(t *testing.T) {
@@ -351,115 +352,5 @@ func TestRegistryModelsHaveDeterministicVision(t *testing.T) {
 				t.Errorf("vendor %q model %q not resolvable via VendorModelVision", v.ID, m.ID)
 			}
 		}
-	}
-}
-
-// TestImplicitLiteModel_EndpointForm covers the new signature
-// ImplicitLiteModelForEndpoint(endpoint config.Endpoint, model string)
-// introduced in PR2 (design §5.5). The precedence is:
-//
-//  1. endpoint.LiteModel non-empty and != model → endpoint.LiteModel
-//  2. otherwise, if endpoint.BaseURL hits an official vendor (via
-//     VendorByBaseURL) and that vendor has a LiteModel → vendor LiteModel
-//  3. otherwise "" (custom endpoint without explicit LiteModel has no
-//     implicit lite — the user must set endpoint.LiteModel)
-//
-// The old ImplicitLiteModel(provider, model, baseURL) is kept as a thin
-// wrapper so existing callers that haven't migrated yet keep working; this
-// test pins the new endpoint-aware behaviour.
-func TestImplicitLiteModel_EndpointForm(t *testing.T) {
-	cases := []struct {
-		name     string
-		endpoint config.Endpoint
-		model    string
-		want     string
-	}{
-		{
-			"endpoint.LiteModel wins when set and differs from model",
-			config.Endpoint{Provider: "custom", BaseURL: "https://relay.example.com", LiteModel: "gpt-5.4-mini"},
-			"claude-sonnet-4-6",
-			"gpt-5.4-mini",
-		},
-		{
-			"endpoint.LiteModel == model → fall through to vendor inference (no implicit lite from endpoint)",
-			// An endpoint that nominally points LiteModel at the same model as
-			// the primary — the lite would be a no-op, so we don't return it.
-			config.Endpoint{Provider: "anthropic", BaseURL: "https://api.anthropic.com", LiteModel: "claude-sonnet-4-6"},
-			"claude-sonnet-4-6",
-			"claude-haiku-4-5", // vendor LiteModel wins because endpoint.LiteModel == model
-		},
-		{
-			"official anthropic endpoint infers vendor LiteModel",
-			config.Endpoint{Provider: "anthropic", BaseURL: "https://api.anthropic.com"},
-			"claude-sonnet-4-6",
-			"claude-haiku-4-5",
-		},
-		{
-			"named-vendor endpoint with empty base_url still infers vendor LiteModel (regression guard for I1)",
-			// Design §3.1: "base_url,omitempty // custom 必填, 命名 vendor 可空
-			// (用 vendor 默认)". A named-vendor endpoint configured without
-			// base_url must still get its vendor's LiteModel — the legacy
-			// ImplicitLiteModel treated baseURL=="" as "trust the provider",
-			// and ImplicitLiteModelForEndpoint must match that. Without the
-			// VendorBaseURL fallback in step 2, this case would silently lose
-			// compaction lite model — a regression that only surfaces after
-			// PR4 migrates callers to the new function.
-			config.Endpoint{Provider: "anthropic"}, // BaseURL empty
-			"claude-sonnet-4-6",
-			"claude-haiku-4-5",
-		},
-		{
-			"named-vendor endpoint with empty base_url still infers vendor LiteModel (deepseek)",
-			config.Endpoint{Provider: "deepseek"},
-			"deepseek-v4-pro",
-			"deepseek-v4-flash",
-		},
-		{
-			"official deepseek endpoint infers vendor LiteModel",
-			config.Endpoint{Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
-			"deepseek-v4-pro",
-			"deepseek-v4-flash",
-		},
-		{
-			"custom endpoint with no LiteModel and off-vendor baseURL → no implicit lite",
-			config.Endpoint{Provider: "custom", BaseURL: "https://relay.example.com"},
-			"claude-sonnet-4-6",
-			"",
-		},
-		{
-			"custom endpoint with named vendor provider but off-vendor baseURL → no implicit lite",
-			// provider=anthropic but baseURL points elsewhere — VendorByBaseURL
-			// won't match anthropic, so we don't infer the anthropic LiteModel.
-			config.Endpoint{Provider: "anthropic", BaseURL: "https://relay.example.com"},
-			"claude-sonnet-4-6",
-			"",
-		},
-		{
-			"primary model already is the vendor LiteModel → no implicit lite",
-			config.Endpoint{Provider: "anthropic", BaseURL: "https://api.anthropic.com"},
-			"claude-haiku-4-5",
-			"",
-		},
-		{
-			"empty endpoint (zero value) → no implicit lite",
-			config.Endpoint{},
-			"anything",
-			"",
-		},
-		{
-			"regional variant endpoint infers vendor LiteModel (or empty if vendor has none)",
-			config.Endpoint{Provider: "minimax", BaseURL: "https://api.minimax.io"}, // intl variant
-			"MiniMax-M3",
-			"", // minimax has no LiteModel in the registry
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := ImplicitLiteModelForEndpoint(tc.endpoint, tc.model)
-			if got != tc.want {
-				t.Errorf("ImplicitLiteModelForEndpoint(endpoint=%+v, model=%q) = %q, want %q",
-					tc.endpoint, tc.model, got, tc.want)
-			}
-		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,10 +122,6 @@ type Endpoint struct {
 	// Protocol is the wire format ("anthropic" | "openai"). Only the
 	// "custom" vendor needs it set explicitly; named vendors pin it.
 	Protocol string `yaml:"protocol,omitempty"`
-	// LiteModel optionally names a model in Models used as the lite model
-	// for compaction. Empty falls back to vendor inference (see
-	// ImplicitLiteModel).
-	LiteModel string `yaml:"lite_model,omitempty"`
 	// Headers are extra HTTP headers sent with every request to this
 	// endpoint's BaseURL. Applied after the client's built-in headers
 	// (Content-Type/User-Agent/Authorization/x-api-key/anthropic-version), so
@@ -182,8 +178,8 @@ type Config struct {
 	// the first endpoint's first model (see ResolveDefault).
 	Default string `yaml:"default,omitempty"`
 	// Lite is the composite id for the compaction lite model. Empty means
-	// fall back to ImplicitLiteModel inference (endpoint.lite_model, else
-	// the vendor registry's LiteModel for official endpoints).
+	// there is no lite model: compaction and title generation run on the
+	// session's primary model. Nothing is inferred from the vendor.
 	Lite string `yaml:"lite,omitempty"`
 	// VisionHelper is the composite id (or bare model name) of a vision-capable
 	// model that describes images on behalf of a text-only primary model. Empty

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -37,7 +37,6 @@ type providerPreset struct {
 	DefaultModel     string            `json:"default_model"`
 	Models           []string          `json:"models,omitempty"`
 	ModelVision      map[string]bool   `json:"model_vision,omitempty"` // model id → accepts image input; lets the form pre-fill the vision toggle
-	LiteModel        string            `json:"lite_model,omitempty"`
 	EndpointVariants []endpointVariant `json:"endpoint_variants,omitempty"`
 	WebsiteURL       string            `json:"website_url,omitempty"`
 	CustomEndpoint   bool              `json:"custom_endpoint,omitempty"`
@@ -66,7 +65,6 @@ func buildProviderPresets() []providerPreset {
 			DefaultModel:     v.DefaultModel,
 			Models:           app.VendorModels(v.ID),
 			ModelVision:      app.VendorModelVisionMap(v.ID),
-			LiteModel:        v.LiteModel,
 			EndpointVariants: variants,
 			WebsiteURL:       v.WebsiteURL,
 			CustomEndpoint:   v.CustomEndpoint,
@@ -279,7 +277,6 @@ type endpointConfigJSON struct {
 	BaseURL   string              `json:"base_url,omitempty"`
 	Protocol  string              `json:"protocol,omitempty"`
 	HasAPIKey bool                `json:"has_api_key"`
-	LiteModel string              `json:"lite_model,omitempty"`
 	Models    []endpointModelJSON `json:"models"`
 	Headers   map[string]string   `json:"headers,omitempty"`
 }
@@ -313,7 +310,6 @@ func (s *Server) handleGetEndpoints(w http.ResponseWriter, r *http.Request) {
 			BaseURL:   ep.BaseURL,
 			Protocol:  ep.Protocol,
 			HasAPIKey: ep.APIKey != "",
-			LiteModel: ep.LiteModel,
 			Models:    make([]endpointModelJSON, 0, len(ep.Models)),
 			Headers:   ep.Headers,
 		}
@@ -779,7 +775,6 @@ type endpointJSONOut struct {
 	BaseURL   string              `json:"base_url,omitempty"`
 	Protocol  string              `json:"protocol,omitempty"`
 	HasAPIKey bool                `json:"has_api_key"`
-	LiteModel string              `json:"lite_model,omitempty"`
 	Models    []endpointModelJSON `json:"models"`
 	Headers   map[string]string   `json:"headers,omitempty"`
 }
@@ -792,7 +787,6 @@ func endpointToJSON(ep config.Endpoint) endpointJSONOut {
 		BaseURL:   ep.BaseURL,
 		Protocol:  ep.Protocol,
 		HasAPIKey: ep.APIKey != "",
-		LiteModel: ep.LiteModel,
 		Models:    make([]endpointModelJSON, 0, len(ep.Models)),
 		Headers:   ep.Headers,
 	}

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -546,76 +546,58 @@ func TestGetEndpoints_HeadersRoundTrip(t *testing.T) {
 	}
 }
 
-func TestBuildAgent_ImplicitLiteFromVendorRegistry(t *testing.T) {
+// Without a configured lite entry the agent carries no lite pair at all —
+// compaction stays on the primary sender. Nothing is inferred from the vendor.
+func TestBuildAgent_NoLiteWithoutExplicitEntry(t *testing.T) {
 	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 	srv.provider = "deepseek"
-	srv.model = "deepseek-v4-pro"
+	srv.model = "deepseek-flash"
 
-	// Unbound session, no explicit lite entry → vendor's registry lite model
-	// on the same (default) sender.
-	sess := agent.NewSession("deepseek-v4-pro", "")
+	sess := agent.NewSession("deepseek-flash", "")
 	a := srv.buildAgent(sess)
-	if a.LiteModel != "deepseek-v4-flash" {
-		t.Errorf("LiteModel = %q, want deepseek-v4-flash", a.LiteModel)
-	}
-	if a.LiteSender == nil || a.LiteSender != srv.sender {
-		t.Error("implicit lite must reuse the session's own sender")
-	}
-
-	// Already on the lite model → no implicit lite.
-	srv.model = "deepseek-v4-flash"
-	sess2 := agent.NewSession("deepseek-v4-flash", "")
-	if a2 := srv.buildAgent(sess2); a2.LiteSender != nil {
-		t.Errorf("no implicit lite expected when primary IS the lite model, got %q", a2.LiteModel)
+	if a.LiteSender != nil || a.LiteModel != "" {
+		t.Errorf("lite pair = (%T, %q), want unset", a.LiteSender, a.LiteModel)
 	}
 }
 
-func TestBuildAgent_ExplicitLiteBeatsImplicit(t *testing.T) {
+// The configured lite entry is the only source of the lite pair, and it is
+// endpoint-independent: a session bound to an endpoint other than the default
+// still compacts on the lite entry's own sender.
+func TestBuildAgent_ExplicitLiteEntry(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Endpoints: []config.Endpoint{
-			{ID: "ep-deepseek", Provider: "deepseek", APIKey: "sk-x", Models: []config.EndpointModel{{Model: "deepseek-v4-pro"}}},
+			{ID: "ep-anthropic", Provider: "anthropic", APIKey: "sk-a", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-deepseek", Provider: "deepseek", APIKey: "sk-x", Models: []config.EndpointModel{{Model: "deepseek-flash"}}},
 			{ID: "ep-kimi", Provider: "kimi", APIKey: "sk-y", Models: []config.EndpointModel{{Model: "kimi-k2.5"}}},
 		},
-		Default: "ep-deepseek::deepseek-v4-pro",
+		Default: "ep-anthropic::claude-sonnet-4-6",
 		Lite:    "ep-kimi::kimi-k2.5",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-	srv.provider = "deepseek"
-	srv.model = "deepseek-v4-pro"
+	srv.provider = "anthropic"
+	srv.model = "claude-sonnet-4-6"
 
-	sess := agent.NewSession("deepseek-v4-pro", "")
-	a := srv.buildAgent(sess)
+	// Session on the default endpoint.
+	a := srv.buildAgent(agent.NewSession("claude-sonnet-4-6", ""))
 	if a.LiteModel != "kimi-k2.5" {
 		t.Errorf("LiteModel = %q, want the explicit entry kimi-k2.5", a.LiteModel)
 	}
 	if a.LiteSender == srv.sender {
 		t.Error("explicit lite entry must get its own sender, not the default one")
 	}
-}
 
-func TestBuildAgent_ImplicitLiteForBoundSession(t *testing.T) {
-	setTestHome(t)
-	seedModels(t, config.Config{
-		Endpoints: []config.Endpoint{
-			{ID: "ep-anthropic", Provider: "anthropic", APIKey: "sk-a", Models: []config.EndpointModel{{Model: "claude-sonnet-4-6"}}},
-			{ID: "ep-deepseek", Provider: "deepseek", APIKey: "sk-d", Models: []config.EndpointModel{{Model: "deepseek-v4-pro"}}},
-		},
-		Default: "ep-anthropic::claude-sonnet-4-6",
-	})
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
-	srv.provider = "anthropic"
-	srv.model = "claude-sonnet-4-6"
-
-	sess := agent.NewSession("deepseek-v4-pro", "")
-	sess.ModelConfig = "deepseek-v4-pro"
-	a := srv.buildAgent(sess)
-	if a.LiteModel != "deepseek-v4-flash" {
-		t.Errorf("LiteModel = %q, want deepseek-v4-flash from the bound entry's vendor", a.LiteModel)
+	// Session bound to a different endpoint — the lite pair is unchanged and
+	// still runs on the lite entry's sender, not the session's.
+	bound := agent.NewSession("deepseek-flash", "")
+	bound.ModelConfig = "ep-deepseek::deepseek-flash"
+	b := srv.buildAgent(bound)
+	if b.LiteModel != "kimi-k2.5" {
+		t.Errorf("bound session LiteModel = %q, want kimi-k2.5", b.LiteModel)
 	}
-	if a.LiteSender == nil || a.LiteSender != a.GetSender() {
-		t.Error("bound session's implicit lite must reuse that session's sender")
+	if b.LiteSender == nil || b.LiteSender == b.GetSender() {
+		t.Error("bound session's lite must be the lite entry's own sender")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1326,19 +1326,6 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 		// configured. Nil (unconfigured) leaves every image path unchanged.
 		a.SetImageDescriber(app.NewVisionDescriber(a, cfg))
 		a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
-		if a.LiteSender == nil {
-			// No explicit lite entry — fall back to the vendor's registry
-			// lite model on the session's OWN sender, keeping compaction on
-			// the endpoint, key, and prompt cache the conversation uses.
-			prov, baseURL := s.getProvider(), resolveBaseURL(s.getProvider(), cfg)
-			if entry, ok := cfg.EntryByModel(sess.ModelConfig); ok {
-				prov, baseURL = entry.Provider, entry.BaseURL
-			}
-			if lm := app.ImplicitLiteModel(prov, a.Model, baseURL); lm != "" {
-				a.LiteSender = sender
-				a.LiteModel = lm
-			}
-		}
 		// Honor the configured auto-compaction threshold, the same way the CLI
 		// does (cmd/octo/chat.go). Without this the server left CompactAutoFraction
 		// at zero, so every web/desktop/IM turn fell back to the built-in 75%
@@ -2531,12 +2518,6 @@ func (s *Server) buildChannelAgent(profile *agentprofile.Profile) *agent.Agent {
 		// agent needs the describer as much as a Web session does.
 		a.SetImageDescriber(app.NewVisionDescriber(a, cfg))
 		a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
-		if a.LiteSender == nil {
-			if lm := app.ImplicitLiteModel(s.getProvider(), model, resolveBaseURL(s.getProvider(), cfg)); lm != "" {
-				a.LiteSender = defaultSender
-				a.LiteModel = lm
-			}
-		}
 	}
 	return a
 }

--- a/internal/skills/defaults/config-setup/SKILL.md
+++ b/internal/skills/defaults/config-setup/SKILL.md
@@ -138,13 +138,14 @@ Endpoint "anthropic"                  Endpoint "relay-a"
   api_key: sk-ant-…                     api_key: sk-…
   models:                               models:
     - claude-sonnet-5                     - gpt-4o
-    - claude-haiku-4-5                    - deepseek-v3
-  default_model: claude-sonnet-5        default_model: gpt-4o
-  lite_model: claude-haiku-4-5          lite_model: deepseek-v3
+    - claude-haiku-4-5                    - deepseek-flash
 ```
 
-The **default model** is what the agent uses for normal turns.
-The **lite model** is used for lightweight tasks (title generation, quick lookups).
+Two top-level composite ids pick across endpoints: `default` (e.g.
+`anthropic::claude-sonnet-5`) is what the agent uses for normal turns, and `lite`
+(e.g. `anthropic::claude-haiku-4-5`) is used for lightweight tasks (title
+generation, compaction summaries). An empty `lite` means those run on the
+primary model — nothing cheaper is inferred.
 
 ### List Endpoints
 

--- a/internal/skills/defaults/product-help/CONFIG.md
+++ b/internal/skills/defaults/product-help/CONFIG.md
@@ -6,9 +6,9 @@ Path: `~/.octo/config.yml`. Every field is optional — a missing file or field 
 
 | Key | Type | Description |
 |---|---|---|
-| `endpoints` | list | Configured providers. Each bundles connection params (`id`, `name`, `provider` (`anthropic`\|`openai`\|`custom`), `base_url`, `api_key`, `protocol` (custom vendor only), optional `lite_model`, optional `rpm` / `max_concurrency` — see [Rate-limiting an endpoint](#rate-limiting-an-endpoint)) and a `models` list whose entries are `{ model, vision }` |
+| `endpoints` | list | Configured providers. Each bundles connection params (`id`, `name`, `provider` (`anthropic`\|`openai`\|`custom`), `base_url`, `api_key`, `protocol` (custom vendor only), optional `rpm` / `max_concurrency` — see [Rate-limiting an endpoint](#rate-limiting-an-endpoint)) and a `models` list whose entries are `{ model, vision }` |
 | `default` | string | Composite id `<endpoint-id>::<model>` used when nothing else selects one; empty → first endpoint's first model. **Only seeds new sessions** — a session that already has turns keeps the model it was bound to until you switch it explicitly (TUI/web chip/IM `/model`/`/api/sessions/{id}/model`). |
-| `lite` | string | Composite id `<endpoint-id>::<model>` for cheap internal calls (compaction summaries, session titles) |
+| `lite` | string | Composite id `<endpoint-id>::<model>` for cheap internal calls (compaction summaries, session titles); empty means those run on the session's primary model |
 | `permission_mode` | string | `interactive` (default) \| `strict` \| `auto` |
 | `coauthor` | bool | Append `Co-authored-by` to git commits (default true) |
 | `reasoning_effort` | string | Global reasoning intensity: `low`\|`medium`\|`high`\|`xhigh`\|`max`; empty = off |

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -126,9 +126,9 @@ func (AgentTool) DefinitionFor(sessionModel string) agent.ToolDefinition {
 // subAgentModelParamBase documents the model-override parameter without any
 // endpoint context: the plain default plus the "lite" keyword.
 const subAgentModelParamBase = "Optional model override. Defaults to the parent's model. " +
-	"Pass \"lite\" to run the sub-agent on the session's lite model (the endpoint's configured " +
-	"or vendor-inferred lite model) — right for mechanical subtasks where speed/cost beats " +
-	"quality; it falls back to the parent's model when the session has no lite model."
+	"Pass \"lite\" to run the sub-agent on the session's configured lite model — right for " +
+	"mechanical subtasks where speed/cost beats quality; it falls back to the parent's model " +
+	"when the session has no lite model."
 
 // subAgentModelParamDesc returns the model-override parameter description,
 // appending the sibling models of the session model's endpoint when the
@@ -152,9 +152,9 @@ func subAgentModelParamDesc(sessionModel string) string {
 // Known ambiguity: the flat session-model string is the only endpoint handle
 // this seam has, so when two endpoints serve the same model id the first match
 // wins and may list the wrong endpoint's siblings — cosmetic only, since an
-// unreachable override fails loudly at the provider. The "(lite)" marker covers
-// only an explicit endpoint lite_model; a vendor-inferred lite (see
-// app.ImplicitLiteModelForEndpoint) may not appear in Models at all.
+// unreachable override fails loudly at the provider. The "(lite)" marker
+// tracks cfg.Lite, the only lite the transports resolve, so it appears only
+// when the configured lite model happens to live on this endpoint.
 func subAgentModelParamDescFor(cfg config.Config, sessionModel string) string {
 	for _, ep := range cfg.Endpoints {
 		for _, m := range ep.Models {
@@ -164,7 +164,7 @@ func subAgentModelParamDescFor(cfg config.Config, sessionModel string) string {
 			names := make([]string, 0, len(ep.Models))
 			for _, mm := range ep.Models {
 				name := mm.Model
-				if name == ep.LiteModel {
+				if cfg.Lite != "" && ep.CompositeID(mm.Model) == cfg.Lite {
 					name += " (lite)"
 				}
 				names = append(names, name)

--- a/internal/tools/agent_model_desc_test.go
+++ b/internal/tools/agent_model_desc_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 // The model-override description must list only the sibling models of the
-// endpoint serving the session model, marking the endpoint's lite model.
+// endpoint serving the session model, marking the configured lite model.
 func TestSubAgentModelParamDescFor_ListsSiblingModels(t *testing.T) {
 	cfg := config.Config{
+		Lite: "main::cheap-model",
 		Endpoints: []config.Endpoint{
 			{
-				ID:        "main",
-				LiteModel: "cheap-model",
+				ID: "main",
 				Models: []config.EndpointModel{
 					{Model: "big-model"},
 					{Model: "cheap-model"},

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -990,7 +990,6 @@ export interface EndpointConfig {
   base_url?: string
   protocol?: string
   has_api_key: boolean
-  lite_model?: string
   headers?: Record<string, string>
   models: EndpointModel[]
 }
@@ -1026,7 +1025,6 @@ export interface EndpointConfigInput {
   base_url?: string
   api_key?: string
   protocol?: string
-  lite_model?: string
   headers?: Record<string, string>
   models?: EndpointModelInput[]
 }
@@ -1039,7 +1037,6 @@ export interface EndpointMutationResult {
   base_url?: string
   protocol?: string
   has_api_key: boolean
-  lite_model?: string
   headers?: Record<string, string>
   models: EndpointModel[]
 }
@@ -1264,7 +1261,6 @@ export interface ProviderPreset {
   default_model: string
   models?: string[]
   model_vision?: Record<string, boolean>  // model id → accepts image input, for pre-filling the vision toggle
-  lite_model?: string
   endpoint_variants?: EndpointVariant[]
   website_url?: string
   custom_endpoint?: boolean


### PR DESCRIPTION
## Registry

The deepseek catalogue is a single model now — `deepseek-flash`, with `Vision: true` — and it replaces `deepseek-v4-pro` as the vendor default. `deepseek-v4-flash`, `deepseek-v4-pro` and `deepseek-v4-flash-vision-exp` are gone.

Three models join their vendors, all vision-capable: `gpt-6-astra` (openai), `claude-fable-5-1` (anthropic), `qwen3.8-max` (bailian). `glm-5.3-flash` was already in the glm catalogue and is unchanged.

## No more implicit lite model

The lite model behind compaction summaries and session-title generation is always explicit from here on. Removed:

- `Vendor.LiteModel` and all six of its registry values
- `app.ImplicitLiteModel` and `app.ImplicitLiteModelForEndpoint` (the latter had no caller but its own test)
- `resumeLite` in `cmd/octo`, plus the fallback blocks in `cmd/octo/chat.go` and the server's web-session and IM-channel paths
- `lite_model` from the `GET /api/providers` response and its TypeScript mirror

With no `lite` configured there is no lite pair at all: compaction and titles run on the session's primary model. A model guessed from the vendor is reachable only on that vendor's own endpoint and absent from every relay's catalogue, so nothing is inferred. The explicit path — `cfg.Lite` as a composite `<endpoint-id>::<model>` id resolved to its own sender — is unchanged.

**Behaviour change:** a user with no `lite` configured previously got compaction and titles on a cheap vendor model (anthropic → `claude-haiku-4-5`, deepseek → `deepseek-v4-flash`, …) for free. Those calls now run on the primary model. Setting `lite` restores the cheaper routing.

### `endpoint.lite_model` deleted with it

Nothing ever resolved this field to a sender: its only reader was the never-called `ImplicitLiteModelForEndpoint`, and the endpoint create/update handlers never accepted it as input, so it could only be set by hand-editing `config.yml` — where it did nothing while the docs said it served as the endpoint's compaction lite model. Deleted from the config struct, the two server response DTOs, three TS interfaces, the config-file reference (both locales), `product-help/CONFIG.md` and the `config-setup` skill's example.

Old configs carrying the key keep working — yaml decoding ignores unknown fields, and the key is dropped on the next save. The top-level legacy `lite_model` → `lite` migration is a different field and is untouched.

The sub-agent model-override description's `(lite)` marker read that dead field; it now tracks `cfg.Lite`, so a lite model configured through the Web UI is finally marked.

## Context windows for the new models

`deepseek-flash` fell through to the generic `deepseek` case in `contextWindow` — 64k, against the 1M of the model it replaces — while being the vendor default. That would have fired auto-compaction at ~48k tokens, pinned the Web context gauge past 100%, and switched Tool Search on early. `gpt-6-astra` landed on the 128k fallback. All three new ids now have explicit entries at 1M.

To stop this recurring, `contextWindow` splits into `lookupContextWindow` (0 on a miss) plus a thin wrapper applying the fallback, with `ContextWindowKnown` exported so a new test can tell "explicitly 128k" (`gpt-4.1`) from "unmatched, defaulted to 128k".

## Tests

- `TestRegistryModelsHaveContextWindow` — every catalogue model and every vendor `DefaultModel` must match the window table explicitly. Includes a negative assertion so the loop can't pass vacuously.
- `TestRegistryDefaultModelIsInCatalogue` — a vendor's `DefaultModel` must be one of its `Models`.
- `TestBuildAgent_NoLiteWithoutExplicitEntry` — no lite pair without configuration.
- `TestBuildAgent_ExplicitLiteEntry` — now also covers a session bound to a non-default endpoint, restoring the coverage a deleted implicit-lite test provided.

The registry-coverage tests live in `internal/app` because `internal/agent` importing `app` would be an import cycle.

## Verification

`gofmt -l` clean, `go vet ./...` clean, `svelte-check` 772 files / 0 errors, `go test ./internal/... ./cmd/...` green except `TestCompressImageData_KeepsSmaller`, a pre-existing local Go 1.27 image-encoder failure unrelated to this change.

The `deepseek-flash` id, its vision capability, and the three 1M context windows were specified by the maintainer; they are not verified against vendor docs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
