### PR TITLE
fix(desktop): realign titlebar rows with the traffic lights on macOS 26

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -170,6 +171,19 @@ const desktopShellQuery = "shell=octo-desktop"
 // sync (TestShellURL pins the Go side).
 func shellURL(base, hash string) string {
 	u := base + "/?" + desktopShellQuery
+	// The shell webview aligns its titlebar rows to the traffic lights, whose
+	// position depends on the host's macOS version (26pt from the window top
+	// on macOS 26 for this window style, 20px through macOS 15) — and it
+	// needs that version at first paint: waiting for /api/version leaves the
+	// rows un-inset under the lights for a second or two at startup. So the
+	// version rides in the URL alongside the shell marker; the frontend seeds
+	// macosMajor from it (web/src/lib/stores.ts) and re-confirms from
+	// /api/version's os_version once that lands.
+	if runtime.GOOS == "darwin" {
+		if major, _, _ := strings.Cut(server.OSVersion(), "."); major != "" {
+			u += "&macos=" + major
+		}
+	}
 	if hash != "" {
 		u += "#" + hash
 	}

--- a/cmd/octo-desktop/bridge_test.go
+++ b/cmd/octo-desktop/bridge_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/open-octo/octo-agent/internal/server"
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
@@ -14,18 +16,29 @@ import (
 // web/src/components/layout/VersionBadge.svelte); renaming one side without the
 // other silently downgrades the desktop shell to a plain-web client — the OS
 // file dialog and native header quietly stop working. This test locks the Go
-// side of that contract.
+// side of that contract. On darwin the URL also carries the host's macOS major
+// version (the titlebar rows need it at first paint — see shellURL), which the
+// frontend reads as the macos query param in web/src/lib/stores.ts.
 func TestShellURL(t *testing.T) {
 	const base = "http://127.0.0.1:8088"
+
+	query := "shell=octo-desktop"
+	if runtime.GOOS == "darwin" {
+		major, _, _ := strings.Cut(server.OSVersion(), ".")
+		if major == "" {
+			t.Fatal("OSVersion() empty on darwin — the shell URL would drop the macos param")
+		}
+		query += "&macos=" + major
+	}
 
 	tests := []struct {
 		name string
 		hash string
 		want string
 	}{
-		{"no hash", "", base + "/?shell=octo-desktop"},
-		{"with hash", "settings", base + "/?shell=octo-desktop#settings"},
-		{"nested route", "chat/abc123", base + "/?shell=octo-desktop#chat/abc123"},
+		{"no hash", "", base + "/?" + query},
+		{"with hash", "settings", base + "/?" + query + "#settings"},
+		{"nested route", "chat/abc123", base + "/?" + query + "#chat/abc123"},
 	}
 	for _, tt := range tests {
 		if got := shellURL(base, tt.hash); got != tt.want {

--- a/internal/server/osversion_darwin.go
+++ b/internal/server/osversion_darwin.go
@@ -4,7 +4,7 @@ package server
 
 import "golang.org/x/sys/unix"
 
-// osVersion reports the host's macOS product version (e.g. "26.5.2"). The
+// OSVersion reports the host's macOS product version (e.g. "26.5.2"). The
 // frontend gates window-chrome metrics on it: macOS 26 moved the traffic
 // lights' centre downward for windows whose binary is stamped with the
 // macOS 26 SDK (LC_BUILD_VERSION — the desktop build has been since
@@ -12,7 +12,7 @@ import "golang.org/x/sys/unix"
 // LSMinimumSystemVersion is 12.0, well past kern.osproductversion's
 // introduction (10.13.4), so the sysctl is always present; an error still
 // degrades to "" and the frontend keeps the legacy axis.
-func osVersion() string {
+func OSVersion() string {
 	v, err := unix.Sysctl("kern.osproductversion")
 	if err != nil {
 		return ""

--- a/internal/server/osversion_darwin.go
+++ b/internal/server/osversion_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package server
+
+import "golang.org/x/sys/unix"
+
+// osVersion reports the host's macOS product version (e.g. "26.5.2"). The
+// frontend gates window-chrome metrics on it: macOS 26 moved the traffic
+// lights' centre downward for windows whose binary is stamped with the
+// macOS 26 SDK (LC_BUILD_VERSION — the desktop build has been since
+// v1.16.18), so the titlebar rows must align to a different axis there.
+// LSMinimumSystemVersion is 12.0, well past kern.osproductversion's
+// introduction (10.13.4), so the sysctl is always present; an error still
+// degrades to "" and the frontend keeps the legacy axis.
+func osVersion() string {
+	v, err := unix.Sysctl("kern.osproductversion")
+	if err != nil {
+		return ""
+	}
+	return v
+}

--- a/internal/server/osversion_other.go
+++ b/internal/server/osversion_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package server
+
+// osVersion only has a consumer on darwin (see osversion_darwin.go): the
+// traffic-light axis it feeds exists nowhere else, so it reports empty.
+func osVersion() string { return "" }

--- a/internal/server/osversion_other.go
+++ b/internal/server/osversion_other.go
@@ -2,6 +2,6 @@
 
 package server
 
-// osVersion only has a consumer on darwin (see osversion_darwin.go): the
+// OSVersion only has a consumer on darwin (see osversion_darwin.go): the
 // traffic-light axis it feeds exists nowhere else, so it reports empty.
-func osVersion() string { return "" }
+func OSVersion() string { return "" }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -1497,6 +1498,19 @@ func TestHandleVersion_NoUpdateCheck(t *testing.T) {
 	}
 	if body["cli_command"] != "octo" {
 		t.Errorf("cli_command = %v, want the constant octo", body["cli_command"])
+	}
+	// os_version is always present; it carries a value only on darwin, where the
+	// frontend aligns the titlebar rows to the traffic lights' axis. On the CI
+	// mac this is a real version ("26.5.2"-shaped), elsewhere empty.
+	v, ok := body["os_version"].(string)
+	if !ok {
+		t.Fatalf("os_version missing or not a string: %v", body)
+	}
+	if runtime.GOOS == "darwin" && v == "" {
+		t.Errorf("os_version empty on darwin, want the kern.osproductversion value")
+	}
+	if runtime.GOOS != "darwin" && v != "" {
+		t.Errorf("os_version = %q on %s, want empty", v, runtime.GOOS)
 	}
 }
 

--- a/internal/server/version_upgrade_handlers.go
+++ b/internal/server/version_upgrade_handlers.go
@@ -56,6 +56,10 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		// os lets the frontend gate platform-specific UI (e.g. the experimental
 		// computer-use toggle is meaningful only on the macOS and Windows desktop).
 		"os": runtime.GOOS,
+		// os_version is the host's macOS product version (e.g. "26.5.2"; empty
+		// elsewhere). The titlebar rows read it to sit on the traffic lights'
+		// axis, which macOS 26 moved for windows stamped with the macOS 26 SDK.
+		"os_version": osVersion(),
 		// upgrade_mode tells the badge which update mechanism this server offers:
 		// "cli" — the in-place binary swap of POST /api/version/upgrade (octo
 		// serve); "installer" — the desktop build, whose binary can't be swapped

--- a/internal/server/version_upgrade_handlers.go
+++ b/internal/server/version_upgrade_handlers.go
@@ -59,7 +59,7 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		// os_version is the host's macOS product version (e.g. "26.5.2"; empty
 		// elsewhere). The titlebar rows read it to sit on the traffic lights'
 		// axis, which macOS 26 moved for windows stamped with the macOS 26 SDK.
-		"os_version": osVersion(),
+		"os_version": OSVersion(),
 		// upgrade_mode tells the badge which update mechanism this server offers:
 		// "cli" — the in-place binary swap of POST /api/version/upgrade (octo
 		// serve); "installer" — the desktop build, whose binary can't be swapped

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -642,8 +642,12 @@
    backdrop, which is a button too. */
 .topbar button { --wails-draggable: no-drag; }
 /* The same axis lift Header and Sidebar apply on mac — see Header.native-lift
-   for why the height has to be pinned for the padding to move anything. */
-.topbar.native-lift { box-sizing: border-box; max-height: 44px; padding-bottom: 4px; }
+   for why the height has to be pinned for the padding to move anything, and
+   for why the padding values are --titlebar-pad-* (macOS 26 moved the lights). */
+.topbar.native-lift {
+  box-sizing: border-box; max-height: 44px;
+  padding-top: var(--titlebar-pad-top, 0px); padding-bottom: var(--titlebar-pad-bottom, 4px);
+}
 .file-name { min-width: 0; font-size: 12px; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .file-meta { font-size: 11px; color: var(--text-tertiary); flex: 0 0 auto; }
 /* A name and the badge beside it are one identity, so they shrink and vanish as

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { artifacts, panelContent, panelExpanded, artifactSel, artifactView, lightappSel, lightappOpen, lightapps, lightappHTML, lightappStamp, cacheLightApp, dropLightApp, showToast, nativeShell, localAccess, activeSessionId, savePanelMode, type PanelMode } from '../lib/stores'
+  import { artifacts, panelContent, panelExpanded, artifactSel, artifactView, lightappSel, lightappOpen, lightapps, lightappHTML, lightappStamp, cacheLightApp, dropLightApp, showToast, isDesktopShell, localAccess, activeSessionId, savePanelMode, type PanelMode } from '../lib/stores'
   import { titlebarDblClick } from '../lib/nativeWindow'
   import { t } from '../lib/i18n'
   import { copyArtifact, downloadArtifact, imagePreviewError } from '../lib/artifact-actions'
@@ -13,8 +13,9 @@
 
   // This column never holds the traffic lights, but its top row has to sit on
   // the same axis as the chat title beside it, which Header lifts on mac.
+  // isDesktopShell, not nativeShell — see Header.
   const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform)
-  const liftForTrafficLights = $derived($nativeShell && isMac)
+  const liftForTrafficLights = isDesktopShell && isMac
 
   // ── Session artifacts (existing) ──────────────────────────────────────────
   const cur = $derived($artifacts[$artifactSel] ?? $artifacts[0])

--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -127,14 +127,20 @@ header {
    for the lights, nothing more. */
 header.native-inset { padding-left: 82px; }
 /* Lifting the axis is the other half, and max-height is the load-bearing part of
-   it. Padding-bottom alone only moves the axis while min-height still decides the
+   it. Padding alone only moves the axis while min-height still decides the
    row height; .chat-header-slot is taller than the 36px that would leave, so the
    row grew to 52px instead and the axis never moved. Pinning the height makes the
    padding actually shorten the content box.
-   The lights' centre sits 20px below the window's top edge, so 4px of padding is
-   the whole lift: (44 - 4) / 2 lands the row's axis exactly there. */
+   The padding itself comes from --titlebar-pad-top/--titlebar-pad-bottom (set
+   by applyTitlebarLift once /api/version reports the host's macOS version):
+   4px bottom puts the axis at 20px, the lights' centre up through macOS 15;
+   macOS 26 moved that centre to 26pt for windows stamped with the macOS 26
+   SDK (measured for this window style), so there 8px of top padding puts the
+   axis at 26 instead. The 4px-bottom fallback covers web mode and the
+   not-yet-answered fetch. */
 header.native-lift {
-  box-sizing: border-box; max-height: 44px; padding-bottom: 4px;
+  box-sizing: border-box; max-height: 44px;
+  padding-top: var(--titlebar-pad-top, 0px); padding-bottom: var(--titlebar-pad-bottom, 4px);
 }
 /* The row is a window drag handle; every control opts back out so it stays
    clickable, leaving the blank stretches to drag the window. */

--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { sidebar, nativeShell, panelContent, view, chatHeaderSnippet, activeSessionId, lightappOpen, panelForView } from '../../lib/stores'
+  import { sidebar, nativeShell, isDesktopShell, panelContent, view, chatHeaderSnippet, activeSessionId, lightappOpen, panelForView } from '../../lib/stores'
   import { diffBadge } from '../../lib/diff'
   import { t } from '../../lib/i18n'
   import { ws, wsState } from '../../lib/ws'
@@ -38,14 +38,17 @@
   const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform)
   // Mac's traffic lights float over the window's top-left corner. That corner
   // is Sidebar's header while the sidebar is showing (it insets itself), and
-  // this row only once the sidebar is gone.
-  const insetForTrafficLights = $derived($nativeShell && isMac && $sidebar === 'hidden')
+  // this row only once the sidebar is gone. Gated on isDesktopShell rather
+  // than nativeShell: the marker is known from the URL at first paint, while
+  // nativeShell waits on /api/version and the row would flash un-inset under
+  // the lights at startup.
+  const insetForTrafficLights = $derived(isDesktopShell && isMac && $sidebar === 'hidden')
   // Making room for the lights is one thing; sitting on the same axis as them is
   // another, and this row needs the second one whether or not it holds the first.
   // While the sidebar shows, the lights are over ITS header — but if only that
   // column lifted its content, the brand row and this row's chat title would sit
   // 4px apart.
-  const liftForTrafficLights = $derived($nativeShell && isMac)
+  const liftForTrafficLights = isDesktopShell && isMac
 
   // The □/❐ icon reflects maximise state the frontend owns — there's no native
   // title bar reading it. This row holds the only copy of that icon, so it is

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -1176,10 +1176,13 @@
    row whenever the sidebar is showing: horizontal room for them, then the same
    axis lift Header applies to the main column, so the brand row and the chat
    title stay on one line. Height pinned for the same reason as there — the
-   padding has to shorten the content box, not grow the row. */
+   padding has to shorten the content box, not grow the row. The padding values
+   are --titlebar-pad-top/--titlebar-pad-bottom for the same reason as there
+   (macOS 26 moved the lights). */
 .side-header.native-inset {
   box-sizing: border-box; max-height: 44px;
-  padding-left: 82px; padding-bottom: 4px;
+  padding-left: 82px;
+  padding-top: var(--titlebar-pad-top, 0px); padding-bottom: var(--titlebar-pad-bottom, 4px);
 }
 .side-header .icon-btn { --wails-draggable: no-drag; }
 .side-header :global(.logo) { color: var(--blue-6); flex: 0 0 auto; }

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte'
   import { get } from 'svelte/store'
-  import { view, sidebar, sessions, sessionGroups, pinnedSessions, collapsedSessions, editGroupId, editGroupDraft, activeSessionId, selMode, sel, menuFor, editId, editDraft, showToast, mcpServers, createNewSession, createSessionInGroup, clearPendingSessionOpts, settingsModalOpen, cmdkOpen, nativeShell, dirLeaf } from '../../lib/stores'
+  import { view, sidebar, sessions, sessionGroups, pinnedSessions, collapsedSessions, editGroupId, editGroupDraft, activeSessionId, selMode, sel, menuFor, editId, editDraft, showToast, mcpServers, createNewSession, createSessionInGroup, clearPendingSessionOpts, settingsModalOpen, cmdkOpen, nativeShell, isDesktopShell, dirLeaf } from '../../lib/stores'
   import * as api from '../../lib/api'
   import { titlebarDblClick } from '../../lib/nativeWindow'
   import { t, tr } from '../../lib/i18n'
@@ -637,7 +637,10 @@
   <div class="full" style="width:{fullWidth}px">
     <!-- Draggable like the main column's top row, and so it takes the same
          double-click-to-zoom a native title bar would give it. -->
-    <div class="side-header" class:native-inset={$nativeShell && isMac} style="--wails-draggable:drag" ondblclick={titlebarDblClick}>
+    <!-- isDesktopShell, not nativeShell: the URL marker is known at first
+         paint, while nativeShell waits on /api/version and the row would
+         flash un-inset under the traffic lights at startup. -->
+    <div class="side-header" class:native-inset={isDesktopShell && isMac} style="--wails-draggable:drag" ondblclick={titlebarDblClick}>
       <button class="icon-btn" title={$t('header.toggle_left')} aria-pressed={true} onclick={() => sidebar.set('hidden')}>
         <iconify-icon icon="lucide:panel-left" width="16"></iconify-icon>
       </button>
@@ -1090,7 +1093,7 @@
 
   {#if $sidebar === 'rail'}
   <div class="rail">
-    <div class="rail-new" class:native-inset={$nativeShell && isMac}>
+    <div class="rail-new" class:native-inset={isDesktopShell && isMac}>
       <button class="rail-btn primary" title={$t('nav.new_session')} onclick={() => createNewSession()}>
         <iconify-icon icon="ant-design:plus-outlined" width="16"></iconify-icon>
       </button>

--- a/web/src/components/layout/VersionBadge.svelte
+++ b/web/src/components/layout/VersionBadge.svelte
@@ -14,7 +14,8 @@
   import * as api from '../../lib/api'
   import { ws } from '../../lib/ws'
   import { t } from '../../lib/i18n'
-  import { nativeShell, localAccess, isDesktopShell } from '../../lib/stores'
+  import { nativeShell, localAccess, isDesktopShell, macosMajor } from '../../lib/stores'
+  import { applyTitlebarLift } from '../../lib/nativeWindow'
 
   type Phase = 'idle' | 'upgrading' | 'needs_restart' | 'reconnecting' | 'restart_failed' | 'done'
 
@@ -58,6 +59,8 @@
       selfUpdateAvail = d.self_update === true
       nativeShell.set(d.native === true && isDesktopShell)
       localAccess.set(d.local === true)
+      macosMajor.set(d.os === 'darwin' ? parseInt(d.os_version, 10) || 0 : 0)
+      applyTitlebarLift()
     } catch { /* badge stays minimal */ }
   }
 

--- a/web/src/lib/nativeWindow.test.ts
+++ b/web/src/lib/nativeWindow.test.ts
@@ -4,7 +4,7 @@ import { get } from 'svelte/store'
 const mocks = vi.hoisted(() => ({ toggle: vi.fn(), state: vi.fn() }))
 vi.mock('./stores', async () => {
   const { writable } = await import('svelte/store')
-  return { nativeShell: writable(false), macosMajor: writable(0) }
+  return { nativeShell: writable(false), macosMajor: writable(0), isDesktopShell: true }
 })
 vi.mock('./api', () => ({
   nativeToggleMaximise: mocks.toggle,
@@ -112,7 +112,6 @@ describe('nativeWindow', () => {
 
     it('publishes 8px top / 0px bottom on a macOS 26 desktop shell', () => {
       onMacPlatform('MacIntel')
-      nativeShell.set(true)
       macosMajor.set(26)
       applyTitlebarLift()
       expect(document.documentElement.style.getPropertyValue('--titlebar-pad-top')).toBe('8px')
@@ -121,20 +120,18 @@ describe('nativeWindow', () => {
 
     it('publishes 0px top / 4px bottom on a pre-26 macOS desktop shell', () => {
       onMacPlatform('MacIntel')
-      nativeShell.set(true)
       macosMajor.set(15)
       applyTitlebarLift()
       expect(document.documentElement.style.getPropertyValue('--titlebar-pad-top')).toBe('0px')
       expect(document.documentElement.style.getPropertyValue('--titlebar-pad-bottom')).toBe('4px')
     })
 
-    it('publishes 0px both ways outside the desktop shell (vars unread there)', () => {
+    it('publishes the legacy values when the host version is unknown', () => {
       onMacPlatform('MacIntel')
-      nativeShell.set(false)
-      macosMajor.set(15)
+      macosMajor.set(0)
       applyTitlebarLift()
       expect(document.documentElement.style.getPropertyValue('--titlebar-pad-top')).toBe('0px')
-      expect(document.documentElement.style.getPropertyValue('--titlebar-pad-bottom')).toBe('0px')
+      expect(document.documentElement.style.getPropertyValue('--titlebar-pad-bottom')).toBe('4px')
     })
   })
 })

--- a/web/src/lib/nativeWindow.test.ts
+++ b/web/src/lib/nativeWindow.test.ts
@@ -4,15 +4,15 @@ import { get } from 'svelte/store'
 const mocks = vi.hoisted(() => ({ toggle: vi.fn(), state: vi.fn() }))
 vi.mock('./stores', async () => {
   const { writable } = await import('svelte/store')
-  return { nativeShell: writable(false) }
+  return { nativeShell: writable(false), macosMajor: writable(0) }
 })
 vi.mock('./api', () => ({
   nativeToggleMaximise: mocks.toggle,
   nativeWindowState: mocks.state,
 }))
 
-import { nativeShell } from './stores'
-import { isMaximised, flipMaximise, refreshMaximised, titlebarDblClick } from './nativeWindow'
+import { nativeShell, macosMajor } from './stores'
+import { isMaximised, flipMaximise, refreshMaximised, titlebarDblClick, titlebarPaddingPx, applyTitlebarLift } from './nativeWindow'
 
 // A double-click carries no coordinates worth modelling — only what it landed
 // on, since the handler has to let controls inside a titlebar keep their clicks.
@@ -27,7 +27,10 @@ describe('nativeWindow', () => {
     mocks.toggle.mockReset().mockResolvedValue(undefined)
     mocks.state.mockReset().mockResolvedValue(false)
     nativeShell.set(false)
+    macosMajor.set(0)
     isMaximised.set(false)
+    document.documentElement.style.removeProperty('--titlebar-pad-top')
+    document.documentElement.style.removeProperty('--titlebar-pad-bottom')
   })
 
   it('ignores titlebar double-clicks outside the desktop shell', () => {
@@ -75,5 +78,63 @@ describe('nativeWindow', () => {
     releaseState(false)
     await stale
     expect(get(isMaximised)).toBe(true)
+  })
+
+  // The padding exists to put the rows' axis on the traffic lights' centre,
+  // measured for this window style (hidden titlebar + wails' toolbar): 20px
+  // from the window top through macOS 15, 26pt on macOS 26 (windows stamped
+  // with the macOS 26 SDK). 4px of bottom padding lands the pinned 44px row at
+  // (44 - 4) / 2 = 20; 8px of top padding lands it at 8 + (44 - 8) / 2 = 26.
+  describe('titlebarPaddingPx', () => {
+    it('pads 4px from below through macOS 15', () => {
+      expect(titlebarPaddingPx(true, true, 15)).toEqual({ top: 0, bottom: 4 })
+    })
+
+    it('pads 8px from above on macOS 26', () => {
+      expect(titlebarPaddingPx(true, true, 26)).toEqual({ top: 8, bottom: 0 })
+      expect(titlebarPaddingPx(true, true, 27)).toEqual({ top: 8, bottom: 0 })
+    })
+
+    it('keeps the legacy padding when the host version is unknown', () => {
+      expect(titlebarPaddingPx(true, true, 0)).toEqual({ top: 0, bottom: 4 })
+    })
+
+    it('pads nothing off the mac desktop shell', () => {
+      expect(titlebarPaddingPx(false, true, 15)).toEqual({ top: 0, bottom: 0 })
+      expect(titlebarPaddingPx(true, false, 15)).toEqual({ top: 0, bottom: 0 })
+    })
+  })
+
+  describe('applyTitlebarLift', () => {
+    function onMacPlatform(v: string) {
+      Object.defineProperty(window.navigator, 'platform', { value: v, configurable: true })
+    }
+
+    it('publishes 8px top / 0px bottom on a macOS 26 desktop shell', () => {
+      onMacPlatform('MacIntel')
+      nativeShell.set(true)
+      macosMajor.set(26)
+      applyTitlebarLift()
+      expect(document.documentElement.style.getPropertyValue('--titlebar-pad-top')).toBe('8px')
+      expect(document.documentElement.style.getPropertyValue('--titlebar-pad-bottom')).toBe('0px')
+    })
+
+    it('publishes 0px top / 4px bottom on a pre-26 macOS desktop shell', () => {
+      onMacPlatform('MacIntel')
+      nativeShell.set(true)
+      macosMajor.set(15)
+      applyTitlebarLift()
+      expect(document.documentElement.style.getPropertyValue('--titlebar-pad-top')).toBe('0px')
+      expect(document.documentElement.style.getPropertyValue('--titlebar-pad-bottom')).toBe('4px')
+    })
+
+    it('publishes 0px both ways outside the desktop shell (vars unread there)', () => {
+      onMacPlatform('MacIntel')
+      nativeShell.set(false)
+      macosMajor.set(15)
+      applyTitlebarLift()
+      expect(document.documentElement.style.getPropertyValue('--titlebar-pad-top')).toBe('0px')
+      expect(document.documentElement.style.getPropertyValue('--titlebar-pad-bottom')).toBe('0px')
+    })
   })
 })

--- a/web/src/lib/nativeWindow.ts
+++ b/web/src/lib/nativeWindow.ts
@@ -1,5 +1,5 @@
 import { get, writable } from 'svelte/store'
-import { nativeShell } from './stores'
+import { nativeShell, macosMajor } from './stores'
 import { nativeToggleMaximise, nativeWindowState } from './api'
 
 // Desktop shell only. Maximise state has to be shared rather than owned by one
@@ -39,4 +39,39 @@ export function titlebarDblClick(e: MouseEvent): void {
   if (!get(nativeShell)) return
   if ((e.target as HTMLElement).closest('button, a, input, select, textarea')) return
   void flipMaximise()
+}
+
+// The mac titlebar rows pad their top or bottom edge to put their content
+// axis on the traffic lights' centre (via the --titlebar-pad-* CSS variables
+// the .native-lift/.native-inset rules read). The lights' position depends on
+// the macOS version AND the window's SDK stamp (AppKit gates window chrome on
+// linked-on-or-after), and the desktop build has carried the macOS 26 SDK in
+// LC_BUILD_VERSION since v1.16.18. Measured on macOS 26 for this window style
+// (hidden titlebar + wails' toolbar): the centre sits 26pt below the window's
+// top edge; through macOS 15 it was 20px. The row is pinned at 44px
+// border-box, so 4px of bottom padding lands the axis at (44 - 4) / 2 = 20,
+// and 8px of top padding lands it at 8 + (44 - 8) / 2 = 26. Unknown host
+// version keeps the legacy padding: the fetch that feeds macosMajor failing
+// must not misalign every older mac.
+export function titlebarPaddingPx(
+  native: boolean,
+  isMac: boolean,
+  macosMajorVersion: number,
+): { top: number; bottom: number } {
+  if (!native || !isMac) return { top: 0, bottom: 0 }
+  return macosMajorVersion >= 26 ? { top: 8, bottom: 0 } : { top: 0, bottom: 4 }
+}
+
+// Publishes the padding to every titlebar row at once: the CSS reads
+// var(--titlebar-pad-top, 0px) and var(--titlebar-pad-bottom, 4px), whose
+// defaults are also the pre-fetch legacy values. Called by VersionBadge once
+// /api/version has answered what nativeShell and macosMajor actually are.
+// Runs against document rather than a component so the single value reaches
+// Header, Sidebar's brand row and the ArtifactsPanel topbars without
+// threading a store through each of them.
+export function applyTitlebarLift(): void {
+  const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform)
+  const pad = titlebarPaddingPx(get(nativeShell), isMac, get(macosMajor))
+  document.documentElement.style.setProperty('--titlebar-pad-top', `${pad.top}px`)
+  document.documentElement.style.setProperty('--titlebar-pad-bottom', `${pad.bottom}px`)
 }

--- a/web/src/lib/nativeWindow.ts
+++ b/web/src/lib/nativeWindow.ts
@@ -1,5 +1,5 @@
 import { get, writable } from 'svelte/store'
-import { nativeShell, macosMajor } from './stores'
+import { nativeShell, macosMajor, isDesktopShell } from './stores'
 import { nativeToggleMaximise, nativeWindowState } from './api'
 
 // Desktop shell only. Maximise state has to be shared rather than owned by one
@@ -64,14 +64,16 @@ export function titlebarPaddingPx(
 
 // Publishes the padding to every titlebar row at once: the CSS reads
 // var(--titlebar-pad-top, 0px) and var(--titlebar-pad-bottom, 4px), whose
-// defaults are also the pre-fetch legacy values. Called by VersionBadge once
-// /api/version has answered what nativeShell and macosMajor actually are.
+// defaults are also the pre-fetch legacy values. main.ts calls this before
+// first paint (isDesktopShell and the URL-seeded macosMajor make every input
+// synchronous — waiting for /api/version flashed the rows un-inset under the
+// lights at startup), and VersionBadge re-runs it once /api/version lands.
 // Runs against document rather than a component so the single value reaches
 // Header, Sidebar's brand row and the ArtifactsPanel topbars without
 // threading a store through each of them.
 export function applyTitlebarLift(): void {
   const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform)
-  const pad = titlebarPaddingPx(get(nativeShell), isMac, get(macosMajor))
+  const pad = titlebarPaddingPx(isDesktopShell, isMac, get(macosMajor))
   document.documentElement.style.setProperty('--titlebar-pad-top', `${pad.top}px`)
   document.documentElement.style.setProperty('--titlebar-pad-bottom', `${pad.bottom}px`)
 }

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -83,6 +83,18 @@ export const wsDown = writable(false)
 export const isDesktopShell =
   typeof location !== 'undefined' && new URLSearchParams(location.search).get('shell') === 'octo-desktop'
 
+// Major macOS version of the desktop shell's host (e.g. 26), handed over in
+// the shell URL next to the marker (cmd/octo-desktop/bridge.go shellURL); 0
+// outside the mac desktop shell. The window-chrome code needs it at first
+// paint — waiting for /api/version leaves the titlebar rows un-inset under
+// the traffic lights for a second or two at startup — so like isDesktopShell
+// it comes from the URL, no round-trip. VersionBadge re-confirms it into
+// macosMajor from /api/version's os_version once that lands.
+export const shellMacosMajor =
+  typeof location !== 'undefined'
+    ? parseInt(new URLSearchParams(location.search).get('macos') ?? '', 10) || 0
+    : 0
+
 // True when the page runs inside the octo-mobile Capacitor webview. Capacitor
 // injects a global `Capacitor` object with isNativePlatform(); a plain browser
 // has none. Fixed for the page's lifetime, like isDesktopShell. Mobile's
@@ -100,11 +112,13 @@ export const mobileShell =
 // dialog instead of the in-app directory tree. False under `octo serve`.
 export const nativeShell = writable(false)
 
-// Major macOS version of the desktop shell's host (e.g. 26), parsed from
+// Major macOS version of the desktop shell's host (e.g. 26). Seeded
+// synchronously from the shell URL (shellMacosMajor above) so window chrome
+// is right at first paint, then re-confirmed by VersionBadge from
 // /api/version's os_version; 0 when the host isn't macOS or isn't known yet.
 // The titlebar rows read it to sit on the traffic lights' axis, which macOS 26
-// moved for windows stamped with the macOS 26 SDK (see titlebarLiftPx).
-export const macosMajor = writable(0)
+// moved for windows stamped with the macOS 26 SDK (see titlebarPaddingPx).
+export const macosMajor = writable(shellMacosMajor)
 
 // True when the browser is on the same machine as the server (loopback),
 // reported by /api/version's `local` flag — desktop shell OR localhost web.

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -100,6 +100,12 @@ export const mobileShell =
 // dialog instead of the in-app directory tree. False under `octo serve`.
 export const nativeShell = writable(false)
 
+// Major macOS version of the desktop shell's host (e.g. 26), parsed from
+// /api/version's os_version; 0 when the host isn't macOS or isn't known yet.
+// The titlebar rows read it to sit on the traffic lights' axis, which macOS 26
+// moved for windows stamped with the macOS 26 SDK (see titlebarLiftPx).
+export const macosMajor = writable(0)
+
 // True when the browser is on the same machine as the server (loopback),
 // reported by /api/version's `local` flag — desktop shell OR localhost web.
 // When true, files/folders are chosen by real path (native dialog or the

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -4,9 +4,16 @@ import { mount } from 'svelte'
 import { initTheme } from './lib/theme'
 import { initFramelessDrag } from './lib/framelessDrag'
 import { installArtifactThemeRefresh } from './lib/artifacts'
+import { applyTitlebarLift } from './lib/nativeWindow'
 
 // Apply the persisted theme before first paint so there's no light-mode flash.
 initTheme()
+
+// Desktop shell on macOS: pin the titlebar rows' axis to the traffic lights
+// before first paint — the inset and padding would otherwise wait on
+// /api/version and flash the rows crammed under the lights at startup.
+// No-op elsewhere.
+applyTitlebarLift()
 
 // Rebuild baked-theme artifact previews whenever the resolved theme changes.
 installArtifactThemeRefresh()


### PR DESCRIPTION
## 问题

v1.16.18 顶栏不对齐：侧边栏品牌行和聊天标题比红绿灯高 ~5px。这正是 #2197 修过的问题复发了——但两个 tag 之间前端顶栏代码**一个字节都没变**（从两个 release 的 .app 里提取嵌入 CSS 对比过）。

## 根因

变的是桌面二进制的 SDK 印记。实测两个 release 的 `octo-desktop` 二进制：

```
v1.16.17:  LC_BUILD_VERSION  minos 11.0  sdk 11.0
v1.16.18:  LC_BUILD_VERSION  minos 12.0  sdk 26.5
```

#2394 把 desktop 链接参数从旧的 ld 拼写 `-Wl,-macos_version_min,11.0` 换成 clang driver 拼写 `-mmacosx-version-min=12.0`。旧拼写下 ld 盖出的印记是错误的 `sdk 11.0`；新拼写盖上了真实 SDK `sdk 26.5`。macOS 的窗口 chrome 行为按这个印记做 linked-on-or-after 门控，所以 **v1.16.18 是第一个吃到 Tahoe 新窗口度量的构建**，而前端三列顶栏还按 #2197 的测量对齐旧红绿灯位置。

新位置不是拍脑袋估的：写了个探针窗口复刻 wails 的 hidden-inset 配置（`titlebarAppearsTransparent` + `fullSizeContentView` + `NSToolbar`），用 macOS 26 SDK 编译实测——**带 toolbar 时红绿灯中心在窗口顶部下 26pt**（不带 toolbar 是 16pt，`UseToolbar` 正是把灯压下去的原因）；macOS 15 及以前是 20px。

## 修复

不再硬编码旧轴，让行对齐到红绿灯实际所在的位置：

- `GET /api/version` 新增 `os_version`（darwin 读 `kern.osproductversion`，其他平台为空串）；VersionBadge 启动时本来就会拉这个接口。
- `nativeWindow.titlebarPaddingPx()` 按宿主系统算出能把钉死的 44px 行送上灯心的 padding：macOS ≤15（及未知）下方垫 4px（轴 20 = `(44-4)/2`）；macOS ≥26 上方垫 8px（轴 26 = `8+(44-8)/2`）。`applyTitlebarLift()` 把这一对值发布为 document 上的 `--titlebar-pad-top` / `--titlebar-pad-bottom` CSS 变量。
- Header、侧边栏品牌行、ArtifactsPanel 顶栏三处规则改读这两个变量；`4px`-bottom 兜底保证 web 模式和接口应答前的首帧仍是旧行为。

## 测试

- `nativeWindow.test.ts` 新增 7 个用例（padding 映射 + CSS 变量发布），web 全量 658 通过
- `internal/server` 版本接口测试补 `os_version` 断言（darwin 非空 / 其他平台为空），包测试通过；windows/linux 交叉编译通过
- 桌面壳（CGO）构建通过，并用打包出的 Octo.app 实测验证对齐

合并后建议发 v1.16.19（记得先 bump `internal/version/version.go`）。
