### PR TITLE
tools: follow cd and split command segments when attributing terminal reads/writes

### DIFF
--- a/internal/tools/read_tracker_test.go
+++ b/internal/tools/read_tracker_test.go
@@ -143,6 +143,10 @@ func TestRegistry_TerminalWriteThenEdit_Allowed(t *testing.T) {
 		{"bash-c-sed", func(p string) string { return "bash -c \"sed -i 's/const a = 1/const a = 2/' " + p + "\"" }},
 		{"sh-c-sed", func(p string) string { return "sh -c \"sed -i 's/const a = 1/const a = 2/' " + p + "\"" }},
 		{"gofmt-w-file", func(p string) string { return "gofmt -w " + p }},
+		// The cd-prefixed shapes below mirror how the agent works inside a
+		// worktree. On Windows CI the Unix writers don't exist; the terminal
+		// folds the failure into its text, so these cases verify the parser's
+		// attribution there rather than the shell's behaviour.
 		{"cd-and-gofmt-relative", func(p string) string {
 			return "cd " + filepath.Dir(p) + " && gofmt -w " + filepath.Base(p) + " && echo BUILD_OK"
 		}},
@@ -583,6 +587,29 @@ func TestRegistry_WriteNotOfTrackedFile_StillBlocked(t *testing.T) {
 		{"heredoc-body-mentions-file", func(other string) string {
 			return "cat > " + filepath.Join(other, "fmt.sh") + " <<'EOF'\n#!/bin/sh\ngofmt -w code.go\nsed -i '' 's/a/b/' code.go\nEOF"
 		}},
+		// A directory change the parser can see but not follow marks the
+		// directory lost, so the relative target is not attributed at all.
+		{"brace-group-cd", func(other string) string {
+			return "{ cd " + other + "; gofmt -w code.go; }"
+		}},
+		{"for-do-cd", func(other string) string {
+			return "for d in " + other + "; do cd " + other + "; gofmt -w code.go; done"
+		}},
+		{"command-cd", func(other string) string {
+			return "command cd " + other + " && gofmt -w code.go"
+		}},
+		{"backslash-cd", func(other string) string {
+			return "\\cd " + other + " && gofmt -w code.go"
+		}},
+		{"eval-cd", func(other string) string {
+			return "eval \"cd " + other + "\" && gofmt -w code.go"
+		}},
+		{"substitution-cd", func(other string) string {
+			return "echo $(cd " + other + " && gofmt -w code.go && echo ok)"
+		}},
+		{"pushd", func(other string) string {
+			return "pushd " + other + " >/dev/null && gofmt -w code.go"
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -805,5 +832,42 @@ func TestShellSegments_FollowsCd(t *testing.T) {
 	}
 	if subst := shellSegments("gofmt -w $(ls) && gofmt -w b.go", base); len(subst) != 2 || subst[1].lost {
 		t.Errorf("$(…) must not mark the line lost, got %+v", subst)
+	}
+
+	// Directory changes followCd can't reproduce all mark the rest of the
+	// line lost — including PowerShell's spellings, which only run on the
+	// Windows CI leg but must be recognised everywhere.
+	for _, cmd := range []string{
+		"Set-Location " + w + "; gofmt -w a.go",
+		"sl " + w + "; gofmt -w a.go",
+		"chdir " + w + " && gofmt -w a.go",
+		"Push-Location " + w + " && gofmt -w a.go",
+		"pushd " + w + " >/dev/null && gofmt -w a.go",
+		"popd && gofmt -w a.go",
+		"eval 'cd " + w + "' && gofmt -w a.go",
+		"{ cd " + w + "; gofmt -w a.go; }",
+		"echo $(cd " + w + " && gofmt -w a.go)",
+		"cd ~nobody && gofmt -w a.go",
+		"cd -- " + w + " && gofmt -w a.go",
+		"cd " + w + " 2>/dev/null && gofmt -w a.go",
+		"cd -P " + w + " && gofmt -w a.go",
+	} {
+		segs := shellSegments(cmd, base)
+		var gofmtSeg *shellSegment
+		for i := range segs {
+			if segs[i].tokens[0] == "gofmt" {
+				gofmtSeg = &segs[i]
+			}
+		}
+		if gofmtSeg == nil {
+			t.Errorf("%q: gofmt segment not found in %+v", cmd, segs)
+			continue
+		}
+		if !gofmtSeg.lost {
+			t.Errorf("%q: directory must be lost, got %+v", cmd, *gofmtSeg)
+		}
+		if abs, ok := gofmtSeg.resolve("a.go"); ok {
+			t.Errorf("%q: relative target must not resolve, got %q", cmd, abs)
+		}
 	}
 }

--- a/internal/tools/read_tracker_test.go
+++ b/internal/tools/read_tracker_test.go
@@ -143,6 +143,21 @@ func TestRegistry_TerminalWriteThenEdit_Allowed(t *testing.T) {
 		{"bash-c-sed", func(p string) string { return "bash -c \"sed -i 's/const a = 1/const a = 2/' " + p + "\"" }},
 		{"sh-c-sed", func(p string) string { return "sh -c \"sed -i 's/const a = 1/const a = 2/' " + p + "\"" }},
 		{"gofmt-w-file", func(p string) string { return "gofmt -w " + p }},
+		{"cd-and-gofmt-relative", func(p string) string {
+			return "cd " + filepath.Dir(p) + " && gofmt -w " + filepath.Base(p) + " && echo BUILD_OK"
+		}},
+		{"cd-and-sed-relative", func(p string) string {
+			return "cd " + filepath.Dir(p) + " && sed -i '' 's/const a = 1/const a = 2/' " + filepath.Base(p) + " && echo done"
+		}},
+		{"cd-semicolon-gofmt-relative", func(p string) string {
+			return "cd " + filepath.Dir(p) + "; gofmt -w " + filepath.Base(p) + " 2>&1 | tail -5"
+		}},
+		{"cd-and-redirect-relative", func(p string) string {
+			return "cd " + filepath.Dir(p) + " && printf 'package x\\nconst c = 3\\n' > " + filepath.Base(p)
+		}},
+		{"bash-c-cd-and-gofmt", func(p string) string {
+			return "bash -c \"cd " + filepath.Dir(p) + " && gofmt -w " + p + "\""
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -539,5 +554,197 @@ func TestRegistry_GrepNumericDashFilename_Allowed(t *testing.T) {
 		"path": p, "old_string": "const a = 1", "new_string": "const a = 2",
 	}); err != nil {
 		t.Errorf("edit after grep on a numeric-dash filename should succeed: %v", err)
+	}
+}
+
+// A relative write target resolves against the directory `cd` moved to, not
+// the process CWD: `cd elsewhere && gofmt -w code.go` names a DIFFERENT file
+// from the tracked one, so the tracked file's stale stamp must survive and a
+// genuine out-of-band edit to it stays blocked.
+func TestRegistry_CdElsewhereThenWriteSameName_StillBlocked(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	other := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(other, "code.go"), []byte("package y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Execute(context.Background(), "read_file", map[string]any{"path": p}); err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+	future := time.Now().Add(2 * time.Hour)
+	if err := os.Chtimes(p, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Execute(context.Background(), "terminal", map[string]any{
+		"command": "cd " + other + " && gofmt -w code.go",
+	}); err != nil {
+		t.Fatalf("terminal: %v", err)
+	}
+	_, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "package x", "new_string": "package y",
+	})
+	if err == nil || !strings.Contains(err.Error(), "modified since") {
+		t.Errorf("a same-named file in another directory must not refresh this one, got %v", err)
+	}
+}
+
+// Following `cd` does not loosen the directory rule: `cd dir && gofmt -w .`
+// still names a directory, and a tracked file beneath it keeps its stale
+// stamp exactly as it does without the cd prefix.
+func TestRegistry_CdThenWriteDir_DoesNotRefreshSiblings(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "notes.md")
+	if err := os.WriteFile(p, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Execute(context.Background(), "read_file", map[string]any{"path": p}); err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+	future := time.Now().Add(2 * time.Hour)
+	if err := os.Chtimes(p, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Execute(context.Background(), "terminal", map[string]any{
+		"command": "cd " + dir + " && gofmt -w . && echo OK",
+	}); err != nil {
+		t.Fatalf("terminal: %v", err)
+	}
+	_, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "hello", "new_string": "goodbye",
+	})
+	if err == nil || !strings.Contains(err.Error(), "modified since") {
+		t.Errorf("directory-level write behind cd must not refresh files beneath it, got %v", err)
+	}
+}
+
+// `cd -` goes somewhere the parser can't know, so a relative target after it
+// is not attributed to any file — the tracked file stays blocked rather than
+// being refreshed against a guessed directory.
+func TestRegistry_CdDashThenWrite_StillBlocked(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Execute(context.Background(), "read_file", map[string]any{"path": p}); err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+	future := time.Now().Add(2 * time.Hour)
+	if err := os.Chtimes(p, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Execute(context.Background(), "terminal", map[string]any{
+		"command": "cd " + dir + " && cd - >/dev/null; gofmt -w code.go",
+	}); err != nil {
+		t.Fatalf("terminal: %v", err)
+	}
+	_, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "package x", "new_string": "package y",
+	})
+	if err == nil || !strings.Contains(err.Error(), "modified since") {
+		t.Errorf("relative write after cd - must not be attributed, got %v", err)
+	}
+}
+
+// A read-style command behind `cd … &&` with a relative path counts as a
+// read of the file the shell actually opened, so the follow-up edit is not
+// refused with "not been read yet".
+func TestRegistry_CdThenTerminalReadThenEdit_Allowed(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Execute(context.Background(), "terminal", map[string]any{
+		"command": "cd " + dir + " && cat code.go",
+	}); err != nil {
+		t.Fatalf("terminal: %v", err)
+	}
+	if _, err := reg.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "package x", "new_string": "package y",
+	}); err != nil {
+		t.Errorf("edit after cd && cat should succeed: %v", err)
+	}
+}
+
+// Without any cd, a relative target resolves against the session's working
+// directory (where the terminal actually ran), not the process CWD.
+func TestRegistry_TerminalWriteRelativeToWorkingDir_Allowed(t *testing.T) {
+	reg := NewDefaultRegistry()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\nconst a = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := WithWorkingDir(context.Background(), dir)
+	if _, err := reg.Execute(ctx, "read_file", map[string]any{"path": p}); err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+	future := time.Now().Add(2 * time.Hour)
+	if err := os.Chtimes(p, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Execute(ctx, "terminal", map[string]any{"command": "gofmt -w code.go"}); err != nil {
+		t.Fatalf("terminal: %v", err)
+	}
+	if _, err := reg.Execute(ctx, "edit_file", map[string]any{
+		"path": p, "old_string": "package x", "new_string": "package y",
+	}); err != nil {
+		t.Errorf("edit after a working-dir-relative terminal write should succeed: %v", err)
+	}
+}
+
+func TestSplitShellSegments(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"gofmt -w a.go", []string{"gofmt -w a.go"}},
+		{"cd /x && gofmt -w a.go && go build ./...", []string{"cd /x ", " gofmt -w a.go ", " go build ./..."}},
+		{"a; b || c | d", []string{"a", " b ", " c ", " d"}},
+		{"go test ./... 2>&1 | tail -5", []string{"go test ./... 2>&1 ", " tail -5"}},
+		// Separators inside quotes belong to the token, not the shell.
+		{"sed -i 's/a;b/c|d/' f.go && echo \"x && y\"", []string{"sed -i 's/a;b/c|d/' f.go ", " echo \"x && y\""}},
+		{"echo one\necho two", []string{"echo one", "echo two"}},
+	}
+	for _, tc := range cases {
+		got := splitShellSegments(tc.in)
+		if strings.Join(got, "\x00") != strings.Join(tc.want, "\x00") {
+			t.Errorf("splitShellSegments(%q)\n got %q\nwant %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestShellSegments_FollowsCd(t *testing.T) {
+	segs := shellSegments("cd /w && gofmt -w a.go; cd sub && sed -i '' 's/x/y/' b.go && cd - && cat c.go", "/base")
+	if len(segs) != 3 {
+		t.Fatalf("want 3 segments, got %d: %+v", len(segs), segs)
+	}
+	if segs[0].dir != "/w" || segs[0].lost {
+		t.Errorf("segment 0: want dir /w, got %+v", segs[0])
+	}
+	if want := filepath.Join("/w", "sub"); segs[1].dir != want || segs[1].lost {
+		t.Errorf("segment 1: want dir %s, got %+v", want, segs[1])
+	}
+	if !segs[2].lost {
+		t.Errorf("segment 2: cd - must mark the directory lost, got %+v", segs[2])
+	}
+	if abs, ok := segs[2].resolve("c.go"); ok {
+		t.Errorf("relative path after cd - must not resolve, got %q", abs)
+	}
+	if abs, ok := segs[2].resolve("/abs/c.go"); !ok || abs != "/abs/c.go" {
+		t.Errorf("absolute path after cd - must still resolve, got %q %v", abs, ok)
+	}
+
+	base := shellSegments("gofmt -w a.go", "/base")
+	if len(base) != 1 || base[0].dir != "/base" {
+		t.Errorf("no cd: want base dir kept, got %+v", base)
 	}
 }

--- a/internal/tools/read_tracker_test.go
+++ b/internal/tools/read_tracker_test.go
@@ -155,8 +155,8 @@ func TestRegistry_TerminalWriteThenEdit_Allowed(t *testing.T) {
 		{"cd-and-redirect-relative", func(p string) string {
 			return "cd " + filepath.Dir(p) + " && printf 'package x\\nconst c = 3\\n' > " + filepath.Base(p)
 		}},
-		{"bash-c-cd-and-gofmt", func(p string) string {
-			return "bash -c \"cd " + filepath.Dir(p) + " && gofmt -w " + p + "\""
+		{"bash-c-cd-and-gofmt-relative", func(p string) string {
+			return "bash -c \"cd " + filepath.Dir(p) + " && gofmt -w " + filepath.Base(p) + "\""
 		}},
 	}
 	for _, tc := range cases {
@@ -557,38 +557,63 @@ func TestRegistry_GrepNumericDashFilename_Allowed(t *testing.T) {
 	}
 }
 
-// A relative write target resolves against the directory `cd` moved to, not
-// the process CWD: `cd elsewhere && gofmt -w code.go` names a DIFFERENT file
-// from the tracked one, so the tracked file's stale stamp must survive and a
-// genuine out-of-band edit to it stays blocked.
-func TestRegistry_CdElsewhereThenWriteSameName_StillBlocked(t *testing.T) {
-	reg := NewDefaultRegistry()
-	dir := t.TempDir()
-	other := t.TempDir()
-	p := filepath.Join(dir, "code.go")
-	if err := os.WriteFile(p, []byte("package x\n"), 0o644); err != nil {
-		t.Fatal(err)
+// Command shapes that name "code.go" without the shell ever writing the
+// tracked code.go must NOT refresh its stamp: a relative target resolves
+// against the directory `cd` moved to (not the session's), a `cd` inside
+// `bash -c` or a `( … )` subshell never changes the outer directory, and
+// heredoc body lines are data, not commands. In every case the tracked file
+// was changed out-of-band, so the follow-up edit must still be refused.
+func TestRegistry_WriteNotOfTrackedFile_StillBlocked(t *testing.T) {
+	cases := []struct {
+		name    string
+		command func(other string) string
+	}{
+		{"cd-elsewhere-relative", func(other string) string {
+			return "cd " + other + " && gofmt -w code.go"
+		}},
+		{"bash-c-cd-elsewhere-relative", func(other string) string {
+			return "bash -c \"cd " + other + " && gofmt -w code.go\""
+		}},
+		{"subshell-cd-elsewhere", func(other string) string {
+			return "( cd " + other + " && gofmt -w code.go )"
+		}},
+		{"subshell-cd-elsewhere-tight", func(other string) string {
+			return "(cd " + other + " && gofmt -w code.go)"
+		}},
+		{"heredoc-body-mentions-file", func(other string) string {
+			return "cat > " + filepath.Join(other, "fmt.sh") + " <<'EOF'\n#!/bin/sh\ngofmt -w code.go\nsed -i '' 's/a/b/' code.go\nEOF"
+		}},
 	}
-	if err := os.WriteFile(filepath.Join(other, "code.go"), []byte("package y\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := reg.Execute(context.Background(), "read_file", map[string]any{"path": p}); err != nil {
-		t.Fatalf("read_file: %v", err)
-	}
-	future := time.Now().Add(2 * time.Hour)
-	if err := os.Chtimes(p, future, future); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := reg.Execute(context.Background(), "terminal", map[string]any{
-		"command": "cd " + other + " && gofmt -w code.go",
-	}); err != nil {
-		t.Fatalf("terminal: %v", err)
-	}
-	_, err := reg.Execute(context.Background(), "edit_file", map[string]any{
-		"path": p, "old_string": "package x", "new_string": "package y",
-	})
-	if err == nil || !strings.Contains(err.Error(), "modified since") {
-		t.Errorf("a same-named file in another directory must not refresh this one, got %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := NewDefaultRegistry()
+			dir := t.TempDir()
+			other := t.TempDir()
+			p := filepath.Join(dir, "code.go")
+			if err := os.WriteFile(p, []byte("package x\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(other, "code.go"), []byte("package y\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			ctx := WithWorkingDir(context.Background(), dir)
+			if _, err := reg.Execute(ctx, "read_file", map[string]any{"path": p}); err != nil {
+				t.Fatalf("read_file: %v", err)
+			}
+			future := time.Now().Add(2 * time.Hour)
+			if err := os.Chtimes(p, future, future); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := reg.Execute(ctx, "terminal", map[string]any{"command": tc.command(other)}); err != nil {
+				t.Fatalf("terminal: %v", err)
+			}
+			_, err := reg.Execute(ctx, "edit_file", map[string]any{
+				"path": p, "old_string": "package x", "new_string": "package y",
+			})
+			if err == nil || !strings.Contains(err.Error(), "modified since") {
+				t.Errorf("command never wrote the tracked file, edit must stay blocked, got %v", err)
+			}
+		})
 	}
 }
 
@@ -713,6 +738,8 @@ func TestSplitShellSegments(t *testing.T) {
 		// Separators inside quotes belong to the token, not the shell.
 		{"sed -i 's/a;b/c|d/' f.go && echo \"x && y\"", []string{"sed -i 's/a;b/c|d/' f.go ", " echo \"x && y\""}},
 		{"echo one\necho two", []string{"echo one", "echo two"}},
+		// A heredoc body is data: the split stops at the newline after `<<`.
+		{"cat > f.sh <<'EOF'\ngofmt -w a.go\nEOF\ngofmt -w b.go", []string{"cat > f.sh <<'EOF'"}},
 	}
 	for _, tc := range cases {
 		got := splitShellSegments(tc.in)
@@ -723,28 +750,60 @@ func TestSplitShellSegments(t *testing.T) {
 }
 
 func TestShellSegments_FollowsCd(t *testing.T) {
-	segs := shellSegments("cd /w && gofmt -w a.go; cd sub && sed -i '' 's/x/y/' b.go && cd - && cat c.go", "/base")
+	// Real absolute paths so the assertions hold on Windows, where "/w" is
+	// not absolute and would be joined onto the base.
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	w := filepath.Join(root, "w")
+	abs := filepath.Join(root, "abs", "c.go")
+
+	segs := shellSegments("cd "+w+" && gofmt -w a.go; cd sub && sed -i '' 's/x/y/' b.go && cd - && cat c.go", base)
 	if len(segs) != 3 {
 		t.Fatalf("want 3 segments, got %d: %+v", len(segs), segs)
 	}
-	if segs[0].dir != "/w" || segs[0].lost {
-		t.Errorf("segment 0: want dir /w, got %+v", segs[0])
+	if segs[0].dir != w || segs[0].lost {
+		t.Errorf("segment 0: want dir %s, got %+v", w, segs[0])
 	}
-	if want := filepath.Join("/w", "sub"); segs[1].dir != want || segs[1].lost {
+	if want := filepath.Join(w, "sub"); segs[1].dir != want || segs[1].lost {
 		t.Errorf("segment 1: want dir %s, got %+v", want, segs[1])
 	}
 	if !segs[2].lost {
 		t.Errorf("segment 2: cd - must mark the directory lost, got %+v", segs[2])
 	}
-	if abs, ok := segs[2].resolve("c.go"); ok {
-		t.Errorf("relative path after cd - must not resolve, got %q", abs)
+	if got, ok := segs[2].resolve("c.go"); ok {
+		t.Errorf("relative path after cd - must not resolve, got %q", got)
 	}
-	if abs, ok := segs[2].resolve("/abs/c.go"); !ok || abs != "/abs/c.go" {
-		t.Errorf("absolute path after cd - must still resolve, got %q %v", abs, ok)
+	if got, ok := segs[2].resolve(abs); !ok || got != abs {
+		t.Errorf("absolute path after cd - must still resolve, got %q %v", got, ok)
 	}
 
-	base := shellSegments("gofmt -w a.go", "/base")
-	if len(base) != 1 || base[0].dir != "/base" {
-		t.Errorf("no cd: want base dir kept, got %+v", base)
+	plain := shellSegments("gofmt -w a.go", base)
+	if len(plain) != 1 || plain[0].dir != base {
+		t.Errorf("no cd: want base dir kept, got %+v", plain)
+	}
+
+	// A wrapper's payload is expanded in place: its cd is followed for the
+	// inner segments (blank lines included) and never leaks to the outer line.
+	wrapped := shellSegments("bash -c 'cd "+w+"\n   \ngofmt -w a.go' && gofmt -w b.go", base)
+	if len(wrapped) != 2 {
+		t.Fatalf("wrapped: want 2 segments, got %d: %+v", len(wrapped), wrapped)
+	}
+	if wrapped[0].dir != w || wrapped[0].tokens[0] != "gofmt" {
+		t.Errorf("wrapped inner: want gofmt in %s, got %+v", w, wrapped[0])
+	}
+	if wrapped[1].dir != base {
+		t.Errorf("wrapped outer: inner cd must not leak, got %+v", wrapped[1])
+	}
+
+	// A bare subshell hides where its cd stops applying, so everything from
+	// it on is lost; `$(…)` substitution is not a subshell.
+	sub := shellSegments("( cd "+w+" && gofmt -w a.go ) && gofmt -w b.go", base)
+	for i, seg := range sub {
+		if !seg.lost {
+			t.Errorf("subshell segment %d must be lost, got %+v", i, seg)
+		}
+	}
+	if subst := shellSegments("gofmt -w $(ls) && gofmt -w b.go", base); len(subst) != 2 || subst[1].lost {
+		t.Errorf("$(…) must not mark the line lost, got %+v", subst)
 	}
 }

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -159,8 +159,8 @@ func (r DefaultRegistry) ExecuteStream(ctx context.Context, name string, input m
 					r.recordGrepReads(ctx, input, out.Text)
 				case "terminal":
 					if cmd, ok := input["command"].(string); ok {
-						r.recordTerminalReads(cmd)
-						r.recordTerminalWrites(cmd)
+						r.recordTerminalReads(ctx, cmd)
+						r.recordTerminalWrites(ctx, cmd)
 					}
 				}
 			}
@@ -187,12 +187,17 @@ func callTool(ctx context.Context, t tool, name string, input map[string]any, pr
 // paths in the read tracker. This closes the gap where `cat file` followed by
 // `write_file file` would wrongly fail with "File has not been read yet".
 //
-// The parser is intentionally lightweight: it tokenises the command string,
-// skips flags and shell metacharacters, and treats any remaining token that
+// The command line is split into its simple commands first (`&&`, `||`, `|`,
+// `;`, newline) so a read behind a `cd … &&` prefix is still seen, and a
+// relative path is resolved against the directory that `cd` established —
+// the same directory the shell resolved it in.
+//
+// The parser is intentionally lightweight: it tokenises each segment, skips
+// flags and shell metacharacters, and treats any remaining token that
 // resolves to an existing file as a read. It does NOT understand subshells,
 // variable expansion, or complex pipelines — those still require an explicit
 // read_file if the model wants to edit afterwards.
-func (r DefaultRegistry) recordTerminalReads(command string) {
+func (r DefaultRegistry) recordTerminalReads(ctx context.Context, command string) {
 	// Commands that are known to read files as positional arguments.
 	readCmds := map[string]bool{
 		"cat": true, "head": true, "tail": true, "less": true, "more": true,
@@ -202,28 +207,25 @@ func (r DefaultRegistry) recordTerminalReads(command string) {
 		"stat": true, "ls": true, "find": true, "readlink": true,
 	}
 
-	tokens := tokenizeCommand(command)
-	if len(tokens) == 0 {
-		return
-	}
-	if !readCmds[tokens[0]] {
-		return
-	}
-
-	for _, tok := range tokens[1:] {
-		if strings.HasPrefix(tok, "-") || strings.HasPrefix(tok, ">") || strings.HasPrefix(tok, "<") {
-			continue // skip flags and redirection operators
-		}
-		if strings.ContainsAny(tok, "|;&$()`") {
-			continue // skip tokens with shell metacharacters
-		}
-		// Try to resolve as a path.  If the file exists, record it.
-		abs, err := resolvePath(tok)
-		if err != nil {
+	for _, seg := range shellSegments(command, WorkingDir(ctx)) {
+		if !readCmds[seg.tokens[0]] {
 			continue
 		}
-		if _, err := os.Stat(abs); err == nil {
-			r.tracker.RecordRead(abs)
+		for _, tok := range seg.tokens[1:] {
+			if strings.HasPrefix(tok, "-") || strings.HasPrefix(tok, ">") || strings.HasPrefix(tok, "<") {
+				continue // skip flags and redirection operators
+			}
+			if strings.ContainsAny(tok, "|;&$()`") {
+				continue // skip tokens with shell metacharacters
+			}
+			// Try to resolve as a path.  If the file exists, record it.
+			abs, ok := seg.resolve(tok)
+			if !ok {
+				continue
+			}
+			if _, err := os.Stat(abs); err == nil {
+				r.tracker.RecordRead(abs)
+			}
 		}
 	}
 }
@@ -302,22 +304,137 @@ func (r DefaultRegistry) recordGrepReads(ctx context.Context, input map[string]a
 // It refreshes the recorded mtime of every tracked file the command names as an
 // exact write target, leaving the guard intact for changes that did NOT come
 // through the terminal tool (a human editing in their IDE never lands here) and
-// for files the command never named. Detection is deliberately conservative —
-// RefreshTarget only ever touches an exact path the tracker already knows.
-// Writers that name a directory or the whole tree rather than specific files
-// (`gofmt -w .`, `go fmt ./...`, `make fmt`) are intentionally not followed
-// inside: attributing a subtree's mtime bumps to the command would let an
-// unrelated out-of-band edit slip through. The model re-reads in that case.
-func (r DefaultRegistry) recordTerminalWrites(command string) {
-	tokens := tokenizeCommand(command)
-	if len(tokens) == 0 {
-		return
-	}
-	for _, target := range writeTargets(tokens) {
-		if abs, err := resolvePath(target); err == nil {
-			r.tracker.RefreshTarget(abs)
+// for files the command never named. The command line is split into its simple
+// commands so a writer behind a `cd … &&` prefix is found, and a relative
+// target resolves against the directory that `cd` established — otherwise the
+// refresh would look up a path the tracker never recorded and silently no-op.
+// Detection is deliberately conservative — RefreshTarget only ever touches an
+// exact path the tracker already knows. Writers that name a directory or the
+// whole tree rather than specific files (`gofmt -w .`, `go fmt ./...`, `make
+// fmt`) are intentionally not followed inside: attributing a subtree's mtime
+// bumps to the command would let an unrelated out-of-band edit slip through.
+// The model re-reads in that case.
+func (r DefaultRegistry) recordTerminalWrites(ctx context.Context, command string) {
+	for _, seg := range shellSegments(command, WorkingDir(ctx)) {
+		for _, target := range writeTargets(seg.tokens) {
+			if abs, ok := seg.resolve(target); ok {
+				r.tracker.RefreshTarget(abs)
+			}
 		}
 	}
+}
+
+// shellSegment is one simple command of a command line together with the
+// directory it ran in, as established by any `cd` segment before it.
+type shellSegment struct {
+	tokens []string
+	// dir is the working directory for this segment: the session's working
+	// directory (or the process CWD when that is empty) until a `cd` changes
+	// it. lost is set once a `cd` went somewhere we can't follow (`cd -`,
+	// `cd "$X"`), after which relative paths are unresolvable — the guard
+	// then errs towards a re-read rather than guessing a directory.
+	dir  string
+	lost bool
+}
+
+// resolve turns a path named by this segment into an absolute path, or
+// reports false when the segment's directory is unknown and the path is
+// relative.
+func (seg shellSegment) resolve(path string) (string, bool) {
+	if seg.lost && !filepath.IsAbs(path) && !strings.HasPrefix(path, "~") {
+		return "", false
+	}
+	abs, err := resolvePathIn(seg.dir, path)
+	if err != nil {
+		return "", false
+	}
+	return abs, true
+}
+
+// shellSegments splits a command line into its simple commands and threads
+// the working directory through them: a segment that is a plain `cd <dir>`
+// changes the directory for every segment after it. base is the directory
+// the command line started in ("" ⇒ process CWD). Segments with no tokens
+// are dropped, so every returned segment has a command head at tokens[0].
+//
+// `cd` is followed only in its plain forms — `cd`, `cd <literal>`, `cd ~/x`.
+// Anything else (`cd -`, an unexpanded variable, extra flags) marks the
+// directory as lost for the remainder of the line.
+func shellSegments(command, base string) []shellSegment {
+	var segs []shellSegment
+	dir, lost := base, false
+	for _, raw := range splitShellSegments(command) {
+		tokens := tokenizeCommand(raw)
+		if len(tokens) == 0 {
+			continue
+		}
+		if tokens[0] == "cd" {
+			dir, lost = followCd(dir, lost, tokens[1:])
+			continue
+		}
+		segs = append(segs, shellSegment{tokens: tokens, dir: dir, lost: lost})
+	}
+	return segs
+}
+
+// followCd returns the directory after `cd args...` runs in dir.
+func followCd(dir string, lost bool, args []string) (string, bool) {
+	switch {
+	case len(args) == 0:
+		if home, err := os.UserHomeDir(); err == nil {
+			return home, false
+		}
+		return "", true
+	case len(args) > 1, strings.HasPrefix(args[0], "-"), strings.ContainsAny(args[0], "$`"):
+		return "", true
+	}
+	if lost && !filepath.IsAbs(args[0]) && !strings.HasPrefix(args[0], "~") {
+		return "", true
+	}
+	abs, err := resolvePathIn(dir, args[0])
+	if err != nil {
+		return "", true
+	}
+	return abs, false
+}
+
+// splitShellSegments splits a command line on the shell's command separators
+// — `&&`, `||`, `|`, `;` and newline — outside single/double quotes. A lone
+// `&` is NOT a separator so `2>&1` stays inside its segment. Redirection
+// operators are left for the tokenizer; only the boundaries between simple
+// commands are cut here.
+func splitShellSegments(s string) []string {
+	var segs []string
+	var cur strings.Builder
+	var inSingle, inDouble bool
+	flush := func() {
+		if cur.Len() > 0 {
+			segs = append(segs, cur.String())
+			cur.Reset()
+		}
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '\'' && !inDouble:
+			inSingle = !inSingle
+			cur.WriteByte(c)
+		case c == '"' && !inSingle:
+			inDouble = !inDouble
+			cur.WriteByte(c)
+		case inSingle || inDouble:
+			cur.WriteByte(c)
+		case (c == '&' || c == '|') && i+1 < len(s) && s[i+1] == c:
+			flush()
+			i++ // consume the second character of && / ||
+		case c == '|' || c == ';' || c == '\n':
+			flush()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	flush()
+	return segs
 }
 
 // writeTargets returns the file paths a terminal command writes to, derived
@@ -362,7 +479,9 @@ func writeTargets(tokens []string) []string {
 	// this, `bash -c "sed -i 's/x/y/' file.go"` bumps the file's mtime without
 	// refreshing the tracker and trips the guard on the next edit_file.
 	if payload := wrappedCommand(head, tokens[1:]); payload != "" {
-		targets = append(targets, writeTargets(tokenizeCommand(payload))...)
+		for _, inner := range splitShellSegments(payload) {
+			targets = append(targets, writeTargets(tokenizeCommand(inner))...)
+		}
 	}
 
 	return targets

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -314,6 +314,14 @@ func (r DefaultRegistry) recordGrepReads(ctx context.Context, input map[string]a
 // fmt`) are intentionally not followed inside: attributing a subtree's mtime
 // bumps to the command would let an unrelated out-of-band edit slip through.
 // The model re-reads in that case.
+//
+// Known gap, accepted: attribution is static. A writer behind a failed `&&`
+// (`go build ./... && gofmt -w f` with the build broken) never ran, yet f is
+// refreshed as if it had. Gating on the command's exit status would close it
+// but would also un-attribute `gofmt -w f && go test` every time the tests
+// fail — the most common shape this tracking exists for. The gap needs an
+// out-of-band edit AND a writer conditional on a failing command at once, so
+// it stays open in favour of the common case.
 func (r DefaultRegistry) recordTerminalWrites(ctx context.Context, command string) {
 	for _, seg := range shellSegments(command, WorkingDir(ctx)) {
 		for _, target := range writeTargets(seg.tokens) {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -341,7 +341,7 @@ type shellSegment struct {
 // reports false when the segment's directory is unknown and the path is
 // relative.
 func (seg shellSegment) resolve(path string) (string, bool) {
-	if seg.lost && !filepath.IsAbs(path) && !strings.HasPrefix(path, "~") {
+	if seg.lost && !filepath.IsAbs(path) && !isHomeRelative(path) {
 		return "", false
 	}
 	abs, err := resolvePathIn(seg.dir, path)
@@ -359,22 +359,62 @@ func (seg shellSegment) resolve(path string) (string, bool) {
 //
 // `cd` is followed only in its plain forms — `cd`, `cd <literal>`, `cd ~/x`.
 // Anything else (`cd -`, an unexpanded variable, extra flags) marks the
-// directory as lost for the remainder of the line.
+// directory as lost for the remainder of the line. A bare `(` outside quotes
+// opens a subshell whose `cd` must not leak out, and we can't see where the
+// subshell ends, so it also marks the directory lost.
+//
+// A shell-wrapped command (`bash -c "cd x && sed -i … f"`) is expanded into
+// its inner segments with the current directory as their base; the inner
+// `cd` is followed there and cannot change the outer directory.
 func shellSegments(command, base string) []shellSegment {
-	var segs []shellSegment
-	dir, lost := base, false
+	return appendShellSegments(nil, command, base, false)
+}
+
+func appendShellSegments(segs []shellSegment, command, dir string, lost bool) []shellSegment {
 	for _, raw := range splitShellSegments(command) {
 		tokens := tokenizeCommand(raw)
 		if len(tokens) == 0 {
 			continue
 		}
+		if hasBareSubshell(raw) {
+			lost = true
+		}
 		if tokens[0] == "cd" {
 			dir, lost = followCd(dir, lost, tokens[1:])
+			continue
+		}
+		if payload := wrappedCommand(filepath.Base(tokens[0]), tokens[1:]); payload != "" {
+			segs = appendShellSegments(segs, payload, dir, lost)
 			continue
 		}
 		segs = append(segs, shellSegment{tokens: tokens, dir: dir, lost: lost})
 	}
 	return segs
+}
+
+// hasBareSubshell reports whether raw opens a `( … )` subshell outside
+// quotes. `$(…)` substitution is not a subshell for our purposes — its
+// output becomes a token, and tokens carrying `$` are already discarded.
+func hasBareSubshell(raw string) bool {
+	var inSingle, inDouble bool
+	for i := 0; i < len(raw); i++ {
+		switch c := raw[i]; {
+		case c == '\'' && !inDouble:
+			inSingle = !inSingle
+		case c == '"' && !inSingle:
+			inDouble = !inDouble
+		case inSingle || inDouble:
+		case c == '(' && (i == 0 || raw[i-1] != '$'):
+			return true
+		}
+	}
+	return false
+}
+
+// isHomeRelative reports whether path is one resolvePathIn expands from the
+// home directory (`~` or `~/…`), so it stays resolvable after a lost cd.
+func isHomeRelative(path string) bool {
+	return path == "~" || strings.HasPrefix(path, "~/")
 }
 
 // followCd returns the directory after `cd args...` runs in dir.
@@ -388,7 +428,7 @@ func followCd(dir string, lost bool, args []string) (string, bool) {
 	case len(args) > 1, strings.HasPrefix(args[0], "-"), strings.ContainsAny(args[0], "$`"):
 		return "", true
 	}
-	if lost && !filepath.IsAbs(args[0]) && !strings.HasPrefix(args[0], "~") {
+	if lost && !filepath.IsAbs(args[0]) && !isHomeRelative(args[0]) {
 		return "", true
 	}
 	abs, err := resolvePathIn(dir, args[0])
@@ -403,10 +443,16 @@ func followCd(dir string, lost bool, args []string) (string, bool) {
 // `&` is NOT a separator so `2>&1` stays inside its segment. Redirection
 // operators are left for the tokenizer; only the boundaries between simple
 // commands are cut here.
+//
+// A heredoc (`<<`) ends the split at the next newline: everything after it is
+// the document body, which the shell writes as data rather than runs. Treating
+// those lines as commands would credit a script's `gofmt -w f` line as a write
+// of f that never happened. Commands after the terminator are dropped too —
+// under-attribution costs a re-read, over-attribution defeats the guard.
 func splitShellSegments(s string) []string {
 	var segs []string
 	var cur strings.Builder
-	var inSingle, inDouble bool
+	var inSingle, inDouble, heredoc bool
 	flush := func() {
 		if cur.Len() > 0 {
 			segs = append(segs, cur.String())
@@ -423,6 +469,12 @@ func splitShellSegments(s string) []string {
 			inDouble = !inDouble
 			cur.WriteByte(c)
 		case inSingle || inDouble:
+			cur.WriteByte(c)
+		case c == '\n' && heredoc:
+			flush()
+			return segs
+		case c == '<' && i+1 < len(s) && s[i+1] == '<':
+			heredoc = true
 			cur.WriteByte(c)
 		case (c == '&' || c == '|') && i+1 < len(s) && s[i+1] == c:
 			flush()
@@ -443,6 +495,9 @@ func splitShellSegments(s string) []string {
 // yields its literal token, which won't match any tracked file, so a
 // whole-subtree format falls through to a re-read rather than over-attributing.
 func writeTargets(tokens []string) []string {
+	if len(tokens) == 0 {
+		return nil
+	}
 	var targets []string
 
 	// Pass 1: redirections (`> f`, `>>f`, `2>f`, `&>f`) and `tee`, which can
@@ -473,24 +528,16 @@ func writeTargets(tokens []string) []string {
 		targets = append(targets, positionals(tokens[1:])...)
 	}
 
-	// Pass 3: shell-wrapped commands (`bash -c "sed -i ... f"`, `sh -c "…"`).
-	// The wrapped payload is a single quoted token the parser can't see into,
-	// so re-parse it as its own command and collect its write targets. Without
-	// this, `bash -c "sed -i 's/x/y/' file.go"` bumps the file's mtime without
-	// refreshing the tracker and trips the guard on the next edit_file.
-	if payload := wrappedCommand(head, tokens[1:]); payload != "" {
-		for _, inner := range splitShellSegments(payload) {
-			targets = append(targets, writeTargets(tokenizeCommand(inner))...)
-		}
-	}
-
+	// Shell-wrapped commands (`bash -c "sed -i ... f"`) are expanded by
+	// shellSegments before they reach here, so the payload's own `cd` is
+	// followed like any other segment's.
 	return targets
 }
 
 // wrappedCommand returns the inner payload of a shell-wrapped invocation, or
 // "" if the command isn't one. Recognizes `bash|sh|zsh -c "..."` (and
 // `--posix -c`). The payload is the single string argument to `-c`, verbatim —
-// it's re-parsed by tokenizeCommand in the caller as its own command line.
+// shellSegments re-parses it as its own command line.
 func wrappedCommand(head string, args []string) string {
 	switch head {
 	case "bash", "sh", "zsh":

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -357,11 +357,14 @@ func (seg shellSegment) resolve(path string) (string, bool) {
 // the command line started in ("" ⇒ process CWD). Segments with no tokens
 // are dropped, so every returned segment has a command head at tokens[0].
 //
-// `cd` is followed only in its plain forms — `cd`, `cd <literal>`, `cd ~/x`.
-// Anything else (`cd -`, an unexpanded variable, extra flags) marks the
-// directory as lost for the remainder of the line. A bare `(` outside quotes
-// opens a subshell whose `cd` must not leak out, and we can't see where the
-// subshell ends, so it also marks the directory lost.
+// `cd` is followed only in its plain forms — `cd`, `cd <literal>`, `cd ~/x`
+// — and only as the head of a segment. Anything else (`cd -`, an unexpanded
+// variable, extra flags) marks the directory as lost for the remainder of the
+// line. So does any directory change we can see but not follow: a `cd` that
+// isn't the head (`{ cd x; …`, `do cd x`, `$(cd x …`), a builtin that runs
+// another command (`eval "cd x"`, `command cd x`), the directory stack
+// (`pushd`/`popd`), PowerShell's equivalents, and a bare `(` subshell whose
+// end we can't see.
 //
 // A shell-wrapped command (`bash -c "cd x && sed -i … f"`) is expanded into
 // its inner segments with the current directory as their base; the inner
@@ -376,7 +379,7 @@ func appendShellSegments(segs []shellSegment, command, dir string, lost bool) []
 		if len(tokens) == 0 {
 			continue
 		}
-		if hasBareSubshell(raw) {
+		if hasBareSubshell(raw) || hidesDirectoryChange(tokens) {
 			lost = true
 		}
 		if tokens[0] == "cd" {
@@ -392,9 +395,45 @@ func appendShellSegments(segs []shellSegment, command, dir string, lost bool) []
 	return segs
 }
 
+// cdNames are the commands that change the shell's directory, in the Unix
+// and PowerShell spellings the terminal tool may run. Compared
+// case-insensitively because PowerShell is.
+var cdNames = map[string]bool{
+	"cd": true, "chdir": true, "pushd": true, "popd": true,
+	"set-location": true, "sl": true, "push-location": true, "pop-location": true,
+}
+
+// opaqueHeads are builtins that run whatever follows them, so a directory
+// change can hide in their arguments (`eval "cd x"`, `command cd x`, `. env.sh`).
+var opaqueHeads = map[string]bool{
+	"eval": true, "source": true, ".": true, "command": true, "builtin": true, "exec": true,
+}
+
+// hidesDirectoryChange reports whether a segment may change the directory in
+// a way followCd can't reproduce — every case here is resolved by marking the
+// directory lost rather than guessing. A plain `cd` at the head is excluded:
+// followCd handles that one.
+func hidesDirectoryChange(tokens []string) bool {
+	if opaqueHeads[strings.ToLower(tokens[0])] {
+		return true
+	}
+	for i, tok := range tokens {
+		if i == 0 && tok == "cd" {
+			continue
+		}
+		// `{cd`, `(cd`, `$(cd` and `\cd` all run cd; strip the prefix that
+		// glued to it.
+		if cdNames[strings.ToLower(strings.TrimLeft(tok, `({$\`))] {
+			return true
+		}
+	}
+	return false
+}
+
 // hasBareSubshell reports whether raw opens a `( … )` subshell outside
-// quotes. `$(…)` substitution is not a subshell for our purposes — its
-// output becomes a token, and tokens carrying `$` are already discarded.
+// quotes. `$(…)` substitution is not treated as one: its exit is where its
+// directory change ends, and a `cd` inside it is caught by
+// hidesDirectoryChange instead.
 func hasBareSubshell(raw string) bool {
 	var inSingle, inDouble bool
 	for i := 0; i < len(raw); i++ {
@@ -427,6 +466,8 @@ func followCd(dir string, lost bool, args []string) (string, bool) {
 		return "", true
 	case len(args) > 1, strings.HasPrefix(args[0], "-"), strings.ContainsAny(args[0], "$`"):
 		return "", true
+	case strings.HasPrefix(args[0], "~") && !isHomeRelative(args[0]):
+		return "", true // `cd ~user`: resolvePathIn would join it as a relative path
 	}
 	if lost && !filepath.IsAbs(args[0]) && !isHomeRelative(args[0]) {
 		return "", true


### PR DESCRIPTION
## Problem

`edit_file` failed with `File has been modified since it was last read` right after the session's own `terminal` command had rewritten the file. In one Web session this fired 5 times; every occurrence was preceded by a command of the shape

```
cd /path/to/worktree && gofmt -w internal/computer/stub.go && go build ...
cd /path/to/worktree && sed -i '' 's/…/…/' internal/computer/darwin_cgo.go && …
```

No external editor touched the files. `recordTerminalWrites` is supposed to adopt the session's own writes by re-stamping the tracked mtime, but it missed these because:

1. `writeTargets` keyed the command head on `tokens[0]` of the whole line, so anything behind a `cd … &&` prefix had head `cd` and the in-place editor was never detected.
2. Relative targets were resolved with `resolvePath` (process CWD) rather than the directory the shell ran in, so even a detected `internal/x.go` never matched the tracked absolute path and `RefreshTarget` no-op'd.

`recordTerminalReads` had the same two gaps (`cd dir && cat f.go` did not count as a read).

## Fix

- `splitShellSegments`: quote-aware split on `&&`, `||`, `|`, `;`, newline. A lone `&` is not a separator so `2>&1` stays intact.
- `shellSegments`: per-segment tokens plus the working directory threaded through plain `cd <dir>` segments (`cd`, `cd <literal>`, `cd ~/x`). `cd -`, `cd $VAR`, or `cd` with flags mark the directory as unknown; relative paths after that are not attributed (conservative: falls back to a re-read).
- Relative paths with no `cd` resolve against the session's `WorkingDir(ctx)`, matching where `applyWorkingDir` actually runs the command.
- `bash -c "…"` payloads are split into segments too before collecting write targets.

Unchanged by design: directory-level targets (`gofmt -w .`, `gofmt -w internal/computer`) are still not followed inside — the model re-reads in that case.

## Tests

New cases mirroring the failing session commands (`cd … && gofmt -w rel`, `cd …; gofmt -w rel 2>&1 | tail`, `cd … && sed -i '' … rel`, `cd … && printf > rel`, `bash -c "cd … && gofmt -w …"`), plus negatives: `cd elsewhere && gofmt -w code.go` does not refresh a same-named tracked file, `cd dir && gofmt -w .` still blocks siblings, `cd -` blocks relative attribution. Unit tests for the splitter and cd tracking.

`gofmt -l .` clean, `go vet ./internal/tools/`, `go test -race ./internal/tools/` pass.


## Review follow-up (second commit)

An isolated review found three over-attribution paths opened by the split (heredoc body lines treated as commands; `cd` inside `bash -c` ignored so the payload path resolved against the outer dir; `cd` inside `( … )` leaking to later segments), a panic on a blank payload line, and a Windows-only test failure. All fixed: the splitter stops at a heredoc, wrapper payloads are expanded through `shellSegments` so their `cd` is followed in place, a bare `(` marks the directory lost, `writeTargets` guards empty input, and the cd test uses `t.TempDir` paths. Negative tests added for each shape (`TestRegistry_WriteNotOfTrackedFile_StillBlocked`).

## Second review (third and fourth commits)

A fresh review found that only a plain head `cd` was followed: `{ cd x; … }`, `do cd x`, `command cd x`, `\cd x`, `eval "cd x"`, `$(cd x && …)`, `pushd x` and PowerShell's `Set-Location`/`sl`/`chdir`/`Push-Location` all left the following relative target resolving against the old directory. Any segment carrying one of these now marks the directory lost (`hidesDirectoryChange`); `cd ~user` is lost too instead of a made-up path. Seven real-shell negatives and thirteen parser-level shapes added.

Accepted and documented rather than fixed: attribution is static, so a writer behind a failed `&&` is still credited. Gating on exit status would un-attribute `gofmt -w f && go test` whenever tests fail, which is the common shape this tracking exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
