### PR TITLE
server: log agent turn failures to serve.log

### DIFF
--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1674,6 +1674,18 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// so turn_done + assistant_message were broadcast by the handler.
 			// Nothing more for the reply itself.
 		} else {
+			// The turn_error broadcast below is the only other trace of this
+			// failure, and it lives in browser memory: switching sessions or
+			// reloading rebuilds the transcript from history, which stops at
+			// the last persisted round with no hint of why. Log it so
+			// serve.log can answer "why did my session just stop".
+			slog.Warn("agent turn failed",
+				"session_id", sess.ID,
+				"model", a.Model,
+				"history_len", a.History.Len(),
+				"input_rolled_back", inputRolledBack,
+				"duration_ms", time.Since(turnCallStart).Milliseconds(),
+				"err", err)
 			// A goal-continuation turn failing on provider rate limits parks
 			// the goal harder: usage_limited persists and stops continuation
 			// until /goal resume. goalContWasPending was captured before the


### PR DESCRIPTION
## Why

A provider error on any round after the first ends the turn with the history intact, and `doAgentTurn`'s only reaction was broadcasting `turn_error` to the web client. That notice lives in browser memory: switching sessions or reloading rebuilds the transcript from history, which stops at the last persisted `tool_result` with no hint of why. Nothing reached `serve.log` either, so a "my session just stopped" report could not be diagnosed after the fact (hit today on a Kimi k3 session).

## What

One `slog.Warn("agent turn failed", …)` in the non-interrupt error branch of `doAgentTurn`, carrying `session_id`, `model`, `history_len`, `input_rolled_back`, `duration_ms` and `err`. Interrupts (`context.Canceled`) stay silent as before.

## Test

`go test ./internal/server/`, `go vet`, `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)