### PR TITLE
release: build the darwin CLI with CGO so computer-use ships working

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 
 # Cut a release by pushing a SemVer tag:
 #   git tag v0.5.0 && git push origin v0.5.0
-# goreleaser then cross-compiles every target and publishes the GitHub Release.
+# goreleaser then builds every target and publishes the GitHub Release. It runs
+# on a macOS runner because the darwin target needs CGO for the computer-use
+# substrate — see the header of .goreleaser.yaml.
 on:
   push:
     tags:
@@ -14,7 +16,10 @@ permissions:
 jobs:
   goreleaser:
     name: goreleaser
-    runs-on: ubuntu-latest
+    # macOS, not ubuntu: the darwin build needs CGO (see .goreleaser.yaml's
+    # darwin override). The Linux and Windows targets are CGO_ENABLED=0 pure Go,
+    # so they cross-compile from here unchanged.
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,7 +53,10 @@ builds:
     # refuses to launch a binary whose minos is newer than the running OS. Left
     # unpinned, every release would silently require whatever macOS the
     # macos-latest runner happens to run. The Makefile's desktop target pins the
-    # same way (DESKTOP_MACOS_VERSION). Verify on a snapshot build with:
+    # same way (DESKTOP_MACOS_VERSION). The link flag is the clang-driver
+    # spelling (-mmacosx-version-min), not -Wl,-macos_version_min: the driver
+    # otherwise derives its own platform version from the host and ld warns
+    # about being passed two min versions. Verify on a snapshot build with:
     #   otool -l dist/octo_darwin_arm64*/octo | grep -A3 LC_BUILD_VERSION
     overrides:
       - goos: darwin
@@ -61,13 +64,13 @@ builds:
         env:
           - CGO_ENABLED=1
           - CGO_CFLAGS=-mmacosx-version-min={{ .Env.DARWIN_MIN_MACOS }}
-          - CGO_LDFLAGS=-Wl,-macos_version_min,{{ .Env.DARWIN_MIN_MACOS }}
+          - CGO_LDFLAGS=-mmacosx-version-min={{ .Env.DARWIN_MIN_MACOS }}
       - goos: darwin
         goarch: arm64
         env:
           - CGO_ENABLED=1
           - CGO_CFLAGS=-mmacosx-version-min={{ .Env.DARWIN_MIN_MACOS }}
-          - CGO_LDFLAGS=-Wl,-macos_version_min,{{ .Env.DARWIN_MIN_MACOS }}
+          - CGO_LDFLAGS=-mmacosx-version-min={{ .Env.DARWIN_MIN_MACOS }}
     # Each target downloads the matching ripgrep before building so the grep
     # tool works out of the box without rg on PATH. The hook writes a single
     # shared file (internal/tools/rgembed/binaries/rg), so builds MUST run

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,18 @@
 # goreleaser config — builds the `octo` binary for every supported platform
 # and publishes a GitHub Release on every `v*` tag push (.github/workflows/release.yml).
 #
-# octo is pure Go (no cgo: the sandbox uses build-tagged syscalls, not C), so a
-# single Linux runner cross-compiles every target with CGO_ENABLED=0.
+# This runs on a macOS runner rather than Linux for one reason: the darwin
+# target needs CGO. The computer-use substrate is Quartz CGEvent / AXUIElement
+# behind cgo (internal/computer), so a CGO_ENABLED=0 darwin build links the stub
+# and every computer action fails — the darwin override below is what turns CGO
+# on. Go's toolchain passes clang the matching -arch per GOARCH, so a single
+# runner still produces both darwin/arm64 and darwin/amd64 natively.
+#
+# Linux and Windows stay CGO_ENABLED=0: they are pure Go, so they cross-compile
+# from macOS exactly as they used to from Linux. Because all targets still come
+# out of this one goreleaser run, so do the archives, the darwin universal
+# binary and checksums.txt — nothing about the published asset set changes, so
+# install.sh, the in-place updater and the macOS .pkg keep working as-is.
 #
 # Validate locally without releasing:
 #   goreleaser check
@@ -27,6 +37,19 @@ builds:
     binary: octo
     env:
       - CGO_ENABLED=0
+    # macOS is the one target that needs a native toolchain: without CGO its
+    # computer-use actions all return ErrUnsupported (internal/computer's stub).
+    # goreleaser's override schema requires goos AND goarch, so it is spelled per
+    # architecture; the override's env replaces the build's, flipping CGO on.
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CGO_ENABLED=1
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CGO_ENABLED=1
     # Each target downloads the matching ripgrep before building so the grep
     # tool works out of the box without rg on PATH. The hook writes a single
     # shared file (internal/tools/rgembed/binaries/rg), so builds MUST run

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,10 @@ project_name: octo
 # download hook below and the rgembed.version ldflag.
 env:
   - RG_VERSION=15.1.0
+  # Minimum macOS the darwin CLI runs on. 12.0 is what Go 1.25's internal
+  # linker stamps into a CGO_ENABLED=0 build, i.e. what the darwin archives
+  # carried before CGO was turned on — see the darwin override below.
+  - DARWIN_MIN_MACOS=12.0
 
 before:
   hooks:
@@ -40,16 +44,30 @@ builds:
     # macOS is the one target that needs a native toolchain: without CGO its
     # computer-use actions all return ErrUnsupported (internal/computer's stub).
     # goreleaser's override schema requires goos AND goarch, so it is spelled per
-    # architecture; the override's env replaces the build's, flipping CGO on.
+    # architecture. The override's env is appended after the build's and the
+    # last value of a variable wins, so CGO_ENABLED=1 here beats the 0 above.
+    #
+    # The deployment target must be pinned. A CGO build is linked by clang,
+    # which — unlike Go's internal linker — defaults the binary's
+    # LC_BUILD_VERSION minos to the *build machine's* macOS version, and dyld
+    # refuses to launch a binary whose minos is newer than the running OS. Left
+    # unpinned, every release would silently require whatever macOS the
+    # macos-latest runner happens to run. The Makefile's desktop target pins the
+    # same way (DESKTOP_MACOS_VERSION). Verify on a snapshot build with:
+    #   otool -l dist/octo_darwin_arm64*/octo | grep -A3 LC_BUILD_VERSION
     overrides:
       - goos: darwin
         goarch: amd64
         env:
           - CGO_ENABLED=1
+          - CGO_CFLAGS=-mmacosx-version-min={{ .Env.DARWIN_MIN_MACOS }}
+          - CGO_LDFLAGS=-Wl,-macos_version_min,{{ .Env.DARWIN_MIN_MACOS }}
       - goos: darwin
         goarch: arm64
         env:
           - CGO_ENABLED=1
+          - CGO_CFLAGS=-mmacosx-version-min={{ .Env.DARWIN_MIN_MACOS }}
+          - CGO_LDFLAGS=-Wl,-macos_version_min,{{ .Env.DARWIN_MIN_MACOS }}
     # Each target downloads the matching ripgrep before building so the grep
     # tool works out of the box without rg on PATH. The hook writes a single
     # shared file (internal/tools/rgembed/binaries/rg), so builds MUST run

--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,13 @@ build-full: build
 # WebView2). Embeds the web UI first (the in-process server go:embeds webdist).
 # Produces a bare binary; use `wails3 build` inside cmd/octo-desktop for a
 # packaged .app / installer.
-# Fixed at 11.0 (matches cmd/octo-desktop's Info.plist LSMinimumSystemVersion
-# and Go's own linker default) rather than derived from the build machine's
-# live macOS version — deriving it from `sw_vers` bakes whatever OS the
-# builder happens to run into the binary's LC_VERSION_MIN, silently raising
-# the real minimum macOS required to launch it.
-DESKTOP_MACOS_VERSION ?= 11.0
+# Fixed at 12.0 (matches cmd/octo-desktop's Info.plist LSMinimumSystemVersion,
+# Go 1.25's own linker default, and DARWIN_MIN_MACOS in .goreleaser.yaml for
+# the CLI) rather than derived from the build machine's live macOS version —
+# deriving it from `sw_vers` bakes whatever OS the builder happens to run into
+# the binary's LC_BUILD_VERSION, silently raising the real minimum macOS
+# required to launch it.
+DESKTOP_MACOS_VERSION ?= 12.0
 desktop: web-build
 	cd cmd/octo-desktop && CGO_ENABLED=1 \
 		CGO_CFLAGS="-mmacosx-version-min=$(DESKTOP_MACOS_VERSION)" \

--- a/Makefile
+++ b/Makefile
@@ -99,12 +99,14 @@ build-full: build
 # the CLI) rather than derived from the build machine's live macOS version —
 # deriving it from `sw_vers` bakes whatever OS the builder happens to run into
 # the binary's LC_BUILD_VERSION, silently raising the real minimum macOS
-# required to launch it.
+# required to launch it. Passed to the link step as -mmacosx-version-min (the
+# clang-driver spelling) rather than -Wl,-macos_version_min, so the driver
+# does not also derive a host-based version and ld does not warn about two.
 DESKTOP_MACOS_VERSION ?= 12.0
 desktop: web-build
 	cd cmd/octo-desktop && CGO_ENABLED=1 \
 		CGO_CFLAGS="-mmacosx-version-min=$(DESKTOP_MACOS_VERSION)" \
-		CGO_LDFLAGS="-Wl,-macos_version_min,$(DESKTOP_MACOS_VERSION) -Wl,-no_warn_duplicate_libraries" \
+		CGO_LDFLAGS="-mmacosx-version-min=$(DESKTOP_MACOS_VERSION) -Wl,-no_warn_duplicate_libraries" \
 		go build -ldflags='$(DESKTOP_LDFLAGS)' -o ../../octo-desktop .
 
 # Package the desktop shell into a double-clickable macOS Octo.app bundle

--- a/cmd/octo-desktop/build/darwin/Info.plist
+++ b/cmd/octo-desktop/build/darwin/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleIconFile</key>
 	<string>icon.icns</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
+	<string>12.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<!-- Loopback-only HTTP to the in-process server; no arbitrary loads.

--- a/dev-docs/agentic-computer-use-design.md
+++ b/dev-docs/agentic-computer-use-design.md
@@ -203,8 +203,8 @@ releases contained. Since the feature must ride releases:
   `CGO_ENABLED=1` on for `darwin/amd64` and `darwin/arm64`. Go passes clang the
   matching `-arch` per GOARCH, so one runner still produces both natively — no
   `CC` override is needed.
-- The same override pins the deployment target (`CGO_CFLAGS=-mmacosx-version-min`
-  and `CGO_LDFLAGS=-Wl,-macos_version_min`, both from the config's
+- The same override pins the deployment target (`-mmacosx-version-min` in both
+  `CGO_CFLAGS` and `CGO_LDFLAGS`, from the config's
   `DARWIN_MIN_MACOS`, 12.0). A CGO build is linked by clang, which defaults the
   binary's `LC_BUILD_VERSION minos` to the build machine's macOS version, and
   dyld refuses to launch a binary whose minos is newer than the running OS —

--- a/dev-docs/agentic-computer-use-design.md
+++ b/dev-docs/agentic-computer-use-design.md
@@ -203,6 +203,14 @@ releases contained. Since the feature must ride releases:
   `CGO_ENABLED=1` on for `darwin/amd64` and `darwin/arm64`. Go passes clang the
   matching `-arch` per GOARCH, so one runner still produces both natively — no
   `CC` override is needed.
+- The same override pins the deployment target (`CGO_CFLAGS=-mmacosx-version-min`
+  and `CGO_LDFLAGS=-Wl,-macos_version_min`, both from the config's
+  `DARWIN_MIN_MACOS`, 12.0). A CGO build is linked by clang, which defaults the
+  binary's `LC_BUILD_VERSION minos` to the build machine's macOS version, and
+  dyld refuses to launch a binary whose minos is newer than the running OS —
+  unpinned, the CLI would require whatever macOS the `macos-latest` runner runs.
+  12.0 is what Go 1.25's internal linker stamps into a `CGO_ENABLED=0` build,
+  so the CLI's minimum macOS is the same as the CGO-less archives carried.
 - `linux/*` and `windows/*` stay `CGO_ENABLED=0`: pure Go, so they
   cross-compile from macOS exactly as they did from Linux. Linux gets the stub,
   Windows the real substrate.

--- a/dev-docs/agentic-computer-use-design.md
+++ b/dev-docs/agentic-computer-use-design.md
@@ -183,24 +183,36 @@ also false on every OS other than macOS and Windows regardless of the yaml
 value: the API already refuses the write there, and a hand-edited config must
 not advertise a tool whose every call fails. A darwin build without CGO still
 advertises it, because its `ErrUnsupported` names the missing CGO — the
-actionable message in that case. Graduate the default once the security
+actionable message in that case. That message only reaches the user because
+every action checks `computer.Supported()` **before** the permission gates: a
+stub reports `Trusted()` and `ScreenCaptureAllowed()` false, so the permission
+errors used to fire first and told the user to grant Accessibility or Screen
+Recording in System Settings — a dead end, since no grant can help a build with
+no implementation behind it. Graduate the default once the security
 model has real mileage.
 
 ## Release & build (settled: ships in release binaries)
 
-Constraint: goreleaser cross-compiles every target from `ubuntu-latest` with
-`CGO_ENABLED=0` (its build `env`), which would silently ship the stub on
-macOS. Since the feature must ride releases:
+The darwin target must be built with **CGO on**: with it off, `internal/computer`
+compiles its stub and every computer action fails. goreleaser's Linux
+cross-build was `CGO_ENABLED=0` for every target, so that stub is what macOS
+releases contained. Since the feature must ride releases:
 
-- The **darwin CLI legs move out of goreleaser** into a `macos-latest`
-  GitHub Actions job building `darwin/arm64` and `darwin/amd64` with
-  `CGO_ENABLED=1`. clang on the runner targets both architectures (`-arch`),
-  so a single arm64 runner produces both; the existing `darwin_all` lipo
-  artifact (the universal-binary entry in `.goreleaser.yaml`) is recreated
-  from those two binaries so
-  `install.sh` and the pkg installer keep working unchanged.
-- `linux/*` and `windows/*` stay in goreleaser with `CGO_ENABLED=0`: Linux
-  gets the stub, Windows gets the real substrate because it is pure Go.
+- **goreleaser runs on `macos-latest`** (`.github/workflows/release.yml`) and
+  the config carries a per-architecture `overrides` entry turning
+  `CGO_ENABLED=1` on for `darwin/amd64` and `darwin/arm64`. Go passes clang the
+  matching `-arch` per GOARCH, so one runner still produces both natively — no
+  `CC` override is needed.
+- `linux/*` and `windows/*` stay `CGO_ENABLED=0`: pure Go, so they
+  cross-compile from macOS exactly as they did from Linux. Linux gets the stub,
+  Windows the real substrate.
+- Every target still comes out of that **single** goreleaser run, so the
+  published asset set is unchanged: the per-arch darwin archives, the
+  `darwin_all` universal binary and `checksums.txt` are produced exactly as
+  before. `landing/install.sh` verifies the per-arch archive against
+  `checksums.txt` and errors out when the entry is missing, so a split — darwin
+  built by a separate job — was rejected: it would leave `checksums.txt`
+  incomplete and break every macOS install.
 - The macOS desktop app is unaffected: it already builds with `CGO_ENABLED=1`
   on `macos-latest` (the desktop target in the `Makefile`).
 - Local dev is unaffected: `make build` on macOS has CGO on by default.

--- a/internal/computer/computer.go
+++ b/internal/computer/computer.go
@@ -3,11 +3,14 @@
 // (screenshot → decide → click/type/key/scroll).
 //
 // Two real implementations exist. macOS lives behind CGO (Quartz CGEvent /
-// CGWindowList / AXUIElement). Windows is pure Go over Win32 (SendInput, GDI
-// capture) and UI Automation COM, so it ships in the CGO_ENABLED=0 release
-// cross-builds unchanged. Every other target — and a macOS build without
-// CGO — gets a stub that reports ErrUnsupported, so the package always
-// compiles and the tool degrades to a clear error instead of a build failure.
+// CGWindowList / AXUIElement) — which is why the darwin release target is
+// built natively on a macOS runner with CGO_ENABLED=1 rather than
+// cross-compiled from Linux with CGO off. Windows is pure Go over Win32
+// (SendInput, GDI capture) and UI Automation COM, so it ships in the
+// CGO_ENABLED=0 release cross-builds unchanged. Every other target — and a
+// macOS build without CGO — gets a stub that reports ErrUnsupported, so the
+// package always compiles and the tool degrades to a clear error instead of a
+// build failure.
 //
 // Coordinates are in the main display's native input space, origin top-left:
 // logical points on macOS (what CGEvent posts in), physical pixels on Windows
@@ -22,9 +25,18 @@ import (
 	"strings"
 )
 
-// ErrUnsupported marks every substrate call on a platform without a native
-// implementation (neither macOS-with-CGO nor Windows).
-var ErrUnsupported = errors.New("computer-use is only supported on macOS builds with CGO enabled and on Windows")
+// ErrUnsupported marks every substrate call in a build with no native
+// implementation: neither macOS-with-CGO nor Windows. It names the CGO build
+// because that is the actionable cause on macOS — a `CGO_ENABLED=0` CLI build
+// (how goreleaser's Linux runner used to cross-compile darwin) ships the stub.
+var ErrUnsupported = errors.New("computer-use is unavailable in this build: it needs macOS with CGO enabled (the desktop app, or a CLI built with CGO_ENABLED=1) or Windows")
+
+// Supported reports whether this build has a real substrate. False for the
+// stub — a platform with no implementation, or a macOS build with CGO
+// disabled. Callers must check this BEFORE the permission gates: a stub has no
+// grant to fetch, so reporting "Screen Recording / Accessibility not granted"
+// would send the user to System Settings for a switch that cannot help.
+func Supported() bool { return supported() }
 
 // Trusted reports whether the process may post input events to other apps
 // (macOS Accessibility permission; Windows has no such grant and reports true).

--- a/internal/computer/computer_test.go
+++ b/internal/computer/computer_test.go
@@ -1,6 +1,9 @@
 package computer
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestParseCombo(t *testing.T) {
 	cases := []struct {
@@ -59,6 +62,45 @@ func TestClickValidation(t *testing.T) {
 	}
 	if err := Click("left", 0, 0, 3); err == nil {
 		t.Error("clicks > 2 should error before touching the substrate")
+	}
+}
+
+// Supported() must agree with the stub: a build reporting no substrate returns
+// ErrUnsupported from every action. Callers (internal/tools) gate on this so a
+// stub build blames the build, not a missing permission grant.
+func TestSupportedMatchesSubstrate(t *testing.T) {
+	if Supported() {
+		// A real substrate may still refuse a specific call (a missing macOS
+		// grant, no on-screen window), so only the stub direction is asserted.
+		return
+	}
+	png, shotErr := Screenshot()
+	_, _, sizeErr := ScreenSize()
+	tree, treeErr := AXTree(0, 1)
+	_, winErr := FindWindow("Finder")
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"screenshot", shotErr},
+		{"screenSize", sizeErr},
+		{"moveTo", MoveTo(0, 0)},
+		{"click", Click("left", 0, 0, 1)},
+		{"scroll", Scroll(0, 1)},
+		{"typeText", TypeText("x")},
+		{"press", Press("enter")},
+		{"axTree", treeErr},
+		{"axPress", AXPress(0, "", "x")},
+		{"axSetValue", AXSetValue(0, "", "x", "1")},
+		{"findWindow", winErr},
+	}
+	if png != nil || tree != nil {
+		t.Error("stub build returned data for screenshot/axTree")
+	}
+	for _, tc := range cases {
+		if !errors.Is(tc.err, ErrUnsupported) {
+			t.Errorf("%s on an unsupported build: err = %v, want ErrUnsupported", tc.name, tc.err)
+		}
 	}
 }
 

--- a/internal/computer/darwin_cgo.go
+++ b/internal/computer/darwin_cgo.go
@@ -17,6 +17,8 @@ import (
 	"unsafe"
 )
 
+func supported() bool { return true }
+
 func trusted() bool {
 	return C.AXIsProcessTrusted() != 0
 }

--- a/internal/computer/stub.go
+++ b/internal/computer/stub.go
@@ -2,6 +2,7 @@
 
 package computer
 
+func supported() bool            { return false }
 func trusted() bool              { return false }
 func screenCaptureAllowed() bool { return false }
 

--- a/internal/computer/windows.go
+++ b/internal/computer/windows.go
@@ -163,6 +163,7 @@ func ensureDPIAware() {
 // capture are available to any interactive process. (UIPI still blocks input
 // into windows of a higher integrity level — an elevated app cannot be
 // driven unless octo runs elevated too; that surfaces as SendInput failing.)
+func supported() bool            { return true }
 func trusted() bool              { return true }
 func screenCaptureAllowed() bool { return true }
 func requestScreenCapture()      {}

--- a/internal/tools/computer.go
+++ b/internal/tools/computer.go
@@ -16,8 +16,14 @@ import (
 	"github.com/open-octo/octo-agent/internal/config"
 )
 
-// computerPlatform reports whether this OS has a computer-use substrate
-// (macOS and Windows; see internal/computer).
+// computerPlatform reports whether this OS has a computer-use substrate at all
+// (macOS and Windows; see internal/computer). It is deliberately weaker than
+// computer.Supported(): a macOS build without CGO still counts here, because
+// the tool keeps advertising there and its ErrUnsupported names the missing
+// CGO, which is the actionable message in that case. Only platforms with no
+// implementation whatsoever are excluded (the Settings API refuses the write
+// there, and a hand-edited yaml must not advertise a tool whose every call
+// fails).
 func computerPlatform() bool {
 	return runtime.GOOS == "darwin" || runtime.GOOS == "windows"
 }
@@ -25,11 +31,6 @@ func computerPlatform() bool {
 // computerEnabled gates advertising of the tool: the experimental
 // tools.computer.enabled switch (default off). Follows browserEnabled's
 // pattern — hidden from the model's tool list when off, still dispatchable.
-// The switch is also ignored on platforms without a substrate: the Settings
-// API already refuses the write there, and a hand-edited yaml must not
-// advertise a tool whose every call fails with ErrUnsupported. (A darwin
-// build without CGO still advertises it — its ErrUnsupported names the
-// missing CGO, which is the actionable message in that case.)
 func computerEnabled() bool {
 	if !computerPlatform() {
 		return false
@@ -224,6 +225,9 @@ var shotScale = struct {
 }{x: 1, y: 1}
 
 func computerScreenshot(ctx context.Context) (agent.ToolResult, error) {
+	if err := requireSubstrate(); err != nil {
+		return agent.ToolResult{}, err
+	}
 	if !computer.ScreenCaptureAllowed() {
 		computer.RequestScreenCapture() // pop the system grant dialog
 		return agent.ToolResult{}, fmt.Errorf("computer: Screen Recording permission not granted — a system dialog may have appeared; grant it to the app running octo in System Settings → Privacy & Security → Screen Recording, then retry (the app may need a restart for the grant to take effect)")
@@ -289,9 +293,24 @@ func computerClick(button string, clicks int, input map[string]any) (agent.ToolR
 	return agent.ToolResult{Text: fmt.Sprintf("%s (%.0f, %.0f) — screenshot to verify the result", verb, x, y)}, nil
 }
 
+// requireSubstrate rejects an action in a build with no native implementation
+// before any permission gate can misreport the cause. A stub has no grant to
+// fetch, so "Screen Recording / Accessibility not granted" would send the user
+// to System Settings for a switch that cannot help — every action of such a
+// build would fail there, forever.
+func requireSubstrate() error {
+	if !computer.Supported() {
+		return computer.ErrUnsupported
+	}
+	return nil
+}
+
 // requireTrusted gates every input-synthesis action on the macOS Accessibility
 // grant, with an actionable error instead of silently dropping events.
 func requireTrusted() error {
+	if err := requireSubstrate(); err != nil {
+		return err
+	}
 	if !computer.Trusted() {
 		computer.RequestAccessibility() // pop the system grant dialog
 		return fmt.Errorf("computer: Accessibility permission not granted — input would be dropped silently. A system dialog may have appeared; grant it to the app running octo in System Settings → Privacy & Security → Accessibility, then retry")

--- a/internal/tools/computer_test.go
+++ b/internal/tools/computer_test.go
@@ -1,9 +1,13 @@
 package tools
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/open-octo/octo-agent/internal/computer"
 )
 
 // The tool ships dark behind tools.computer.enabled: unset must hide it from
@@ -19,7 +23,9 @@ func TestComputerTool_GatedOffByDefault(t *testing.T) {
 }
 
 // With the switch on, the tool is advertised — on macOS and Windows only;
-// elsewhere the switch is ignored because the substrate does not exist.
+// elsewhere the switch is ignored because the substrate does not exist. A
+// macOS build without CGO still advertises (see computerPlatform): its actions
+// fail with an ErrUnsupported that names the missing CGO.
 func TestComputerTool_AdvertisedWhenEnabled(t *testing.T) {
 	home := setHome(t)
 	if err := os.MkdirAll(filepath.Join(home, ".octo"), 0o755); err != nil {
@@ -43,5 +49,31 @@ func TestComputerTool_AdvertisedWhenEnabled(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("computer tool should be advertised when tools.computer.enabled is on")
+	}
+}
+
+// A build with no substrate must say so rather than blame a missing permission
+// grant. The stub reports Trusted() and ScreenCaptureAllowed() false, so before
+// requireSubstrate the permission gates fired first and told the user to grant
+// Accessibility in System Settings — a switch that cannot help, because there
+// is no implementation behind it (the case CGO-less darwin CLI builds shipped).
+func TestComputerTool_UnsupportedBuildBlamesNoPermission(t *testing.T) {
+	if computer.Supported() {
+		t.Skip("build has a substrate; the stub path runs on the unsupported/CGO-less CI legs")
+	}
+	// Enough arguments that any action would get past its own operand checks.
+	input := map[string]any{
+		"action": "left_click", "x": 1.0, "y": 1.0, "text": "x",
+		"key": "enter", "app": "Finder", "label": "OK", "role": "AXButton",
+	}
+	for _, action := range []string{
+		"screenshot", "left_click", "right_click", "double_click", "mouse_move",
+		"type", "key", "scroll", "ax_tree", "ax_press", "ax_set",
+	} {
+		input["action"] = action
+		_, err := ComputerTool{}.Execute(context.Background(), "computer", input)
+		if !errors.Is(err, computer.ErrUnsupported) {
+			t.Errorf("%s: err = %v, want ErrUnsupported — a permission error here is the misleading case", action, err)
+		}
 	}
 }

--- a/scripts/package-desktop-macos.sh
+++ b/scripts/package-desktop-macos.sh
@@ -49,11 +49,12 @@ for arch in amd64 arm64; do
 	# the CI runner's live OS version into the binary's LC_VERSION_MIN load
 	# command — on a runner newer than a user's Mac, launching failed with
 	# "You can't use this version of the application... with this version of
-	# macOS", unrelated to the LSMinimumSystemVersion=11.0 in Info.plist).
-	# 11.0 matches that Info.plist value and Go's own linker default, so it
-	# also fully eliminates the SDK-vs-link-target warning this flag was
-	# added for in the first place.
-	macos_ver="11.0"
+	# macOS", unrelated to the LSMinimumSystemVersion=12.0 in Info.plist).
+	# 12.0 matches that Info.plist value, Go 1.25's own linker default and the
+	# CLI's DARWIN_MIN_MACOS in .goreleaser.yaml, so it also fully eliminates
+	# the SDK-vs-link-target warning this flag was added for in the first
+	# place.
+	macos_ver="12.0"
 	( cd "$MOD_DIR" && \
 		GOOS=darwin GOARCH="$arch" CGO_ENABLED=1 CC="clang -arch $cc_arch" \
 		CGO_CFLAGS="-mmacosx-version-min=$macos_ver" \

--- a/scripts/package-desktop-macos.sh
+++ b/scripts/package-desktop-macos.sh
@@ -53,12 +53,14 @@ for arch in amd64 arm64; do
 	# 12.0 matches that Info.plist value, Go 1.25's own linker default and the
 	# CLI's DARWIN_MIN_MACOS in .goreleaser.yaml, so it also fully eliminates
 	# the SDK-vs-link-target warning this flag was added for in the first
-	# place.
+	# place. The link flag is the clang-driver spelling (-mmacosx-version-min),
+	# not -Wl,-macos_version_min, so the driver does not also derive a
+	# host-based version and ld does not warn about two min versions.
 	macos_ver="12.0"
 	( cd "$MOD_DIR" && \
 		GOOS=darwin GOARCH="$arch" CGO_ENABLED=1 CC="clang -arch $cc_arch" \
 		CGO_CFLAGS="-mmacosx-version-min=$macos_ver" \
-		CGO_LDFLAGS="-Wl,-macos_version_min,$macos_ver -Wl,-no_warn_duplicate_libraries" \
+		CGO_LDFLAGS="-mmacosx-version-min=$macos_ver -Wl,-no_warn_duplicate_libraries" \
 		go build -tags embedrg -ldflags "$LDFLAGS" -o "$out" . )
 	slices+=("$out")
 done


### PR DESCRIPTION
## Summary

Fixes what #2391 / #2393 shipped on macOS: the released darwin CLI advertised the `computer` tool and then failed *every* action. Two defects, one cause.

**1. The released CLI linked the stub.** The computer-use substrate is cgo (Quartz CGEvent / AXUIElement), but goreleaser built every target from `ubuntu-latest` with `CGO_ENABLED=0` — so `octo_<v>_darwin_*.tar.gz` contained a binary with no implementation behind the tool. The goreleaser job now runs on `macos-latest` and turns CGO on for `darwin/amd64` + `darwin/arm64` via per-target `overrides`. Go passes clang the matching `-arch` per GOARCH, so one runner still produces both architectures natively and no `CC` override is needed. Linux and Windows stay `CGO_ENABLED=0` (pure Go) and cross-compile from macOS unchanged.

**Why not move the darwin legs into a separate job** (the shape the design doc originally described): every target must stay inside the one goreleaser run so the archives, the `darwin_all` universal binary and `checksums.txt` are produced exactly as before. `landing/install.sh` verifies the archive it downloads against `checksums.txt` and hard-fails when the entry is missing, so a partial `checksums.txt` would break every macOS install — and a separate job would also have to rebuild the fat binary by hand.

**2. The stub blamed a missing permission grant.** In a build with no substrate, `Trusted()` and `ScreenCaptureAllowed()` are both false, and every action checked those gates first — so a CGO-less CLI told the user to grant Accessibility (or Screen Recording) in System Settings, indefinitely, while the one actionable message (`ErrUnsupported`, naming the missing CGO) was unreachable. The code comment asserting that it surfaced was wrong. New `computer.Supported()` is now checked ahead of the permission gates.

**3. The CGO build must pin its deployment target.** clang, unlike Go's internal linker, defaults the binary's `LC_BUILD_VERSION minos` to the *build machine's* macOS, and dyld refuses to launch a binary whose minos is newer than the running OS — so an unpinned build on `macos-latest` would silently require the runner's macOS. The darwin overrides now set `-mmacosx-version-min=12.0` in both `CGO_CFLAGS` and `CGO_LDFLAGS` (the clang-driver spelling at link time too, so ld does not warn about two min versions) (config env `DARWIN_MIN_MACOS`): that is what Go 1.25's internal linker stamps into the `CGO_ENABLED=0` builds that shipped before, so the CLI's minimum macOS does not move. The desktop shell pinned 11.0 in three places (Makefile, `package-desktop-macos.sh`, Info.plist's `LSMinimumSystemVersion`) on the stale premise that 11.0 was Go's linker default; those move to 12.0 too, so the app and the CLI declare the same, true minimum.

Deliberately unchanged: `computerEnabled` still gates *advertising* on the platform rather than on `Supported()` — a macOS build without CGO keeps advertising the tool, which is what lets that message reach the user at all.

## Test plan

- [x] `goreleaser release --snapshot --clean` on macOS (the same runner OS the job now uses) — same seven archives with the same name template, a complete seven-entry `checksums.txt`, `darwin_all` fat for x86_64+arm64
- [x] the extracted `octo_<v>_darwin_amd64.tar.gz` binary — the artifact `install.sh` downloads — carries the cgo substrate (`octoRequestAccessibility`, `_cgo_` symbols) and passes install.sh's own grep+shasum verification; the linux archive has no cgo symbols
- [x] `otool -l` on both snapshot darwin binaries reports `minos 12.0` (unpinned it reported the build host's version), with the cgo symbols still present
- [x] `cmd/octo-desktop` built with the Makefile's pinned flags reports `minos 12.0`
- [x] `go test -race ./internal/computer/ ./internal/tools/ ./internal/server/`
- [x] `CGO_ENABLED=0 go test ./internal/tools/ -run TestComputerTool` and `./internal/computer/ -run TestSupportedMatchesSubstrate` — the stub path, asserting all 11 actions return `ErrUnsupported`
- [x] `go vet` under darwin±cgo, linux/amd64+CGO=0, windows/amd64; `GOOS=windows GOARCH=arm64 go build ./...`
- [x] `goreleaser check`, `gofmt -l .`

**Not verifiable here:** `release.yml` only runs on a tag push, so PR CI does not exercise the moved goreleaser job. The snapshot reproduces its build matrix on the same runner OS, but the publish path (release creation, asset uploads, and the downstream jobs that download `darwin_all`) is first exercised by the next real tag.

Five commits — code fix, release fix, CLI deployment-target pin, desktop pin, link-flag spelling — kept separate for reading; squash-merge is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

