### PR TITLE
chore: bump version to 1.16.17

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.16"
+var Version = "1.16.17"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch over v1.16.16, carrying the five commits merged since:

- #2384 — one deepseek model (`deepseek-flash`, vision-capable, now the vendor default), three new models (`gpt-6-astra`, `claude-fable-5-1`, `qwen3.8-max`), and the implicit lite model removed: with no `lite` configured, compaction summaries and session titles run on the primary model instead of a vendor-guessed cheap one
- #2383 — fix the race in `TestLimiterSerialisesCalls`' own measurement
- #2381 — the export bar's "include tool calls" toggle now means the same thing in every format
- #2380 — warn when a turn's assistant reply carries no text
- #2379 — sidebar session rename commits on Enter, cancels on Escape

version.go only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
