### PR TITLE
agent: widen title timeout to 10s and send thinking=disabled to non-Claude backends

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1661,8 +1661,11 @@ const titleMaxTokens = 250
 // TitleGenerationTimeout bounds a throwaway session-title call. The TUI and
 // the server share one title mechanism: within this budget the model produces
 // a title, otherwise GenerateTitleOrSnippet falls back to a message snippet,
-// so a title always lands ~5s after the first user message.
-const TitleGenerationTimeout = 5 * time.Second
+// so a title always lands within ~10s of the first user message. 10s rather
+// than 5s because the Kimi coding endpoint (k3) has an ~9s first-token latency
+// even for a ten-token reply, so a 5s budget fell back to the snippet on
+// every session there.
+const TitleGenerationTimeout = 10 * time.Second
 
 // titleContextMaxRunes caps how much of the first user message feeds the
 // title prompt. A title only needs the topic; an unbounded paste (a dumped

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1661,9 +1661,9 @@ const titleMaxTokens = 250
 // TitleGenerationTimeout bounds a throwaway session-title call. The TUI and
 // the server share one title mechanism: within this budget the model produces
 // a title, otherwise GenerateTitleOrSnippet falls back to a message snippet,
-// so a title always lands within ~10s of the first user message. 10s rather
-// than 5s because the Kimi coding endpoint (k3) has an ~9s first-token latency
-// even for a ten-token reply, so a 5s budget fell back to the snippet on
+// so a title always lands within this budget of the first user message. It
+// was 5s; a 2026-09 probe of the Kimi coding endpoint (k3) measured 8.5–9.5s
+// end to end for a ~15-token title reply, so 5s fell back to the snippet on
 // every session there.
 const TitleGenerationTimeout = 10 * time.Second
 
@@ -1754,7 +1754,8 @@ func (a *Agent) GenerateTitleFrom(ctx context.Context, snap []Message) (string, 
 // of the first user message in snap. This is THE session-title mechanism —
 // the TUI and the server both call it (wrapped in TitleGenerationTimeout) so
 // every frontend gets the same behaviour: an LLM title when the call works, a
-// snippet otherwise, always within ~5s of the first user message. Returns ""
+// snippet otherwise, always within TitleGenerationTimeout of the first user
+// message. Returns ""
 // only when snap carries no user text at all.
 func (a *Agent) GenerateTitleOrSnippet(ctx context.Context, snap []Message) (string, error) {
 	t, err := a.GenerateTitleFrom(ctx, snap)

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -412,19 +412,17 @@ func applyReasoning(body *apiRequest, model, effort string, budget int) {
 
 // thinksWhenUnspecified reports whether a backend turns thinking ON when the
 // request omits the thinking field. Claude defaults to off, so omitting is
-// enough; Kimi's coding endpoint (k3, kimi-for-coding, kimi-k2.x) defaults to
-// on and only stays quiet when told `thinking: {type: "disabled"}` outright
-// (verified live: an omitted field on k3 still produced thinking tokens).
-// Without this, NoReasoning callers such as title generation pay for
-// reasoning they asked not to have.
+// enough. Every non-Claude Anthropic-protocol backend probed so far defaults
+// to on and only stays quiet when told `thinking: {type: "disabled"}`
+// outright: Kimi k3 returned thinking tokens on an omitted field, and
+// DeepSeek's /anthropic endpoint (deepseek-flash) went further — its thinking
+// consumed the whole max_tokens budget and the reply carried no text block at
+// all, so a title call came back empty. "disabled" is a documented value of
+// the Anthropic API, so sending it is safe for any backend claiming
+// compatibility; the model name is the only signal this layer has for
+// telling Claude from the rest.
 func thinksWhenUnspecified(model string) bool {
-	m := strings.ToLower(model)
-	for _, s := range []string{"kimi", "k2", "k3"} {
-		if strings.Contains(m, s) {
-			return true
-		}
-	}
-	return false
+	return !strings.Contains(strings.ToLower(model), "claude")
 }
 
 // usesAdaptiveEffort reports whether a model takes adaptive thinking +

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -399,12 +399,32 @@ func applyReasoning(body *apiRequest, model, effort string, budget int) {
 	// Legacy budget_tokens path (older Claude, Kimi-for-coding): triggered by a
 	// positive budget, independent of the effort string.
 	if budget <= 0 {
+		if thinksWhenUnspecified(model) {
+			body.Thinking = &apiThinking{Type: "disabled"}
+		}
 		return
 	}
 	body.Thinking = &apiThinking{Type: "enabled", BudgetTokens: budget}
 	if body.MaxTokens <= budget {
 		body.MaxTokens = budget + DefaultMaxTokens
 	}
+}
+
+// thinksWhenUnspecified reports whether a backend turns thinking ON when the
+// request omits the thinking field. Claude defaults to off, so omitting is
+// enough; Kimi's coding endpoint (k3, kimi-for-coding, kimi-k2.x) defaults to
+// on and only stays quiet when told `thinking: {type: "disabled"}` outright
+// (verified live: an omitted field on k3 still produced thinking tokens).
+// Without this, NoReasoning callers such as title generation pay for
+// reasoning they asked not to have.
+func thinksWhenUnspecified(model string) bool {
+	m := strings.ToLower(model)
+	for _, s := range []string{"kimi", "k2", "k3"} {
+		if strings.Contains(m, s) {
+			return true
+		}
+	}
+	return false
 }
 
 // usesAdaptiveEffort reports whether a model takes adaptive thinking +

--- a/internal/provider/anthropic/reasoning_test.go
+++ b/internal/provider/anthropic/reasoning_test.go
@@ -60,13 +60,32 @@ func TestApplyReasoning_BudgetPath(t *testing.T) {
 	}
 }
 
-// Effort off (empty) sends no thinking or effort on any model.
+// Effort off (empty) sends no thinking or effort on Claude, adaptive or
+// legacy: Claude defaults to no thinking when the field is absent.
 func TestApplyReasoning_Off(t *testing.T) {
-	for _, model := range []string{"claude-opus-4-7", "kimi-for-coding"} {
+	for _, model := range []string{"claude-opus-4-7", "claude-haiku-4-5"} {
 		b := apiRequest{MaxTokens: 4096}
 		applyReasoning(&b, model, "", 0)
 		if b.Thinking != nil || b.OutputConfig != nil {
 			t.Errorf("%s off: Thinking=%+v OutputConfig=%+v, want both nil", model, b.Thinking, b.OutputConfig)
+		}
+	}
+}
+
+// Effort off on Kimi must say so explicitly: the Kimi coding endpoint turns
+// thinking on when the field is omitted, so an absent field is not "off".
+func TestApplyReasoning_OffKimiSendsDisabled(t *testing.T) {
+	for _, model := range []string{"kimi-for-coding", "k3", "kimi-k2.7"} {
+		b := apiRequest{MaxTokens: 4096}
+		applyReasoning(&b, model, "", 0)
+		if b.Thinking == nil || b.Thinking.Type != "disabled" || b.Thinking.BudgetTokens != 0 {
+			t.Errorf("%s off: Thinking=%+v, want type=disabled without budget_tokens", model, b.Thinking)
+		}
+		if b.OutputConfig != nil {
+			t.Errorf("%s off: OutputConfig=%+v, want nil", model, b.OutputConfig)
+		}
+		if b.MaxTokens != 4096 {
+			t.Errorf("%s off: MaxTokens = %d, want untouched 4096", model, b.MaxTokens)
 		}
 	}
 }

--- a/internal/provider/anthropic/reasoning_test.go
+++ b/internal/provider/anthropic/reasoning_test.go
@@ -63,7 +63,7 @@ func TestApplyReasoning_BudgetPath(t *testing.T) {
 // Effort off (empty) sends no thinking or effort on Claude, adaptive or
 // legacy: Claude defaults to no thinking when the field is absent.
 func TestApplyReasoning_Off(t *testing.T) {
-	for _, model := range []string{"claude-opus-4-7", "claude-haiku-4-5"} {
+	for _, model := range []string{"claude-opus-4-7", "claude-haiku-4-5", "claude-fable-5"} {
 		b := apiRequest{MaxTokens: 4096}
 		applyReasoning(&b, model, "", 0)
 		if b.Thinking != nil || b.OutputConfig != nil {
@@ -72,10 +72,11 @@ func TestApplyReasoning_Off(t *testing.T) {
 	}
 }
 
-// Effort off on Kimi must say so explicitly: the Kimi coding endpoint turns
-// thinking on when the field is omitted, so an absent field is not "off".
-func TestApplyReasoning_OffKimiSendsDisabled(t *testing.T) {
-	for _, model := range []string{"kimi-for-coding", "k3", "kimi-k2.7"} {
+// Effort off on a non-Claude backend must say so explicitly: Kimi and
+// DeepSeek's Anthropic-protocol endpoints turn thinking on when the field is
+// omitted, so an absent field is not "off" there.
+func TestApplyReasoning_OffNonClaudeSendsDisabled(t *testing.T) {
+	for _, model := range []string{"kimi-for-coding", "k3", "kimi-k2.7", "deepseek-flash", "deepseek-reasoner"} {
 		b := apiRequest{MaxTokens: 4096}
 		applyReasoning(&b, model, "", 0)
 		if b.Thinking == nil || b.Thinking.Type != "disabled" || b.Thinking.BudgetTokens != 0 {

--- a/internal/provider/anthropic/thinking_test.go
+++ b/internal/provider/anthropic/thinking_test.go
@@ -150,3 +150,54 @@ func TestSend_ThinkingBlock_RoundTrips(t *testing.T) {
 		t.Fatalf("no assistant message in wire body: %s", capturedBody)
 	}
 }
+
+// TestSendStream_ReasoningOff_WireBody pins the on-the-wire shape of "no
+// reasoning" (ThinkingBudget 0) per backend family: a non-Claude model gets an
+// explicit `"thinking":{"type":"disabled"}` with no budget_tokens key (the
+// omitempty must actually drop it), a legacy Claude model gets no thinking key
+// at all, and an adaptive Claude model likewise — it would 400 on "disabled".
+func TestSendStream_ReasoningOff_WireBody(t *testing.T) {
+	cases := []struct {
+		model        string
+		wantDisabled bool
+	}{
+		{"k3", true},
+		{"deepseek-flash", true},
+		{"claude-haiku-4-5", false},
+		{"claude-fable-5", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			var raw string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, _ := io.ReadAll(r.Body)
+				raw = string(b)
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, canonicalStream)
+			}))
+			defer srv.Close()
+
+			c, _ := New("test-key")
+			c.BaseURL = srv.URL
+			if _, err := c.SendStream(context.Background(), provider.Request{
+				Model:     tc.model,
+				Messages:  []agent.Message{agent.NewUserMessage("title me")},
+				MaxTokens: 250,
+			}, provider.StreamCallbacks{}); err != nil {
+				t.Fatalf("SendStream: %v", err)
+			}
+
+			hasDisabled := strings.Contains(raw, `"thinking":{"type":"disabled"}`)
+			if hasDisabled != tc.wantDisabled {
+				t.Errorf("thinking disabled on wire = %v, want %v; body: %s", hasDisabled, tc.wantDisabled, raw)
+			}
+			if !tc.wantDisabled && strings.Contains(raw, `"thinking"`) {
+				t.Errorf("Claude model must not carry a thinking key; body: %s", raw)
+			}
+			if strings.Contains(raw, "budget_tokens") {
+				t.Errorf("budget_tokens must be omitted when reasoning is off; body: %s", raw)
+			}
+		})
+	}
+}

--- a/internal/provider/anthropic/types.go
+++ b/internal/provider/anthropic/types.go
@@ -68,7 +68,7 @@ type apiRequest struct {
 // protocol-compatible backends (e.g. Kimi for coding). BudgetTokens is omitted
 // on the adaptive path.
 type apiThinking struct {
-	Type         string `json:"type"` // "adaptive" | "enabled"
+	Type         string `json:"type"` // "adaptive" | "enabled" | "disabled"
 	BudgetTokens int    `json:"budget_tokens,omitempty"`
 }
 

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -69,7 +69,9 @@ const DialectBailian = "bailian"
 //     the toggle is always {type: "enabled"}.
 //   - k3: a top-level reasoning_effort field, but the only value it currently
 //     accepts is "max" — the generic fallback's clamp-to-"high" would send an
-//     unsupported value.
+//     unsupported value. Reasoning is on by default, so "off" must be sent
+//     as the nested {type: "disabled"} toggle (which k3 also accepts) —
+//     omitting both fields leaves it reasoning.
 //
 // Assign it to Client.Dialect for the "kimi" vendor (kimi-coding-plan speaks
 // the Anthropic protocol and never reaches this client). See
@@ -146,7 +148,8 @@ type Client struct {
 //   - Kimi: model-dependent (see DialectKimi) — k2.6/k2.5 get the same
 //     nested toggle as DeepSeek with no reasoning_effort; k2.7-code always
 //     gets the toggle forced to "enabled"; k3 gets a top-level
-//     reasoning_effort clamped to its only supported value, "max".
+//     reasoning_effort clamped to its only supported value, "max", or the
+//     nested toggle set to "disabled" when effort is "".
 //   - Generic OpenAI-compatible: top out at "high" and reject unknown enums, so
 //     both "xhigh" and "max" clamp to "high"; "thinking" is never sent.
 func (c *Client) applyReasoning(body *apiRequest, effort string) {
@@ -179,6 +182,8 @@ func (c *Client) applyReasoning(body *apiRequest, effort string) {
 		case strings.Contains(m, "k3"):
 			if effort != "" {
 				body.ReasoningEffort = "max"
+			} else {
+				body.Thinking = &apiThinking{Type: "disabled"}
 			}
 		case strings.Contains(m, "k2.7-code") || strings.Contains(m, "k2-7-code"):
 			body.Thinking = &apiThinking{Type: "enabled"}

--- a/internal/provider/openai/reasoning_dialect_test.go
+++ b/internal/provider/openai/reasoning_dialect_test.go
@@ -216,9 +216,14 @@ func TestKimiDialect_ModelDependentShape(t *testing.T) {
 				t.Errorf("stream=%v: thinking = %+v, want omitted (k3 uses reasoning_effort)", stream, got.Thinking)
 			}
 
+			// Off must be explicit: k3 reasons by default when both fields
+			// are omitted, and it accepts the nested toggle for turning off.
 			off := captureRequestModel(t, DialectKimi, "k3", "", stream)
 			if off.ReasoningEffort != "" {
 				t.Errorf("stream=%v: off reasoning_effort = %q, want empty", stream, off.ReasoningEffort)
+			}
+			if off.Thinking == nil || off.Thinking.Type != "disabled" {
+				t.Errorf("stream=%v: off thinking = %+v, want {type: disabled}", stream, off.Thinking)
 			}
 		}
 	})


### PR DESCRIPTION
## Why

Sessions on the Kimi coding endpoint (`k3`) never got an LLM-generated title: the sidebar always showed the truncated first-message snippet. `serve.log` has five title failures, all identical:

```
session title generation failed, falling back to message snippet
err="anthropic: send: Post \"https://api.kimi.com/coding/v1/messages\": context deadline exceeded"
```

A live probe of the exact title request against `api.kimi.com/coding` took **8.5–9.5s** end to end for a 14–46 token reply, four runs, thinking on or off. `TitleGenerationTimeout` was 5s, so the fallback fired every time.

The same probes showed that omitting the `thinking` field does **not** turn thinking off on non-Claude Anthropic-protocol backends. Claude defaults to off when the field is absent; these default to on:

| Backend | Field omitted | `thinking: {type: "disabled"}` |
|---|---|---|
| Kimi coding `k3` | 16–27 thinking tokens, text present | text only |
| DeepSeek `/anthropic` `deepseek-flash` | thinking ate the whole 250 `max_tokens`, **no text block at all** | text only, 10 tokens |

So on DeepSeek's Anthropic endpoint the title call returned an empty title and fell back to the snippet too, just by a different route. The `NoReasoning()` sender used by title generation was not actually disabling reasoning on either.

## What

- `TitleGenerationTimeout` 5s → 10s (`internal/agent/agent.go`).
- `applyReasoning` legacy path (`internal/provider/anthropic/client.go`): when the budget is zero and the model name does not contain `claude`, send `thinking: {type: "disabled"}` explicitly instead of omitting the field. Claude models (legacy and adaptive) keep omitting it; the adaptive branch returns before this code, so Fable/Opus 4.7+ never see `disabled`.
- `apiThinking.Type` comment lists `"disabled"`.

## OpenAI-protocol side

Checked the same "does reasoning-off actually reach the wire" question for the OpenAI adapter, sending exactly the shape each dialect produces:

| Backend | octo sends for effort `""` | Result |
|---|---|---|
| DeepSeek `deepseek-flash` | `thinking: {type: disabled}` | no reasoning, title present (omitting instead: 751-char reasoning, empty content) |
| Bailian `qwen3.7-plus` | `enable_thinking: false` | no reasoning, title present |
| Kimi `k3` | nothing | **36 reasoning tokens** — the same gap |

DeepSeek and Bailian were already correct. The `DialectKimi` k3 branch now sends the nested `thinking: {type: "disabled"}` toggle for effort `""` (probed: accepted on `api.kimi.com/coding/v1/chat/completions`, reasoning drops to zero); non-empty effort still maps to `reasoning_effort: max`. `TestKimiDialect_ModelDependentShape` asserts the new off shape.

## Scope note

This changes every zero-budget request to a non-Claude backend, not only title generation: a user who sets `reasoning_effort: off` on Kimi/DeepSeek-anthropic now sends `disabled` on normal turns, and `Suggest` (which replays full history) does too. Probed both k3 and deepseek-flash with `disabled` + signed thinking blocks + a `tool_use`/`tool_result` round-trip already in history: HTTP 200, text-only reply, on both.

## Tests

- `TestApplyReasoning_Off`: Claude only (`opus-4-7`, `haiku-4-5`, `fable-5`), still expects no `thinking`.
- `TestApplyReasoning_OffNonClaudeSendsDisabled`: `kimi-for-coding`, `k3`, `kimi-k2.7`, `deepseek-flash`, `deepseek-reasoner` → `type=disabled`, no `budget_tokens`, `max_tokens` untouched.
- `TestSendStream_ReasoningOff_WireBody` (new, `thinking_test.go`): captures the raw JSON via httptest; asserts `"thinking":{"type":"disabled"}` and no `budget_tokens` key for `k3`/`deepseek-flash`, and no `thinking` key at all for `claude-haiku-4-5`/`claude-fable-5`.
- `go test -race` green on `internal/provider/anthropic`, `internal/app`, `internal/server`, `cmd/octo`. `internal/agent` fails only on `TestCompressImageData_KeepsSmaller`, the known local Go 1.27 image-encoder flake unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
