### PR TITLE
chore: bump version to 1.16.18

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.16.17"
+var Version = "1.16.18"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump `internal/version` default to 1.16.18 ahead of the v1.16.18 tag, matching the previous release flow (#2386).
