### PR TITLE
fix: coalesce terminal tool_stdout broadcasts, drop frontend join/split

### DIFF
--- a/internal/server/live_replay_test.go
+++ b/internal/server/live_replay_test.go
@@ -253,10 +253,20 @@ func TestSessionLiveState_EventBufferCap(t *testing.T) {
 	}
 }
 
-// EventToolProgress must reach subscribed tabs immediately as tool_stdout
-// (issue #1094) — before this, the agent loop never even called
-// ExecuteStream (see DefaultRegistry.ExecuteStream), so this event never
-// fired in production regardless of what handleEvent did with it.
+// EventToolProgress must reach subscribed tabs as tool_stdout (issue #1094) —
+// before this, the agent loop never even called ExecuteStream (see
+// DefaultRegistry.ExecuteStream), so this event never fired in production
+// regardless of what handleEvent did with it.
+//
+// Chunks arriving within stdoutCoalesceWindow of the last flush are coalesced
+// into one broadcast rather than one WS message (and one frontend re-render)
+// per line — a verbose command can otherwise force enough per-line DOM
+// updates to pin the desktop shell's webview render thread long enough for
+// Windows to mark the whole window "not responding". The very first chunk
+// still flushes on its own immediately (stdoutFlushAt's zero value reads as
+// long-elapsed) so the user sees output start without an extra delay;
+// EventToolDone flushes whatever is still buffered afterward so the last
+// chunk is never left stranded waiting for a next line that never comes.
 func TestHandleEvent_ToolProgress_BroadcastsToolStdout(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 	srv.initWS()
@@ -273,12 +283,19 @@ func TestHandleEvent_ToolProgress_BroadcastsToolStdout(t *testing.T) {
 		Kind: agent.EventToolStarted, ToolName: "terminal", ToolID: "t1",
 		Input: map[string]any{"command": "make test"},
 	})
+	// "compiling..." is the very first chunk since sw was created, so it
+	// flushes alone immediately. "building" and "ok" follow fast enough
+	// behind it to land in the same coalescing window and must merge into a
+	// single later broadcast rather than one each.
 	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolProgress, ToolID: "t1", Chunk: "compiling..."})
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolProgress, ToolID: "t1", Chunk: "building"})
 	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolProgress, ToolID: "t1", Chunk: "ok"})
+	// Forces the flush of "building"/"ok", still buffered at this point.
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolDone, ToolID: "t1", Output: "done"})
 
 	// hub.broadcast is delivered by the hub's async dispatch goroutine, not
 	// inline in handleEvent — wait for it instead of draining immediately.
-	waitFor(t, func() bool { return len(conn.send) >= 3 }) // tool_call + 2 tool_stdout
+	waitFor(t, func() bool { return len(conn.send) >= 4 }) // tool_call + 2 tool_stdout + tool_result (+ more)
 
 	var stdoutEvents []map[string]any
 	for _, ev := range drainConn(t, conn) {
@@ -287,13 +304,66 @@ func TestHandleEvent_ToolProgress_BroadcastsToolStdout(t *testing.T) {
 		}
 	}
 	if len(stdoutEvents) != 2 {
-		t.Fatalf("got %d tool_stdout broadcasts, want 2", len(stdoutEvents))
+		t.Fatalf("got %d tool_stdout broadcasts, want 2 (first chunk alone, then the coalesced rest)", len(stdoutEvents))
 	}
-	if stdoutEvents[0]["tool_id"] != "t1" {
-		t.Errorf("tool_stdout missing tool_id, got %v", stdoutEvents[0])
+	if stdoutEvents[0]["tool_id"] != "t1" || stdoutEvents[1]["tool_id"] != "t1" {
+		t.Errorf("tool_stdout missing tool_id, got %v / %v", stdoutEvents[0], stdoutEvents[1])
 	}
-	if lines, ok := stdoutEvents[1]["lines"].([]any); !ok || len(lines) != 1 || lines[0] != "ok" {
-		t.Errorf("second tool_stdout lines = %v, want [\"ok\"]", stdoutEvents[1]["lines"])
+	if lines, ok := stdoutEvents[0]["lines"].([]any); !ok || len(lines) != 1 || lines[0] != "compiling..." {
+		t.Errorf("first tool_stdout lines = %v, want [\"compiling...\"]", stdoutEvents[0]["lines"])
+	}
+	lines, ok := stdoutEvents[1]["lines"].([]any)
+	if !ok || len(lines) != 2 || lines[0] != "building" || lines[1] != "ok" {
+		t.Errorf("second tool_stdout lines = %v, want [\"building\", \"ok\"] (coalesced)", stdoutEvents[1]["lines"])
+	}
+}
+
+// Two commands run back to back (sequentially — terminal never streams
+// concurrently with itself, see concurrencySafe in agent.go) must not have
+// their output cross-contaminate: a still-buffered chunk from the first tool
+// must flush under its own tool_id before the second tool's first chunk is
+// buffered.
+func TestHandleEvent_ToolProgress_FlushesOnToolIDChange(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "progress-toolid-change-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+	seedLiveTurn(srv, sid)
+	sw := srv.newWSStreamWriter(sid)
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.wsHub.subscribe(conn, sid)
+
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolName: "terminal", ToolID: "t1"})
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolProgress, ToolID: "t1", Chunk: "first"})
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolDone, ToolID: "t1", Output: "done"})
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolName: "terminal", ToolID: "t2"})
+	// Simulates a chunk arriving for the new tool before ToolDone's flush of
+	// t1 would otherwise have run — the tool-id-change guard in
+	// EventToolProgress must still keep the two tools' lines apart.
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolProgress, ToolID: "t2", Chunk: "second"})
+	sw.handleEvent(agent.AgentEvent{Kind: agent.EventToolDone, ToolID: "t2", Output: "done"})
+
+	waitFor(t, func() bool { return len(conn.send) >= 6 })
+
+	var stdoutEvents []map[string]any
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] == "tool_stdout" {
+			stdoutEvents = append(stdoutEvents, ev)
+		}
+	}
+	if len(stdoutEvents) != 2 {
+		t.Fatalf("got %d tool_stdout broadcasts, want 2 (one per tool)", len(stdoutEvents))
+	}
+	if stdoutEvents[0]["tool_id"] != "t1" || stdoutEvents[1]["tool_id"] != "t2" {
+		t.Errorf("tool_stdout tool_ids = %v, %v, want t1, t2", stdoutEvents[0]["tool_id"], stdoutEvents[1]["tool_id"])
+	}
+	if lines, ok := stdoutEvents[0]["lines"].([]any); !ok || len(lines) != 1 || lines[0] != "first" {
+		t.Errorf("t1 tool_stdout lines = %v, want [\"first\"]", stdoutEvents[0]["lines"])
+	}
+	if lines, ok := stdoutEvents[1]["lines"].([]any); !ok || len(lines) != 1 || lines[0] != "second" {
+		t.Errorf("t2 tool_stdout lines = %v, want [\"second\"]", stdoutEvents[1]["lines"])
 	}
 }
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -62,6 +62,17 @@ const maxLiveTurnEvents = 200
 // what a page refresh mid-command can catch up on.
 const maxLiveStdoutLines = 200
 
+// stdoutCoalesceWindow batches EventToolProgress chunks arriving faster than
+// this into a single tool_stdout broadcast, rather than one WS message (and
+// one frontend re-render) per line. A verbose build can emit output far
+// faster than this — without coalescing, that hammers the desktop shell's
+// webview render thread with one DOM update per line, which can pin it long
+// enough to trip Windows' "not responding" hang detector on the whole window.
+// Terminal is the only tool that streams EventToolProgress and it never runs
+// concurrently with another tool call (see concurrencySafe in agent.go), so a
+// single pending buffer on wsStreamWriter (not keyed by tool_id) is safe.
+const stdoutCoalesceWindow = 80 * time.Millisecond
+
 // appendEvent adds an already-broadcast turn event to the replay buffer.
 // Caller holds liveStateMu.
 func (ls *sessionLiveState) appendEvent(ev map[string]any) {
@@ -1962,6 +1973,13 @@ type wsStreamWriter struct {
 	// broadcastContextUsage, so parallel tool calls in one round (same count)
 	// broadcast once. Guarded by mu (handleEvent holds it).
 	lastCtxTokens int
+
+	// stdoutPending/stdoutPendingTool buffer EventToolProgress chunks between
+	// flushes (see stdoutCoalesceWindow); stdoutFlushAt is when the buffer was
+	// last flushed. All three guarded by mu (handleEvent holds it).
+	stdoutPending     []string
+	stdoutPendingTool string
+	stdoutFlushAt     time.Time
 }
 
 func (s *Server) newWSStreamWriter(sessionID string) *wsStreamWriter {
@@ -2091,6 +2109,26 @@ func (w *wsStreamWriter) broadcastContextUsage() {
 
 // handleEvent converts agent.AgentEvent to WS JSON events and broadcasts them.
 // It also updates the server's live state for late-subscriber replay.
+// flushStdout broadcasts any buffered EventToolProgress chunks as one
+// tool_stdout message and resets the coalescing window. No-op when nothing is
+// pending, so it's safe to call defensively from every event that could end a
+// tool's output (EventToolDone, EventToolError, EventTurnDone) in addition to
+// the coalescing check in EventToolProgress itself. Caller holds w.mu.
+func (w *wsStreamWriter) flushStdout() {
+	if len(w.stdoutPending) == 0 {
+		return
+	}
+	evt := map[string]any{
+		"type":       "tool_stdout",
+		"session_id": w.sessionID,
+		"tool_id":    w.stdoutPendingTool,
+		"lines":      w.stdoutPending,
+	}
+	w.hub.broadcast(w.sessionID, evt)
+	w.stdoutPending = nil
+	w.stdoutFlushAt = time.Now()
+}
+
 func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -2149,13 +2187,6 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 		// StreamingToolExecutor tools (currently just terminal) emit this;
 		// most tools never reach here. tool_id lets the frontend attribute the
 		// chunk to the right card (see #1193's pickToolIndex).
-		evt := map[string]any{
-			"type":       "tool_stdout",
-			"session_id": w.sessionID,
-			"tool_id":    ev.ToolID,
-			"lines":      []string{ev.Chunk},
-		}
-		w.hub.broadcast(w.sessionID, evt)
 		w.server.liveStateMu.Lock()
 		if ls, ok := w.server.liveStates[w.sessionID]; ok {
 			ls.stdoutToolID = ev.ToolID
@@ -2166,7 +2197,24 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 		}
 		w.server.liveStateMu.Unlock()
 
+		// Coalesce rather than broadcast this single chunk immediately — see
+		// stdoutCoalesceWindow. A tool_id change can only mean the previous
+		// tool's buffer was somehow left unflushed (EventToolDone/Error below
+		// already flush it); flush defensively so a chunk is never attributed
+		// to the wrong card.
+		if w.stdoutPendingTool != "" && w.stdoutPendingTool != ev.ToolID {
+			w.flushStdout()
+		}
+		w.stdoutPendingTool = ev.ToolID
+		w.stdoutPending = append(w.stdoutPending, ev.Chunk)
+		if time.Since(w.stdoutFlushAt) >= stdoutCoalesceWindow {
+			w.flushStdout()
+		}
+
 	case agent.EventToolDone:
+		// Flush any buffered progress lines before the result, so the last
+		// coalesced chunk isn't left waiting for a next line that never comes.
+		w.flushStdout()
 		toolResult := map[string]any{
 			"type":       "tool_result",
 			"session_id": w.sessionID,
@@ -2203,6 +2251,8 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 		w.server.broadcastBackgroundTasks(w.sessionID)
 
 	case agent.EventToolError:
+		// Same reasoning as EventToolDone: don't leave the last chunk stranded.
+		w.flushStdout()
 		evt := map[string]any{
 			"type":       "tool_error",
 			"session_id": w.sessionID,
@@ -2314,6 +2364,9 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 		}
 
 	case agent.EventTurnDone:
+		// Defensive: a turn interrupted mid-stream could in principle reach
+		// here without an EventToolDone/Error for the in-flight tool.
+		w.flushStdout()
 		if ev.Reply != nil {
 			w.hub.broadcast(w.sessionID, map[string]any{
 				"type":       "turn_done",

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -636,9 +636,15 @@
             </button>
           {/if}
         {:else if tool.stdout && tool.stdout.length > 0}
-          {@const full = tool.stdout.join('\n')}
+          <!-- tool.stdout is already one line per array entry (see
+               appendToolStdout in stores.ts) — joining it into a string and
+               immediately re-splitting it on every streamed chunk was pure
+               waste, and on a chatty command re-ran that join/split on the
+               whole buffer for every incoming line. Iterate the array
+               directly, keyed by index so Svelte only patches the new tail
+               instead of re-diffing every line each time. -->
           <div class="term-wrap">
-            <pre class="terminal-output" use:pinBottom>{#each full.split('\n') as line}{line}
+            <pre class="terminal-output" use:pinBottom>{#each tool.stdout as line, i (i)}{line}
 {/each}{#if !tool.done}<span class="blink-caret"></span>{/if}</pre>
           </div>
         {:else if tool.name === 'web_search' && searchResults(tool)}


### PR DESCRIPTION
## Summary

A Windows user reported the Octo desktop window going "(Not Responding)" while running compile/build commands. Root cause: `EventToolProgress` streams stdout one line at a time with zero batching, and the frontend mirrored that per-line cost — each line triggered its own WS broadcast, a full `chatMessages` store rebuild, and a `join('\n')` + `split('\n')` round trip over the whole buffer just to re-render an array it already had. Under a fast/verbose build (e.g. a cross-compile with heavy gcc/link output) this can pin the desktop shell's webview render thread long enough to miss its liveness heartbeat and trip Windows' hang detector — and since it happens while the window is already in the foreground, the shell's existing revive/probe self-heal (`cmd/octo-desktop/bridge.go`, keyed off window-show events) never engages.

- **`internal/server/ws_handlers.go`**: buffer `EventToolProgress` chunks per `wsStreamWriter` and broadcast at most once per `stdoutCoalesceWindow` (80ms) instead of once per line. Flushes immediately on a tool_id change, and on `EventToolDone`/`EventToolError`/`EventTurnDone` so no buffered line is ever left stranded waiting for a next line that never comes. The very first chunk after a fresh `wsStreamWriter` still flushes on its own, so output still starts without an extra delay.
- **`web/src/components/chat/ToolGroup.svelte`**: `tool.stdout` is already an array of lines (see `appendToolStdout` in `stores.ts`) — iterate it directly instead of `join()`-ing the whole buffer into a string and immediately `split()`-ing it back apart on every streamed update. Keyed the `{#each}` by index so Svelte patches only the new tail instead of re-diffing the whole list.

## Scope / what this does NOT fix

Two related issues were identified but intentionally left out of this PR (not asked for):
- `pinBottom`'s `MutationObserver` still forces a synchronous `scrollTop = scrollHeight` layout read/write on every DOM mutation.
- The shell's revive/probe self-heal only runs on `showWindowAt` (window re-shown from hidden/minimized) — a freeze while the window is already foregrounded and in active use isn't covered by any auto-recovery.

This change reduces the frequency and duration of main-thread pinning during a chatty command, which should make the reported freeze substantially less likely, but has not been verified against an actual repro (e.g. the reporting user's mbedtls cross-compile build) — recommend a real-world retest before considering this fully resolved.

## Test plan

- [x] `go build ./internal/server/...`
- [x] `go test -race ./internal/server/...` (existing suite + 1 updated test + 1 new test for tool-id-change flushing)
- [x] `gofmt -l` / `go vet ./...` clean
- [x] `npx vitest run` (full web suite, 651 tests, incl. `ToolGroup.test.ts`)
- [x] `npx svelte-check` (774 files, 0 errors)
- [ ] Real-world repro against a verbose compile command on Windows (not done — recommend before merge/closing the report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)