### PR TITLE
computer: focus the target app before pixel input, address AX elements by id

### DIFF
--- a/internal/computer/ax_darwin.go
+++ b/internal/computer/ax_darwin.go
@@ -122,24 +122,29 @@ func axTree(pid, maxDepth int) ([]AXElement, error) {
 // the same pid + maxDepth. This is the id-addressed counterpart to
 // axFindDo's role+label matching, for elements ax_tree shows with an empty
 // or duplicate label (axFindDo can't disambiguate those by contains/role).
-func axActByIndex(pid, maxDepth, target int, action func(C.AXUIElementRef) error) error {
+// Returns the matched element's digest (role/label/frame) alongside any
+// error so the caller can echo back what it actually hit — the one signal
+// that an index-addressed action landed on the right widget.
+func axActByIndex(pid, maxDepth, target int, action func(C.AXUIElementRef) error) (AXElement, error) {
 	var found bool
+	var matched AXElement
 	var actErr error
-	err := axWalk(pid, maxDepth, func(i int, el C.AXUIElementRef, _ AXElement) bool {
+	err := axWalk(pid, maxDepth, func(i int, el C.AXUIElementRef, e AXElement) bool {
 		if i == target {
 			found = true
+			matched = e
 			actErr = action(el)
 			return false
 		}
 		return true
 	})
 	if err != nil {
-		return err
+		return AXElement{}, err
 	}
 	if !found {
-		return fmt.Errorf("computer: no element with id e%d (re-dump ax_tree — the tree may have changed, or max_depth differs from the dump that produced this id)", target)
+		return AXElement{}, fmt.Errorf("computer: no element with id e%d (re-dump ax_tree — the tree may have changed, or max_depth differs from the dump that produced this id)", target)
 	}
-	return actErr
+	return matched, actErr
 }
 
 // axFind locates the first element matching role+contains (same rules as
@@ -241,7 +246,7 @@ func axPress(pid int, role, contains string) error {
 	return axFindDo(pid, role, contains, doAXPress)
 }
 
-func axPressByID(pid, maxDepth, id int) error {
+func axPressByID(pid, maxDepth, id int) (AXElement, error) {
 	return axActByIndex(pid, maxDepth, id, doAXPress)
 }
 
@@ -270,7 +275,7 @@ func axSetValue(pid int, role, contains, value string) error {
 	})
 }
 
-func axSetValueByID(pid, maxDepth, id int, value string) error {
+func axSetValueByID(pid, maxDepth, id int, value string) (AXElement, error) {
 	return axActByIndex(pid, maxDepth, id, func(el C.AXUIElementRef) error {
 		return doAXSetValue(el, value)
 	})

--- a/internal/computer/ax_darwin.go
+++ b/internal/computer/ax_darwin.go
@@ -39,20 +39,27 @@ func axRoots(app C.AXUIElementRef, withMenuBar bool) (arrays []C.CFArrayRef, sin
 	return arrays, singles
 }
 
-func axTree(pid, maxDepth int) ([]AXElement, error) {
+// axWalk performs the same depth-first traversal axTree renders (windows +
+// menu bar, depth- and fan-out-capped) and calls visit for every element
+// with its 0-based traversal index while the raw element is still valid.
+// visit returning false stops the whole walk immediately — used by
+// axActByIndex to act on one element without paying for the rest of a
+// possibly-large tree.
+func axWalk(pid, maxDepth int, visit func(index int, el C.AXUIElementRef, e AXElement) bool) error {
 	if maxDepth <= 0 {
 		maxDepth = 12
 	}
 	app := C.octoAXApp(C.int(pid))
 	if app == 0 {
-		return nil, fmt.Errorf("computer: cannot create AX handle for pid %d", pid)
+		return fmt.Errorf("computer: cannot create AX handle for pid %d", pid)
 	}
 	defer C.CFRelease(C.CFTypeRef(app))
 
-	out := make([]AXElement, 0, 256)
+	index := 0
+	stop := false
 	var walk func(el C.AXUIElementRef, depth int)
 	walk = func(el C.AXUIElementRef, depth int) {
-		if depth > maxDepth || len(out) >= axMaxTotal {
+		if stop || depth > maxDepth || index >= axMaxTotal {
 			return
 		}
 		e := AXElement{Depth: depth}
@@ -65,7 +72,11 @@ func axTree(pid, maxDepth int) ([]AXElement, error) {
 		if C.octoAXFrame(el, &x, &y, &w, &h) == 0 {
 			e.X, e.Y, e.W, e.H = float64(x), float64(y), float64(w), float64(h)
 		}
-		out = append(out, e)
+		if !visit(index, el, e) {
+			stop = true
+			return
+		}
+		index++
 
 		kids := C.octoAXCopyArray(el, C.kAXChildrenAttribute)
 		if kids == 0 {
@@ -73,7 +84,7 @@ func axTree(pid, maxDepth int) ([]AXElement, error) {
 		}
 		defer C.CFRelease(C.CFTypeRef(kids))
 		n := int(C.CFArrayGetCount(kids))
-		for i := 0; i < n && i < axMaxChildren && len(out) < axMaxTotal; i++ {
+		for i := 0; i < n && i < axMaxChildren && !stop; i++ {
 			// Array-owned reference: valid until kids is released, no extra
 			// retain needed for the recursive call.
 			walk(C.AXUIElementRef(C.CFArrayGetValueAtIndex(kids, C.CFIndex(i))), depth+1)
@@ -83,16 +94,52 @@ func axTree(pid, maxDepth int) ([]AXElement, error) {
 	arrays, singles := axRoots(app, true)
 	for _, arr := range arrays {
 		n := int(C.CFArrayGetCount(arr))
-		for i := 0; i < n && len(out) < axMaxTotal; i++ {
+		for i := 0; i < n && !stop; i++ {
 			walk(C.AXUIElementRef(C.CFArrayGetValueAtIndex(arr, C.CFIndex(i))), 0)
 		}
 		C.CFRelease(C.CFTypeRef(arr))
 	}
 	for _, el := range singles {
-		walk(el, 0)
+		if !stop {
+			walk(el, 0)
+		}
 		C.CFRelease(C.CFTypeRef(el))
 	}
-	return out, nil
+	return nil
+}
+
+func axTree(pid, maxDepth int) ([]AXElement, error) {
+	out := make([]AXElement, 0, 256)
+	err := axWalk(pid, maxDepth, func(_ int, _ C.AXUIElementRef, e AXElement) bool {
+		out = append(out, e)
+		return true
+	})
+	return out, err
+}
+
+// axActByIndex performs action on the element at the given 0-based
+// traversal index — the same numbering axTree's returned slice uses, under
+// the same pid + maxDepth. This is the id-addressed counterpart to
+// axFindDo's role+label matching, for elements ax_tree shows with an empty
+// or duplicate label (axFindDo can't disambiguate those by contains/role).
+func axActByIndex(pid, maxDepth, target int, action func(C.AXUIElementRef) error) error {
+	var found bool
+	var actErr error
+	err := axWalk(pid, maxDepth, func(i int, el C.AXUIElementRef, _ AXElement) bool {
+		if i == target {
+			found = true
+			actErr = action(el)
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("computer: no element with id e%d (re-dump ax_tree — the tree may have changed, or max_depth differs from the dump that produced this id)", target)
+	}
+	return actErr
 }
 
 // axFind locates the first element matching role+contains (same rules as
@@ -181,32 +228,51 @@ func axFindDo(pid int, role, contains string, action func(C.AXUIElementRef) erro
 	return actErr
 }
 
+// doAXPress performs an already-located element's press action; shared by
+// the label-matched (axPress) and id-addressed (axPressByID) paths.
+func doAXPress(el C.AXUIElementRef) error {
+	if rc := C.octoAXPress(el); rc != 0 {
+		return fmt.Errorf("computer: AXPress failed (AXError %d)", int(rc))
+	}
+	return nil
+}
+
 func axPress(pid int, role, contains string) error {
-	return axFindDo(pid, role, contains, func(el C.AXUIElementRef) error {
-		if rc := C.octoAXPress(el); rc != 0 {
-			return fmt.Errorf("computer: AXPress failed (AXError %d)", int(rc))
+	return axFindDo(pid, role, contains, doAXPress)
+}
+
+func axPressByID(pid, maxDepth, id int) error {
+	return axActByIndex(pid, maxDepth, id, doAXPress)
+}
+
+// doAXSetValue is axSetValue/axSetValueByID's shared element-level action:
+// sliders/steppers take a number, everything else takes a string.
+func doAXSetValue(el C.AXUIElementRef, value string) error {
+	if isAXValueRole(eRoleOf(el)) {
+		if f, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
+			if rc := C.octoAXSetDouble(el, C.double(f)); rc != 0 {
+				return fmt.Errorf("computer: AXSetValue(%g) failed (AXError %d)", f, int(rc))
+			}
+			return nil
 		}
-		return nil
-	})
+	}
+	cv := C.CString(value)
+	defer C.free(unsafe.Pointer(cv))
+	if rc := C.octoAXSetString(el, cv); rc != 0 {
+		return fmt.Errorf("computer: AXSetValue(%q) failed (AXError %d)", value, int(rc))
+	}
+	return nil
 }
 
 func axSetValue(pid int, role, contains, value string) error {
 	return axFindDo(pid, role, contains, func(el C.AXUIElementRef) error {
-		// Sliders/steppers take a number; everything else takes a string.
-		if isAXValueRole(eRoleOf(el)) {
-			if f, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
-				if rc := C.octoAXSetDouble(el, C.double(f)); rc != 0 {
-					return fmt.Errorf("computer: AXSetValue(%g) failed (AXError %d)", f, int(rc))
-				}
-				return nil
-			}
-		}
-		cv := C.CString(value)
-		defer C.free(unsafe.Pointer(cv))
-		if rc := C.octoAXSetString(el, cv); rc != 0 {
-			return fmt.Errorf("computer: AXSetValue(%q) failed (AXError %d)", value, int(rc))
-		}
-		return nil
+		return doAXSetValue(el, value)
+	})
+}
+
+func axSetValueByID(pid, maxDepth, id int, value string) error {
+	return axActByIndex(pid, maxDepth, id, func(el C.AXUIElementRef) error {
+		return doAXSetValue(el, value)
 	})
 }
 

--- a/internal/computer/computer.go
+++ b/internal/computer/computer.go
@@ -98,6 +98,19 @@ type Window struct {
 	X, Y, W, H float64
 }
 
+// ActivateApp brings pid's app to the foreground without moving the cursor —
+// call it before a pixel-channel click/type/key targeting an app that might
+// not already have focus. Octo's own window can otherwise hold focus and
+// silently swallow the input; ClickPid/TypeTextPid's per-process delivery
+// (below) was tried first and measured unreliable (dropped by both SwiftUI
+// and custom-drawn views), so real focus is the fix that actually works.
+func ActivateApp(pid int) error { return activateApp(pid) }
+
+// FrontmostAppName reports the name of the app currently in the foreground,
+// "" if it could not be determined — used to sanity-check that a type/key
+// action actually landed in the intended app instead of Octo's own window.
+func FrontmostAppName() string { return frontmostAppName() }
+
 // FindWindow locates the front-most normal window of the app named owner:
 // on macOS the process name as shown in the menu bar (e.g. "国际象棋" for
 // Chess); on Windows the executable name without ".exe" or, failing that, a
@@ -200,7 +213,11 @@ func MatchAXExact(e AXElement, role, label string) bool {
 }
 
 // AXTree returns a depth-limited digest of the app's accessibility tree —
-// windows plus the menu bar. Works on backgrounded apps.
+// windows plus the menu bar. Works on backgrounded apps. Each element's
+// position in the returned slice is its addressable id: AXPressByID and
+// AXSetValueByID take that same 0-based index (under the same maxDepth) to
+// act on an element ax_tree shows with an empty or duplicate label, which
+// role+contains matching (AXPress/AXSetValue) cannot disambiguate.
 func AXTree(pid, maxDepth int) ([]AXElement, error) { return axTree(pid, maxDepth) }
 
 // AXPress finds the first element matching role+label (see MatchAX) and
@@ -214,6 +231,16 @@ func AXPress(pid int, role, contains string) error {
 	return axPress(pid, role, contains)
 }
 
+// AXPressByID is AXPress's id-addressed counterpart: it presses the element
+// at the given 0-based index into AXTree(pid, maxDepth)'s result, bypassing
+// role/label matching entirely.
+func AXPressByID(pid, maxDepth, id int) error {
+	if id < 0 {
+		return fmt.Errorf("computer: element id must be >= 0")
+	}
+	return axPressByID(pid, maxDepth, id)
+}
+
 // AXSetValue sets the value of the first matching element: numeric for
 // sliders/steppers, string for text fields.
 func AXSetValue(pid int, role, contains, value string) error {
@@ -221,6 +248,14 @@ func AXSetValue(pid int, role, contains, value string) error {
 		return fmt.Errorf("computer: AXSetValue needs a label to match")
 	}
 	return axSetValue(pid, role, contains, value)
+}
+
+// AXSetValueByID is AXSetValue's id-addressed counterpart; see AXPressByID.
+func AXSetValueByID(pid, maxDepth, id int, value string) error {
+	if id < 0 {
+		return fmt.Errorf("computer: element id must be >= 0")
+	}
+	return axSetValueByID(pid, maxDepth, id, value)
 }
 
 // modifier flag bits, mirroring CGEventFlags so parseCombo stays

--- a/internal/computer/computer.go
+++ b/internal/computer/computer.go
@@ -233,10 +233,11 @@ func AXPress(pid int, role, contains string) error {
 
 // AXPressByID is AXPress's id-addressed counterpart: it presses the element
 // at the given 0-based index into AXTree(pid, maxDepth)'s result, bypassing
-// role/label matching entirely.
-func AXPressByID(pid, maxDepth, id int) error {
+// role/label matching entirely. Returns the matched element's digest so the
+// caller can echo back what it actually pressed.
+func AXPressByID(pid, maxDepth, id int) (AXElement, error) {
 	if id < 0 {
-		return fmt.Errorf("computer: element id must be >= 0")
+		return AXElement{}, fmt.Errorf("computer: element id must be >= 0")
 	}
 	return axPressByID(pid, maxDepth, id)
 }
@@ -251,9 +252,9 @@ func AXSetValue(pid int, role, contains, value string) error {
 }
 
 // AXSetValueByID is AXSetValue's id-addressed counterpart; see AXPressByID.
-func AXSetValueByID(pid, maxDepth, id int, value string) error {
+func AXSetValueByID(pid, maxDepth, id int, value string) (AXElement, error) {
 	if id < 0 {
-		return fmt.Errorf("computer: element id must be >= 0")
+		return AXElement{}, fmt.Errorf("computer: element id must be >= 0")
 	}
 	return axSetValueByID(pid, maxDepth, id, value)
 }

--- a/internal/computer/computer_test.go
+++ b/internal/computer/computer_test.go
@@ -62,6 +62,18 @@ func TestClickValidation(t *testing.T) {
 	}
 }
 
+func TestAXPressByIDValidation(t *testing.T) {
+	if err := AXPressByID(999999, 12, -1); err == nil {
+		t.Error("negative element id should error before touching the substrate")
+	}
+}
+
+func TestAXSetValueByIDValidation(t *testing.T) {
+	if err := AXSetValueByID(999999, 12, -1, "1"); err == nil {
+		t.Error("negative element id should error before touching the substrate")
+	}
+}
+
 func TestMatchAX(t *testing.T) {
 	el := AXElement{Role: "AXButton", Title: "存储", Description: "保存文档"}
 	cases := []struct {

--- a/internal/computer/computer_test.go
+++ b/internal/computer/computer_test.go
@@ -63,13 +63,13 @@ func TestClickValidation(t *testing.T) {
 }
 
 func TestAXPressByIDValidation(t *testing.T) {
-	if err := AXPressByID(999999, 12, -1); err == nil {
+	if _, err := AXPressByID(999999, 12, -1); err == nil {
 		t.Error("negative element id should error before touching the substrate")
 	}
 }
 
 func TestAXSetValueByIDValidation(t *testing.T) {
-	if err := AXSetValueByID(999999, 12, -1, "1"); err == nil {
+	if _, err := AXSetValueByID(999999, 12, -1, "1"); err == nil {
 		t.Error("negative element id should error before touching the substrate")
 	}
 }

--- a/internal/computer/darwin_cgo.go
+++ b/internal/computer/darwin_cgo.go
@@ -29,6 +29,28 @@ func requestScreenCapture() { C.CGRequestScreenCaptureAccess() }
 
 func requestAccessibility() { C.octoRequestAccessibility() }
 
+// activateApp brings pid's app to the foreground (see octoAXSetFrontmost) —
+// the pixel channel's real fix for Octo's own window silently holding focus
+// and swallowing a click/type/key meant for a backgrounded app.
+func activateApp(pid int) error {
+	if rc := C.octoAXSetFrontmost(C.int(pid)); rc != 0 {
+		return fmt.Errorf("computer: activating app (pid %d) failed (AXError %d)", pid, int(rc))
+	}
+	return nil
+}
+
+// frontmostAppName reports the currently-frontmost app's name, "" if
+// undetermined, so a type/key action can sanity-check where it landed.
+func frontmostAppName() string {
+	cs := C.octoFrontmostAppName()
+	if cs == nil {
+		return ""
+	}
+	s := C.GoString(cs)
+	C.free(unsafe.Pointer(cs))
+	return s
+}
+
 func screenSize() (float64, float64, error) {
 	b := C.CGDisplayBounds(C.CGMainDisplayID())
 	return float64(b.size.width), float64(b.size.height), nil

--- a/internal/computer/helpers.h
+++ b/internal/computer/helpers.h
@@ -158,6 +158,46 @@ static inline int octoClickPid(int pid, int winID, int right, double x, double y
 	return 0;
 }
 
+// octoAXSetFrontmost brings pid's app forward — the standard third-party way
+// apps raise another app (Rectangle, Hammerspoon use the same attribute).
+// This is the real fix for pixel-channel input silently missing a
+// backgrounded app: octoClickPid/octoTypePid above were measured to be
+// dropped by both SwiftUI and custom-drawn views even while "delivered", so
+// genuine focus is the only reliable path.
+static inline int octoAXSetFrontmost(int pid) {
+	AXUIElementRef app = AXUIElementCreateApplication((pid_t)pid);
+	AXError rc = AXUIElementSetAttributeValue(app, kAXFrontmostAttribute, kCFBooleanTrue);
+	CFRelease(app);
+	return (int)rc;
+}
+
+// octoFrontmostAppName reads the owner name of the front-most normal-layer
+// on-screen window: CGWindowListCopyWindowInfo with
+// kCGWindowListOptionOnScreenOnly returns windows in front-to-back z-order,
+// so the first layer-0 entry belongs to the frontmost app. Caller frees with
+// free(); NULL if undetermined.
+static inline char *octoFrontmostAppName(void) {
+	CFArrayRef list = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+	if (!list) return NULL;
+	char *out = NULL;
+	CFIndex n = CFArrayGetCount(list);
+	for (CFIndex i = 0; i < n; i++) {
+		CFDictionaryRef d = (CFDictionaryRef)CFArrayGetValueAtIndex(list, i);
+		CFNumberRef layerN = (CFNumberRef)CFDictionaryGetValue(d, kCGWindowLayer);
+		int layer = -1;
+		if (layerN) CFNumberGetValue(layerN, kCFNumberIntType, &layer);
+		if (layer != 0) continue;
+		CFStringRef o = (CFStringRef)CFDictionaryGetValue(d, kCGWindowOwnerName);
+		if (!o) break;
+		CFIndex max = CFStringGetMaximumSizeForEncoding(CFStringGetLength(o), kCFStringEncodingUTF8) + 1;
+		out = (char *)malloc(max);
+		if (!CFStringGetCString(o, out, max, kCFStringEncodingUTF8)) { free(out); out = NULL; }
+		break;
+	}
+	CFRelease(list);
+	return out;
+}
+
 // ── Accessibility (AX) layer ───────────────────────────────────────────────
 // AX actions (AXPress / AXSetValue) are served by the target app's own AX
 // server: they need no cursor, no focus, no foreground — the one true

--- a/internal/computer/stub.go
+++ b/internal/computer/stub.go
@@ -41,6 +41,8 @@ func axPress(pid int, role, contains string) error { return ErrUnsupported }
 
 func axSetValue(pid int, role, contains, value string) error { return ErrUnsupported }
 
-func axPressByID(pid, maxDepth, id int) error { return ErrUnsupported }
+func axPressByID(pid, maxDepth, id int) (AXElement, error) { return AXElement{}, ErrUnsupported }
 
-func axSetValueByID(pid, maxDepth, id int, value string) error { return ErrUnsupported }
+func axSetValueByID(pid, maxDepth, id int, value string) (AXElement, error) {
+	return AXElement{}, ErrUnsupported
+}

--- a/internal/computer/stub.go
+++ b/internal/computer/stub.go
@@ -9,6 +9,10 @@ func requestScreenCapture() {}
 
 func requestAccessibility() {}
 
+func activateApp(pid int) error { return ErrUnsupported }
+
+func frontmostAppName() string { return "" }
+
 func screenSize() (float64, float64, error) { return 0, 0, ErrUnsupported }
 
 func screenshot() ([]byte, error) { return nil, ErrUnsupported }
@@ -36,3 +40,7 @@ func axTree(pid, maxDepth int) ([]AXElement, error) { return nil, ErrUnsupported
 func axPress(pid int, role, contains string) error { return ErrUnsupported }
 
 func axSetValue(pid int, role, contains, value string) error { return ErrUnsupported }
+
+func axPressByID(pid, maxDepth, id int) error { return ErrUnsupported }
+
+func axSetValueByID(pid, maxDepth, id int, value string) error { return ErrUnsupported }

--- a/internal/computer/uia_windows.go
+++ b/internal/computer/uia_windows.go
@@ -293,16 +293,21 @@ func walkChildren(walker, el comObj, visit func(child comObj) bool) {
 	}
 }
 
-func axTree(pid, maxDepth int) ([]AXElement, error) {
+// axWalk performs the same depth-first traversal axTree renders (from pid's
+// top-most window, depth- and fan-out-capped) and calls visit for every
+// element with its 0-based traversal index while the COM element is still
+// alive. visit returning false stops the whole walk immediately — used by
+// axActByIndex to act on one element without paying for the rest of a
+// possibly-large tree.
+func axWalk(pid, maxDepth int, visit func(index int, el comObj, e AXElement) bool) error {
 	if maxDepth <= 0 {
 		maxDepth = 12
 	}
 	win, err := windowForPid(pid)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	out := make([]AXElement, 0, 256)
-	err = withCOM(func(auto comObj) error {
+	return withCOM(func(auto comObj) error {
 		root, err := elementFromHandle(auto, uintptr(win.ID))
 		if err != nil {
 			return err
@@ -314,21 +319,59 @@ func axTree(pid, maxDepth int) ([]AXElement, error) {
 		}
 		defer walker.release()
 
+		index := 0
+		stop := false
 		var walk func(el comObj, depth int)
 		walk = func(el comObj, depth int) {
-			if depth > maxDepth || len(out) >= axMaxTotal {
+			if stop || depth > maxDepth || index >= axMaxTotal {
 				return
 			}
-			out = append(out, uiaElement(el, depth))
+			if !visit(index, el, uiaElement(el, depth)) {
+				stop = true
+				return
+			}
+			index++
 			walkChildren(walker, el, func(child comObj) bool {
 				walk(child, depth+1)
-				return len(out) < axMaxTotal
+				return !stop
 			})
 		}
 		walk(root, 0)
 		return nil
 	})
+}
+
+func axTree(pid, maxDepth int) ([]AXElement, error) {
+	out := make([]AXElement, 0, 256)
+	err := axWalk(pid, maxDepth, func(_ int, _ comObj, e AXElement) bool {
+		out = append(out, e)
+		return true
+	})
 	return out, err
+}
+
+// axActByIndex performs action on the element at the given 0-based
+// traversal index — the same numbering axTree's returned slice uses, under
+// the same pid + maxDepth. Id-addressed counterpart to axFindDo's role+label
+// matching, for elements ax_tree shows with an empty or duplicate label.
+func axActByIndex(pid, maxDepth, target int, action func(el comObj) error) error {
+	var found bool
+	var actErr error
+	err := axWalk(pid, maxDepth, func(i int, el comObj, _ AXElement) bool {
+		if i == target {
+			found = true
+			actErr = action(el)
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("computer: no element with id e%d (re-dump ax_tree — the tree may have changed, or max_depth differs from the dump that produced this id)", target)
+	}
+	return actErr
 }
 
 // axFindDo mirrors the macOS search: an exact-label pass wins over a
@@ -391,55 +434,75 @@ func axFindDo(pid int, role, contains string, action func(el comObj) error) erro
 	})
 }
 
+// doAXPress performs an already-located element's Invoke/Toggle/default
+// action; shared by the label-matched (axPress) and id-addressed
+// (axPressByID) paths.
+func doAXPress(el comObj) error {
+	if p := elementPattern(el, uiaInvokePatternId, &iidIUIAutomationInvokePattern); p != 0 {
+		defer p.release()
+		if hr := p.call(slotInvokePatternInvoke); failed(hr) {
+			return hresultErr("IUIAutomationInvokePattern::Invoke", hr)
+		}
+		return nil
+	}
+	if p := elementPattern(el, uiaTogglePatternId, &iidIUIAutomationTogglePattern); p != 0 {
+		defer p.release()
+		if hr := p.call(slotTogglePatternToggle); failed(hr) {
+			return hresultErr("IUIAutomationTogglePattern::Toggle", hr)
+		}
+		return nil
+	}
+	if p := elementPattern(el, uiaLegacyIAccessiblePatternId, &iidIUIAutomationLegacyIAccessiblePattern); p != 0 {
+		defer p.release()
+		if hr := p.call(slotLegacyPatternDoDefaultAction); failed(hr) {
+			return hresultErr("IUIAutomationLegacyIAccessiblePattern::DoDefaultAction", hr)
+		}
+		return nil
+	}
+	return fmt.Errorf("computer: element supports neither Invoke, Toggle nor a default action — click it by coordinate instead")
+}
+
 func axPress(pid int, role, contains string) error {
-	return axFindDo(pid, role, contains, func(el comObj) error {
-		if p := elementPattern(el, uiaInvokePatternId, &iidIUIAutomationInvokePattern); p != 0 {
-			defer p.release()
-			if hr := p.call(slotInvokePatternInvoke); failed(hr) {
-				return hresultErr("IUIAutomationInvokePattern::Invoke", hr)
-			}
-			return nil
+	return axFindDo(pid, role, contains, doAXPress)
+}
+
+func axPressByID(pid, maxDepth, id int) error {
+	return axActByIndex(pid, maxDepth, id, doAXPress)
+}
+
+// doAXSetValue is axSetValue/axSetValueByID's shared element-level action.
+func doAXSetValue(el comObj, value string) error {
+	wide, err := windows.UTF16PtrFromString(value)
+	if err != nil {
+		return fmt.Errorf("computer: value %q: %w", value, err)
+	}
+	if p := elementPattern(el, uiaValuePatternId, &iidIUIAutomationValuePattern); p != 0 {
+		defer p.release()
+		b, _, _ := procSysAllocString.Call(uintptr(unsafe.Pointer(wide)))
+		defer freeBSTR(b)
+		if hr := p.call(slotValuePatternSetValue, b); failed(hr) {
+			return hresultErr(fmt.Sprintf("IUIAutomationValuePattern::SetValue(%q)", value), hr)
 		}
-		if p := elementPattern(el, uiaTogglePatternId, &iidIUIAutomationTogglePattern); p != 0 {
-			defer p.release()
-			if hr := p.call(slotTogglePatternToggle); failed(hr) {
-				return hresultErr("IUIAutomationTogglePattern::Toggle", hr)
-			}
-			return nil
+		return nil
+	}
+	if p := elementPattern(el, uiaLegacyIAccessiblePatternId, &iidIUIAutomationLegacyIAccessiblePattern); p != 0 {
+		defer p.release()
+		if hr := p.call(slotLegacyPatternSetValue, uintptr(unsafe.Pointer(wide))); failed(hr) {
+			return hresultErr(fmt.Sprintf("IUIAutomationLegacyIAccessiblePattern::SetValue(%q)", value), hr)
 		}
-		if p := elementPattern(el, uiaLegacyIAccessiblePatternId, &iidIUIAutomationLegacyIAccessiblePattern); p != 0 {
-			defer p.release()
-			if hr := p.call(slotLegacyPatternDoDefaultAction); failed(hr) {
-				return hresultErr("IUIAutomationLegacyIAccessiblePattern::DoDefaultAction", hr)
-			}
-			return nil
-		}
-		return fmt.Errorf("computer: element supports neither Invoke, Toggle nor a default action — click it by coordinate instead")
-	})
+		return nil
+	}
+	return fmt.Errorf("computer: element accepts no text value (RangeValue-only controls cannot be set from this build; focus it with ax_press and use key arrows instead)")
 }
 
 func axSetValue(pid int, role, contains, value string) error {
 	return axFindDo(pid, role, contains, func(el comObj) error {
-		wide, err := windows.UTF16PtrFromString(value)
-		if err != nil {
-			return fmt.Errorf("computer: value %q: %w", value, err)
-		}
-		if p := elementPattern(el, uiaValuePatternId, &iidIUIAutomationValuePattern); p != 0 {
-			defer p.release()
-			b, _, _ := procSysAllocString.Call(uintptr(unsafe.Pointer(wide)))
-			defer freeBSTR(b)
-			if hr := p.call(slotValuePatternSetValue, b); failed(hr) {
-				return hresultErr(fmt.Sprintf("IUIAutomationValuePattern::SetValue(%q)", value), hr)
-			}
-			return nil
-		}
-		if p := elementPattern(el, uiaLegacyIAccessiblePatternId, &iidIUIAutomationLegacyIAccessiblePattern); p != 0 {
-			defer p.release()
-			if hr := p.call(slotLegacyPatternSetValue, uintptr(unsafe.Pointer(wide))); failed(hr) {
-				return hresultErr(fmt.Sprintf("IUIAutomationLegacyIAccessiblePattern::SetValue(%q)", value), hr)
-			}
-			return nil
-		}
-		return fmt.Errorf("computer: element accepts no text value (RangeValue-only controls cannot be set from this build; focus it with ax_press and use key arrows instead)")
+		return doAXSetValue(el, value)
+	})
+}
+
+func axSetValueByID(pid, maxDepth, id int, value string) error {
+	return axActByIndex(pid, maxDepth, id, func(el comObj) error {
+		return doAXSetValue(el, value)
 	})
 }

--- a/internal/computer/uia_windows.go
+++ b/internal/computer/uia_windows.go
@@ -354,24 +354,28 @@ func axTree(pid, maxDepth int) ([]AXElement, error) {
 // traversal index — the same numbering axTree's returned slice uses, under
 // the same pid + maxDepth. Id-addressed counterpart to axFindDo's role+label
 // matching, for elements ax_tree shows with an empty or duplicate label.
-func axActByIndex(pid, maxDepth, target int, action func(el comObj) error) error {
+// Returns the matched element's digest alongside any error so the caller can
+// echo back what it actually hit.
+func axActByIndex(pid, maxDepth, target int, action func(el comObj) error) (AXElement, error) {
 	var found bool
+	var matched AXElement
 	var actErr error
-	err := axWalk(pid, maxDepth, func(i int, el comObj, _ AXElement) bool {
+	err := axWalk(pid, maxDepth, func(i int, el comObj, e AXElement) bool {
 		if i == target {
 			found = true
+			matched = e
 			actErr = action(el)
 			return false
 		}
 		return true
 	})
 	if err != nil {
-		return err
+		return AXElement{}, err
 	}
 	if !found {
-		return fmt.Errorf("computer: no element with id e%d (re-dump ax_tree — the tree may have changed, or max_depth differs from the dump that produced this id)", target)
+		return AXElement{}, fmt.Errorf("computer: no element with id e%d (re-dump ax_tree — the tree may have changed, or max_depth differs from the dump that produced this id)", target)
 	}
-	return actErr
+	return matched, actErr
 }
 
 // axFindDo mirrors the macOS search: an exact-label pass wins over a
@@ -466,7 +470,7 @@ func axPress(pid int, role, contains string) error {
 	return axFindDo(pid, role, contains, doAXPress)
 }
 
-func axPressByID(pid, maxDepth, id int) error {
+func axPressByID(pid, maxDepth, id int) (AXElement, error) {
 	return axActByIndex(pid, maxDepth, id, doAXPress)
 }
 
@@ -501,7 +505,7 @@ func axSetValue(pid int, role, contains, value string) error {
 	})
 }
 
-func axSetValueByID(pid, maxDepth, id int, value string) error {
+func axSetValueByID(pid, maxDepth, id int, value string) (AXElement, error) {
 	return axActByIndex(pid, maxDepth, id, func(el comObj) error {
 		return doAXSetValue(el, value)
 	})

--- a/internal/computer/windows.go
+++ b/internal/computer/windows.go
@@ -33,6 +33,9 @@ var (
 	procReleaseDC                     = user32.NewProc("ReleaseDC")
 	procSetProcessDpiAwarenessContext = user32.NewProc("SetProcessDpiAwarenessContext")
 	procVkKeyScanW                    = user32.NewProc("VkKeyScanW")
+	procSetForegroundWindow           = user32.NewProc("SetForegroundWindow")
+	procAttachThreadInput             = user32.NewProc("AttachThreadInput")
+	procBringWindowToTop              = user32.NewProc("BringWindowToTop")
 
 	procBitBlt                 = gdi32.NewProc("BitBlt")
 	procCreateCompatibleDC     = gdi32.NewProc("CreateCompatibleDC")
@@ -167,6 +170,50 @@ func trusted() bool              { return true }
 func screenCaptureAllowed() bool { return true }
 func requestScreenCapture()      {}
 func requestAccessibility()      {}
+
+// activateApp brings pid's top-most window to the foreground. Windows
+// normally refuses SetForegroundWindow from a process that isn't itself
+// foreground (the "foreground lock" anti-focus-stealing rule); attaching our
+// thread's input queue to the current foreground window's thread while the
+// call is made is the standard workaround (same trick AutoHotkey / pywinauto
+// use), so a click/type/key aimed at a backgrounded app doesn't silently
+// land in Octo's own window instead.
+func activateApp(pid int) error {
+	w, err := windowForPid(pid)
+	if err != nil {
+		return err
+	}
+	hwnd := uintptr(w.ID)
+
+	curTid := windows.GetCurrentThreadId()
+	fg := windows.GetForegroundWindow()
+	var fgPid uint32
+	fgTid, _ := windows.GetWindowThreadProcessId(fg, &fgPid)
+
+	if fgTid != 0 && fgTid != curTid {
+		procAttachThreadInput.Call(uintptr(curTid), uintptr(fgTid), 1)
+		defer procAttachThreadInput.Call(uintptr(curTid), uintptr(fgTid), 0)
+	}
+	procBringWindowToTop.Call(hwnd)
+	if ok, _, e := procSetForegroundWindow.Call(hwnd); ok == 0 {
+		return fmt.Errorf("computer: SetForegroundWindow failed: %v (Windows may be blocking focus theft — click the target window once manually, then retry)", e)
+	}
+	return nil
+}
+
+// frontmostAppName reports the executable name of the currently-foreground
+// window's owning process, "" if undetermined.
+func frontmostAppName() string {
+	fg := windows.GetForegroundWindow()
+	if fg == 0 {
+		return ""
+	}
+	var pid uint32
+	if _, err := windows.GetWindowThreadProcessId(fg, &pid); err != nil {
+		return ""
+	}
+	return processBaseName(pid)
+}
 
 func screenSize() (float64, float64, error) {
 	ensureDPIAware()

--- a/internal/computer/windows.go
+++ b/internal/computer/windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"image"
 	"image/png"
+	"runtime"
 	"strings"
 	"sync"
 	"unicode/utf16"
@@ -184,6 +185,14 @@ func activateApp(pid int) error {
 		return err
 	}
 	hwnd := uintptr(w.ID)
+
+	// AttachThreadInput/SetForegroundWindow are thread-affine: GetCurrentThreadId
+	// must name the OS thread that actually makes those calls, or the input-queue
+	// attach targets a thread nobody is running on. Go's scheduler can otherwise
+	// migrate this goroutine between the ID read and the calls below (same reason
+	// withCOM in uia_windows.go pins its thread for COM's apartment model).
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	curTid := windows.GetCurrentThreadId()
 	fg := windows.GetForegroundWindow()

--- a/internal/tools/computer.go
+++ b/internal/tools/computer.go
@@ -187,10 +187,11 @@ func (ComputerTool) Execute(ctx context.Context, name string, input map[string]a
 			return agent.ToolResult{}, err
 		} else if has {
 			maxDepth := int(numArg(input, "max_depth"))
-			if err := computer.AXPressByID(pid, maxDepth, id); err != nil {
+			e, err := computer.AXPressByID(pid, maxDepth, id)
+			if err != nil {
 				return agent.ToolResult{}, err
 			}
-			return agent.ToolResult{Text: fmt.Sprintf("pressed element e%d — re-dump ax_tree (or screenshot) to verify the result", id)}, nil
+			return agent.ToolResult{Text: fmt.Sprintf("pressed element e%d%s — re-dump ax_tree (or screenshot) to verify the result", id, axDigestSuffix(e))}, nil
 		}
 		label := stringArg(input, "label")
 		if err := computer.AXPress(pid, stringArg(input, "role"), label); err != nil {
@@ -207,10 +208,11 @@ func (ComputerTool) Execute(ctx context.Context, name string, input map[string]a
 			return agent.ToolResult{}, err
 		} else if has {
 			maxDepth := int(numArg(input, "max_depth"))
-			if err := computer.AXSetValueByID(pid, maxDepth, id, value); err != nil {
+			e, err := computer.AXSetValueByID(pid, maxDepth, id, value)
+			if err != nil {
 				return agent.ToolResult{}, err
 			}
-			return agent.ToolResult{Text: fmt.Sprintf("set element e%d to %s — re-dump ax_tree to verify", id, value)}, nil
+			return agent.ToolResult{Text: fmt.Sprintf("set element e%d%s to %s — re-dump ax_tree to verify", id, axDigestSuffix(e), value)}, nil
 		}
 		label := stringArg(input, "label")
 		if err := computer.AXSetValue(pid, stringArg(input, "role"), label, value); err != nil {
@@ -315,6 +317,18 @@ func computerAXTree(input map[string]any) (agent.ToolResult, error) {
 	if err != nil {
 		return agent.ToolResult{}, err
 	}
+	return agent.ToolResult{Text: renderAXTree(els)}, nil
+}
+
+// renderAXTree formats an already-fetched digest — split out from
+// computerAXTree so the one invariant that matters (the printed e<N> is
+// always the element's true index into els, never a display-only counter,
+// even though some elements are hidden from the printed text by
+// axStructuralRoles) is unit-testable without the AX/UIA substrate. Silently
+// switching the "e%d" to the shown-so-far count instead of the loop index i
+// would make every id-addressed ax_press/ax_set land on the wrong element
+// with no error — this is the one line that must never regress.
+func renderAXTree(els []computer.AXElement) string {
 	var b strings.Builder
 	shown := 0
 	for i, e := range els {
@@ -329,7 +343,18 @@ func computerAXTree(input map[string]any) (agent.ToolResult, error) {
 		shown++
 	}
 	fmt.Fprintf(&b, "(%d of %d elements shown; pass id=e<N> — preferred — or role+label verbatim to ax_press/ax_set)", shown, len(els))
-	return agent.ToolResult{Text: b.String()}, nil
+	return b.String()
+}
+
+// axDigestSuffix renders a matched element's role+label for an id-addressed
+// ax_press/ax_set success message, e.g. " (AXButton \"Save\")" — "" when both
+// are empty (nothing informative to add).
+func axDigestSuffix(e computer.AXElement) string {
+	label := e.Label()
+	if e.Role == "" && label == "" {
+		return ""
+	}
+	return fmt.Sprintf(" (%s %q)", e.Role, label)
 }
 
 // shotScale converts model coordinates — pixels of the last screenshot as

--- a/internal/tools/computer.go
+++ b/internal/tools/computer.go
@@ -8,8 +8,10 @@ import (
 	_ "image/jpeg" // DecodeConfig on the JPEG re-encode NewImageBlock produces
 	_ "image/png"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/computer"
@@ -56,11 +58,15 @@ func (ComputerTool) Definition() agent.ToolDefinition {
 		Name: "computer",
 		Description: "See and operate the desktop (macOS or Windows) directly, two channels: " +
 			"(1) accessibility (PREFERRED when the app exposes elements): ax_tree reads an app's UI " +
-			"as a semantic list (role + label + frame) — macOS Accessibility or Windows UI Automation — " +
-			"and ax_press/ax_set act by label; these work on BACKGROUNDED apps with no cursor move and " +
-			"no focus change, and are far more precise than pixel guessing. (2) pixels: screenshot the " +
-			"main display, then click/move/type/key/scroll by coordinate — needed for custom-drawn UIs " +
-			"(games, CAD) with no accessibility tree; this channel shares the user's cursor and focus. " +
+			"as a semantic list (role + label + frame, each prefixed with an e<N> id) — macOS " +
+			"Accessibility or Windows UI Automation — and ax_press/ax_set act on an element by that id " +
+			"(reliable — works even when the label is empty or repeated, e.g. ten sliders all labelled " +
+			"\"0\") or by role+label matching; these work on BACKGROUNDED apps with no cursor move and no " +
+			"focus change, and are far more precise than pixel guessing. (2) pixels: screenshot the main " +
+			"display, then click/move/type/key/scroll by coordinate — needed for custom-drawn UIs (games, " +
+			"CAD) with no accessibility tree; this channel shares the user's cursor and focus, so pass " +
+			"\"app\" on left_click/right_click/double_click/type/key to bring that app to the foreground " +
+			"first — otherwise Octo's own window can hold focus and the input silently lands nowhere. " +
 			"Use for tasks in native apps with no CLI/API (the browser tool covers anything web). Pixel " +
 			"workflow: screenshot FIRST, act, screenshot again to verify. On macOS this requires the " +
 			"Accessibility (input) and Screen Recording (capture) permissions granted to the app running " +
@@ -73,18 +79,23 @@ func (ComputerTool) Definition() agent.ToolDefinition {
 				"action": map[string]any{
 					"type": "string",
 					"enum": computerActions,
-					"description": "ax_tree: dump the target app's accessibility tree (start here for AX-rich apps). " +
-						"ax_press: press the element whose label matches (button/menu item/square...). " +
-						"ax_set: set a text field's string or a slider's number. " +
-						"screenshot: capture the screen. left_click/right_click/double_click/mouse_move at (x, y). " +
-						"type: type text at the current focus. key: press a key or combo like \"enter\", \"cmd+c\". " +
+					"description": "ax_tree: dump the target app's accessibility tree, each line prefixed \"e<N>\" " +
+						"(start here for AX-rich apps). " +
+						"ax_press: press the element given by id (preferred) or whose label matches (button/menu " +
+						"item/square...). " +
+						"ax_set: set a text field's string or a slider's number, by id or label. " +
+						"screenshot: capture the screen. left_click/right_click/double_click/mouse_move at (x, y); " +
+						"pass \"app\" to focus that app first. " +
+						"type: type text at the current focus; pass \"app\" to focus it first. " +
+						"key: press a key or combo like \"enter\", \"cmd+c\"; pass \"app\" to focus it first. " +
 						"scroll: scroll at the cursor by (dx, dy) lines, positive dy = down.",
 				},
-				"app":       map[string]any{"type": "string", "description": "Target app name for ax_* actions. macOS: the process name as shown in its menu bar, e.g. \"国际象棋\", \"Safari\". Windows: the executable name without .exe (e.g. \"notepad\") or a substring of the window title. The app must have at least one on-screen (non-minimized) window."},
-				"role":      map[string]any{"type": "string", "description": "Accessibility role filter for ax_press/ax_set — pass what ax_tree shows, e.g. \"AXButton\", \"AXMenuItem\", \"AXSlider\" on macOS or \"Button\", \"MenuItem\", \"Edit\" on Windows (the AX prefix is optional on both). Optional but strongly recommended to disambiguate."},
-				"label":     map[string]any{"type": "string", "description": "Element label to match for ax_press/ax_set: exact label wins, otherwise case-insensitive substring of title/description/value. Copy labels verbatim from ax_tree output."},
+				"app":       map[string]any{"type": "string", "description": "Target app name. Required for ax_* actions; optional for left_click/right_click/double_click/type/key to bring that app to the foreground before acting (its own window may otherwise steal focus and swallow the input silently — reported result includes the frontmost app afterward so a miss is visible). macOS: the process name as shown in its menu bar, e.g. \"国际象棋\", \"Safari\". Windows: the executable name without .exe (e.g. \"notepad\") or a substring of the window title. The app must have at least one on-screen (non-minimized) window."},
+				"id":        map[string]any{"type": "string", "description": "Element id for ax_press/ax_set, copied verbatim from ax_tree's \"e<N>\" prefix (e.g. \"e12\" or \"12\"). Preferred over role+label — the only way to address an element whose label is empty or shared with others. Only valid against a tree dumped with the same max_depth; re-dump ax_tree if the app's UI may have changed since."},
+				"role":      map[string]any{"type": "string", "description": "Accessibility role filter for ax_press/ax_set when matching by label (ignored when id is given) — pass what ax_tree shows, e.g. \"AXButton\", \"AXMenuItem\", \"AXSlider\" on macOS or \"Button\", \"MenuItem\", \"Edit\" on Windows (the AX prefix is optional on both). Optional but strongly recommended to disambiguate."},
+				"label":     map[string]any{"type": "string", "description": "Element label to match for ax_press/ax_set when id is not given: exact label wins, otherwise case-insensitive substring of title/description/value. Copy labels verbatim from ax_tree output."},
 				"value":     map[string]any{"type": "string", "description": "Value to set (ax_set): a number for sliders/steppers, a string for text fields."},
-				"max_depth": map[string]any{"type": "number", "description": "Tree depth limit for ax_tree (default 12; smaller = shorter output)."},
+				"max_depth": map[string]any{"type": "number", "description": "Tree depth limit for ax_tree (default 12; smaller = shorter output). Also pass the same value to ax_press/ax_set when addressing by id if a non-default depth was used for the dump — otherwise indices can shift."},
 				"x":         map[string]any{"type": "number", "description": "X coordinate in screenshot pixels (click/move)."},
 				"y":         map[string]any{"type": "number", "description": "Y coordinate in screenshot pixels (click/move)."},
 				"text":      map[string]any{"type": "string", "description": "Text to type (type action)."},
@@ -103,10 +114,19 @@ func (ComputerTool) Execute(ctx context.Context, name string, input map[string]a
 	case "screenshot":
 		return computerScreenshot(ctx)
 	case "left_click":
+		if err := activateAppArg(input); err != nil {
+			return agent.ToolResult{}, err
+		}
 		return computerClick("left", 1, input)
 	case "right_click":
+		if err := activateAppArg(input); err != nil {
+			return agent.ToolResult{}, err
+		}
 		return computerClick("right", 1, input)
 	case "double_click":
+		if err := activateAppArg(input); err != nil {
+			return agent.ToolResult{}, err
+		}
 		return computerClick("left", 2, input)
 	case "mouse_move":
 		if err := requireTrusted(); err != nil {
@@ -121,19 +141,33 @@ func (ComputerTool) Execute(ctx context.Context, name string, input map[string]a
 		if err := requireTrusted(); err != nil {
 			return agent.ToolResult{}, err
 		}
+		if err := activateAppArg(input); err != nil {
+			return agent.ToolResult{}, err
+		}
 		text := stringArg(input, "text")
 		if err := computer.TypeText(text); err != nil {
 			return agent.ToolResult{}, err
 		}
-		return agent.ToolResult{Text: fmt.Sprintf("typed %d characters", len([]rune(text)))}, nil
+		msg := fmt.Sprintf("typed %d characters", len([]rune(text)))
+		if front := computer.FrontmostAppName(); front != "" {
+			msg += fmt.Sprintf(" — frontmost app is now %q (make sure that's the intended target)", front)
+		}
+		return agent.ToolResult{Text: msg}, nil
 	case "key":
 		if err := requireTrusted(); err != nil {
+			return agent.ToolResult{}, err
+		}
+		if err := activateAppArg(input); err != nil {
 			return agent.ToolResult{}, err
 		}
 		if err := computer.Press(stringArg(input, "key")); err != nil {
 			return agent.ToolResult{}, err
 		}
-		return agent.ToolResult{Text: "pressed " + stringArg(input, "key")}, nil
+		msg := "pressed " + stringArg(input, "key")
+		if front := computer.FrontmostAppName(); front != "" {
+			msg += fmt.Sprintf(" — frontmost app is now %q (make sure that's the intended target)", front)
+		}
+		return agent.ToolResult{Text: msg}, nil
 	case "scroll":
 		if err := requireTrusted(); err != nil {
 			return agent.ToolResult{}, err
@@ -149,6 +183,15 @@ func (ComputerTool) Execute(ctx context.Context, name string, input map[string]a
 		if err != nil {
 			return agent.ToolResult{}, err
 		}
+		if id, has, err := parseElementID(input); err != nil {
+			return agent.ToolResult{}, err
+		} else if has {
+			maxDepth := int(numArg(input, "max_depth"))
+			if err := computer.AXPressByID(pid, maxDepth, id); err != nil {
+				return agent.ToolResult{}, err
+			}
+			return agent.ToolResult{Text: fmt.Sprintf("pressed element e%d — re-dump ax_tree (or screenshot) to verify the result", id)}, nil
+		}
 		label := stringArg(input, "label")
 		if err := computer.AXPress(pid, stringArg(input, "role"), label); err != nil {
 			return agent.ToolResult{}, err
@@ -159,13 +202,71 @@ func (ComputerTool) Execute(ctx context.Context, name string, input map[string]a
 		if err != nil {
 			return agent.ToolResult{}, err
 		}
+		value := stringArg(input, "value")
+		if id, has, err := parseElementID(input); err != nil {
+			return agent.ToolResult{}, err
+		} else if has {
+			maxDepth := int(numArg(input, "max_depth"))
+			if err := computer.AXSetValueByID(pid, maxDepth, id, value); err != nil {
+				return agent.ToolResult{}, err
+			}
+			return agent.ToolResult{Text: fmt.Sprintf("set element e%d to %s — re-dump ax_tree to verify", id, value)}, nil
+		}
 		label := stringArg(input, "label")
-		if err := computer.AXSetValue(pid, stringArg(input, "role"), label, stringArg(input, "value")); err != nil {
+		if err := computer.AXSetValue(pid, stringArg(input, "role"), label, value); err != nil {
 			return agent.ToolResult{}, err
 		}
-		return agent.ToolResult{Text: "set element matching " + label + " to " + stringArg(input, "value") + " — re-dump ax_tree to verify"}, nil
+		return agent.ToolResult{Text: "set element matching " + label + " to " + value + " — re-dump ax_tree to verify"}, nil
 	default:
 		return agent.ToolResult{}, fmt.Errorf("computer: unknown action %q (valid: %v)", action, computerActions)
+	}
+}
+
+// activateAppArg brings the optional "app" argument's window to the
+// foreground before a pixel-channel click/type/key — Octo's own window can
+// otherwise hold focus and silently swallow the input (see
+// computer.ActivateApp). A no-op when "app" is omitted, so existing calls
+// without it behave exactly as before.
+func activateAppArg(input map[string]any) error {
+	app := stringArg(input, "app")
+	if app == "" {
+		return nil
+	}
+	if err := requireTrusted(); err != nil {
+		return err
+	}
+	w, err := computer.FindWindow(app)
+	if err != nil {
+		return err
+	}
+	if err := computer.ActivateApp(w.PID); err != nil {
+		return err
+	}
+	time.Sleep(100 * time.Millisecond) // let the window manager finish raising it before input follows
+	return nil
+}
+
+// parseElementID reads the optional "id" argument for ax_press/ax_set,
+// tolerating the "e12" string ax_tree prints, a bare "12", or a JSON number.
+func parseElementID(input map[string]any) (id int, has bool, err error) {
+	raw, ok := input["id"]
+	if !ok || raw == nil {
+		return 0, false, nil
+	}
+	switch v := raw.(type) {
+	case float64:
+		return int(v), true, nil
+	case int:
+		return v, true, nil
+	case string:
+		s := strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(v), "e"), "E")
+		n, perr := strconv.Atoi(s)
+		if perr != nil {
+			return 0, true, fmt.Errorf("computer: bad element id %q (want e.g. \"e12\" or 12)", v)
+		}
+		return n, true, nil
+	default:
+		return 0, true, fmt.Errorf("computer: bad element id %v", raw)
 	}
 }
 
@@ -187,7 +288,23 @@ func computerAppPid(input map[string]any) (int, error) {
 	return w.PID, nil
 }
 
+// axStructuralRoles are pure layout/grouping roles that carry no meaning of
+// their own when unlabeled — spacer groups, panes, split views. Interactive
+// controls (buttons, fields, sliders, menu items, static text...) are always
+// shown even unlabeled: their e<N> id is often the ONLY way to address them
+// (ten sliders all labelled "0", an empty-label text area), which is the
+// whole point of numbering every element.
+var axStructuralRoles = map[string]bool{
+	"AXGroup": true, "AXUnknown": true, "AXSplitGroup": true,
+	"AXScrollArea": true, "AXLayoutArea": true, "AXLayoutItem": true,
+	"AXGenericElement": true,
+	"Group":            true, "Pane": true, "Custom": true,
+}
+
 // computerAXTree renders the app's accessibility tree as an indented digest.
+// Each line is prefixed with its e<N> id — N is the element's position in
+// AXTree's returned slice, stable for ax_press/ax_set(id=...) as long as the
+// same pid + max_depth is used and the app's UI hasn't changed since.
 func computerAXTree(input map[string]any) (agent.ToolResult, error) {
 	pid, err := computerAppPid(input)
 	if err != nil {
@@ -199,17 +316,19 @@ func computerAXTree(input map[string]any) (agent.ToolResult, error) {
 		return agent.ToolResult{}, err
 	}
 	var b strings.Builder
-	for _, e := range els {
+	shown := 0
+	for i, e := range els {
 		label := e.Label()
-		if label == "" && !computer.SameRole(e.Role, "AXWindow") {
-			continue // anonymous spacer groups are noise to the model
+		if label == "" && !computer.SameRole(e.Role, "AXWindow") && axStructuralRoles[e.Role] {
+			continue // anonymous layout groups are noise to the model
 		}
-		for i := 0; i < e.Depth; i++ {
+		for d := 0; d < e.Depth; d++ {
 			b.WriteString("  ")
 		}
-		fmt.Fprintf(&b, "%s %q [%.0f,%.0f %.0fx%.0f]\n", e.Role, label, e.X, e.Y, e.W, e.H)
+		fmt.Fprintf(&b, "e%d %s %q [%.0f,%.0f %.0fx%.0f]\n", i, e.Role, label, e.X, e.Y, e.W, e.H)
+		shown++
 	}
-	fmt.Fprintf(&b, "(%d elements; pass role+label verbatim to ax_press/ax_set)", len(els))
+	fmt.Fprintf(&b, "(%d of %d elements shown; pass id=e<N> — preferred — or role+label verbatim to ax_press/ax_set)", shown, len(els))
 	return agent.ToolResult{Text: b.String()}, nil
 }
 

--- a/internal/tools/computer_test.go
+++ b/internal/tools/computer_test.go
@@ -3,7 +3,10 @@ package tools
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/open-octo/octo-agent/internal/computer"
 )
 
 func TestParseElementID(t *testing.T) {
@@ -93,5 +96,45 @@ func TestComputerTool_AdvertisedWhenEnabled(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("computer tool should be advertised when tools.computer.enabled is on")
+	}
+}
+
+// TestRenderAXTree_IDsAreTrueIndexNotDisplayCounter locks the one invariant
+// an id-addressed ax_press/ax_set depends on: the printed "e<N>" must be the
+// element's real position in the slice AXTree returned (what axActByIndex
+// re-walks to), never a counter of how many lines were actually printed.
+// axStructuralRoles filters some elements out of the text, so a naive
+// "shown so far" counter would silently desync ids from real indices —
+// this test would catch that regression even though it needs no AX/UIA
+// substrate.
+func TestRenderAXTree_IDsAreTrueIndexNotDisplayCounter(t *testing.T) {
+	els := []computer.AXElement{
+		{Role: "AXWindow", Title: "Untitled"},       // e0 - window, always shown
+		{Role: "AXGroup", Title: ""},                // e1 - filtered: structural + unlabeled
+		{Role: "AXTextField", Title: "", Value: ""}, // e2 - shown: not a noise role, even unlabeled
+		{Role: "AXButton", Title: "Save"},           // e3 - shown
+		{Role: "AXSplitGroup", Title: ""},           // e4 - filtered: structural + unlabeled
+		{Role: "AXSlider", Title: "", Value: "0"},   // e5 - shown: Value counts as label
+	}
+	out := renderAXTree(els)
+
+	for _, want := range []string{"e0 AXWindow", "e2 AXTextField", "e3 AXButton", "e5 AXSlider"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderAXTree output missing %q; got:\n%s", want, out)
+		}
+	}
+	for _, mustNotAppearAsID := range []string{"e1 ", "e4 "} {
+		if strings.Contains(out, mustNotAppearAsID) {
+			t.Errorf("renderAXTree must not print a line for filtered element as %q; got:\n%s", mustNotAppearAsID, out)
+		}
+	}
+	// The filtered elements (e1, e4) must not cause the surviving ones to be
+	// renumbered — e.g. e2 must never print as "e1" just because one line
+	// was skipped before it.
+	if strings.Contains(out, "e1 AXTextField") || strings.Contains(out, "e2 AXButton") {
+		t.Fatalf("ids were renumbered after filtering instead of keeping the true slice index; got:\n%s", out)
+	}
+	if !strings.Contains(out, "(4 of 6 elements shown") {
+		t.Errorf("summary line should count 4 shown of 6 total; got:\n%s", out)
 	}
 }

--- a/internal/tools/computer_test.go
+++ b/internal/tools/computer_test.go
@@ -6,6 +6,56 @@ import (
 	"testing"
 )
 
+func TestParseElementID(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]any
+		wantID  int
+		wantHas bool
+		wantErr bool
+	}{
+		{"absent", map[string]any{}, 0, false, false},
+		{"nil value", map[string]any{"id": nil}, 0, false, false},
+		{"e-prefixed string", map[string]any{"id": "e12"}, 12, true, false},
+		{"upper E-prefixed string", map[string]any{"id": "E7"}, 7, true, false},
+		{"bare numeric string", map[string]any{"id": "3"}, 3, true, false},
+		{"whitespace padded", map[string]any{"id": " e5 "}, 5, true, false},
+		{"json number (float64)", map[string]any{"id": float64(9)}, 9, true, false},
+		{"plain int", map[string]any{"id": 4}, 4, true, false},
+		{"garbage string", map[string]any{"id": "banana"}, 0, true, true},
+		{"unsupported type", map[string]any{"id": true}, 0, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, has, err := parseElementID(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseElementID(%v): want error, got id=%d has=%v", tc.input, id, has)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseElementID(%v): %v", tc.input, err)
+			}
+			if id != tc.wantID || has != tc.wantHas {
+				t.Fatalf("parseElementID(%v) = (%d, %v), want (%d, %v)", tc.input, id, has, tc.wantID, tc.wantHas)
+			}
+		})
+	}
+}
+
+func TestActivateAppArg_NoopWithoutApp(t *testing.T) {
+	// No "app" key at all must short-circuit before touching the substrate
+	// (no Accessibility/window-list calls), so this must not error even
+	// without the permission grants a real activation would need.
+	if err := activateAppArg(map[string]any{}); err != nil {
+		t.Fatalf("activateAppArg with no app must no-op, got: %v", err)
+	}
+	if err := activateAppArg(map[string]any{"app": ""}); err != nil {
+		t.Fatalf("activateAppArg with empty app must no-op, got: %v", err)
+	}
+}
+
 // The tool ships dark behind tools.computer.enabled: unset must hide it from
 // the model's tool list. setHome (overwrite_backup_test.go) redirects
 // os.UserHomeDir — on Windows that's USERPROFILE, not HOME, so both are set.


### PR DESCRIPTION
## Summary
- Addresses 2 of the 5 gaps reported in #2395 from real computer-use runs (macOS Notes, Lightroom Classic): focus management (#1) and AX element addressing (#2). The other three (menu-bar noise, coordinate-system unification, drag primitive) are left for follow-up PRs.
- `left_click`/`right_click`/`double_click`/`type`/`key` gain an optional `app` parameter that brings the target app to the foreground first (`kAXFrontmostAttribute` on macOS; `SetForegroundWindow` + `AttachThreadInput` on Windows to work around the foreground-lock rule) — Octo's own window could otherwise hold focus and silently swallow pixel-channel input. The existing `ClickPid`/`TypeTextPid` per-process delivery was already known unreliable per its own doc comments (dropped by both SwiftUI and custom-drawn views), so real focus is the fix that actually works. `type`/`key` now also report the frontmost app afterward so a miss is visible instead of silent.
- `ax_tree` now prefixes every line with its `e<N>` traversal index; `ax_press`/`ax_set` accept that `id` instead of role+label matching — the only way to address an element with an empty or duplicate label (e.g. several sliders all labelled `"0"`, or an empty-label text area). Implemented as an index-based re-walk (`axWalk`/`axActByIndex`, shared with `AXTree`) rather than a cached native-pointer table, to avoid cross-call lifetime/invalidation complexity. Ids are stable as long as the app's tree and the `max_depth` used haven't changed since the dump.
- Elements with empty labels are no longer filtered out of `ax_tree` unless they're pure layout containers (`AXGroup`/`AXSplitGroup`/etc.) — those are exactly the elements that need an id to be reachable at all.

## Test plan
- [x] `go build ./...` — darwin (cgo), `GOOS=windows CGO_ENABLED=0` cross-build, `GOOS=linux CGO_ENABLED=0` stub build
- [x] `go vet ./...` on all three
- [x] `gofmt -l .` clean
- [x] `go test -race ./...` passes, including new unit tests for id parsing and negative-id validation
- [ ] Real GUI interaction (focus switching, `AttachThreadInput` on Windows) not yet exercised on a live desktop — build/unit-test verified only, needs a manual pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)